### PR TITLE
feat(transaction)!: exclude seal signature witness data from the transaction id

### DIFF
--- a/applications/tari_walletd/src/handlers/context.rs
+++ b/applications/tari_walletd/src/handlers/context.rs
@@ -287,7 +287,13 @@ impl HandlerContext {
     }
 
     /// Returns a TransactionBuilder with the current network configured.
+    ///
+    /// The builder is stamped with a random nonce so that repeated identical intents (same
+    /// instructions, inputs and signer) produce distinct transaction ids. Paths that submit
+    /// caller-provided bytes replace the whole unsigned transaction via
+    /// `with_unsigned_transaction`, which discards the stamp — the caller's bytes are preserved
+    /// verbatim there.
     pub fn transaction_builder(&self) -> TransactionBuilder {
-        Transaction::builder(self.config().network.as_byte())
+        Transaction::builder(self.config().network.as_byte()).with_nonce(rand::random())
     }
 }

--- a/bindings/package.json
+++ b/bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/ootle-ts-bindings",
-  "version": "1.47.1",
+  "version": "1.48.0",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/bindings/src/types/PrunedUnsignedTransactionV1.ts
+++ b/bindings/src/types/PrunedUnsignedTransactionV1.ts
@@ -30,4 +30,8 @@ export type PrunedUnsignedTransactionV1 = {
    * archives that didn't record sizes.
    */
   blob_sizes: Array<number>;
+  /**
+   * Mirrors `UnsignedTransactionV1::nonce` of the full form.
+   */
+  nonce: bigint;
 };

--- a/bindings/src/types/UnsignedTransactionV1.ts
+++ b/bindings/src/types/UnsignedTransactionV1.ts
@@ -23,4 +23,11 @@ export type UnsignedTransactionV1 = {
    * signature verifiability or transaction id.
    */
   blobs: Blobs;
+  /**
+   * Distinguishes otherwise-identical transactions. The transaction id excludes the seal
+   * signature, so two identical bodies sealed by the same key are the *same* transaction —
+   * an intent builder (e.g. a wallet) that wants each submission to execute independently
+   * must stamp a distinct nonce per intent. Part of the signing and id domains.
+   */
+  nonce: bigint;
 };

--- a/crates/consensus_tests/src/consensus.rs
+++ b/crates/consensus_tests/src/consensus.rs
@@ -1125,16 +1125,19 @@ async fn single_shard_input_conflict() {
     let mut test = Test::builder().add_committee(0, vec!["1", "2"]).start().await;
 
     let substate_id = test.create_substates_on_vns(TestVnDestination::All, 1).pop().unwrap();
-    let secret = PrivateKey::from_canonical_bytes(&[1u8; 32]).unwrap();
+    // Distinct sealers: the transaction id excludes the seal nonce, so an identical body sealed
+    // by the same key would be one transaction, not two conflicting ones.
+    let secret1 = PrivateKey::from_canonical_bytes(&[1u8; 32]).unwrap();
+    let secret2 = PrivateKey::from_canonical_bytes(&[2u8; 32]).unwrap();
 
     let tx1 = Transaction::builder_localnet()
         .add_input(substate_id.clone())
-        .build_and_seal(&secret);
+        .build_and_seal(&secret1);
     let tx1 = TransactionRecord::new(tx1);
 
     let tx2 = Transaction::builder_localnet()
         .add_input(substate_id.clone())
-        .build_and_seal(&secret);
+        .build_and_seal(&secret2);
     let tx2 = TransactionRecord::new(tx2);
 
     test.add_execution_at_destination(TestVnDestination::All, ExecuteSpec {
@@ -1344,16 +1347,18 @@ async fn multishard_unversioned_input_conflict() {
         .pop()
         .unwrap();
 
+    // Distinct sealers: the transaction id excludes the seal nonce, so an identical body sealed
+    // by the same key would be one transaction, not two conflicting ones.
     let tx1 = Transaction::builder_localnet()
         .add_input(SubstateRequirement::unversioned(id0.substate_id().clone()))
         .add_input(SubstateRequirement::unversioned(id1.substate_id().clone()))
-        .build_and_seal(&Default::default());
+        .build_and_seal(&PrivateKey::from_canonical_bytes(&[1u8; 32]).unwrap());
     let tx1 = TransactionRecord::new(tx1);
 
     let tx2 = Transaction::builder_localnet()
         .add_input(SubstateRequirement::unversioned(id0.substate_id().clone()))
         .add_input(SubstateRequirement::unversioned(id1.substate_id().clone()))
-        .build_and_seal(&Default::default());
+        .build_and_seal(&PrivateKey::from_canonical_bytes(&[2u8; 32]).unwrap());
     let tx2 = TransactionRecord::new(tx2);
 
     test.add_execution_at_destination(TestVnDestination::All, ExecuteSpec {

--- a/crates/ootle_sdk_core/fixtures/account_balances/multi_vault_u64.json
+++ b/crates/ootle_sdk_core/fixtures/account_balances/multi_vault_u64.json
@@ -2,8 +2,8 @@
   "name": "account_balances/multi_vault_u64",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "account_balances",

--- a/crates/ootle_sdk_core/fixtures/address_codec/identity_esmeralda.json
+++ b/crates/ootle_sdk_core/fixtures/address_codec/identity_esmeralda.json
@@ -2,8 +2,8 @@
   "name": "address_codec/identity_esmeralda",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "format_identity_address",

--- a/crates/ootle_sdk_core/fixtures/address_codec/identity_localnet_with_pay_ref.json
+++ b/crates/ootle_sdk_core/fixtures/address_codec/identity_localnet_with_pay_ref.json
@@ -2,8 +2,8 @@
   "name": "address_codec/identity_localnet_with_pay_ref",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "format_identity_address",

--- a/crates/ootle_sdk_core/fixtures/address_codec/identity_mainnet.json
+++ b/crates/ootle_sdk_core/fixtures/address_codec/identity_mainnet.json
@@ -2,8 +2,8 @@
   "name": "address_codec/identity_mainnet",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "format_identity_address",

--- a/crates/ootle_sdk_core/fixtures/address_codec/parse_component.json
+++ b/crates/ootle_sdk_core/fixtures/address_codec/parse_component.json
@@ -2,8 +2,8 @@
   "name": "address_codec/parse_component",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "parse_address",

--- a/crates/ootle_sdk_core/fixtures/address_codec/parse_identity_esmeralda.json
+++ b/crates/ootle_sdk_core/fixtures/address_codec/parse_identity_esmeralda.json
@@ -2,8 +2,8 @@
   "name": "address_codec/parse_identity_esmeralda",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "parse_address",

--- a/crates/ootle_sdk_core/fixtures/address_codec/parse_resource.json
+++ b/crates/ootle_sdk_core/fixtures/address_codec/parse_resource.json
@@ -2,8 +2,8 @@
   "name": "address_codec/parse_resource",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "parse_address",

--- a/crates/ootle_sdk_core/fixtures/address_derive/from_curve_pk.json
+++ b/crates/ootle_sdk_core/fixtures/address_derive/from_curve_pk.json
@@ -2,8 +2,8 @@
   "name": "address_derive/from_curve_pk",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "derive_account_address",

--- a/crates/ootle_sdk_core/fixtures/address_derive/from_recipient_pk.json
+++ b/crates/ootle_sdk_core/fixtures/address_derive/from_recipient_pk.json
@@ -2,8 +2,8 @@
   "name": "address_derive/from_recipient_pk",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "derive_account_address",

--- a/crates/ootle_sdk_core/fixtures/address_derive/from_seed_account_pk.json
+++ b/crates/ootle_sdk_core/fixtures/address_derive/from_seed_account_pk.json
@@ -2,8 +2,8 @@
   "name": "address_derive/from_seed_account_pk",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "derive_account_address",

--- a/crates/ootle_sdk_core/fixtures/arg_dsl/address_component.json
+++ b/crates/ootle_sdk_core/fixtures/arg_dsl/address_component.json
@@ -2,8 +2,8 @@
   "name": "arg_dsl/address_component",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "encode_arg",

--- a/crates/ootle_sdk_core/fixtures/arg_dsl/address_non_fungible.json
+++ b/crates/ootle_sdk_core/fixtures/arg_dsl/address_non_fungible.json
@@ -2,8 +2,8 @@
   "name": "arg_dsl/address_non_fungible",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "encode_arg",

--- a/crates/ootle_sdk_core/fixtures/arg_dsl/address_resource.json
+++ b/crates/ootle_sdk_core/fixtures/arg_dsl/address_resource.json
@@ -2,8 +2,8 @@
   "name": "arg_dsl/address_resource",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "encode_arg",

--- a/crates/ootle_sdk_core/fixtures/arg_dsl/address_template.json
+++ b/crates/ootle_sdk_core/fixtures/arg_dsl/address_template.json
@@ -2,8 +2,8 @@
   "name": "arg_dsl/address_template",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "encode_arg",

--- a/crates/ootle_sdk_core/fixtures/arg_dsl/address_tombstone.json
+++ b/crates/ootle_sdk_core/fixtures/arg_dsl/address_tombstone.json
@@ -2,8 +2,8 @@
   "name": "arg_dsl/address_tombstone",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "encode_arg",

--- a/crates/ootle_sdk_core/fixtures/arg_dsl/address_transaction_receipt.json
+++ b/crates/ootle_sdk_core/fixtures/arg_dsl/address_transaction_receipt.json
@@ -2,8 +2,8 @@
   "name": "arg_dsl/address_transaction_receipt",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "encode_arg",

--- a/crates/ootle_sdk_core/fixtures/arg_dsl/address_utxo.json
+++ b/crates/ootle_sdk_core/fixtures/arg_dsl/address_utxo.json
@@ -2,8 +2,8 @@
   "name": "arg_dsl/address_utxo",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "encode_arg",

--- a/crates/ootle_sdk_core/fixtures/arg_dsl/address_validator_fee_pool.json
+++ b/crates/ootle_sdk_core/fixtures/arg_dsl/address_validator_fee_pool.json
@@ -2,8 +2,8 @@
   "name": "arg_dsl/address_validator_fee_pool",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "encode_arg",

--- a/crates/ootle_sdk_core/fixtures/arg_dsl/address_vault.json
+++ b/crates/ootle_sdk_core/fixtures/arg_dsl/address_vault.json
@@ -2,8 +2,8 @@
   "name": "arg_dsl/address_vault",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "encode_arg",

--- a/crates/ootle_sdk_core/fixtures/arg_dsl/amount.json
+++ b/crates/ootle_sdk_core/fixtures/arg_dsl/amount.json
@@ -2,8 +2,8 @@
   "name": "arg_dsl/amount",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "encode_arg",

--- a/crates/ootle_sdk_core/fixtures/arg_dsl/amount_above_2_pow_33.json
+++ b/crates/ootle_sdk_core/fixtures/arg_dsl/amount_above_2_pow_33.json
@@ -2,8 +2,8 @@
   "name": "arg_dsl/amount_above_2_pow_33",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "encode_arg",

--- a/crates/ootle_sdk_core/fixtures/arg_dsl/bool_false.json
+++ b/crates/ootle_sdk_core/fixtures/arg_dsl/bool_false.json
@@ -2,8 +2,8 @@
   "name": "arg_dsl/bool_false",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "encode_arg",

--- a/crates/ootle_sdk_core/fixtures/arg_dsl/bool_true.json
+++ b/crates/ootle_sdk_core/fixtures/arg_dsl/bool_true.json
@@ -2,8 +2,8 @@
   "name": "arg_dsl/bool_true",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "encode_arg",

--- a/crates/ootle_sdk_core/fixtures/arg_dsl/bytes.json
+++ b/crates/ootle_sdk_core/fixtures/arg_dsl/bytes.json
@@ -2,8 +2,8 @@
   "name": "arg_dsl/bytes",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "encode_arg",

--- a/crates/ootle_sdk_core/fixtures/arg_dsl/i64_min.json
+++ b/crates/ootle_sdk_core/fixtures/arg_dsl/i64_min.json
@@ -2,8 +2,8 @@
   "name": "arg_dsl/i64_min",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "encode_arg",

--- a/crates/ootle_sdk_core/fixtures/arg_dsl/i64_negative.json
+++ b/crates/ootle_sdk_core/fixtures/arg_dsl/i64_negative.json
@@ -2,8 +2,8 @@
   "name": "arg_dsl/i64_negative",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "encode_arg",

--- a/crates/ootle_sdk_core/fixtures/arg_dsl/i64_positive.json
+++ b/crates/ootle_sdk_core/fixtures/arg_dsl/i64_positive.json
@@ -2,8 +2,8 @@
   "name": "arg_dsl/i64_positive",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "encode_arg",

--- a/crates/ootle_sdk_core/fixtures/arg_dsl/list_empty.json
+++ b/crates/ootle_sdk_core/fixtures/arg_dsl/list_empty.json
@@ -2,8 +2,8 @@
   "name": "arg_dsl/list_empty",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "encode_arg",

--- a/crates/ootle_sdk_core/fixtures/arg_dsl/list_nested.json
+++ b/crates/ootle_sdk_core/fixtures/arg_dsl/list_nested.json
@@ -2,8 +2,8 @@
   "name": "arg_dsl/list_nested",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "encode_arg",

--- a/crates/ootle_sdk_core/fixtures/arg_dsl/list_of_addresses.json
+++ b/crates/ootle_sdk_core/fixtures/arg_dsl/list_of_addresses.json
@@ -2,8 +2,8 @@
   "name": "arg_dsl/list_of_addresses",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "encode_arg",

--- a/crates/ootle_sdk_core/fixtures/arg_dsl/list_of_nfids.json
+++ b/crates/ootle_sdk_core/fixtures/arg_dsl/list_of_nfids.json
@@ -2,8 +2,8 @@
   "name": "arg_dsl/list_of_nfids",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "encode_arg",

--- a/crates/ootle_sdk_core/fixtures/arg_dsl/metadata.json
+++ b/crates/ootle_sdk_core/fixtures/arg_dsl/metadata.json
@@ -2,8 +2,8 @@
   "name": "arg_dsl/metadata",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "encode_arg",

--- a/crates/ootle_sdk_core/fixtures/arg_dsl/nfid_str.json
+++ b/crates/ootle_sdk_core/fixtures/arg_dsl/nfid_str.json
@@ -2,8 +2,8 @@
   "name": "arg_dsl/nfid_str",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "encode_arg",

--- a/crates/ootle_sdk_core/fixtures/arg_dsl/nfid_u32.json
+++ b/crates/ootle_sdk_core/fixtures/arg_dsl/nfid_u32.json
@@ -2,8 +2,8 @@
   "name": "arg_dsl/nfid_u32",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "encode_arg",

--- a/crates/ootle_sdk_core/fixtures/arg_dsl/nfid_u64.json
+++ b/crates/ootle_sdk_core/fixtures/arg_dsl/nfid_u64.json
@@ -2,8 +2,8 @@
   "name": "arg_dsl/nfid_u64",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "encode_arg",

--- a/crates/ootle_sdk_core/fixtures/arg_dsl/nfid_uuid.json
+++ b/crates/ootle_sdk_core/fixtures/arg_dsl/nfid_uuid.json
@@ -2,8 +2,8 @@
   "name": "arg_dsl/nfid_uuid",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "encode_arg",

--- a/crates/ootle_sdk_core/fixtures/arg_dsl/optional_address.json
+++ b/crates/ootle_sdk_core/fixtures/arg_dsl/optional_address.json
@@ -2,8 +2,8 @@
   "name": "arg_dsl/optional_address",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "encode_arg",

--- a/crates/ootle_sdk_core/fixtures/arg_dsl/optional_none.json
+++ b/crates/ootle_sdk_core/fixtures/arg_dsl/optional_none.json
@@ -2,8 +2,8 @@
   "name": "arg_dsl/optional_none",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "encode_arg",

--- a/crates/ootle_sdk_core/fixtures/arg_dsl/optional_some.json
+++ b/crates/ootle_sdk_core/fixtures/arg_dsl/optional_some.json
@@ -2,8 +2,8 @@
   "name": "arg_dsl/optional_some",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "encode_arg",

--- a/crates/ootle_sdk_core/fixtures/arg_dsl/string.json
+++ b/crates/ootle_sdk_core/fixtures/arg_dsl/string.json
@@ -2,8 +2,8 @@
   "name": "arg_dsl/string",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "encode_arg",

--- a/crates/ootle_sdk_core/fixtures/arg_dsl/u64.json
+++ b/crates/ootle_sdk_core/fixtures/arg_dsl/u64.json
@@ -2,8 +2,8 @@
   "name": "arg_dsl/u64",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "encode_arg",

--- a/crates/ootle_sdk_core/fixtures/arg_dsl/u64_above_2_pow_33.json
+++ b/crates/ootle_sdk_core/fixtures/arg_dsl/u64_above_2_pow_33.json
@@ -2,8 +2,8 @@
   "name": "arg_dsl/u64_above_2_pow_33",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "encode_arg",

--- a/crates/ootle_sdk_core/fixtures/cosign/seal_with_auth.json
+++ b/crates/ootle_sdk_core/fixtures/cosign/seal_with_auth.json
@@ -2,8 +2,8 @@
   "name": "cosign/seal_with_auth",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "184979ea3d66d6e0a1bcde32fdae049582dbb8b8",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "cosign_seal_with_auth",
@@ -156,7 +156,8 @@
             "is_seal_signer_authorized": false,
             "max_epoch": 10,
             "min_epoch": 1,
-            "network": 38
+            "network": 38,
+            "nonce": 0
           }
         },
         "seal_signature": {

--- a/crates/ootle_sdk_core/fixtures/generic_build/call_function.json
+++ b/crates/ootle_sdk_core/fixtures/generic_build/call_function.json
@@ -2,8 +2,8 @@
   "name": "generic_build/call_function",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "184979ea3d66d6e0a1bcde32fdae049582dbb8b8",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "build_and_encode_instructions",
@@ -88,7 +88,8 @@
             "is_seal_signer_authorized": true,
             "max_epoch": null,
             "min_epoch": null,
-            "network": 38
+            "network": 38,
+            "nonce": 0
           }
         },
         "seal_signature": {

--- a/crates/ootle_sdk_core/fixtures/generic_build/call_method_transfer.json
+++ b/crates/ootle_sdk_core/fixtures/generic_build/call_method_transfer.json
@@ -2,8 +2,8 @@
   "name": "generic_build/call_method_transfer",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "184979ea3d66d6e0a1bcde32fdae049582dbb8b8",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "build_and_encode_instructions",
@@ -131,7 +131,8 @@
             "is_seal_signer_authorized": true,
             "max_epoch": 10,
             "min_epoch": 1,
-            "network": 38
+            "network": 38,
+            "nonce": 0
           }
         },
         "seal_signature": {

--- a/crates/ootle_sdk_core/fixtures/generic_build/create_account.json
+++ b/crates/ootle_sdk_core/fixtures/generic_build/create_account.json
@@ -2,8 +2,8 @@
   "name": "generic_build/create_account",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "184979ea3d66d6e0a1bcde32fdae049582dbb8b8",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "build_and_encode_instructions",
@@ -89,7 +89,8 @@
             "is_seal_signer_authorized": true,
             "max_epoch": null,
             "min_epoch": null,
-            "network": 38
+            "network": 38,
+            "nonce": 0
           }
         },
         "seal_signature": {

--- a/crates/ootle_sdk_core/fixtures/generic_build/faucet_claim.json
+++ b/crates/ootle_sdk_core/fixtures/generic_build/faucet_claim.json
@@ -2,8 +2,8 @@
   "name": "generic_build/faucet_claim",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "184979ea3d66d6e0a1bcde32fdae049582dbb8b8",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "build_and_encode_faucet_claim",
@@ -143,7 +143,8 @@
             "is_seal_signer_authorized": true,
             "max_epoch": null,
             "min_epoch": null,
-            "network": 38
+            "network": 38,
+            "nonce": 0
           }
         },
         "seal_signature": {

--- a/crates/ootle_sdk_core/fixtures/generic_build/publish_template.json
+++ b/crates/ootle_sdk_core/fixtures/generic_build/publish_template.json
@@ -2,8 +2,8 @@
   "name": "generic_build/publish_template",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "184979ea3d66d6e0a1bcde32fdae049582dbb8b8",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "build_and_encode_instructions",
@@ -92,7 +92,8 @@
             "is_seal_signer_authorized": true,
             "max_epoch": null,
             "min_epoch": null,
-            "network": 38
+            "network": 38,
+            "nonce": 0
           }
         },
         "seal_signature": {

--- a/crates/ootle_sdk_core/fixtures/generic_build/self_funding_faucet.json
+++ b/crates/ootle_sdk_core/fixtures/generic_build/self_funding_faucet.json
@@ -2,8 +2,8 @@
   "name": "generic_build/self_funding_faucet",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "184979ea3d66d6e0a1bcde32fdae049582dbb8b8",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "build_and_encode_instructions",
@@ -129,7 +129,8 @@
             "is_seal_signer_authorized": true,
             "max_epoch": null,
             "min_epoch": null,
-            "network": 38
+            "network": 38,
+            "nonce": 0
           }
         },
         "seal_signature": {

--- a/crates/ootle_sdk_core/fixtures/generic_build/workspace_pipe.json
+++ b/crates/ootle_sdk_core/fixtures/generic_build/workspace_pipe.json
@@ -2,8 +2,8 @@
   "name": "generic_build/workspace_pipe",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "184979ea3d66d6e0a1bcde32fdae049582dbb8b8",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "build_and_encode_instructions",
@@ -145,7 +145,8 @@
             "is_seal_signer_authorized": true,
             "max_epoch": null,
             "min_epoch": null,
-            "network": 38
+            "network": 38,
+            "nonce": 0
           }
         },
         "seal_signature": {

--- a/crates/ootle_sdk_core/fixtures/keys/account_from_seed.json
+++ b/crates/ootle_sdk_core/fixtures/keys/account_from_seed.json
@@ -2,8 +2,8 @@
   "name": "keys/account_from_seed",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "derive_account_key_from_seed",

--- a/crates/ootle_sdk_core/fixtures/keys/view_from_seed.json
+++ b/crates/ootle_sdk_core/fixtures/keys/view_from_seed.json
@@ -2,8 +2,8 @@
   "name": "keys/view_from_seed",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "derive_view_key_from_seed",

--- a/crates/ootle_sdk_core/fixtures/parse_finalized_result/accept.json
+++ b/crates/ootle_sdk_core/fixtures/parse_finalized_result/accept.json
@@ -2,8 +2,8 @@
   "name": "parse_finalized_result/accept",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "parse_finalized_result",

--- a/crates/ootle_sdk_core/fixtures/parse_finalized_result/accept_fee_reject_rest.json
+++ b/crates/ootle_sdk_core/fixtures/parse_finalized_result/accept_fee_reject_rest.json
@@ -2,8 +2,8 @@
   "name": "parse_finalized_result/accept_fee_reject_rest",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "parse_finalized_result",

--- a/crates/ootle_sdk_core/fixtures/parse_finalized_result/dry_run.json
+++ b/crates/ootle_sdk_core/fixtures/parse_finalized_result/dry_run.json
@@ -2,8 +2,8 @@
   "name": "parse_finalized_result/dry_run",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "parse_finalized_result",

--- a/crates/ootle_sdk_core/fixtures/parse_finalized_result/reject_epoch_expired.json
+++ b/crates/ootle_sdk_core/fixtures/parse_finalized_result/reject_epoch_expired.json
@@ -2,8 +2,8 @@
   "name": "parse_finalized_result/reject_epoch_expired",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "parse_finalized_result",

--- a/crates/ootle_sdk_core/fixtures/public_transfer/large_amount.json
+++ b/crates/ootle_sdk_core/fixtures/public_transfer/large_amount.json
@@ -2,8 +2,8 @@
   "name": "public_transfer/large_amount",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "184979ea3d66d6e0a1bcde32fdae049582dbb8b8",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "build_and_encode_public_transfer",
@@ -103,7 +103,8 @@
             "is_seal_signer_authorized": true,
             "max_epoch": 10,
             "min_epoch": 1,
-            "network": 38
+            "network": 38,
+            "nonce": 0
           }
         },
         "seal_signature": {

--- a/crates/ootle_sdk_core/fixtures/public_transfer/sample_single_key_basic.json
+++ b/crates/ootle_sdk_core/fixtures/public_transfer/sample_single_key_basic.json
@@ -2,8 +2,8 @@
   "name": "sample/public_transfer_single_key_basic",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "184979ea3d66d6e0a1bcde32fdae049582dbb8b8",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "build_and_encode_public_transfer",
@@ -103,7 +103,8 @@
             "is_seal_signer_authorized": true,
             "max_epoch": 99,
             "min_epoch": 5,
-            "network": 38
+            "network": 38,
+            "nonce": 0
           }
         },
         "seal_signature": {

--- a/crates/ootle_sdk_core/fixtures/public_transfer/single_key_basic.json
+++ b/crates/ootle_sdk_core/fixtures/public_transfer/single_key_basic.json
@@ -2,8 +2,8 @@
   "name": "public_transfer/single_key_basic",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "184979ea3d66d6e0a1bcde32fdae049582dbb8b8",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "build_and_encode_public_transfer",
@@ -103,7 +103,8 @@
             "is_seal_signer_authorized": true,
             "max_epoch": 10,
             "min_epoch": 1,
-            "network": 38
+            "network": 38,
+            "nonce": 0
           }
         },
         "seal_signature": {

--- a/crates/ootle_sdk_core/fixtures/resolve_public_transfer/large_amount.json
+++ b/crates/ootle_sdk_core/fixtures/resolve_public_transfer/large_amount.json
@@ -2,8 +2,8 @@
   "name": "resolve_public_transfer/large_amount",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "184979ea3d66d6e0a1bcde32fdae049582dbb8b8",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "resolve_and_encode_public_transfer",
@@ -153,7 +153,8 @@
             "is_seal_signer_authorized": true,
             "max_epoch": 10,
             "min_epoch": 1,
-            "network": 38
+            "network": 38,
+            "nonce": 0
           }
         },
         "seal_signature": {

--- a/crates/ootle_sdk_core/fixtures/resolve_public_transfer/single_key_basic.json
+++ b/crates/ootle_sdk_core/fixtures/resolve_public_transfer/single_key_basic.json
@@ -2,8 +2,8 @@
   "name": "resolve_public_transfer/single_key_basic",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "184979ea3d66d6e0a1bcde32fdae049582dbb8b8",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "resolve_and_encode_public_transfer",
@@ -153,7 +153,8 @@
             "is_seal_signer_authorized": true,
             "max_epoch": 10,
             "min_epoch": 1,
-            "network": 38
+            "network": 38,
+            "nonce": 0
           }
         },
         "seal_signature": {

--- a/crates/ootle_sdk_core/fixtures/stealth_outputs_statement/single_output_no_view_key.json
+++ b/crates/ootle_sdk_core/fixtures/stealth_outputs_statement/single_output_no_view_key.json
@@ -2,8 +2,8 @@
   "name": "stealth_outputs_statement/single_output_no_view_key",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "0634fac32d77faefa1a196071423ddbc3c4abbe5",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "build_stealth_outputs_statement",

--- a/crates/ootle_sdk_core/fixtures/stealth_outputs_statement/single_output_with_view_key.json
+++ b/crates/ootle_sdk_core/fixtures/stealth_outputs_statement/single_output_with_view_key.json
@@ -2,8 +2,8 @@
   "name": "stealth_outputs_statement/single_output_with_view_key",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "0634fac32d77faefa1a196071423ddbc3c4abbe5",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "build_stealth_outputs_statement",

--- a/crates/ootle_sdk_core/fixtures/stealth_scan/decode_utxo.json
+++ b/crates/ootle_sdk_core/fixtures/stealth_scan/decode_utxo.json
@@ -2,8 +2,8 @@
   "name": "stealth_scan/decode_utxo",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "0634fac32d77faefa1a196071423ddbc3c4abbe5",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "decode_stealth_utxo",

--- a/crates/ootle_sdk_core/fixtures/stealth_scan/mine_basic.json
+++ b/crates/ootle_sdk_core/fixtures/stealth_scan/mine_basic.json
@@ -2,8 +2,8 @@
   "name": "stealth_scan/mine_basic",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "scan_stealth_output",

--- a/crates/ootle_sdk_core/fixtures/stealth_scan/not_mine.json
+++ b/crates/ootle_sdk_core/fixtures/stealth_scan/not_mine.json
@@ -2,8 +2,8 @@
   "name": "stealth_scan/not_mine",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "scan_stealth_output",

--- a/crates/ootle_sdk_core/fixtures/stealth_transfer/account_key_seal_with_revealed_input.json
+++ b/crates/ootle_sdk_core/fixtures/stealth_transfer/account_key_seal_with_revealed_input.json
@@ -2,8 +2,8 @@
   "name": "stealth_transfer/account_key_seal_with_revealed_input",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "0634fac32d77faefa1a196071423ddbc3c4abbe5",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "build_and_encode_stealth_transfer",
@@ -134,7 +134,8 @@
             "is_seal_signer_authorized": true,
             "max_epoch": null,
             "min_epoch": null,
-            "network": 38
+            "network": 38,
+            "nonce": 0
           }
         },
         "seal_signature": {

--- a/crates/ootle_sdk_core/fixtures/stealth_transfer/revealed_output_multi.json
+++ b/crates/ootle_sdk_core/fixtures/stealth_transfer/revealed_output_multi.json
@@ -2,8 +2,8 @@
   "name": "stealth_transfer/revealed_output_multi",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "0634fac32d77faefa1a196071423ddbc3c4abbe5",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "build_and_encode_stealth_transfer",
@@ -206,7 +206,8 @@
             "is_seal_signer_authorized": true,
             "max_epoch": null,
             "min_epoch": null,
-            "network": 38
+            "network": 38,
+            "nonce": 0
           }
         },
         "seal_signature": {

--- a/crates/ootle_sdk_core/fixtures/stealth_transfer/revealed_output_single.json
+++ b/crates/ootle_sdk_core/fixtures/stealth_transfer/revealed_output_single.json
@@ -2,8 +2,8 @@
   "name": "stealth_transfer/revealed_output_single",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "0634fac32d77faefa1a196071423ddbc3c4abbe5",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "build_and_encode_stealth_transfer",
@@ -150,7 +150,8 @@
             "is_seal_signer_authorized": true,
             "max_epoch": null,
             "min_epoch": null,
-            "network": 38
+            "network": 38,
+            "nonce": 0
           }
         },
         "seal_signature": {

--- a/crates/ootle_sdk_core/fixtures/stealth_transfer/stealth_seal_with_input.json
+++ b/crates/ootle_sdk_core/fixtures/stealth_transfer/stealth_seal_with_input.json
@@ -2,8 +2,8 @@
   "name": "stealth_transfer/stealth_seal_with_input",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "0634fac32d77faefa1a196071423ddbc3c4abbe5",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "build_and_encode_stealth_transfer",
@@ -146,7 +146,8 @@
             "is_seal_signer_authorized": true,
             "max_epoch": null,
             "min_epoch": null,
-            "network": 38
+            "network": 38,
+            "nonce": 0
           }
         },
         "seal_signature": {

--- a/crates/ootle_sdk_core/fixtures/substate_decode/component.json
+++ b/crates/ootle_sdk_core/fixtures/substate_decode/component.json
@@ -2,8 +2,8 @@
   "name": "substate_decode/component",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "decode_substate",

--- a/crates/ootle_sdk_core/fixtures/substate_decode/fungible_vault.json
+++ b/crates/ootle_sdk_core/fixtures/substate_decode/fungible_vault.json
@@ -2,8 +2,8 @@
   "name": "substate_decode/fungible_vault",
   "schema_version": 1,
   "provenance": {
-    "core_version": "0.35.0",
-    "git_rev": "acdba58436eaa92184dfa7947942acc881fd6521",
+    "core_version": "0.37.0",
+    "git_rev": "be2591689b664cddf465a7540277d41b09ecfd0d",
     "generated_by": "ootle_sdk_core golden-vector generator"
   },
   "operation": "decode_substate",

--- a/crates/template_test_tooling/src/template_test.rs
+++ b/crates/template_test_tooling/src/template_test.rs
@@ -2,6 +2,7 @@
 //  SPDX-License-Identifier: BSD-3-Clause
 
 use std::{
+    cell::Cell,
     collections::{HashMap, HashSet},
     env,
     ffi::OsStr,
@@ -36,7 +37,12 @@ use tari_engine_types::{
     substate::{SubstateDiff, SubstateId},
     virtual_substate::{VirtualSubstate, VirtualSubstateId},
 };
-use tari_ootle_common_types::{SubstateRequirement, crypto::create_key_pair_from_seed, substate_type::SubstateType};
+use tari_ootle_common_types::{
+    Epoch,
+    SubstateRequirement,
+    crypto::create_key_pair_from_seed,
+    substate_type::SubstateType,
+};
 use tari_ootle_transaction::{
     Instruction,
     Network,
@@ -109,6 +115,12 @@ pub struct TemplateTest {
     virtual_substates: HashMap<VirtualSubstateId, VirtualSubstate>,
     key_seed: u8,
     auto_add_proofs_from_signers: bool,
+    /// Uniquifies each transaction built via [`Self::transaction`]. The transaction id excludes
+    /// the seal signature, so two transactions with identical bodies sealed by the same test key
+    /// are the *same* transaction — and would collide on id-derived addresses. A distinct
+    /// `max_epoch` per transaction keeps bodies distinct; the engine does not evaluate epoch
+    /// bounds, so this has no behavioural effect.
+    transaction_seq: Cell<u64>,
 }
 
 impl TemplateTest {
@@ -224,6 +236,7 @@ impl TemplateTest {
             last_outputs: HashSet::new(),
             state_store: MemoryStateStore::new(),
             virtual_substates,
+            transaction_seq: Cell::new(0),
             enable_fees: false,
             fee_table: FeeTable {
                 per_transaction_weight_cost: 1,
@@ -454,7 +467,8 @@ impl TemplateTest {
     ) -> ComponentAddress {
         let result = self
             .build_and_execute(
-                Transaction::builder_localnet().create_account_custom(owner_public_key, None, None, workspace_id),
+                self.transaction()
+                    .create_account_custom(owner_public_key, None, None, workspace_id),
                 proofs,
             )
             .unwrap_success();
@@ -590,7 +604,7 @@ impl TemplateTest {
         let old_fail_fees = self.enable_fees;
         self.enable_fees = false;
         self.execute_expect_success(
-            Transaction::builder_localnet()
+            self.transaction()
                 .create_account(public_key.to_byte_type())
                 .put_last_instruction_output_on_workspace("account")
                 .call_method(xtr_faucet_component(), "take", args![Workspace("account")])
@@ -623,7 +637,7 @@ impl TemplateTest {
         self.enable_fees = false;
         let public_key_bytes = public_key.to_byte_type();
         self.execute_expect_success(
-            Transaction::builder_localnet()
+            self.transaction()
                 .create_account(public_key_bytes)
                 .put_last_instruction_output_on_workspace("account")
                 .call_method(xtr_faucet_component(), "take", args![Workspace("account")])
@@ -667,7 +681,8 @@ impl TemplateTest {
         instructions: Vec<Instruction>,
         proofs: Vec<NonFungibleAddress>,
     ) -> Result<ExecuteResult, TransactionError> {
-        let transaction = Transaction::builder_localnet()
+        let transaction = self
+            .transaction()
             .with_fee_instructions(fee_instructions)
             .with_instructions(instructions)
             .build_and_seal(&self.secret_key);
@@ -775,8 +790,13 @@ impl TemplateTest {
 
     /// Returns a new [`TransactionBuilder`] configured for the local test network.
     /// Use this to construct custom transactions with multiple instructions.
+    ///
+    /// Each returned builder carries a distinct `max_epoch` so that otherwise-identical
+    /// transactions produce distinct transaction ids (see [`Self::transaction_seq`]).
     pub fn transaction(&self) -> TransactionBuilder<MainIntent> {
-        Transaction::builder(Network::LocalNet)
+        let seq = self.transaction_seq.get();
+        self.transaction_seq.set(seq + 1);
+        Transaction::builder(Network::LocalNet).with_max_epoch(Some(Epoch(seq)))
     }
 
     /// Executes a transaction. Panics if the transaction is not finalized (fee transaction fails). Does not panic if

--- a/crates/transaction/src/builder/mod.rs
+++ b/crates/transaction/src/builder/mod.rs
@@ -199,6 +199,14 @@ impl TransactionBuilder<MainIntent> {
         self
     }
 
+    /// Stamps the transaction nonce. The transaction id excludes the seal signature, so an
+    /// intent builder must give otherwise-identical transactions distinct nonces for each to
+    /// execute independently.
+    pub fn with_nonce(mut self, nonce: u64) -> Self {
+        self.unsigned_transaction.set_nonce(nonce);
+        self
+    }
+
     pub fn add_signer(
         self,
         sealed_signer: &RistrettoPublicKeyBytes,

--- a/crates/transaction/src/unsigned_transaction.rs
+++ b/crates/transaction/src/unsigned_transaction.rs
@@ -165,6 +165,19 @@ impl UnsignedTransaction {
         self
     }
 
+    pub fn nonce(&self) -> u64 {
+        match self {
+            Self::V1(tx) => tx.nonce,
+        }
+    }
+
+    pub fn set_nonce(&mut self, nonce: u64) -> &mut Self {
+        match self {
+            Self::V1(tx) => tx.nonce = nonce,
+        }
+        self
+    }
+
     pub fn with_inputs<I: IntoIterator<Item = SubstateRequirement>>(mut self, inputs: I) -> Self {
         self.inputs_mut().extend(inputs);
         self

--- a/crates/transaction/src/v1/pruned.rs
+++ b/crates/transaction/src/v1/pruned.rs
@@ -12,7 +12,6 @@
 
 use indexmap::IndexSet;
 use log::*;
-use tari_engine_types::hashing::{EngineHashDomainLabel, hasher32};
 use tari_ootle_common_types::{Epoch, SubstateRequirement};
 use tari_template_lib_types::crypto::RistrettoPublicKeyBytes;
 
@@ -257,17 +256,16 @@ impl PrunedTransactionV1 {
         self.body.transaction.dry_run
     }
 
-    /// Compute the deterministic transaction id. Identical to the full form's id.
+    /// Compute the deterministic transaction id. Identical to the full form's id — see
+    /// [`calculate_id_v1`](super::transaction::calculate_id_v1) for the projection invariants.
     pub fn calculate_id(&self) -> TransactionId {
-        hasher32(EngineHashDomainLabel::Transaction)
-            .chain(&self.schema_version())
-            .chain(&TransactionSignatureFields::from(&self.body.transaction))
-            .chain(self.blob_hashes())
-            .chain(self.signatures())
-            .chain(&self.seal_signature)
-            .result()
-            .into_array()
-            .into()
+        super::transaction::calculate_id_v1(
+            self.schema_version(),
+            TransactionSignatureFields::from(&self.body.transaction),
+            self.blob_hashes(),
+            self.signatures(),
+            self.seal_signature.public_key(),
+        )
     }
 
     /// Verify the seal and all extra signatures.

--- a/crates/transaction/src/v1/pruned.rs
+++ b/crates/transaction/src/v1/pruned.rs
@@ -67,6 +67,11 @@ pub struct PrunedUnsignedTransactionV1 {
     #[cbor(default)]
     #[borsh(skip)]
     pub blob_sizes: Vec<u32>,
+    /// Mirrors `UnsignedTransactionV1::nonce` of the full form.
+    #[n(10)]
+    #[cfg_attr(feature = "serde", serde(default))]
+    #[cbor(default)]
+    pub nonce: u64,
 }
 
 impl PrunedUnsignedTransactionV1 {
@@ -106,6 +111,7 @@ impl From<UnsignedTransactionV1> for PrunedUnsignedTransactionV1 {
             dry_run: t.dry_run,
             blob_hashes,
             blob_sizes,
+            nonce: t.nonce,
         }
     }
 }
@@ -309,6 +315,7 @@ impl PrunedTransactionV1 {
             dry_run,
             blob_hashes: _,
             blob_sizes: _,
+            nonce,
         } = transaction;
 
         let unsigned = UnsignedTransactionV1 {
@@ -321,6 +328,7 @@ impl PrunedTransactionV1 {
             is_seal_signer_authorized,
             dry_run,
             blobs,
+            nonce,
         };
         let unsealed = UnsealedTransactionV1::new(unsigned, signatures);
         Ok(TransactionV1::new(unsealed, seal_signature))
@@ -366,6 +374,7 @@ mod tests {
             is_seal_signer_authorized: false,
             dry_run: true,
             blobs,
+            nonce: 7,
         }
     }
 

--- a/crates/transaction/src/v1/signature.rs
+++ b/crates/transaction/src/v1/signature.rs
@@ -42,8 +42,9 @@ pub enum PreimageField {
     MaxEpoch = 7,
     IsSealSignerAuthorized = 8,
     DryRun = 9,
-    BlobHashes = 10,
-    Signatures = 11,
+    Nonce = 10,
+    BlobHashes = 11,
+    Signatures = 12,
 }
 
 /// One ordered segment of the canonical signing preimage: the exact borsh bytes chained into the
@@ -179,6 +180,7 @@ impl TransactionSealSignature {
                 &unsigned.is_seal_signer_authorized,
             ),
             preimage_segment(PreimageField::DryRun, &unsigned.dry_run),
+            preimage_segment(PreimageField::Nonce, &unsigned.nonce),
             preimage_segment(PreimageField::BlobHashes, &blob_hashes),
             preimage_segment(PreimageField::Signatures, transaction.signatures()),
         ]
@@ -346,6 +348,7 @@ impl TransactionSignature {
                 &transaction.is_seal_signer_authorized,
             ),
             preimage_segment(PreimageField::DryRun, &transaction.dry_run),
+            preimage_segment(PreimageField::Nonce, &transaction.nonce),
             preimage_segment(PreimageField::BlobHashes, &blob_hashes),
         ]
     }
@@ -411,6 +414,7 @@ pub(crate) struct TransactionSignatureFields<'a> {
     max_epoch: Option<Epoch>,
     is_seal_signer_authorized: bool,
     dry_run: bool,
+    nonce: u64,
 }
 
 impl<'a> From<&'a UnsignedTransactionV1> for TransactionSignatureFields<'a> {
@@ -424,6 +428,7 @@ impl<'a> From<&'a UnsignedTransactionV1> for TransactionSignatureFields<'a> {
             max_epoch: transaction.max_epoch,
             is_seal_signer_authorized: transaction.is_seal_signer_authorized,
             dry_run: transaction.dry_run,
+            nonce: transaction.nonce,
         }
     }
 }
@@ -441,6 +446,7 @@ impl<'a> From<&'a PrunedUnsignedTransactionV1> for TransactionSignatureFields<'a
             max_epoch: transaction.max_epoch,
             is_seal_signer_authorized: transaction.is_seal_signer_authorized,
             dry_run: transaction.dry_run,
+            nonce: transaction.nonce,
         }
     }
 }
@@ -481,6 +487,7 @@ mod tests {
             is_seal_signer_authorized: false,
             dry_run: true,
             blobs: crate::Blobs::empty(),
+            nonce: 5,
         }
     }
 
@@ -586,6 +593,11 @@ mod tests {
         let mut tx = base.clone();
         tx.dry_run = !tx.dry_run;
         assert_ne!(sig_msg(&signer, &tx), base_msg, "dry_run");
+
+        // nonce
+        let mut tx = base.clone();
+        tx.nonce = tx.nonce.wrapping_add(1);
+        assert_ne!(sig_msg(&signer, &tx), base_msg, "nonce");
 
         // blobs: payload contents must influence the digest via per-blob commitments
         let mut tx = base.clone();
@@ -710,6 +722,11 @@ mod tests {
         let mut u = base_unsigned.clone();
         u.dry_run = !u.dry_run;
         assert_ne!(seal_msg(&with_body(u)), base_msg, "dry_run");
+
+        // nonce
+        let mut u = base_unsigned.clone();
+        u.nonce = u.nonce.wrapping_add(1);
+        assert_ne!(seal_msg(&with_body(u)), base_msg, "nonce");
 
         // blobs: changes to the payload must alter the seal digest via per-blob commitments
         let mut u = base_unsigned.clone();

--- a/crates/transaction/src/v1/transaction.rs
+++ b/crates/transaction/src/v1/transaction.rs
@@ -425,6 +425,7 @@ mod blob_validation_tests {
             is_seal_signer_authorized: true,
             dry_run: false,
             blobs,
+            nonce: 0,
         };
         let sealer = RistrettoSecretKey::random(&mut rand::rng());
         let unsealed = UnsealedTransactionV1::new(unsigned, vec![]);
@@ -582,6 +583,7 @@ mod transaction_id_tests {
             is_seal_signer_authorized: true,
             dry_run: false,
             blobs: Blobs::empty(),
+            nonce: 0,
         }
     }
 
@@ -635,6 +637,30 @@ mod transaction_id_tests {
 
         let a = TransactionV1::new(unsealed.clone(), TransactionSealSignature::sign_v1(&sk_a, &unsealed));
         let b = TransactionV1::new(unsealed.clone(), TransactionSealSignature::sign_v1(&sk_b, &unsealed));
+
+        assert_ne!(a.calculate_id(), b.calculate_id());
+    }
+
+    /// The nonce is the intent-level distinguisher: identical bodies sealed by the same key
+    /// differing only in nonce must be distinct transactions.
+    #[test]
+    fn id_binds_nonce() {
+        let (sealer_sk, _) = random_key();
+        let mut a_unsigned = sample_unsigned();
+        a_unsigned.nonce = 1;
+        let mut b_unsigned = sample_unsigned();
+        b_unsigned.nonce = 2;
+
+        let a_unsealed = UnsealedTransactionV1::new(a_unsigned, vec![]);
+        let b_unsealed = UnsealedTransactionV1::new(b_unsigned, vec![]);
+        let a = TransactionV1::new(
+            a_unsealed.clone(),
+            TransactionSealSignature::sign_v1(&sealer_sk, &a_unsealed),
+        );
+        let b = TransactionV1::new(
+            b_unsealed.clone(),
+            TransactionSealSignature::sign_v1(&sealer_sk, &b_unsealed),
+        );
 
         assert_ne!(a.calculate_id(), b.calculate_id());
     }

--- a/crates/transaction/src/v1/transaction.rs
+++ b/crates/transaction/src/v1/transaction.rs
@@ -12,7 +12,12 @@ use tari_engine_types::{
     substate::SubstateId,
 };
 use tari_ootle_common_types::{Epoch, SubstateRequirement, SubstateRequirementRef};
-use tari_template_lib_types::{ComponentAddress, constants::TARI_TOKEN, stealth::StealthTransferStatement};
+use tari_template_lib_types::{
+    ComponentAddress,
+    constants::TARI_TOKEN,
+    crypto::RistrettoPublicKeyBytes,
+    stealth::StealthTransferStatement,
+};
 
 use crate::{
     Blobs,
@@ -115,23 +120,18 @@ impl TransactionV1 {
         &self.body
     }
 
-    /// Compute the deterministic transaction id.
-    ///
-    /// The id projection deliberately excludes raw blob bytes — only their per-blob commitments
-    /// (`BlobHashes`) participate. This keeps the id stable across pruning: a `TransactionV1`
-    /// and the `PrunedTransactionV1` derived from it produce the same id.
+    /// Compute the deterministic transaction id. See [`calculate_id_v1`] for the projection
+    /// invariants.
     pub fn calculate_id(&self) -> TransactionId {
         let unsigned = self.body.unsigned_transaction();
         let blob_hashes = unsigned.blobs.hashes();
-        hasher32(EngineHashDomainLabel::Transaction)
-            .chain(&self.schema_version())
-            .chain(&TransactionSignatureFields::from(unsigned))
-            .chain(&blob_hashes)
-            .chain(self.body.signatures())
-            .chain(&self.seal_signature)
-            .result()
-            .into_array()
-            .into()
+        calculate_id_v1(
+            self.schema_version(),
+            TransactionSignatureFields::from(unsigned),
+            &blob_hashes,
+            self.body.signatures(),
+            self.seal_signature.public_key(),
+        )
     }
 
     pub fn calculate_transaction_weight(&self) -> TransactionWeight {
@@ -237,6 +237,37 @@ impl TransactionV1 {
         }
         Ok(())
     }
+}
+
+/// The shared v1 transaction id projection — the full and pruned forms must produce the
+/// identical id, so both delegate here.
+///
+/// The projection deliberately excludes raw blob bytes — only their per-blob commitments
+/// (`BlobHashes`) participate, keeping the id stable across pruning.
+///
+/// The seal *signature* is also excluded — only the seal signer's public key participates.
+/// The signature is witness data (a fresh Schnorr nonce per seal), so hashing it would give
+/// every re-seal of the same body, signatures and sealer a distinct id, defeating id-based
+/// dedup: a co-signature authorizes one id, and the network must be able to recognise a
+/// re-sealed copy as the same transaction. The public key must remain in the projection —
+/// with no co-signatures nothing else binds the sealer, and excluding it would let a
+/// different sealer produce a colliding id for a semantically different transaction.
+pub(crate) fn calculate_id_v1(
+    schema_version: u16,
+    fields: TransactionSignatureFields<'_>,
+    blob_hashes: &crate::BlobHashes,
+    signatures: &[TransactionSignature],
+    seal_signer: &RistrettoPublicKeyBytes,
+) -> TransactionId {
+    hasher32(EngineHashDomainLabel::Transaction)
+        .chain(&schema_version)
+        .chain(&fields)
+        .chain(blob_hashes)
+        .chain(signatures)
+        .chain(seal_signer)
+        .result()
+        .into_array()
+        .into()
 }
 
 /// Failure modes for `TransactionV1::validate_blob_references`.
@@ -525,5 +556,106 @@ mod blob_validation_tests {
     #[allow(dead_code)]
     fn pk_smoke() {
         let _ = RistrettoPublicKey::from_secret_key(&RistrettoSecretKey::random(&mut rand::rng())).to_byte_type();
+    }
+}
+
+#[cfg(test)]
+mod transaction_id_tests {
+    use ootle_byte_type::ToByteType;
+    use tari_crypto::{
+        keys::{PublicKey as PublicKeyT, SecretKey},
+        ristretto::{RistrettoPublicKey, RistrettoSecretKey},
+    };
+    use tari_template_lib_types::crypto::RistrettoPublicKeyBytes;
+
+    use super::*;
+    use crate::{TransactionSealSignature, UnsignedTransactionV1, v1::signature::TransactionSignature};
+
+    fn sample_unsigned() -> UnsignedTransactionV1 {
+        UnsignedTransactionV1 {
+            network: 1,
+            fee_instructions: vec![Instruction::DropAllProofsInWorkspace],
+            instructions: vec![Instruction::PutLastInstructionOutputOnWorkspace { key: 3 }],
+            inputs: indexmap::IndexSet::new(),
+            min_epoch: None,
+            max_epoch: Some(Epoch(10)),
+            is_seal_signer_authorized: true,
+            dry_run: false,
+            blobs: Blobs::empty(),
+        }
+    }
+
+    fn random_key() -> (RistrettoSecretKey, RistrettoPublicKeyBytes) {
+        let sk = RistrettoSecretKey::random(&mut rand::rng());
+        let pk = RistrettoPublicKey::from_secret_key(&sk).to_byte_type();
+        (sk, pk)
+    }
+
+    fn cosigned(seal_signer: &RistrettoPublicKeyBytes) -> UnsealedTransactionV1 {
+        let (cosigner, _) = random_key();
+        let unsigned = sample_unsigned();
+        let sig = TransactionSignature::sign_v1(&cosigner, seal_signer, &unsigned);
+        UnsealedTransactionV1::new(unsigned, vec![sig])
+    }
+
+    /// One authorization set = one id: re-sealing the identical body + signatures with the same
+    /// key must produce the same id even though each seal carries a fresh Schnorr nonce. Id-based
+    /// dedup relies on this — a co-signature authorizes a single id, and a re-sealed copy must be
+    /// recognisable as the same transaction.
+    #[test]
+    fn id_is_stable_across_reseals() {
+        let (sealer_sk, sealer_pk) = random_key();
+        let unsealed = cosigned(&sealer_pk);
+
+        let a = TransactionV1::new(
+            unsealed.clone(),
+            TransactionSealSignature::sign_v1(&sealer_sk, &unsealed),
+        );
+        let b = TransactionV1::new(
+            unsealed.clone(),
+            TransactionSealSignature::sign_v1(&sealer_sk, &unsealed),
+        );
+
+        assert_ne!(
+            a.seal_signature().signature(),
+            b.seal_signature().signature(),
+            "two seals must carry distinct nonces for this test to be meaningful",
+        );
+        assert_eq!(a.calculate_id(), b.calculate_id());
+    }
+
+    /// With zero co-signatures the id is the only thing binding the sealer: the same body sealed
+    /// by two different keys is two semantically different transactions (different authorized
+    /// signer) and must not collide on one id.
+    #[test]
+    fn id_binds_seal_signer_public_key() {
+        let unsealed = UnsealedTransactionV1::new(sample_unsigned(), vec![]);
+        let (sk_a, _) = random_key();
+        let (sk_b, _) = random_key();
+
+        let a = TransactionV1::new(unsealed.clone(), TransactionSealSignature::sign_v1(&sk_a, &unsealed));
+        let b = TransactionV1::new(unsealed.clone(), TransactionSealSignature::sign_v1(&sk_b, &unsealed));
+
+        assert_ne!(a.calculate_id(), b.calculate_id());
+    }
+
+    /// The co-signature set stays inside the id: a sealer that strips (or gains) a co-signature
+    /// produces a different transaction, not a same-id variant.
+    #[test]
+    fn id_binds_co_signatures() {
+        let (sealer_sk, sealer_pk) = random_key();
+        let with_sig = cosigned(&sealer_pk);
+        let without_sig = UnsealedTransactionV1::new(sample_unsigned(), vec![]);
+
+        let a = TransactionV1::new(
+            with_sig.clone(),
+            TransactionSealSignature::sign_v1(&sealer_sk, &with_sig),
+        );
+        let b = TransactionV1::new(
+            without_sig.clone(),
+            TransactionSealSignature::sign_v1(&sealer_sk, &without_sig),
+        );
+
+        assert_ne!(a.calculate_id(), b.calculate_id());
     }
 }

--- a/crates/transaction/src/v1/unsigned.rs
+++ b/crates/transaction/src/v1/unsigned.rs
@@ -45,6 +45,15 @@ pub struct UnsignedTransactionV1 {
     #[cfg_attr(feature = "serde", serde(default))]
     #[cbor(default)]
     pub blobs: Blobs,
+
+    /// Distinguishes otherwise-identical transactions. The transaction id excludes the seal
+    /// signature, so two identical bodies sealed by the same key are the *same* transaction —
+    /// an intent builder (e.g. a wallet) that wants each submission to execute independently
+    /// must stamp a distinct nonce per intent. Part of the signing and id domains.
+    #[n(9)]
+    #[cfg_attr(feature = "serde", serde(default))]
+    #[cbor(default)]
+    pub nonce: u64,
 }
 
 impl UnsignedTransactionV1 {
@@ -59,6 +68,7 @@ impl UnsignedTransactionV1 {
             is_seal_signer_authorized: true,
             dry_run: false,
             blobs: Blobs::empty(),
+            nonce: 0,
         }
     }
 
@@ -81,6 +91,7 @@ impl UnsignedTransactionV1 {
             is_seal_signer_authorized: true,
             dry_run,
             blobs: Blobs::empty(),
+            nonce: 0,
         }
     }
 

--- a/crates/wallet/ledger/client/src/client.rs
+++ b/crates/wallet/ledger/client/src/client.rs
@@ -252,6 +252,7 @@ mod tests {
             max_epoch: None,
             is_seal_signer_authorized: false,
             dry_run: false,
+            nonce: 0,
             blobs,
         }
     }

--- a/crates/wallet/ledger/client/tests/signing_recipe.rs
+++ b/crates/wallet/ledger/client/tests/signing_recipe.rs
@@ -182,6 +182,7 @@ fn sample_unsigned() -> UnsignedTransactionV1 {
         is_seal_signer_authorized: false,
         dry_run: true,
         blobs,
+        nonce: 42,
     }
 }
 
@@ -208,6 +209,7 @@ fn preimage_field_tags_match_protocol() {
             SigningField::IsSealSignerAuthorized,
         ),
         (PreimageField::DryRun, SigningField::DryRun),
+        (PreimageField::Nonce, SigningField::TransactionNonce),
         (PreimageField::BlobHashes, SigningField::BlobHashes),
         (PreimageField::Signatures, SigningField::Signatures),
     ];

--- a/crates/wallet/ledger/common/src/arg_types.rs
+++ b/crates/wallet/ledger/common/src/arg_types.rs
@@ -115,8 +115,9 @@ pub enum SigningField {
     MaxEpoch = 7,
     IsSealSignerAuthorized = 8,
     DryRun = 9,
-    BlobHashes = 10,
-    Signatures = 11,
+    TransactionNonce = 10,
+    BlobHashes = 11,
+    Signatures = 12,
 }
 
 impl SigningField {
@@ -142,8 +143,9 @@ impl TryFrom<u8> for SigningField {
             7 => Ok(MaxEpoch),
             8 => Ok(IsSealSignerAuthorized),
             9 => Ok(DryRun),
-            10 => Ok(BlobHashes),
-            11 => Ok(Signatures),
+            10 => Ok(TransactionNonce),
+            11 => Ok(BlobHashes),
+            12 => Ok(Signatures),
             _ => Err(()),
         }
     }

--- a/crates/wallet/ootle-rs/src/signer/ledger.rs
+++ b/crates/wallet/ootle-rs/src/signer/ledger.rs
@@ -221,6 +221,7 @@ fn to_wire(field: PreimageField) -> SigningField {
         PreimageField::IsSealSignerAuthorized => SigningField::IsSealSignerAuthorized,
         PreimageField::DryRun => SigningField::DryRun,
         PreimageField::BlobHashes => SigningField::BlobHashes,
+        PreimageField::Nonce => SigningField::TransactionNonce,
         PreimageField::Signatures => SigningField::Signatures,
     }
 }

--- a/integration_tests/src/util.rs
+++ b/integration_tests/src/util.rs
@@ -4,8 +4,12 @@
 use tari_ootle_address::Network;
 use tari_ootle_transaction::TransactionBuilder;
 
+/// The builder is stamped with a random nonce so that repeated identical calls (concurrent or
+/// sequential steps invoking the same method with unversioned inputs) build distinct
+/// transactions — the transaction id excludes the seal signature, so identical bodies sealed by
+/// the same key would otherwise be a single transaction.
 pub fn transaction_builder() -> TransactionBuilder {
-    TransactionBuilder::new(Network::LocalNet)
+    TransactionBuilder::new(Network::LocalNet).with_nonce(rand::random())
 }
 
 #[macro_export]


### PR DESCRIPTION
## Motivation

The seal signature carries a fresh random Schnorr nonce per seal, so hashing it into the
transaction id gives every re-seal of the identical body + co-signature set a distinct id.
Since the network dedups by transaction id (mempool `transaction_exists` + finalized-record
checks), a sealer holding collected co-signatures could seal the same authorized body N
times and produce N distinct, individually-valid transactions - with unversioned inputs,
an approve-once-execute-many replay. This is particularly relevant to multi-party flows
(walletd transaction requests #2348, SDK co-signing) where co-signers authorize a body
once: a co-signature should authorize one id.

## Changes

- `TransactionV1::calculate_id` and `PrunedTransactionV1::calculate_id` now hash only the
  seal signer's **public key**, not the full `TransactionSealSignature` - the signature
  scalar/nonce is excluded as witness data. Same reasoning as Bitcoin's SegWit txid/wtxid
  split, and Radix Babylon's intent hash, which excludes all signatures including the
  notary's.
- The public key stays in the projection: with zero co-signatures nothing else binds the
  sealer, and excluding the key would let a different sealer produce a colliding id for a
  semantically different transaction (different authorized-signer set) - a griefing vector
  where a re-sealed variant consumes the id of a legitimate transaction.
- Both id computations now delegate to a single shared `pub(crate) fn calculate_id_v1`
  helper in `crates/transaction/src/v1/transaction.rs` documenting the projection
  invariants, keeping the full and pruned forms provably identical.
- Three new tests in `transaction_id_tests` pin the semantics:
  - `id_is_stable_across_reseals` - same body + co-signatures re-sealed by the same key
    (fresh nonce each time) -> identical id
  - `id_binds_seal_signer_public_key` - zero co-signatures, same body sealed by two
    different keys -> different ids
  - `id_binds_co_signatures` - dropping/adding a co-signature changes the id

## Effects

- One authorization set = one id: re-sealing identical bytes is recognised as the same
  transaction and dedups instead of double-executing.
- Identical logical re-runs now require a body distinguisher (e.g. a different epoch
  window) - resubmission after a timeout becomes idempotent-safe rather than a
  double-spend risk.
- Committed transactions already collide on the `TransactionReceipt` substate address
  (derived from the tx id), so the receipt becomes the on-chain enforcer of commit-once
  for the stable id.

## Breaking change

**This is a consensus-breaking change** - transaction ids change for all existing
transactions. Intended for the same testnet-reset batch as #2350. No `TransactionV2`
gating - this is landing directly on `TransactionV1` by explicit decision. External
id-asserting fixtures (notably ootle-go golden vectors) will need re-vendoring in a
coordinated follow-up.

## Verification

- `cargo nextest r -p tari_ootle_transaction --release` - 49/49 pass, including the three
  new id tests and the existing pruned-form tests asserting full <-> pruned id equality
- `cargo check --all-targets` and `cargo lints clippy -p tari_ootle_transaction
  --all-targets` clean
- Formatted with `cargo +nightly-2025-12-05 fmt`
- A full workspace `nextest` sweep (excluding `integration_tests`) is running; results
  will be reported on this PR