### PR TITLE
chore: bump workspace to 0.38.0 for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1733,7 +1733,7 @@ dependencies = [
 
 [[package]]
 name = "consensus_tests"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "fern",
  "futures 0.3.31",
@@ -2739,12 +2739,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "db-inspector"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -4011,9 +4011,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -5117,7 +5119,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "integration_tests"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "config",
@@ -5885,7 +5887,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-messaging"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "futures-bounded 0.2.4",
@@ -6063,7 +6065,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-substream"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "libp2p",
  "prometheus-client",
@@ -7723,7 +7725,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -7734,7 +7736,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm-core"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -7794,7 +7796,7 @@ dependencies = [
 
 [[package]]
 name = "ootle_sdk_core"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "blake2 0.10.6",
  "hex",
@@ -7820,7 +7822,7 @@ dependencies = [
 
 [[package]]
 name = "ootle_sdk_ffi_c"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "cbindgen",
  "hex",
@@ -8815,7 +8817,7 @@ dependencies = [
 
 [[package]]
 name = "proto_builder"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "prost-build 0.14.3",
  "sha2 0.10.9",
@@ -8958,16 +8960,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.16"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "lru-slab",
- "rand 0.10.1",
- "rand_pcg",
+ "rand 0.9.4",
  "ring",
  "rustc-hash 2.1.1",
  "rustls",
@@ -9135,15 +9136,6 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
-
-[[package]]
-name = "rand_pcg"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
-dependencies = [
- "rand_core 0.10.1",
-]
 
 [[package]]
 name = "random-pick"
@@ -10666,7 +10658,7 @@ dependencies = [
 
 [[package]]
 name = "sqlite_message_logger"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "chrono",
  "diesel",
@@ -11014,7 +11006,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node_client"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "futures-util",
  "log",
@@ -11245,7 +11237,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -11270,7 +11262,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "borsh",
  "minicbor",
@@ -11373,7 +11365,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "blake2 0.10.6",
  "bytes",
@@ -11406,7 +11398,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11436,7 +11428,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_manager"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "log",
@@ -11456,7 +11448,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_oracles"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",
@@ -11502,7 +11494,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -11578,7 +11570,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_client"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "anyhow",
  "bounded-vec",
@@ -11607,7 +11599,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_lib"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "log",
@@ -11704,7 +11696,7 @@ dependencies = [
 
 [[package]]
 name = "tari_networking"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11758,7 +11750,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_app_utilities"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11799,7 +11791,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11828,7 +11820,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_p2p"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "libp2p-identity 0.2.14",
@@ -11852,7 +11844,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -11881,7 +11873,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage_sqlite"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -11934,7 +11926,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_template_provider"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "dashmap 5.5.3",
@@ -11951,7 +11943,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "borsh",
  "hex",
@@ -11977,7 +11969,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction_validation"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -11993,7 +11985,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_cli"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -12023,7 +12015,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_crypto"
-version = "0.38.1"
+version = "0.39.0"
 dependencies = [
  "argon2 0.5.3",
  "blake2 0.10.6",
@@ -12053,7 +12045,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12115,7 +12107,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk_tests"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "digest 0.10.7",
  "ootle_byte_type",
@@ -12137,7 +12129,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_storage_sqlite"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -12161,7 +12153,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",
@@ -12232,7 +12224,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd_client"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "hex",
  "ootle_serde",
@@ -12288,7 +12280,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_framework"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "bitflags 2.13.0",
@@ -12312,7 +12304,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_macros"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12321,7 +12313,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_state_sync"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12403,7 +12395,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_store_rocksdb"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12435,7 +12427,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_tree"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "indexmap 2.13.0",
  "log",
@@ -12464,7 +12456,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "libp2p",
  "libp2p-messaging",
@@ -12476,7 +12468,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm_daemon"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12532,7 +12524,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_builtin"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "minicbor",
@@ -12589,7 +12581,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_test_tooling"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "cargo_toml 0.22.3",
@@ -12705,7 +12697,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_manifest"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "proc-macro2",
  "serde_json",
@@ -12740,7 +12732,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -12803,7 +12795,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_client"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "indexmap 2.13.0",
  "multiaddr 0.18.3",
@@ -12827,7 +12819,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_rpc"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12851,7 +12843,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_rollback"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12888,7 +12880,7 @@ dependencies = [
 
 [[package]]
 name = "tari_watcher"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -12917,7 +12909,7 @@ dependencies = [
 
 [[package]]
 name = "tariswap_bench"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13600,7 +13592,7 @@ dependencies = [
 
 [[package]]
 name = "traffic-sim"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13624,7 +13616,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_generator"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -13645,7 +13637,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_submitter"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "clap 4.5.54",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.37.1"
+version = "0.38.0"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-ootle"
@@ -99,41 +99,41 @@ tari_ootle_app_utilities = { path = "applications/tari_ootle_app_utilities" }
 tari_consensus = { path = "crates/consensus" }
 tari_ootle_address = { path = "crates/ootle_address", version = "0.8" }
 ootle-network = { path = "crates/ootle_network", version = "0.2" }
-tari_engine = { path = "crates/engine", version = "0.37" }
+tari_engine = { path = "crates/engine", version = "0.38" }
 tari_ootle_p2p = { path = "crates/p2p" }
 tari_ootle_storage = { path = "crates/storage" }
 tari_ootle_storage_sqlite = { path = "crates/storage_sqlite" }
-tari_ootle_wallet_crypto = { path = "crates/wallet/crypto", version = "0.38.1" }
-tari_ootle_wallet_sdk = { path = "crates/wallet/sdk", version = "0.37" }
+tari_ootle_wallet_crypto = { path = "crates/wallet/crypto", version = "0.39.0" }
+tari_ootle_wallet_sdk = { path = "crates/wallet/sdk", version = "0.38" }
 tari_ootle_wallet_sdk_services = { path = "crates/wallet/sdk_services" }
-tari_ootle_wallet_storage_sqlite = { path = "crates/wallet/storage_sqlite", version = "0.37" }
+tari_ootle_wallet_storage_sqlite = { path = "crates/wallet/storage_sqlite", version = "0.38" }
 tari_epoch_manager = { path = "crates/epoch_manager" }
 tari_epoch_oracles = { path = "crates/epoch_oracles" }
 tari_indexer_lib = { path = "crates/indexer_lib" }
 tari_rpc_state_sync = { path = "crates/rpc_state_sync" }
 tari_state_store_rocksdb = { path = "crates/state_store_rocksdb" }
 tari_state_tree = { path = "crates/state_tree" }
-tari_template_test_tooling = { path = "crates/template_test_tooling", version = "0.37" }
-tari_transaction_manifest = { path = "crates/transaction_manifest", version = "0.37" }
+tari_template_test_tooling = { path = "crates/template_test_tooling", version = "0.38" }
+tari_transaction_manifest = { path = "crates/transaction_manifest", version = "0.38" }
 tari_validator_node_rpc = { path = "crates/validator_node_rpc" }
 sqlite_message_logger = { path = "networking/sqlite_message_logger" }
 tari_base_node_client = { path = "clients/base_node_client" }
-tari_indexer_client = { path = "clients/tari_indexer_client", default-features = false, version = "0.36" }
+tari_indexer_client = { path = "clients/tari_indexer_client", default-features = false, version = "0.37" }
 tari_networking = { path = "networking/core" }
 tari_rpc_framework = { path = "networking/rpc_framework" }
 tari_rpc_macros = { path = "networking/rpc_macros" }
 tari_swarm = { path = "networking/swarm" }
 tari_validator_node_client = { path = "clients/validator_node_client" }
-tari_validator_rollback = { path = "utilities/validator_rollback", version = "0.37" }
-tari_ootle_walletd_client = { path = "clients/wallet_daemon_client", version = "0.37" }
+tari_validator_rollback = { path = "utilities/validator_rollback", version = "0.38" }
+tari_ootle_walletd_client = { path = "clients/wallet_daemon_client", version = "0.38" }
 transaction_generator = { path = "utilities/transaction_generator" }
 
 # Dependency crates on crates.io (update versions here as well when updating the workspace version)
-tari_consensus_types = { path = "crates/consensus_types", version = "0.37" }
-tari_ootle_common_types = { path = "crates/common_types", version = "0.37" }
-tari_engine_types = { path = "crates/engine_types", version = "0.37" }
-tari_template_builtin = { path = "crates/template_builtin", version = "0.37" }
-tari_ootle_transaction = { path = "crates/transaction", version = "0.37" }
+tari_consensus_types = { path = "crates/consensus_types", version = "0.38" }
+tari_ootle_common_types = { path = "crates/common_types", version = "0.38" }
+tari_engine_types = { path = "crates/engine_types", version = "0.38" }
+tari_template_builtin = { path = "crates/template_builtin", version = "0.38" }
+tari_ootle_transaction = { path = "crates/transaction", version = "0.38" }
 tari_ootle_transaction_validation = { path = "crates/transaction_validation" }
 
 # Template lib
@@ -148,8 +148,8 @@ tari_bor = { version = "0.14.2", path = "crates/tari_bor", default-features = fa
 
 ootle_byte_type = { path = "crates/ootle_byte_type", version = "0.10" }
 ootle_serde = { path = "crates/ootle_serde", version = "0.3" }
-ootle-wasm-core = { path = "crates/ootle_wasm/core", version = "0.37" }
-ootle_sdk_core = { path = "crates/ootle_sdk_core", version = "0.37" }
+ootle-wasm-core = { path = "crates/ootle_wasm/core", version = "0.38" }
+ootle_sdk_core = { path = "crates/ootle_sdk_core", version = "0.38" }
 
 # external minotari/tari dependencies
 minotari_app_grpc = "5.5.0"

--- a/clients/tari_indexer_client/Cargo.toml
+++ b/clients/tari_indexer_client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_indexer_client"
 description = "Tari indexer client library"
-version = "0.36.0"
+version = "0.37.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/clients/wallet_daemon_client/Cargo.toml
+++ b/clients/wallet_daemon_client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_walletd_client"
 description = "Tari wallet daemon client library"
-version = "0.37.0"
+version = "0.38.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/ootle_wasm/wasm/Cargo.toml
+++ b/crates/ootle_wasm/wasm/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../NPM_README.md"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-ootle-wasm-core = { path = "../core", version = "0.37" }
+ootle-wasm-core = { path = "../core", version = "0.38" }
 wasm-bindgen = "0.2"
 # getrandom is pulled in transitively via `rand` and `tari_bulletproofs_plus`. The wasm32-unknown-unknown
 # target requires explicit feature opt-in for both major versions used in the graph.

--- a/crates/template_builtin/Cargo.toml
+++ b/crates/template_builtin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_template_builtin"
 description = "Tari Ootle built-in templates"
-version = "0.37.0"
+version = "0.38.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/wallet/crypto/Cargo.toml
+++ b/crates/wallet/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_ootle_wallet_crypto"
-version = "0.38.1"
+version = "0.39.0"
 description = "Cryptographic utilities and types for Tari Ootle wallet"
 edition.workspace = true
 authors.workspace = true

--- a/crates/wallet/sdk/Cargo.toml
+++ b/crates/wallet/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_wallet_sdk"
 description = "The Tari wallet library"
-version = "0.37.1"
+version = "0.38.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/wallet/storage_sqlite/Cargo.toml
+++ b/crates/wallet/storage_sqlite/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_wallet_storage_sqlite"
 description = "The Tari wallet SQLite storage library"
-version = "0.37.0"
+version = "0.38.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## Description
Version bump preparing the next crates.io release after the v0.37.0 tag. No functional changes — Cargo.toml/Cargo.lock only.

## Motivation
Three commits landed since v0.37.0 with breaking API changes in tier-3 core crates:
- 7639a6231 fix(engine)! stealth claim_validator_fees race — `ValidatorFeePool::withdraw_all` signature change, `Instruction::ClaimValidatorFees` gained `max_amount`
- dadecb488 `StealthLimits` gained pub field `max_fee_intent_transfers`
- 72db71c32 wallet sdk fee-from-transfer-statement

Per `scripts/crate_versioning.py impact tari_engine_types --breaking`, the whole tier-3 core set rolls up together, and dependents that re-expose changed core types get minor bumps.

## Changes
- `workspace.package.version` 0.37.0 → 0.38.0, applied to all tier-3/core crates (tari_engine_types, tari_ootle_common_types, tari_ootle_transaction, tari_template_builtin, tari_transaction_manifest, tari_engine, tari_consensus_types, ootle-wasm-core, ootle-wasm, tari_template_test_tooling)
- Root `[workspace.dependencies]` pins bumped 0.37 → 0.38 accordingly (incl. tari_validator_rollback, ootle_sdk_core, which inherit the workspace version)
- Independent crates re-exposing changed core types bumped: tari_ootle_wallet_crypto 0.38.0 → 0.39.0, tari_ootle_wallet_sdk 0.37.0 → 0.38.0, tari_ootle_wallet_storage_sqlite 0.37.0 → 0.38.0, tari_indexer_client 0.36.0 → 0.37.0, tari_ootle_walletd_client 0.37.0 → 0.38.0, ootle-rs 0.16.0 → 0.17.0
- `crates/ootle_wasm/wasm` direct pin on ootle-wasm-core 0.37 → 0.38
- `crates/template_builtin` explicit version → 0.38.0
- `Cargo.lock` refreshed via `cargo update --workspace`