### PR TITLE
fix(walletd): reject malformed PayTo condition sets as InvalidParams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1733,7 +1733,7 @@ dependencies = [
 
 [[package]]
 name = "consensus_tests"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "fern",
  "futures 0.3.31",
@@ -2744,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "db-inspector"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -5117,7 +5117,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "integration_tests"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "config",
@@ -5885,7 +5885,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-messaging"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "async-trait",
  "futures-bounded 0.2.4",
@@ -6063,7 +6063,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-substream"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "libp2p",
  "prometheus-client",
@@ -7723,7 +7723,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -7734,7 +7734,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm-core"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -7794,7 +7794,7 @@ dependencies = [
 
 [[package]]
 name = "ootle_sdk_core"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "blake2 0.10.6",
  "hex",
@@ -7820,7 +7820,7 @@ dependencies = [
 
 [[package]]
 name = "ootle_sdk_ffi_c"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "cbindgen",
  "hex",
@@ -8815,7 +8815,7 @@ dependencies = [
 
 [[package]]
 name = "proto_builder"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "prost-build 0.14.3",
  "sha2 0.10.9",
@@ -10666,7 +10666,7 @@ dependencies = [
 
 [[package]]
 name = "sqlite_message_logger"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "chrono",
  "diesel",
@@ -11014,7 +11014,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node_client"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "futures-util",
  "log",
@@ -11245,7 +11245,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -11270,7 +11270,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "borsh",
  "minicbor",
@@ -11373,7 +11373,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "blake2 0.10.6",
  "bytes",
@@ -11406,7 +11406,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11436,7 +11436,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_manager"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "log",
@@ -11456,7 +11456,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_oracles"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",
@@ -11502,7 +11502,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -11607,7 +11607,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_lib"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "async-trait",
  "log",
@@ -11704,7 +11704,7 @@ dependencies = [
 
 [[package]]
 name = "tari_networking"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11758,7 +11758,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_app_utilities"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11799,7 +11799,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11828,7 +11828,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_p2p"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "libp2p-identity 0.2.14",
@@ -11852,7 +11852,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -11881,7 +11881,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage_sqlite"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -11934,7 +11934,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_template_provider"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "dashmap 5.5.3",
@@ -11951,7 +11951,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "borsh",
  "hex",
@@ -11977,7 +11977,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction_validation"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -11993,7 +11993,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_cli"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -12023,7 +12023,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_crypto"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "argon2 0.5.3",
  "blake2 0.10.6",
@@ -12053,7 +12053,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12115,7 +12115,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk_tests"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "digest 0.10.7",
  "ootle_byte_type",
@@ -12161,7 +12161,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",
@@ -12288,7 +12288,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_framework"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "async-trait",
  "bitflags 2.13.0",
@@ -12312,7 +12312,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_macros"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12321,7 +12321,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_state_sync"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12403,7 +12403,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_store_rocksdb"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12435,7 +12435,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_tree"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "indexmap 2.13.0",
  "log",
@@ -12464,7 +12464,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "libp2p",
  "libp2p-messaging",
@@ -12476,7 +12476,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm_daemon"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12589,7 +12589,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_test_tooling"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "cargo_toml 0.22.3",
@@ -12705,7 +12705,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_manifest"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "proc-macro2",
  "serde_json",
@@ -12740,7 +12740,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -12803,7 +12803,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_client"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "indexmap 2.13.0",
  "multiaddr 0.18.3",
@@ -12827,7 +12827,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_rpc"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12851,7 +12851,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_rollback"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12888,7 +12888,7 @@ dependencies = [
 
 [[package]]
 name = "tari_watcher"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -12917,7 +12917,7 @@ dependencies = [
 
 [[package]]
 name = "tariswap_bench"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13600,7 +13600,7 @@ dependencies = [
 
 [[package]]
 name = "traffic-sim"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13624,7 +13624,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_generator"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -13645,7 +13645,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_submitter"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "clap 4.5.54",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.37.0"
+version = "0.37.1"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-ootle"
@@ -103,7 +103,7 @@ tari_engine = { path = "crates/engine", version = "0.37" }
 tari_ootle_p2p = { path = "crates/p2p" }
 tari_ootle_storage = { path = "crates/storage" }
 tari_ootle_storage_sqlite = { path = "crates/storage_sqlite" }
-tari_ootle_wallet_crypto = { path = "crates/wallet/crypto", version = "0.38.0" }
+tari_ootle_wallet_crypto = { path = "crates/wallet/crypto", version = "0.38.1" }
 tari_ootle_wallet_sdk = { path = "crates/wallet/sdk", version = "0.37" }
 tari_ootle_wallet_sdk_services = { path = "crates/wallet/sdk_services" }
 tari_ootle_wallet_storage_sqlite = { path = "crates/wallet/storage_sqlite", version = "0.37" }

--- a/applications/tari_walletd/src/handlers/accounts.rs
+++ b/applications/tari_walletd/src/handlers/accounts.rs
@@ -19,6 +19,7 @@ use tari_ootle_common_types::{SubstateRequirement, optional::Optional};
 use tari_ootle_transaction::{Transaction, args};
 use tari_ootle_wallet_crypto::{
     OutputWitness,
+    StealthCryptoApiError,
     StealthInputWitness,
     StealthOutputWitness,
     WalletCryptoError,
@@ -1401,6 +1402,14 @@ pub async fn handle_create_stealth_transfer_statement(
             ));
         }
 
+        // Checked before any input is locked: a malformed or silently-discarded `pay_to` is a request error, and
+        // rejecting it here avoids taking a lock this request can never use.
+        for output in &req.outputs {
+            output
+                .validate_pay_to()
+                .map_err(|reason| invalid_params("pay_to", Some(reason)))?;
+        }
+
         let amount_to_spend = req.total_output_amount();
 
         let inputs = if let Some(utxo_addresses) = req.input_selection.as_specific() {
@@ -1516,13 +1525,22 @@ fn map_specific_selection_error(err: StealthOutputsApiError) -> anyhow::Error {
     }
 }
 
-/// Map a `generate_transfer_statement` failure to an RPC error. `WalletCryptoError::InvalidArgument` is only raised
-/// for a malformed request payload — chiefly a `PayTo` intent whose condition set cannot form a tree (empty, or with
-/// duplicate leaves) — so it is a caller error carrying the offending field name; everything else propagates
-/// unchanged as a server error.
+/// Map a `generate_transfer_statement` failure to an RPC error. `WalletCryptoError::InvalidArgument` names a
+/// malformed field of the request — a `PayTo` condition set the engine could never admit, a negative revealed
+/// amount, an unbalanced covenant partition — so it is reported as a caller error carrying that field name;
+/// everything else propagates unchanged as a server error.
+///
+/// The variant reaches this handler by two routes: directly, from the output-authorization step, and wrapped in
+/// `StealthCryptoApiError` from statement construction. Both must be recognised.
 fn map_statement_construction_error(err: StealthOutputsApiError) -> anyhow::Error {
-    match &err {
-        StealthOutputsApiError::WalletCrypto(WalletCryptoError::InvalidArgument { name, details }) => {
+    let invalid_argument = match &err {
+        StealthOutputsApiError::WalletCrypto(e) |
+        StealthOutputsApiError::Crypto(StealthCryptoApiError::WalletCryptoError(e)) => Some(e),
+        _ => None,
+    };
+
+    match invalid_argument {
+        Some(WalletCryptoError::InvalidArgument { name, details }) => {
             debug!(target: LOG_TARGET, "Rejected stealth transfer statement: {err}");
             invalid_params(name, Some(details.clone()))
         },
@@ -2420,35 +2438,41 @@ mod create_stealth_transfer_statement_handler_tests {
         }
     }
 
-    /// A condition set that cannot form a tree is a malformed request, not a server fault: it must surface as
-    /// `InvalidParams` naming the offending field, and must not leave the selected input locked.
-    #[tokio::test]
-    async fn empty_condition_set_is_rejected_as_invalid_params() {
-        let test = setup().await;
+    /// Asserts a request is rejected as `InvalidParams` naming `expected_field`, and that the named input was never
+    /// locked — these are all request errors caught before any input selection runs.
+    async fn assert_rejected_without_locking(
+        test: &StatementTest,
+        input: &StealthOutputModel,
+        request: AccountsCreateStealthTransferStatementRequest,
+        expected_field: &str,
+    ) {
         let bearer = test.bearer(&test.transfer_and_read_scopes());
-        let input = insert_valid_output(&test, 100);
-
-        let err = handle_create_stealth_transfer_statement(
-            &test.context,
-            Some(&bearer),
-            pay_to_conditions_request(&test, &input, vec![]),
-        )
-        .await
-        .expect_err("an empty condition set must be rejected");
+        let err = handle_create_stealth_transfer_statement(&test.context, Some(&bearer), request)
+            .await
+            .expect_err("a malformed pay_to must be rejected");
 
         let message = assert_invalid_params(&err).to_string();
         assert!(
-            message.contains("conditions"),
-            "expected the offending field to be named, got: {message}"
+            message.contains(expected_field),
+            "expected the offending field `{expected_field}` to be named, got: {message}"
         );
 
-        let stored = stored_output(&test, &input.commitment);
+        let stored = stored_output(test, &input.commitment);
         assert!(
             matches!(stored.status, OutputStatus::Unspent),
-            "expected Unspent after release, got {:?}",
+            "expected Unspent, got {:?}",
             stored.status
         );
         assert_eq!(stored.lock_id, None);
+    }
+
+    /// A condition set that cannot form a tree is a malformed request, not a server fault.
+    #[tokio::test]
+    async fn empty_condition_set_is_rejected_as_invalid_params() {
+        let test = setup().await;
+        let input = insert_valid_output(&test, 100);
+        let request = pay_to_conditions_request(&test, &input, vec![]);
+        assert_rejected_without_locking(&test, &input, request, "conditions").await;
     }
 
     /// Duplicate leaves are likewise a caller error: the tree rejects them rather than silently deduplicating, so the
@@ -2456,33 +2480,91 @@ mod create_stealth_transfer_statement_handler_tests {
     #[tokio::test]
     async fn duplicate_condition_leaves_are_rejected_as_invalid_params() {
         let test = setup().await;
-        let bearer = test.bearer(&test.transfer_and_read_scopes());
         let input = insert_valid_output(&test, 100);
 
         let (claim_condition, _) =
             htlc_conditions(b"preimage", 4_242, htlc_participant_key(1), htlc_participant_key(2));
-        let conditions = vec![claim_condition.clone(), claim_condition];
+        let request = pay_to_conditions_request(&test, &input, vec![claim_condition.clone(), claim_condition]);
 
-        let err = handle_create_stealth_transfer_statement(
-            &test.context,
-            Some(&bearer),
-            pay_to_conditions_request(&test, &input, conditions),
-        )
-        .await
-        .expect_err("a duplicate condition leaf must be rejected");
+        assert_rejected_without_locking(&test, &input, request, "conditions").await;
+    }
 
-        let message = assert_invalid_params(&err).to_string();
+    /// An empty conjunction forms a perfectly good one-leaf tree, but the engine refuses to evaluate such a leaf, so
+    /// the only committed spend path could never be taken and the funds would be unrecoverable.
+    #[tokio::test]
+    async fn structurally_inadmissible_leaf_is_rejected_as_invalid_params() {
+        let test = setup().await;
+        let input = insert_valid_output(&test, 100);
+        let request = pay_to_conditions_request(&test, &input, vec![SpendCondition::all([])]);
+        assert_rejected_without_locking(&test, &input, request, "conditions").await;
+    }
+
+    /// `pay_to` gates the blinded output. A revealed-only output produces no stealth output at all, so honouring the
+    /// request as written is impossible: reject it rather than deposit the funds ungated.
+    #[tokio::test]
+    async fn gated_output_with_no_blinded_amount_is_rejected_as_invalid_params() {
+        let test = setup().await;
+        let input = insert_valid_output(&test, 100);
+
+        let (claim_condition, _) =
+            htlc_conditions(b"preimage", 4_242, htlc_participant_key(1), htlc_participant_key(2));
+        let mut request = pay_to_conditions_request(&test, &input, vec![claim_condition]);
+        request.requests[0].outputs[0].blinded_amount = 0;
+        request.requests[0].outputs[0].revealed_amount = Amount::from(100u64);
+
+        assert_rejected_without_locking(&test, &input, request, "pay_to").await;
+    }
+}
+
+#[cfg(test)]
+mod map_statement_construction_error_tests {
+    use axum_jrpc::error::{JsonRpcError, JsonRpcErrorReason};
+
+    use super::*;
+
+    fn invalid_argument() -> WalletCryptoError {
+        WalletCryptoError::InvalidArgument {
+            name: "covenant",
+            details: "a covenant partition may not receive more value than it spends".to_string(),
+        }
+    }
+
+    fn assert_maps_to_invalid_params(err: StealthOutputsApiError) {
+        let mapped = map_statement_construction_error(err);
+        let rpc = mapped
+            .downcast_ref::<JsonRpcError>()
+            .unwrap_or_else(|| panic!("expected a JsonRpcError, got: {mapped}"));
         assert!(
-            message.contains("conditions"),
-            "expected the offending field to be named, got: {message}"
+            matches!(rpc.error_reason(), JsonRpcErrorReason::InvalidParams),
+            "expected InvalidParams, got: {:?}",
+            rpc.error_reason()
         );
-
-        let stored = stored_output(&test, &input.commitment);
         assert!(
-            matches!(stored.status, OutputStatus::Unspent),
-            "expected Unspent after release, got {:?}",
-            stored.status
+            rpc.to_string().contains("covenant"),
+            "expected the offending field to be named, got: {rpc}"
         );
-        assert_eq!(stored.lock_id, None);
+    }
+
+    /// The output-authorization step returns the error directly.
+    #[test]
+    fn maps_a_direct_invalid_argument() {
+        assert_maps_to_invalid_params(StealthOutputsApiError::WalletCrypto(invalid_argument()));
+    }
+
+    /// Statement construction returns the same error wrapped a layer deeper. Both routes reach this handler, so
+    /// recognising only the direct one would leave the wrapped case reported as a server fault.
+    #[test]
+    fn maps_an_invalid_argument_wrapped_by_the_crypto_api() {
+        assert_maps_to_invalid_params(StealthOutputsApiError::Crypto(invalid_argument().into()));
+    }
+
+    /// Anything that is not a malformed argument stays a server error.
+    #[test]
+    fn leaves_other_failures_as_server_errors() {
+        let mapped = map_statement_construction_error(StealthOutputsApiError::InsufficientFunds);
+        assert!(
+            mapped.downcast_ref::<JsonRpcError>().is_none(),
+            "expected a plain error, got a JsonRpcError: {mapped}"
+        );
     }
 }

--- a/applications/tari_walletd/src/handlers/accounts.rs
+++ b/applications/tari_walletd/src/handlers/accounts.rs
@@ -17,7 +17,13 @@ use tari_engine_types::{
 };
 use tari_ootle_common_types::{SubstateRequirement, optional::Optional};
 use tari_ootle_transaction::{Transaction, args};
-use tari_ootle_wallet_crypto::{OutputWitness, StealthInputWitness, StealthOutputWitness, memo::Memo};
+use tari_ootle_wallet_crypto::{
+    OutputWitness,
+    StealthInputWitness,
+    StealthOutputWitness,
+    WalletCryptoError,
+    memo::Memo,
+};
 use tari_ootle_wallet_sdk::{
     apis::{
         confidential_transfer::ConfidentialTransferParams,
@@ -1471,7 +1477,8 @@ pub async fn handle_create_stealth_transfer_statement(
                     })?,
                 outputs,
                 output_revealed_amount,
-            })?;
+            })
+            .map_err(map_statement_construction_error)?;
 
         utxo_signers.extend(inputs.iter().flat_map(|i| &i.inputs).map(|i| StealthUtxoSpendKeyId {
             account_key_id: sender_key_id,
@@ -1506,6 +1513,20 @@ fn map_specific_selection_error(err: StealthOutputsApiError) -> anyhow::Error {
         )
     } else {
         err.into()
+    }
+}
+
+/// Map a `generate_transfer_statement` failure to an RPC error. `WalletCryptoError::InvalidArgument` is only raised
+/// for a malformed request payload — chiefly a `PayTo` intent whose condition set cannot form a tree (empty, or with
+/// duplicate leaves) — so it is a caller error carrying the offending field name; everything else propagates
+/// unchanged as a server error.
+fn map_statement_construction_error(err: StealthOutputsApiError) -> anyhow::Error {
+    match &err {
+        StealthOutputsApiError::WalletCrypto(WalletCryptoError::InvalidArgument { name, details }) => {
+            debug!(target: LOG_TARGET, "Rejected stealth transfer statement: {err}");
+            invalid_params(name, Some(details.clone()))
+        },
+        _ => err.into(),
     }
 }
 
@@ -2373,5 +2394,95 @@ mod create_stealth_transfer_statement_handler_tests {
             );
             assert_eq!(stored.lock_id, Some(response.lock_id));
         }
+    }
+
+    /// Builds a balanced single-output request paying the whole of one 100-value input to `conditions`.
+    fn pay_to_conditions_request(
+        test: &StatementTest,
+        input: &StealthOutputModel,
+        conditions: Vec<SpendCondition>,
+    ) -> AccountsCreateStealthTransferStatementRequest {
+        AccountsCreateStealthTransferStatementRequest {
+            requests: vec![TransferStatementRequest {
+                sender_account: test.account.into(),
+                resource_address: test.stealth_resource,
+                input_selection: InputSelection::Specific {
+                    utxo_addresses: vec![input.to_utxo_address()],
+                },
+                outputs: vec![TransferOutput {
+                    address: account_ootle_address(test),
+                    revealed_amount: Amount::zero(),
+                    blinded_amount: 100,
+                    memo: None,
+                    pay_to: PayTo::Conditions(conditions),
+                }],
+            }],
+        }
+    }
+
+    /// A condition set that cannot form a tree is a malformed request, not a server fault: it must surface as
+    /// `InvalidParams` naming the offending field, and must not leave the selected input locked.
+    #[tokio::test]
+    async fn empty_condition_set_is_rejected_as_invalid_params() {
+        let test = setup().await;
+        let bearer = test.bearer(&test.transfer_and_read_scopes());
+        let input = insert_valid_output(&test, 100);
+
+        let err = handle_create_stealth_transfer_statement(
+            &test.context,
+            Some(&bearer),
+            pay_to_conditions_request(&test, &input, vec![]),
+        )
+        .await
+        .expect_err("an empty condition set must be rejected");
+
+        let message = assert_invalid_params(&err).to_string();
+        assert!(
+            message.contains("conditions"),
+            "expected the offending field to be named, got: {message}"
+        );
+
+        let stored = stored_output(&test, &input.commitment);
+        assert!(
+            matches!(stored.status, OutputStatus::Unspent),
+            "expected Unspent after release, got {:?}",
+            stored.status
+        );
+        assert_eq!(stored.lock_id, None);
+    }
+
+    /// Duplicate leaves are likewise a caller error: the tree rejects them rather than silently deduplicating, so the
+    /// caller learns the condition set is malformed instead of receiving a root over fewer leaves than they supplied.
+    #[tokio::test]
+    async fn duplicate_condition_leaves_are_rejected_as_invalid_params() {
+        let test = setup().await;
+        let bearer = test.bearer(&test.transfer_and_read_scopes());
+        let input = insert_valid_output(&test, 100);
+
+        let (claim_condition, _) =
+            htlc_conditions(b"preimage", 4_242, htlc_participant_key(1), htlc_participant_key(2));
+        let conditions = vec![claim_condition.clone(), claim_condition];
+
+        let err = handle_create_stealth_transfer_statement(
+            &test.context,
+            Some(&bearer),
+            pay_to_conditions_request(&test, &input, conditions),
+        )
+        .await
+        .expect_err("a duplicate condition leaf must be rejected");
+
+        let message = assert_invalid_params(&err).to_string();
+        assert!(
+            message.contains("conditions"),
+            "expected the offending field to be named, got: {message}"
+        );
+
+        let stored = stored_output(&test, &input.commitment);
+        assert!(
+            matches!(stored.status, OutputStatus::Unspent),
+            "expected Unspent after release, got {:?}",
+            stored.status
+        );
+        assert_eq!(stored.lock_id, None);
     }
 }

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -760,50 +760,18 @@ impl<TStore: StateReader + Clone + 'static, TTemplateProvider: TemplateProvider<
         )
     }
 
-    /// Validates a revealed condition leaf's structure before it is hashed or evaluated.
-    ///
-    /// A leaf is a conjunction of atoms (logical AND). It must be non-empty and must not exceed
-    /// `STEALTH_LIMITS.max_conditions_per_conjunction`, which caps the worst-case work of evaluating one leaf.
-    ///
-    /// A data-consuming builtin (e.g. a hashlock) reads the entire witness `data` blob as its own raw input and cannot
-    /// know the blob's shape relative to siblings, so it must be the sole consumer of `data` in its leaf: a leaf may
-    /// hold at most one data-consuming builtin, and one may not share a leaf with a `TemplateFunction` (which may also
-    /// read `data`). Context-only conditions (timelocks, covenants, access rules) consume nothing and compose freely.
+    /// Validates a revealed condition leaf's structure before it is hashed or evaluated. The rule itself lives in
+    /// [`stealth::validate_condition_structure`] so the wallet can apply the same admissibility test before committing
+    /// funds to a tree; this only attributes a failure to the UTXO being spent.
     fn validate_condition_structure(
         leaf: &SpendCondition,
         commitment: &PedersenCommitmentBytes,
     ) -> Result<(), RuntimeError> {
-        let reject = |details: String| Err(RuntimeError::ResourceError(ResourceError::InvalidSpend { details }));
-
-        let conditions = leaf.conditions();
-        if conditions.is_empty() {
-            return reject(format!(
-                "Empty conjunction in spend condition for stealth UTXO {commitment}"
-            ));
-        }
-        let max_conditions = limits::STEALTH_LIMITS.max_conditions_per_conjunction;
-        if conditions.len() > max_conditions {
-            return reject(format!(
-                "Conjunction in spend condition for stealth UTXO {commitment} has {} conditions, exceeding the limit \
-                 of {max_conditions}",
-                conditions.len()
-            ));
-        }
-
-        let data_owning_builtins = conditions.iter().filter(|c| c.is_data_owning_builtin()).count();
-        if data_owning_builtins > 1 {
-            return reject(format!(
-                "Spend condition for stealth UTXO {commitment} has {data_owning_builtins} data-consuming builtins; at \
-                 most one may consume the witness data"
-            ));
-        }
-        if data_owning_builtins == 1 && conditions.iter().any(AtomicCondition::is_template_function) {
-            return reject(format!(
-                "Spend condition for stealth UTXO {commitment} pairs a data-consuming builtin with a \
-                 TemplateFunction; a data-consuming builtin must be the sole consumer of the witness data"
-            ));
-        }
-        Ok(())
+        stealth::validate_condition_structure(leaf).map_err(|err| {
+            RuntimeError::ResourceError(ResourceError::InvalidSpend {
+                details: format!("Spend condition for stealth UTXO {commitment}: {err}"),
+            })
+        })
     }
 
     /// Evaluates a revealed condition leaf that has already been proven included in the committed root. The leaf is a

--- a/crates/engine_types/src/stealth/condition_structure.rs
+++ b/crates/engine_types/src/stealth/condition_structure.rs
@@ -1,0 +1,141 @@
+//    Copyright 2025 The Tari Project
+//    SPDX-License-Identifier: BSD-3-Clause
+
+use tari_template_lib::types::stealth::{AtomicCondition, SpendCondition};
+
+use crate::limits;
+
+/// A condition leaf whose shape the engine will reject at spend time.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ConditionStructureError {
+    #[error("Empty conjunction in spend condition")]
+    EmptyConjunction,
+    #[error("Conjunction has {num_conditions} conditions, exceeding the limit of {max_conditions}")]
+    TooManyConditions {
+        num_conditions: usize,
+        max_conditions: usize,
+    },
+    #[error("{num_consumers} data-consuming builtins; at most one may consume the witness data")]
+    MultipleDataConsumers { num_consumers: usize },
+    #[error(
+        "pairs a data-consuming builtin with a TemplateFunction; a data-consuming builtin must be the sole consumer \
+         of the witness data"
+    )]
+    DataConsumerWithTemplateFunction,
+}
+
+/// Validates a condition leaf's structure. This is the spend-time admissibility rule for a leaf, applied by the engine
+/// before a revealed leaf is evaluated and by the wallet before funds are committed to a tree containing it — a leaf
+/// that fails here can never be satisfied, so an output whose only spend paths are such leaves is unspendable.
+///
+/// A leaf is a conjunction of atoms (logical AND). It must be non-empty and must not exceed
+/// `STEALTH_LIMITS.max_conditions_per_conjunction`, which caps the worst-case work of evaluating one leaf.
+///
+/// A data-consuming builtin (e.g. a hashlock) reads the entire witness `data` blob as its own raw input and cannot
+/// know the blob's shape relative to siblings, so it must be the sole consumer of `data` in its leaf: a leaf may hold
+/// at most one data-consuming builtin, and one may not share a leaf with a `TemplateFunction` (which may also read
+/// `data`). Context-only conditions (timelocks, covenants, access rules) consume nothing and compose freely.
+pub fn validate_condition_structure(leaf: &SpendCondition) -> Result<(), ConditionStructureError> {
+    let conditions = leaf.conditions();
+    if conditions.is_empty() {
+        return Err(ConditionStructureError::EmptyConjunction);
+    }
+
+    let max_conditions = limits::STEALTH_LIMITS.max_conditions_per_conjunction;
+    if conditions.len() > max_conditions {
+        return Err(ConditionStructureError::TooManyConditions {
+            num_conditions: conditions.len(),
+            max_conditions,
+        });
+    }
+
+    let num_consumers = conditions.iter().filter(|c| c.is_data_owning_builtin()).count();
+    if num_consumers > 1 {
+        return Err(ConditionStructureError::MultipleDataConsumers { num_consumers });
+    }
+    if num_consumers == 1 && conditions.iter().any(AtomicCondition::is_template_function) {
+        return Err(ConditionStructureError::DataConsumerWithTemplateFunction);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use tari_template_lib::types::{
+        access_rules::AccessRule,
+        stealth::{BuiltinPredicate, HashAlg, TemplateFunction},
+    };
+
+    use super::*;
+
+    fn hashlock() -> AtomicCondition {
+        AtomicCondition::Builtin(BuiltinPredicate::HashLock {
+            hash: Default::default(),
+            alg: HashAlg::Sha256,
+        })
+    }
+
+    fn context_only() -> AtomicCondition {
+        AtomicCondition::Builtin(BuiltinPredicate::AfterEpoch(1))
+    }
+
+    fn template_function() -> AtomicCondition {
+        AtomicCondition::TemplateFunction(TemplateFunction {
+            template: Default::default(),
+            function: "predicate".try_into().unwrap(),
+            args: Default::default(),
+        })
+    }
+
+    #[test]
+    fn accepts_a_conjunction_of_context_only_atoms() {
+        let leaf = SpendCondition::all([context_only(), AtomicCondition::AccessRule(AccessRule::AllowAll)]);
+        validate_condition_structure(&leaf).unwrap();
+    }
+
+    #[test]
+    fn accepts_a_single_data_consumer_alongside_context_only_atoms() {
+        let leaf = SpendCondition::all([hashlock(), context_only()]);
+        validate_condition_structure(&leaf).unwrap();
+    }
+
+    #[test]
+    fn rejects_an_empty_conjunction() {
+        assert_eq!(
+            validate_condition_structure(&SpendCondition::all([])),
+            Err(ConditionStructureError::EmptyConjunction)
+        );
+    }
+
+    #[test]
+    fn rejects_a_conjunction_over_the_limit() {
+        let max_conditions = limits::STEALTH_LIMITS.max_conditions_per_conjunction;
+        let leaf = SpendCondition::all(vec![context_only(); max_conditions + 1]);
+        assert_eq!(
+            validate_condition_structure(&leaf),
+            Err(ConditionStructureError::TooManyConditions {
+                num_conditions: max_conditions + 1,
+                max_conditions,
+            })
+        );
+        // The limit itself is admissible.
+        validate_condition_structure(&SpendCondition::all(vec![context_only(); max_conditions])).unwrap();
+    }
+
+    #[test]
+    fn rejects_two_data_consumers_in_one_leaf() {
+        assert_eq!(
+            validate_condition_structure(&SpendCondition::all([hashlock(), hashlock()])),
+            Err(ConditionStructureError::MultipleDataConsumers { num_consumers: 2 })
+        );
+    }
+
+    #[test]
+    fn rejects_a_data_consumer_sharing_a_leaf_with_a_template_function() {
+        assert_eq!(
+            validate_condition_structure(&SpendCondition::all([hashlock(), template_function()])),
+            Err(ConditionStructureError::DataConsumerWithTemplateFunction)
+        );
+    }
+}

--- a/crates/engine_types/src/stealth/mod.rs
+++ b/crates/engine_types/src/stealth/mod.rs
@@ -1,12 +1,14 @@
 //    Copyright 2025 The Tari Project
 //    SPDX-License-Identifier: BSD-3-Clause
 
+mod condition_structure;
 mod condition_tree;
 mod hashlock;
 mod outputs;
 mod transfer;
 mod value_proof;
 
+pub use condition_structure::*;
 pub use condition_tree::*;
 pub use hashlock::*;
 pub use outputs::*;

--- a/crates/wallet/crypto/Cargo.toml
+++ b/crates/wallet/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_ootle_wallet_crypto"
-version = "0.38.0"
+version = "0.38.1"
 description = "Cryptographic utilities and types for Tari Ootle wallet"
 edition.workspace = true
 authors.workspace = true

--- a/crates/wallet/crypto/src/stealth.rs
+++ b/crates/wallet/crypto/src/stealth.rs
@@ -7,7 +7,10 @@ use tari_crypto::ristretto::RistrettoSecretKey;
 /// [`BuiltinPredicate::HashLock`](tari_template_lib_types::stealth::BuiltinPredicate::HashLock)
 /// preimage, re-exported so a wallet can build a hashlock condition without depending on `tari_engine_types`.
 pub use tari_engine_types::stealth::hashlock_digest;
-use tari_engine_types::{limits::STEALTH_LIMITS, stealth::MerkleTree};
+use tari_engine_types::{
+    limits::STEALTH_LIMITS,
+    stealth::{MerkleTree, validate_condition_structure},
+};
 use tari_template_lib_types::{
     Amount,
     Hash32,
@@ -41,6 +44,9 @@ use crate::{
 /// Computes the committed condition-tree (MAST) root for a set of spend-condition leaves. The root is independent of
 /// leaf order. Native hashing lives in `tari_engine_types`; this is the wallet-side entry point for building a
 /// script-gated output.
+///
+/// This is the bare tree construction: it rejects a set that cannot form a tree, but says nothing about whether the
+/// individual leaves are ones the engine will admit. Use [`validated_condition_root`] for a caller-supplied set.
 pub fn condition_root(conditions: &[SpendCondition]) -> Result<Hash32, WalletCryptoError> {
     MerkleTree::from_conditions(conditions)
         .map(|tree| tree.root())
@@ -48,6 +54,23 @@ pub fn condition_root(conditions: &[SpendCondition]) -> Result<Hash32, WalletCry
             name: "conditions",
             details: e.to_string(),
         })
+}
+
+/// Computes the committed condition-tree root for a caller-supplied set, checking each leaf against the engine's
+/// spend-time structural rule first.
+///
+/// A leaf the engine will refuse to evaluate is a spend path that can never be taken, so a tree whose leaves are all
+/// inadmissible commits funds to an output nobody can spend. The wallet must not build such an output, even though
+/// the tree itself is well formed.
+pub fn validated_condition_root(conditions: &[SpendCondition]) -> Result<Hash32, WalletCryptoError> {
+    for leaf in conditions {
+        validate_condition_structure(leaf).map_err(|e| WalletCryptoError::InvalidArgument {
+            name: "conditions",
+            details: e.to_string(),
+        })?;
+    }
+
+    condition_root(conditions)
 }
 
 /// Resolves a [`PayTo`] intent to a stealth output's [`SpendAuthorization`]. The one-time stealth key is derived lazily
@@ -64,7 +87,7 @@ pub fn pay_to_output_authorization(
         PayTo::TemplateFunction(tf) => Ok(SpendAuthorization::Script(condition_root(&[
             SpendCondition::template_function(tf.clone()),
         ])?)),
-        PayTo::Conditions(conditions) => Ok(SpendAuthorization::Script(condition_root(conditions)?)),
+        PayTo::Conditions(conditions) => Ok(SpendAuthorization::Script(validated_condition_root(conditions)?)),
     }
 }
 

--- a/crates/wallet/sdk/Cargo.toml
+++ b/crates/wallet/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_wallet_sdk"
 description = "The Tari wallet library"
-version = "0.37.0"
+version = "0.37.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/wallet/sdk/src/apis/stealth_transfer/params.rs
+++ b/crates/wallet/sdk/src/apis/stealth_transfer/params.rs
@@ -6,7 +6,7 @@ use ootle_network::Network;
 use tari_bor::{Deserialize, Serialize};
 use tari_engine_types::crypto::MAX_LAZY_BP_AGG_FACTORS;
 use tari_ootle_address::OotleAddress;
-use tari_ootle_wallet_crypto::{memo::Memo, pay_to::PayTo};
+use tari_ootle_wallet_crypto::{memo::Memo, pay_to::PayTo, stealth::condition_root};
 use tari_template_lib::types::{Amount, ComponentAddress, NonFungibleAddress, ResourceAddress};
 
 use crate::apis::{
@@ -84,6 +84,16 @@ impl StealthTransferParams {
                     param: "destination_address",
                     reason: format!("Invalid destination address: {}", e),
                 })?;
+
+            // A condition set that cannot form a tree (empty, or with duplicate leaves) is rejected here so the
+            // caller is told which field is malformed, rather than failing deep in output construction after
+            // inputs have been locked.
+            if let PayTo::Conditions(conditions) = &output.pay_to {
+                condition_root(conditions).map_err(|e| StealthTransferApiError::InvalidParameter {
+                    param: "pay_to",
+                    reason: e.to_string(),
+                })?;
+            }
         }
 
         Ok(())
@@ -193,4 +203,75 @@ pub struct PayFeeWithSwapParams {
     pub input_resource: ResourceAddress,
     pub input_amount: Amount,
     pub min_xtr_output_amount: Amount,
+}
+
+#[cfg(test)]
+mod tests {
+    use ootle_byte_type::ToByteType;
+    use tari_crypto::{keys::PublicKey as _, ristretto::RistrettoPublicKey};
+    use tari_template_lib::types::{
+        constants::STEALTH_TARI_RESOURCE_ADDRESS,
+        stealth::{AtomicCondition, BuiltinPredicate, SpendCondition},
+    };
+
+    use super::*;
+
+    const NETWORK: Network = Network::LocalNet;
+
+    fn address() -> OotleAddress {
+        let (_, view_only) = RistrettoPublicKey::random_keypair(&mut rand::rng());
+        let (_, account) = RistrettoPublicKey::random_keypair(&mut rand::rng());
+        OotleAddress::new(NETWORK, view_only.to_byte_type(), account.to_byte_type())
+    }
+
+    /// A single-leaf condition, distinct per `epoch`.
+    fn a_condition(epoch: u64) -> SpendCondition {
+        SpendCondition::all([AtomicCondition::Builtin(BuiltinPredicate::AfterEpoch(epoch))])
+    }
+
+    fn params_paying_to(pay_to: PayTo) -> StealthTransferParams {
+        StealthTransferParams {
+            fee_params: TransferFeeParams::new(UtxoInputSelection::PreferConfidential),
+            input_selection: UtxoInputSelection::PreferConfidential,
+            outputs: vec![TransferOutput {
+                address: address(),
+                revealed_amount: Amount::zero(),
+                blinded_amount: 100,
+                memo: None,
+                pay_to,
+            }],
+            badge_usage: BadgeUsage::None,
+            resource_address: STEALTH_TARI_RESOURCE_ADDRESS,
+            max_fee: 1000,
+            is_dry_run: false,
+        }
+    }
+
+    fn assert_rejects_pay_to(pay_to: PayTo) {
+        let err = params_paying_to(pay_to)
+            .validate(NETWORK)
+            .expect_err("a condition set that cannot form a tree must be rejected");
+        assert!(
+            matches!(err, StealthTransferApiError::InvalidParameter { param: "pay_to", .. }),
+            "expected an InvalidParameter naming pay_to, got: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_an_empty_condition_set() {
+        assert_rejects_pay_to(PayTo::Conditions(vec![]));
+    }
+
+    #[test]
+    fn rejects_duplicate_condition_leaves() {
+        let condition = a_condition(1);
+        assert_rejects_pay_to(PayTo::Conditions(vec![condition.clone(), condition]));
+    }
+
+    #[test]
+    fn accepts_a_well_formed_condition_set() {
+        params_paying_to(PayTo::Conditions(vec![a_condition(1), a_condition(2)]))
+            .validate(NETWORK)
+            .expect("distinct condition leaves form a tree");
+    }
 }

--- a/crates/wallet/sdk/src/apis/stealth_transfer/params.rs
+++ b/crates/wallet/sdk/src/apis/stealth_transfer/params.rs
@@ -6,7 +6,7 @@ use ootle_network::Network;
 use tari_bor::{Deserialize, Serialize};
 use tari_engine_types::crypto::MAX_LAZY_BP_AGG_FACTORS;
 use tari_ootle_address::OotleAddress;
-use tari_ootle_wallet_crypto::{memo::Memo, pay_to::PayTo, stealth::condition_root};
+use tari_ootle_wallet_crypto::{memo::Memo, pay_to::PayTo, stealth::validated_condition_root};
 use tari_template_lib::types::{Amount, ComponentAddress, NonFungibleAddress, ResourceAddress};
 
 use crate::apis::{
@@ -85,15 +85,12 @@ impl StealthTransferParams {
                     reason: format!("Invalid destination address: {}", e),
                 })?;
 
-            // A condition set that cannot form a tree (empty, or with duplicate leaves) is rejected here so the
-            // caller is told which field is malformed, rather than failing deep in output construction after
-            // inputs have been locked.
-            if let PayTo::Conditions(conditions) = &output.pay_to {
-                condition_root(conditions).map_err(|e| StealthTransferApiError::InvalidParameter {
+            output
+                .validate_pay_to()
+                .map_err(|reason| StealthTransferApiError::InvalidParameter {
                     param: "pay_to",
-                    reason: e.to_string(),
+                    reason,
                 })?;
-            }
         }
 
         Ok(())
@@ -126,6 +123,31 @@ pub struct TransferOutput {
 impl TransferOutput {
     pub fn total_output_amount(&self) -> Amount {
         self.revealed_amount + Amount::from(self.blinded_amount)
+    }
+
+    /// Checks that this output's `pay_to` intent will be honoured as written, returning the reason it will not.
+    ///
+    /// `pay_to` gates the spend of the *blinded* output. An output with no blinded amount produces no stealth output
+    /// at all — statement construction filters it out — so a gating intent on one would be silently dropped and the
+    /// funds deposited unguarded. Reject it rather than mislead the caller.
+    ///
+    /// For a condition set, the tree is built here so a malformed set is reported against the field the caller
+    /// supplied, before any inputs are locked, rather than failing deep in output construction.
+    pub fn validate_pay_to(&self) -> Result<(), String> {
+        if self.blinded_amount == 0 {
+            if matches!(self.pay_to, PayTo::StealthPublicKey) {
+                return Ok(());
+            }
+            return Err(
+                "An output with no blinded amount produces no stealth output, so its spend cannot be gated".to_string(),
+            );
+        }
+
+        if let PayTo::Conditions(conditions) = &self.pay_to {
+            validated_condition_root(conditions).map_err(|e| e.to_string())?;
+        }
+
+        Ok(())
     }
 }
 
@@ -209,6 +231,7 @@ pub struct PayFeeWithSwapParams {
 mod tests {
     use ootle_byte_type::ToByteType;
     use tari_crypto::{keys::PublicKey as _, ristretto::RistrettoPublicKey};
+    use tari_engine_types::limits::STEALTH_LIMITS;
     use tari_template_lib::types::{
         constants::STEALTH_TARI_RESOURCE_ADDRESS,
         stealth::{AtomicCondition, BuiltinPredicate, SpendCondition},
@@ -229,14 +252,15 @@ mod tests {
         SpendCondition::all([AtomicCondition::Builtin(BuiltinPredicate::AfterEpoch(epoch))])
     }
 
-    fn params_paying_to(pay_to: PayTo) -> StealthTransferParams {
+    /// A single output of `blinded_amount` blinded plus `revealed_amount` revealed, paying to `pay_to`.
+    fn params_paying_to(blinded_amount: u64, revealed_amount: u64, pay_to: PayTo) -> StealthTransferParams {
         StealthTransferParams {
             fee_params: TransferFeeParams::new(UtxoInputSelection::PreferConfidential),
             input_selection: UtxoInputSelection::PreferConfidential,
             outputs: vec![TransferOutput {
                 address: address(),
-                revealed_amount: Amount::zero(),
-                blinded_amount: 100,
+                revealed_amount: Amount::from(revealed_amount),
+                blinded_amount,
                 memo: None,
                 pay_to,
             }],
@@ -247,14 +271,22 @@ mod tests {
         }
     }
 
-    fn assert_rejects_pay_to(pay_to: PayTo) {
-        let err = params_paying_to(pay_to)
+    fn blinded_paying_to(pay_to: PayTo) -> StealthTransferParams {
+        params_paying_to(100, 0, pay_to)
+    }
+
+    fn assert_rejects(params: StealthTransferParams) {
+        let err = params
             .validate(NETWORK)
-            .expect_err("a condition set that cannot form a tree must be rejected");
+            .expect_err("a pay_to that will not be honoured as written must be rejected");
         assert!(
             matches!(err, StealthTransferApiError::InvalidParameter { param: "pay_to", .. }),
             "expected an InvalidParameter naming pay_to, got: {err}"
         );
+    }
+
+    fn assert_rejects_pay_to(pay_to: PayTo) {
+        assert_rejects(blinded_paying_to(pay_to));
     }
 
     #[test]
@@ -268,9 +300,34 @@ mod tests {
         assert_rejects_pay_to(PayTo::Conditions(vec![condition.clone(), condition]));
     }
 
+    /// A leaf the engine refuses to evaluate is a spend path that can never be taken. A tree built only from such
+    /// leaves is well formed but unspendable, so it must not reach an output.
+    #[test]
+    fn rejects_a_structurally_inadmissible_leaf() {
+        assert_rejects_pay_to(PayTo::Conditions(vec![SpendCondition::all([])]));
+        assert_rejects_pay_to(PayTo::Conditions(vec![SpendCondition::all(vec![
+            AtomicCondition::Builtin(BuiltinPredicate::AfterEpoch(1));
+            STEALTH_LIMITS.max_conditions_per_conjunction + 1
+        ])]));
+    }
+
+    /// `pay_to` gates the blinded output, which a revealed-only transfer never produces. Silently depositing the
+    /// funds unguarded would give the caller the opposite of what they asked for.
+    #[test]
+    fn rejects_a_gated_output_with_no_blinded_amount() {
+        assert_rejects(params_paying_to(0, 100, PayTo::Conditions(vec![a_condition(1)])));
+    }
+
+    #[test]
+    fn accepts_an_ungated_output_with_no_blinded_amount() {
+        params_paying_to(0, 100, PayTo::StealthPublicKey)
+            .validate(NETWORK)
+            .expect("a revealed-only output needs no spend gating");
+    }
+
     #[test]
     fn accepts_a_well_formed_condition_set() {
-        params_paying_to(PayTo::Conditions(vec![a_condition(1), a_condition(2)]))
+        blinded_paying_to(PayTo::Conditions(vec![a_condition(1), a_condition(2)]))
             .validate(NETWORK)
             .expect("distinct condition leaves form a tree");
     }

--- a/scripts/crate_versioning.py
+++ b/scripts/crate_versioning.py
@@ -16,7 +16,7 @@ Usage:
 Tier semantics (mirrors publish_crates.py). Tier 3 is the only workspace-versioned
 cohort; every other tier is independently versioned:
   1 = stable/foundational, rarely changes
-  2 = template authoring crates
+  2 = template authoring crates & the built-in templates
   3 = core, all share workspace.package.version (move together)
   4 = wallet (SDK, clients, storage), decoupled from the core version
 

--- a/scripts/publish_crates.py
+++ b/scripts/publish_crates.py
@@ -24,7 +24,7 @@ import urllib.error
 # Version tiers (concern domains). Tier 3 is the only workspace-versioned cohort;
 # every other tier is independently versioned (each crate carries its own version):
 #   1 = Stable/foundational — shared primitives, rarely change
-#   2 = Template — template authoring crates
+#   2 = Template — template authoring crates & the built-in templates
 #   3 = Core — workspace-versioned (shares [workspace.package].version), moves together
 #   4 = Wallet — wallet SDK, clients & storage, decoupled from the core version
 #
@@ -48,7 +48,9 @@ CRATES = [
     ("tari_ootle_wallet_crypto", "crates/wallet/crypto", 4),
     ("tari_ootle_address", "crates/ootle_address", 1),
     ("tari_ootle_transaction", "crates/transaction", 3),
-    ("tari_template_builtin", "crates/template_builtin", 3),
+    # Tier 2, not tier 3: its only build dependency is tari_template_lib_types, so it has no build-time coupling to
+    # the core cohort (its tari_engine_types / tari_ootle_transaction deps are dev-only) and carries its own version.
+    ("tari_template_builtin", "crates/template_builtin", 2),
     ("tari_transaction_manifest", "crates/transaction_manifest", 3),
     ("tari_engine", "crates/engine", 3),
     ("tari_consensus_types", "crates/consensus_types", 3),


### PR DESCRIPTION
## Description

A `PayTo::Conditions` set that cannot form a condition tree — empty, or containing duplicate leaves — surfaced as an internal server error rather than a request error, on both stealth transfer entry points. `MerkleTree::new` rejects both cases (`MerkleTreeError::Empty` / `DuplicateLeaf`), and `condition_root` wraps that as `WalletCryptoError::InvalidArgument { name: "conditions", .. }`, but neither handler mapped it.

**`accounts.create_stealth_transfer_statement`** propagated the error with a bare `?`, so a malformed request became a 500. Every other caller-error path in that handler returns `InvalidParams` (`invalid_params`, `map_specific_selection_error`). Added `map_statement_construction_error`, which maps `StealthOutputsApiError::WalletCrypto(WalletCryptoError::InvalidArgument { name, details })` to `invalid_params(name, details)` and leaves everything else to propagate as a server error. Scoped deliberately to that one variant — every construction site of it in `crates/wallet/crypto/src/stealth.rs` is a request-payload error.

**`accounts.stealth_transfer`** hit the same failure deep in output construction, inside the spawned transfer task and *after* the selected inputs had been locked. Rather than mapping the error there, the condition set is now checked in `StealthTransferParams::validate`, alongside the other per-output request checks and before any locking; the handler already maps a `validate` failure to `invalid_params("params", ..)`. The check calls `condition_root` so the empty/duplicate rules are not reimplemented.

Other `generate_transfer_statement` call sites were checked and are unaffected: `handle_claim_burn` (`accounts.rs:657`) and the validator claim (`validator.rs:366`) build `SpendAuthorization::Key` themselves, and the fee statement in `stealth_transfer/api.rs:391` is not caller-controlled. `StealthTransferRequest` and `TransferStatementRequest` are the only JSON-RPC request types carrying a `PayTo`.

## Motivation and Context

Follow-up to #2386, which added happy-path coverage for `PayTo::Conditions`. The error path was the remaining gap: a client posting an empty or duplicate condition list got an opaque 500 and, on the `stealth_transfer` path, left its inputs locked until the guard unwound.

## How Has This Been Tested?

Five new tests, all verified to fail before the fix and pass after:

- `applications/tari_walletd/src/handlers/accounts.rs` — `empty_condition_set_is_rejected_as_invalid_params` and `duplicate_condition_leaves_are_rejected_as_invalid_params`. Each asserts `InvalidParams`, that the message names `conditions`, and that the lock guard released the input (`Unspent`, `lock_id: None`).
- `crates/wallet/sdk/src/apis/stealth_transfer/params.rs` — `rejects_an_empty_condition_set`, `rejects_duplicate_condition_leaves`, `accepts_a_well_formed_condition_set`.

`cargo test -p tari_ootle_wallet_sdk -p tari_ootle_walletd --lib` passes (36 + 25). Clippy clean apart from pre-existing `too_many_arguments` warnings. Formatted with the pinned nightly.

## What process can a PR reviewer use to test or verify this change?

Post a `accounts.create_stealth_transfer_statement` or `accounts.stealth_transfer` request with `pay_to: { "Conditions": [] }`, or with the same condition repeated twice. Before: HTTP 500 / opaque application error. After: `InvalidParams` naming the offending field. On the `stealth_transfer` path, confirm the named inputs are never locked.

## Breaking Changes

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other