### PR TITLE
fix(ootle-rs): bind stealth authorizations to the key that seals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7692,7 +7692,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-rs"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/crates/wallet/ootle-rs/Cargo.toml
+++ b/crates/wallet/ootle-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ootle-rs"
-version = "0.16.0"
+version = "0.17.0"
 description = "A Rust library for interacting with the Tari Ootle network."
 edition.workspace = true
 authors.workspace = true

--- a/crates/wallet/ootle-rs/examples/adaptor_claim.rs
+++ b/crates/wallet/ootle-rs/examples/adaptor_claim.rs
@@ -187,6 +187,7 @@ async fn main() {
         .stealth_authorizer(SignatureRequirements::account_key_seal());
     let claim_msg = authorizer
         .authorization_message(&claim_tx)
+        .await
         .expect("account-key seal yields an authorization message");
 
     // Our side of the 2-of-2: an ordinary signature we make outright.

--- a/crates/wallet/ootle-rs/examples/stealth_transfer.rs
+++ b/crates/wallet/ootle-rs/examples/stealth_transfer.rs
@@ -29,7 +29,7 @@ async fn main() {
     //     .init();
 
     // This is the address that we will transfer to (Feel free to change this another address!)
-    let recipient = address!( "otl_loc_1c370ayp9849gzmj9gwelyyd086ntrt84w5nkclu32tzyr2pvcfpre43z8z2xvupm6wltw9k5e8tzay3qqf9nfj9v5xuxwcpcxmg22vqlvz86l" );
+    let recipient = address!( "otl_loc_1em0npr8f3uzs3fznygglr4eujwl0qgr6e30hu3whr9fpfh2w99r743uxd7qg6f7jchgm6pdht7lpcwcggcjgfejfpd4jgvfmzve9vec5xep5t" );
 
     let indexer_api_url = default_indexer_url(recipient.network());
 
@@ -67,14 +67,18 @@ async fn main() {
     // The faucet funds are split across two outputs so that the transfer below spends two stealth inputs. One of them
     // seals that transaction and the other must attach an authorization signature committing to the seal signer's
     // one-time public key.
-    const FEE_BUDGET: u64 = 2000;
+
+    // The revealed amount each transaction reserves to pay its fee. It is deliberately generous rather than fitted to
+    // a dry-run estimate: the budget is part of the transfer statement, so spending an estimate would change the
+    // transaction it was estimated from. Whatever is not charged is refunded (see the receipt's overcharge line).
+    const FEE_BUDGET: u64 = 20_000;
     const FIRST_INPUT_AMOUNT: u64 = 6 * TARI;
-    const SECOND_INPUT_AMOUNT: u64 = 10 * TARI + 2 * FEE_BUDGET - FEE_BUDGET - FIRST_INPUT_AMOUNT;
+    const SECOND_INPUT_AMOUNT: u64 = 10 * TARI + FEE_BUDGET - FIRST_INPUT_AMOUNT;
     // // This builder creates a stealth transfer statement (spend proof). This is added to the transaction later.
     let (faucet_transfer, required_signers) = StealthTransfer::new(tari_token, &provider)
         // Tell the transfer to expect 10 TARI (plus a fee budget for this transaction and the transfer below) as revealed funds from a bucket (the faucet looks at this value and automatically provides the bucket).
         .spend_revealed_input(10 * TARI + 2 * FEE_BUDGET)
-        // The transfer will output the fee budget as revealed funds to pay for the fee. Creating each stealth output costs a substate-creation premium plus its stored bytes, so this has to cover two of them.
+        // The transfer will output the fee budget as revealed funds to pay for the fee.
         .to_revealed_output(FEE_BUDGET)
         // Spend the remaining value (10 TARI - fee) into outputs for the sender address. NOTE: the sender address is not actually included in the output (privacy!),
         // but a supporting wallet that holds the secret key would be able to spend the output.
@@ -120,7 +124,7 @@ async fn main() {
         // Together these are worth 10 TARI plus the second transaction's fee budget.
         .spend_stealth_input(sender_address.clone(), inputs_to_spend[0].commitment())
         .spend_stealth_input(sender_address.clone(), inputs_to_spend[1].commitment())
-        // The transfer will output the fee budget as revealed funds to pay for the fee. Two inputs means an extra authorization signature to verify on top of the two new outputs.
+        // The transfer will output the fee budget as revealed funds to pay for the fee.
         .to_revealed_output(FEE_BUDGET)
         // Spend to a new output (8 TARI) that we'll generate for the recipient address.
         .to_stealth_output(
@@ -160,6 +164,8 @@ async fn main() {
         .unwrap();
     let _diff = result.expect_success();
     println!("Dry run successful!");
+    // Informational: the fee budget above is not derived from this number. Spending the estimate would mean changing
+    // the transfer statement, which would change the transaction the estimate was taken from.
     println!(
         "Estimated fees for transfer: {}",
         result.finalize.fee_receipt.total_fees_charged()

--- a/crates/wallet/ootle-rs/examples/stealth_transfer.rs
+++ b/crates/wallet/ootle-rs/examples/stealth_transfer.rs
@@ -67,14 +67,15 @@ async fn main() {
     // The faucet funds are split across two outputs so that the transfer below spends two stealth inputs. One of them
     // seals that transaction and the other must attach an authorization signature committing to the seal signer's
     // one-time public key.
+    const FEE_BUDGET: u64 = 2000;
     const FIRST_INPUT_AMOUNT: u64 = 6 * TARI;
-    const SECOND_INPUT_AMOUNT: u64 = 10 * TARI + 1000 - 500 - FIRST_INPUT_AMOUNT;
+    const SECOND_INPUT_AMOUNT: u64 = 10 * TARI + 2 * FEE_BUDGET - FEE_BUDGET - FIRST_INPUT_AMOUNT;
     // // This builder creates a stealth transfer statement (spend proof). This is added to the transaction later.
     let (faucet_transfer, required_signers) = StealthTransfer::new(tari_token, &provider)
-        // Tell the transfer to expect 10 TARI (+1000 to cover fees) as revealed funds from a bucket (the faucet looks at this value and automatically provides the bucket).
-        .spend_revealed_input(10 * TARI + 1000)
-        // The transfer will output 500 micro TARI as revealed funds to pay for the fee
-        .to_revealed_output(500u64)
+        // Tell the transfer to expect 10 TARI (plus a fee budget for this transaction and the transfer below) as revealed funds from a bucket (the faucet looks at this value and automatically provides the bucket).
+        .spend_revealed_input(10 * TARI + 2 * FEE_BUDGET)
+        // The transfer will output the fee budget as revealed funds to pay for the fee. Creating each stealth output costs a substate-creation premium plus its stored bytes, so this has to cover two of them.
+        .to_revealed_output(FEE_BUDGET)
         // Spend the remaining value (10 TARI - fee) into outputs for the sender address. NOTE: the sender address is not actually included in the output (privacy!),
         // but a supporting wallet that holds the secret key would be able to spend the output.
         // You can specify any address here and split up into many outputs as needed, as long as ∑inputs == ∑outputs.
@@ -116,11 +117,11 @@ async fn main() {
     // This builder creates a stealth transfer statement (spend proof). This is added to the transaction later.
     let (transfer, required_signers) = StealthTransfer::new(tari_token, &provider)
         // Spend both existing stealth inputs that are controlled by the sender address.
-        // Together these are worth 10.000500 TARI
+        // Together these are worth 10 TARI plus the second transaction's fee budget.
         .spend_stealth_input(sender_address.clone(), inputs_to_spend[0].commitment())
         .spend_stealth_input(sender_address.clone(), inputs_to_spend[1].commitment())
-        // The transfer will output 0.000500 TARI as revealed funds to pay for the fee
-        .to_revealed_output(500u64)
+        // The transfer will output the fee budget as revealed funds to pay for the fee. Two inputs means an extra authorization signature to verify on top of the two new outputs.
+        .to_revealed_output(FEE_BUDGET)
         // Spend to a new output (8 TARI) that we'll generate for the recipient address.
         .to_stealth_output(
             Output::new(recipient, tari_token, const_nonzero_u64!(8 * TARI))

--- a/crates/wallet/ootle-rs/examples/stealth_transfer.rs
+++ b/crates/wallet/ootle-rs/examples/stealth_transfer.rs
@@ -64,25 +64,32 @@ async fn main() {
     // Send some TARI to another address. You can replace TARI with any other fungible token resource address.
     let tari_token = TARI_TOKEN; // resource_address!("resource_0123456789abcdef...");
 
-    const INPUT_AMOUNT: u64 = 10 * TARI + 1000 - 500;
+    // The faucet funds are split across two outputs so that the transfer below spends two stealth inputs. One of them
+    // seals that transaction and the other must attach an authorization signature committing to the seal signer's
+    // one-time public key.
+    const FIRST_INPUT_AMOUNT: u64 = 6 * TARI;
+    const SECOND_INPUT_AMOUNT: u64 = 10 * TARI + 1000 - 500 - FIRST_INPUT_AMOUNT;
     // // This builder creates a stealth transfer statement (spend proof). This is added to the transaction later.
     let (faucet_transfer, required_signers) = StealthTransfer::new(tari_token, &provider)
         // Tell the transfer to expect 10 TARI (+1000 to cover fees) as revealed funds from a bucket (the faucet looks at this value and automatically provides the bucket).
         .spend_revealed_input(10 * TARI + 1000)
         // The transfer will output 500 micro TARI as revealed funds to pay for the fee
         .to_revealed_output(500u64)
-        // Spend the remaining value (10 TARI - fee) into an output for the sender address. NOTE: the sender address is not actually included in the output (privacy!),
+        // Spend the remaining value (10 TARI - fee) into outputs for the sender address. NOTE: the sender address is not actually included in the output (privacy!),
         // but a supporting wallet that holds the secret key would be able to spend the output.
         // You can specify any address here and split up into many outputs as needed, as long as ∑inputs == ∑outputs.
         .to_stealth_output(
-            Output::new(sender_address.clone(), tari_token, const_nonzero_u64!(INPUT_AMOUNT))
+            Output::new(sender_address.clone(), tari_token, const_nonzero_u64!(FIRST_INPUT_AMOUNT))
+        )
+        .to_stealth_output(
+            Output::new(sender_address.clone(), tari_token, const_nonzero_u64!(SECOND_INPUT_AMOUNT))
         )
         .prepare()
         .await
         .unwrap();
 
     // Keep track of the input commitments to spend later.
-    let input_to_spend = faucet_transfer.stealth_outputs().to_vec();
+    let inputs_to_spend = faucet_transfer.stealth_outputs().to_vec();
 
     // First let's transfer some faucet TARI to our account to have funds for fees and transfers.
     let unsigned_tx = IFaucet::new(&provider)
@@ -108,9 +115,10 @@ async fn main() {
     // Then we'll send it to the recipient
     // This builder creates a stealth transfer statement (spend proof). This is added to the transaction later.
     let (transfer, required_signers) = StealthTransfer::new(tari_token, &provider)
-        // Spend an existing stealth input that is controlled by the sender address.
-        // This is worth 10.000500 TARI
-        .spend_stealth_input(sender_address.clone(), input_to_spend[0].commitment())
+        // Spend both existing stealth inputs that are controlled by the sender address.
+        // Together these are worth 10.000500 TARI
+        .spend_stealth_input(sender_address.clone(), inputs_to_spend[0].commitment())
+        .spend_stealth_input(sender_address.clone(), inputs_to_spend[1].commitment())
         // The transfer will output 0.000500 TARI as revealed funds to pay for the fee
         .to_revealed_output(500u64)
         // Spend to a new output (8 TARI) that we'll generate for the recipient address.
@@ -137,8 +145,9 @@ async fn main() {
         })
         // This isn't necessary because all transactions implicitly use TARI for fees, but you'd need to include this if other resources are being used
         .add_input(tari_token)
-        // Add the UTXO substate as an input. This will be DOWNed (destroyed) if the transaction is successful.
-        .add_input(UtxoAddress::new(tari_token, input_to_spend[0].commitment().into()))
+        // Add the UTXO substates as inputs. These will be DOWNed (destroyed) if the transaction is successful.
+        .add_input(UtxoAddress::new(tari_token, inputs_to_spend[0].commitment().into()))
+        .add_input(UtxoAddress::new(tari_token, inputs_to_spend[1].commitment().into()))
         .build_unsigned();
 
     // This authorizer adds the required (stealth) signatures to spend inputs
@@ -154,10 +163,10 @@ async fn main() {
         "Estimated fees for transfer: {}",
         result.finalize.fee_receipt.total_fees_charged()
     );
-    let authorizations = authorizer.create_authorizations(&unsigned_tx).await.unwrap();
+    // One of the two stealth inputs seals the transaction; `build` asks the authorizer for the authorization signature
+    // the other one needs, which commits to the seal signer's one-time public key.
     let transaction = TransactionRequest::default()
         .with_transaction(unsigned_tx)
-        .with_authorizations(authorizations)
         .build(&authorizer)
         .await
         .unwrap();

--- a/crates/wallet/ootle-rs/src/key_provider/local/generic_impls.rs
+++ b/crates/wallet/ootle-rs/src/key_provider/local/generic_impls.rs
@@ -307,6 +307,11 @@ impl<C: StealthKeyPrehashSigner<(RistrettoSchnorr, RistrettoPublicKey)> + Send +
         let sig = TransactionSealSignature::new(public_key.to_byte_type(), signature.to_byte_type());
         Ok(sig)
     }
+
+    async fn stealth_public_key(&self, public_nonce: &RistrettoPublicKey) -> signer::Result<RistrettoPublicKeyBytes> {
+        let public_key = self.credentials.stealth_public_key(public_nonce).await?;
+        Ok(public_key.to_byte_type())
+    }
 }
 
 #[cfg(test)]
@@ -564,5 +569,31 @@ mod tests {
         assert_eq!(statement.inputs_statement.inputs.len(), 1);
         assert_eq!(statement.inputs_statement.inputs[0].commitment, commitment);
         validate_transfer(&statement, None).expect("the engine must accept the burn claim statement");
+    }
+
+    /// `stealth_public_key` must agree with the key the signing methods actually use, since authorization signatures
+    /// commit to it before any signature over the transaction is made.
+    #[tokio::test]
+    async fn the_derived_stealth_public_key_is_the_one_that_signs() {
+        let provider = PrivateKeyProvider::random(Network::LocalNet);
+        let (_, public_nonce) = RistrettoPublicKey::random_keypair(&mut rand::rng());
+        let unsigned = tari_ootle_transaction::Transaction::builder(Network::LocalNet).build_unsigned();
+
+        let derived = provider
+            .stealth_public_key(&public_nonce)
+            .await
+            .expect("a local provider derives its own stealth key");
+
+        let seal = provider
+            .seal_transaction_with_stealth(&public_nonce, &unsigned.clone().finish())
+            .await
+            .expect("sealing with a stealth key must succeed");
+        assert_eq!(seal.public_key(), &derived);
+
+        let auth = provider
+            .sign_authorization_with_stealth(&public_nonce, &derived, &unsigned)
+            .await
+            .expect("authorizing with a stealth key must succeed");
+        assert_eq!(auth.signature().public_key(), &derived);
     }
 }

--- a/crates/wallet/ootle-rs/src/keys/secret.rs
+++ b/crates/wallet/ootle-rs/src/keys/secret.rs
@@ -111,6 +111,11 @@ impl StealthKeyPrehashSigner<(RistrettoSchnorr, RistrettoPublicKey)> for OotleSe
         let public_key = RistrettoPublicKey::from_secret_key(&secret);
         Ok((signature, public_key))
     }
+
+    async fn stealth_public_key(&self, public_nonce: &RistrettoPublicKey) -> signer::Result<RistrettoPublicKey> {
+        let secret = kdfs::owner_stealth_dh_secret(self.network(), self.account_secret(), public_nonce);
+        Ok(RistrettoPublicKey::from_secret_key(&secret))
+    }
 }
 
 #[async_trait]

--- a/crates/wallet/ootle-rs/src/signer/ledger.rs
+++ b/crates/wallet/ootle-rs/src/signer/ledger.rs
@@ -155,6 +155,15 @@ where
     T: Exchange + Send + Sync,
     T::Error: core::fmt::Display + Send + Sync,
 {
+    async fn stealth_public_key(&self, _public_nonce: &RistrettoPublicKey) -> signer::Result<RistrettoPublicKeyBytes> {
+        // `GetPublicKey` derives from (account, index, key_type) only; the device has no request that takes a sender
+        // public nonce, so `c + k` is only ever returned alongside a signature it makes with it.
+        Err(SignerError::other(
+            "the Ledger device cannot derive a stealth public key without signing, so it cannot seal a stealth \
+             transfer that also needs authorization signatures",
+        ))
+    }
+
     async fn sign_authorization_with_stealth(
         &self,
         public_nonce: &RistrettoPublicKey,

--- a/crates/wallet/ootle-rs/src/signer/stealth_key.rs
+++ b/crates/wallet/ootle-rs/src/signer/stealth_key.rs
@@ -13,4 +13,11 @@ pub trait StealthKeyPrehashSigner<S> {
         public_key: &RistrettoPublicKey,
         prehash: &[u8],
     ) -> impl Future<Output = signer::Result<S>> + Send;
+
+    /// The public key [`sign_prehash_with_stealth_key`](Self::sign_prehash_with_stealth_key) signs with for
+    /// `public_nonce`, derived without producing a signature.
+    fn stealth_public_key(
+        &self,
+        public_nonce: &RistrettoPublicKey,
+    ) -> impl Future<Output = signer::Result<RistrettoPublicKey>> + Send;
 }

--- a/crates/wallet/ootle-rs/src/stealth/builder.rs
+++ b/crates/wallet/ootle-rs/src/stealth/builder.rs
@@ -1,7 +1,7 @@
 //   Copyright 2026 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use indexmap::IndexSet;
+use indexmap::{IndexMap, IndexSet};
 use ootle_byte_type::FromByteType;
 use tari_ootle_common_types::engine_types::{stealth::validate_transfer, substate::SubstateId};
 use tari_template_lib_types::{
@@ -87,38 +87,39 @@ impl<'a, P: WalletProvider<Wallet = OotleWallet>> StealthTransfer<'a, P> {
     /// here is public material, so it stays on this side of the
     /// [`StealthStatementProvider`](crate::stealth::StealthStatementProvider) boundary.
     async fn resolve_inputs(&mut self) -> WalletResult<(Vec<ResolvedStealthInput>, SignatureRequirements)> {
-        // The UTXO each input spends, in the order the caller added them. A commitment may only appear once: the same
-        // UTXO cannot be spent twice, and two entries naming it would otherwise silently collapse into one.
-        let mut utxo_ids = Vec::with_capacity(self.spec.inputs_to_spend.len());
-        for (_, input) in &self.spec.inputs_to_spend {
+        // Keyed by the UTXO each input spends, so several inputs owned by one address stay distinct, and iterated in
+        // the order the caller added them. A commitment may appear only once: the same UTXO cannot be spent twice, and
+        // two entries naming it would otherwise silently collapse into one.
+        let mut inputs_by_utxo = IndexMap::with_capacity(self.spec.inputs_to_spend.len());
+        for (spender_addr, input) in self.spec.inputs_to_spend.drain(..) {
             let id = SubstateId::from(UtxoAddress::new(self.spec.resource_address, input.commitment.into()));
-            if utxo_ids.contains(&id) {
+            if inputs_by_utxo.contains_key(&id) {
                 return Err(StealthProviderError::UnexpectedError {
                     details: format!("The stealth input {id} was added to this transfer more than once"),
                 }
                 .into());
             }
-            utxo_ids.push(id);
+            inputs_by_utxo.insert(id, (spender_addr, input));
         }
 
         let mut found_substates = self
             .provider
-            .fetch_substates(utxo_ids.iter().cloned())
+            .fetch_substates(inputs_by_utxo.keys().cloned())
             .await
             .map_err(|e| StealthProviderError::UnexpectedError {
                 details: format!("Failed to fetch stealth input substates: {}", e),
             })?;
 
-        let mut required_signers = IndexSet::with_capacity(utxo_ids.len());
+        let mut required_signers = IndexSet::with_capacity(inputs_by_utxo.len());
         // Accessing the account component to take the revealed input bucket requires the account key's badge, so it
         // must seal; otherwise the inputs' own one-time keys are all the transaction needs.
         let must_sign_with_account_key = self.spec.revealed_input_amount.is_positive();
-        let mut resolved_inputs = Vec::with_capacity(utxo_ids.len());
+        let mut resolved_inputs = Vec::with_capacity(inputs_by_utxo.len());
 
         // Driven by the caller's inputs rather than the fetched substates, which arrive in a `HashMap`: the first
         // input is promoted to seal signer, so iterating in a nondeterministic order would pick a different seal
         // signer, and order the statement's inputs differently, from one run to the next.
-        for ((spender_addr, to_spend), id) in self.spec.inputs_to_spend.drain(..).zip(utxo_ids) {
+        for (id, (spender_addr, to_spend)) in inputs_by_utxo {
             // TODO: work on the error types
             let Some(address) = id.as_utxo_address() else {
                 return Err(StealthProviderError::UnexpectedError {

--- a/crates/wallet/ootle-rs/src/stealth/builder.rs
+++ b/crates/wallet/ootle-rs/src/stealth/builder.rs
@@ -89,26 +89,27 @@ impl<'a, P: WalletProvider<Wallet = OotleWallet>> StealthTransfer<'a, P> {
     /// here is public material, so it stays on this side of the
     /// [`StealthStatementProvider`](crate::stealth::StealthStatementProvider) boundary.
     async fn resolve_inputs(&mut self) -> WalletResult<(Vec<ResolvedStealthInput>, SignatureRequirements)> {
-        let substate_id_to_addr_map = self
+        // Keyed by the UTXO each input spends, so that several inputs owned by the same address stay distinct.
+        let mut inputs_by_utxo = self
             .spec
             .inputs_to_spend
-            .iter()
+            .drain(..)
             .map(|(addr, i)| {
                 (
                     SubstateId::from(UtxoAddress::new(self.spec.resource_address, i.commitment.into())),
-                    addr.clone(),
+                    (addr, i),
                 )
             })
             .collect::<HashMap<_, _>>();
 
         let found_substates = self
             .provider
-            .fetch_substates(substate_id_to_addr_map.keys().cloned())
+            .fetch_substates(inputs_by_utxo.keys().cloned())
             .await
             .map_err(|e| StealthProviderError::UnexpectedError {
                 details: format!("Failed to fetch stealth input substates: {}", e),
             })?;
-        if found_substates.len() != self.spec.inputs_to_spend.len() {
+        if found_substates.len() != inputs_by_utxo.len() {
             return Err(StealthProviderError::UnexpectedError {
                 details: "Some stealth inputs could not be found in the provider substates".to_string(),
             }
@@ -116,7 +117,8 @@ impl<'a, P: WalletProvider<Wallet = OotleWallet>> StealthTransfer<'a, P> {
         }
 
         let mut required_signers = IndexSet::with_capacity(found_substates.len());
-        let mut seal_signer = None;
+        // Accessing the account component to take the revealed input bucket requires the account key's badge, so it
+        // must seal; otherwise the inputs' own one-time keys are all the transaction needs.
         let must_sign_with_account_key = self.spec.revealed_input_amount.is_positive();
         let mut resolved_inputs = Vec::with_capacity(found_substates.len());
 
@@ -156,33 +158,22 @@ impl<'a, P: WalletProvider<Wallet = OotleWallet>> StealthTransfer<'a, P> {
                 }
                 .into());
             };
-            let Some(spender_addr) = substate_id_to_addr_map.get(&id) else {
+            let Some((spender_addr, to_spend)) = inputs_by_utxo.remove(&id) else {
                 tracing::warn!(
                     "The provider returned a substate that we did not request: {id}. We'll continue but that should \
                      never happen!"
                 );
                 continue;
             };
-            if !must_sign_with_account_key && seal_signer.is_none() {
-                seal_signer = Some(StealthSignerRequirement::new(spender_addr.clone(), public_nonce));
-            } else {
-                required_signers.insert(StealthSignerRequirement::new(spender_addr.clone(), public_nonce));
-            }
-
-            let Some(to_spend) = self.spec.inputs_to_spend.remove(spender_addr) else {
-                return Err(StealthProviderError::UnexpectedError {
-                    details: format!("No stealth input to spend for resolved address {spender_addr}"),
-                }
-                .into());
-            };
+            required_signers.insert(StealthSignerRequirement::new(spender_addr, public_nonce));
 
             resolved_inputs.push(ResolvedStealthInput::new(to_spend, input.output().clone()));
         }
 
         let signatures = if must_sign_with_account_key {
-            SignatureRequirements::new_must_sign_with_account_key(required_signers)
+            SignatureRequirements::account_key_seal_with(required_signers)
         } else {
-            SignatureRequirements::new_opt_with_seal_signer(required_signers, seal_signer)
+            SignatureRequirements::stealth_seal(required_signers)
         };
 
         Ok((resolved_inputs, signatures))
@@ -200,9 +191,10 @@ impl<'a, P: WalletProvider<Wallet = OotleWallet>> StealthTransfer<'a, P> {
         self
     }
 
+    /// Spend a stealth input owned by `owner_address`. Call repeatedly to spend several inputs, including several
+    /// owned by the same address.
     pub fn spend_stealth_input<I: Into<StealthInput>>(mut self, owner_address: Address, input: I) -> Self {
-        let input = input.into();
-        self.spec.inputs_to_spend.insert(owner_address, input);
+        self.spec.inputs_to_spend.push((owner_address, input.into()));
         self
     }
 
@@ -230,7 +222,7 @@ impl<'a, P: WalletProvider<Wallet = OotleWallet>> StealthTransfer<'a, P> {
 pub struct StealthTransferSpec {
     pub resource_address: ResourceAddress,
     pub revealed_input_amount: Amount,
-    pub inputs_to_spend: HashMap<Address, StealthInput>,
+    pub inputs_to_spend: Vec<(Address, StealthInput)>,
     pub outputs: Vec<Output>,
     pub revealed_output_amount: Amount,
 }

--- a/crates/wallet/ootle-rs/src/stealth/builder.rs
+++ b/crates/wallet/ootle-rs/src/stealth/builder.rs
@@ -1,8 +1,6 @@
 //   Copyright 2026 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::collections::HashMap;
-
 use indexmap::IndexSet;
 use ootle_byte_type::FromByteType;
 use tari_ootle_common_types::engine_types::{stealth::validate_transfer, substate::SubstateId};
@@ -89,44 +87,48 @@ impl<'a, P: WalletProvider<Wallet = OotleWallet>> StealthTransfer<'a, P> {
     /// here is public material, so it stays on this side of the
     /// [`StealthStatementProvider`](crate::stealth::StealthStatementProvider) boundary.
     async fn resolve_inputs(&mut self) -> WalletResult<(Vec<ResolvedStealthInput>, SignatureRequirements)> {
-        // Keyed by the UTXO each input spends, so that several inputs owned by the same address stay distinct.
-        let mut inputs_by_utxo = self
-            .spec
-            .inputs_to_spend
-            .drain(..)
-            .map(|(addr, i)| {
-                (
-                    SubstateId::from(UtxoAddress::new(self.spec.resource_address, i.commitment.into())),
-                    (addr, i),
-                )
-            })
-            .collect::<HashMap<_, _>>();
+        // The UTXO each input spends, in the order the caller added them. A commitment may only appear once: the same
+        // UTXO cannot be spent twice, and two entries naming it would otherwise silently collapse into one.
+        let mut utxo_ids = Vec::with_capacity(self.spec.inputs_to_spend.len());
+        for (_, input) in &self.spec.inputs_to_spend {
+            let id = SubstateId::from(UtxoAddress::new(self.spec.resource_address, input.commitment.into()));
+            if utxo_ids.contains(&id) {
+                return Err(StealthProviderError::UnexpectedError {
+                    details: format!("The stealth input {id} was added to this transfer more than once"),
+                }
+                .into());
+            }
+            utxo_ids.push(id);
+        }
 
-        let found_substates = self
+        let mut found_substates = self
             .provider
-            .fetch_substates(inputs_by_utxo.keys().cloned())
+            .fetch_substates(utxo_ids.iter().cloned())
             .await
             .map_err(|e| StealthProviderError::UnexpectedError {
                 details: format!("Failed to fetch stealth input substates: {}", e),
             })?;
-        if found_substates.len() != inputs_by_utxo.len() {
-            return Err(StealthProviderError::UnexpectedError {
-                details: "Some stealth inputs could not be found in the provider substates".to_string(),
-            }
-            .into());
-        }
 
-        let mut required_signers = IndexSet::with_capacity(found_substates.len());
+        let mut required_signers = IndexSet::with_capacity(utxo_ids.len());
         // Accessing the account component to take the revealed input bucket requires the account key's badge, so it
         // must seal; otherwise the inputs' own one-time keys are all the transaction needs.
         let must_sign_with_account_key = self.spec.revealed_input_amount.is_positive();
-        let mut resolved_inputs = Vec::with_capacity(found_substates.len());
+        let mut resolved_inputs = Vec::with_capacity(utxo_ids.len());
 
-        for (id, substate) in found_substates {
+        // Driven by the caller's inputs rather than the fetched substates, which arrive in a `HashMap`: the first
+        // input is promoted to seal signer, so iterating in a nondeterministic order would pick a different seal
+        // signer, and order the statement's inputs differently, from one run to the next.
+        for ((spender_addr, to_spend), id) in self.spec.inputs_to_spend.drain(..).zip(utxo_ids) {
             // TODO: work on the error types
             let Some(address) = id.as_utxo_address() else {
                 return Err(StealthProviderError::UnexpectedError {
                     details: format!("Expected UTXO address substate id, got: {}", id),
+                }
+                .into());
+            };
+            let Some(substate) = found_substates.remove(&id) else {
+                return Err(StealthProviderError::UnexpectedError {
+                    details: format!("The stealth input {id} could not be found in the provider substates"),
                 }
                 .into());
             };
@@ -157,13 +159,6 @@ impl<'a, P: WalletProvider<Wallet = OotleWallet>> StealthTransfer<'a, P> {
                     ),
                 }
                 .into());
-            };
-            let Some((spender_addr, to_spend)) = inputs_by_utxo.remove(&id) else {
-                tracing::warn!(
-                    "The provider returned a substate that we did not request: {id}. We'll continue but that should \
-                     never happen!"
-                );
-                continue;
             };
             required_signers.insert(StealthSignerRequirement::new(spender_addr, public_nonce));
 
@@ -241,5 +236,179 @@ impl StealthTransferSpec {
     pub fn total_output_amount(&self) -> Amount {
         let stealth_output_total: Amount = self.outputs.iter().map(|o| Amount::from(o.amount.get())).sum();
         stealth_output_total + self.revealed_output_amount
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::{HashMap, HashSet},
+        num::NonZeroU64,
+        sync::Weak,
+    };
+
+    use tari_ootle_common_types::engine_types::{Utxo, UtxoOutput, crypto::OutputBody, substate::Substate};
+    use tari_ootle_transaction::UnsignedTransaction;
+    use tari_template_lib_types::{
+        constants::TARI_TOKEN,
+        crypto::UtxoTag,
+        stealth::{SpendAuthorization, StealthUnspentOutput},
+    };
+
+    use super::*;
+    use crate::{
+        Network,
+        key_provider::PrivateKeyProvider,
+        provider::{ProviderResult, WantInput},
+        stealth::{StealthOutputStatementFactory, spec::SealSource},
+        transaction::TransactionSigner,
+    };
+
+    /// A provider that serves a fixed set of substates and nothing else. Only [`Provider::fetch_substates`] and
+    /// [`WalletProvider::wallet`] are reached by input resolution.
+    struct FixedSubstateProvider {
+        wallet: OotleWallet,
+        address: Address,
+        substates: HashMap<SubstateId, Substate>,
+    }
+
+    impl Provider for FixedSubstateProvider {
+        type Client = ();
+
+        fn network(&self) -> Network {
+            Network::LocalNet
+        }
+
+        fn weak_client(&self) -> Weak<Self::Client> {
+            Weak::new()
+        }
+
+        fn default_signer_address(&self) -> &Address {
+            &self.address
+        }
+
+        async fn resolve_input_want_list(
+            &self,
+            transaction: UnsignedTransaction,
+            _want_list: &HashSet<WantInput>,
+        ) -> ProviderResult<UnsignedTransaction> {
+            Ok(transaction)
+        }
+
+        async fn fetch_substates<I: IntoIterator<Item = SubstateId> + Send>(
+            &self,
+            substate_ids: I,
+        ) -> ProviderResult<HashMap<SubstateId, Substate>> {
+            Ok(substate_ids
+                .into_iter()
+                .filter_map(|id| self.substates.get(&id).map(|s| (id, s.clone())))
+                .collect())
+        }
+    }
+
+    impl WalletProvider for FixedSubstateProvider {
+        type Wallet = OotleWallet;
+
+        fn wallet(&self) -> &Self::Wallet {
+            &self.wallet
+        }
+
+        fn wallet_mut(&mut self) -> &mut Self::Wallet {
+            &mut self.wallet
+        }
+    }
+
+    /// Mint `count` stealth outputs owned by a fresh key provider and serve them as spendable UTXO substates.
+    async fn provider_owning(count: usize) -> (FixedSubstateProvider, Address, Vec<StealthUnspentOutput>) {
+        let key_provider = PrivateKeyProvider::random(Network::LocalNet);
+        let address = key_provider.address().clone();
+
+        let specs = (0..count)
+            .map(|i| {
+                Output::new(
+                    address.clone(),
+                    TARI_TOKEN,
+                    NonZeroU64::new(1_000_000 + i as u64).expect("test value is non-zero"),
+                )
+            })
+            .collect();
+        let (statement, _mask) = key_provider
+            .generate_outputs_statement(specs, Amount::zero())
+            .await
+            .expect("minting stealth outputs must succeed");
+
+        let substates = statement
+            .outputs
+            .iter()
+            .map(|minted| {
+                let id = SubstateId::from(UtxoAddress::new(TARI_TOKEN, minted.output.commitment.into()));
+                let utxo = Utxo::new(UtxoOutput {
+                    output: OutputBody {
+                        public_nonce: minted.output.sender_public_nonce,
+                        encrypted_data: minted.output.encrypted_data.clone(),
+                        minimum_value_promise: minted.output.minimum_value_promise,
+                        viewable_balance: None,
+                    },
+                    auth: SpendAuthorization::Key(*address.account_public_key()),
+                    tag: UtxoTag::new(0),
+                });
+                (id, Substate::new(0, utxo))
+            })
+            .collect();
+
+        let provider = FixedSubstateProvider {
+            wallet: OotleWallet::from(key_provider),
+            address: address.clone(),
+            substates,
+        };
+        (provider, address, statement.outputs)
+    }
+
+    /// The seal signer and the statement's input order follow the order inputs were added, not the hash order the
+    /// provider happens to return its substates in.
+    #[tokio::test]
+    async fn input_resolution_follows_the_order_inputs_were_added() {
+        let (provider, address, minted) = provider_owning(4).await;
+        let commitments: Vec<_> = minted.iter().map(|o| o.output.commitment).collect();
+
+        // Resolving the same inputs repeatedly must agree; a HashMap-ordered resolution would drift across runs.
+        let mut seen = None;
+        for _ in 0..8 {
+            let mut transfer = StealthTransfer::new(TARI_TOKEN, &provider);
+            for commitment in &commitments {
+                transfer = transfer.spend_stealth_input(address.clone(), *commitment);
+            }
+
+            let (resolved, requirements) = transfer.resolve_inputs().await.expect("inputs are owned and unspent");
+
+            let order: Vec<_> = resolved.iter().map(|i| *i.commitment()).collect();
+            assert_eq!(order, commitments, "inputs must resolve in the order they were added");
+
+            let SealSource::StealthInput(seal_signer) = requirements.seal() else {
+                panic!("stealth inputs with no revealed input must seal with a stealth key");
+            };
+            let nonce = seal_signer.public_nonce().clone();
+            assert_eq!(
+                seen.get_or_insert_with(|| nonce.clone()),
+                &nonce,
+                "the seal signer must not vary across runs"
+            );
+        }
+    }
+
+    /// Spending the same UTXO twice is rejected rather than silently collapsing to a single input.
+    #[tokio::test]
+    async fn the_same_input_cannot_be_spent_twice() {
+        let (provider, address, minted) = provider_owning(1).await;
+        let commitment = minted[0].output.commitment;
+
+        let err = StealthTransfer::new(TARI_TOKEN, &provider)
+            .spend_stealth_input(address.clone(), commitment)
+            .spend_stealth_input(address, commitment)
+            .resolve_inputs()
+            .await
+            .expect_err("the same UTXO cannot be spent twice");
+
+        assert!(err.to_string().contains("more than once"), "unexpected error: {err}");
     }
 }

--- a/crates/wallet/ootle-rs/src/stealth/spec.rs
+++ b/crates/wallet/ootle-rs/src/stealth/spec.rs
@@ -1,7 +1,7 @@
 //   Copyright 2026 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::{num::NonZeroU64, ops::Not};
+use std::num::NonZeroU64;
 
 use indexmap::IndexSet;
 use tari_crypto::ristretto::RistrettoPublicKey;
@@ -37,85 +37,92 @@ impl StealthSignerRequirement {
     }
 }
 
-/// Specifies the signature requirements for a stealth transfer transaction.
-/// This aims to capture the invariants around which signers are required to sign a transaction to either provider the
-/// necessary access or to stealth inputs and/or substate components. If no access is required to substate components,
-/// the public keys appear to be ephemeral to any outside observer. If no input access nor substate access is required,
-/// an ephemeral key can be used to seal the transaction.
+/// The key that seals a stealth transaction.
+///
+/// Every authorization signature commits to the seal signer's public key, so which key seals must be settled — and
+/// its public key known — before any authorization is produced.
+// One instance exists per transaction, so the size gap to the unit variants does not matter.
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SealSource {
+    /// The wallet's default account key seals. Required whenever the transaction touches the account component itself,
+    /// e.g. it funds the transfer from a revealed input bucket.
+    AccountKey,
+    /// A stealth input's one-time key seals. The seal signature is that input's spend authorization, which is why the
+    /// same signer does not also appear in [`SignatureRequirements::authorizers`].
+    StealthInput(StealthSignerRequirement),
+    /// Nothing is spent and the account is not touched, so a fresh one-time key seals and is discarded. This keeps the
+    /// wallet's account key off a transaction that has no need of it.
+    Ephemeral,
+}
+
+/// Which key seals a stealth transfer transaction, and which stealth signers must additionally authorize it.
+///
+/// Every stealth input has to be authorized by its owner's one-time key. One of those signers seals the transaction —
+/// its seal signature doubles as its own authorization — and the rest sign an authorization committing to the seal
+/// signer's public key. When the account component itself is accessed (a revealed input bucket) the account key must
+/// seal instead, and every stealth input signer authorizes. When neither applies the public keys on the transaction
+/// are ephemeral to an outside observer.
 #[derive(Debug, Clone)]
 pub struct SignatureRequirements {
-    required_signers: IndexSet<StealthSignerRequirement>,
-    must_sign_with_account_key: bool,
-    seal_signer: Option<StealthSignerRequirement>,
+    seal: SealSource,
+    authorizers: IndexSet<StealthSignerRequirement>,
 }
 
 impl SignatureRequirements {
-    /// Creates a new `SignatureSpec` where the account key must sign, along with the provided required signers.
-    /// The seal signer is always None, meaning users should sign with some account key.
-    pub fn new_must_sign_with_account_key(required_signers: IndexSet<StealthSignerRequirement>) -> Self {
+    /// The account key seals and each of `authorizers` authorizes with its one-time stealth key. Use when the
+    /// transaction accesses the account component, e.g. it spends a revealed input bucket.
+    pub fn account_key_seal_with(authorizers: IndexSet<StealthSignerRequirement>) -> Self {
         Self {
-            required_signers,
-            must_sign_with_account_key: true,
-            seal_signer: None,
+            seal: SealSource::AccountKey,
+            authorizers,
         }
     }
 
-    /// A requirement where the wallet's account key seals the transaction and no stealth signers are derived. The
-    /// account key is the seal signer only (`is_seal_signer_authorized` stays false when authorizations are attached),
-    /// so its badge is not added to the auth scope. Use this when every authorization is supplied externally — e.g. a
-    /// script-path `AccessRule` leaf whose keys the wallet does not own (adaptor-signature co-signers) — so the seal
-    /// signer, and hence the authorization message, is fixed and known before the authorizations are produced.
+    /// The account key seals and no stealth signers are derived. Use this when every authorization is supplied
+    /// externally — e.g. a script-path `AccessRule` leaf whose keys the wallet does not own (adaptor-signature
+    /// co-signers) — so the seal signer, and hence the authorization message, is known without consulting a key
+    /// provider.
     pub fn account_key_seal() -> Self {
-        Self::new_must_sign_with_account_key(IndexSet::new())
+        Self::account_key_seal_with(IndexSet::new())
     }
 
-    /// Creates a new `SignatureSpec` with the provided required signers and an optional seal signer.
-    /// The account key is not required to sign the transaction. If there are no required signers, an ephemeral key
-    /// will be used to seal the transaction.
-    pub fn new_opt_with_seal_signer(
-        required_signers: IndexSet<StealthSignerRequirement>,
-        seal_signer: Option<StealthSignerRequirement>,
+    /// The first of `signers` seals with its one-time stealth key and the rest authorize against it. With no signers
+    /// there is nothing to authorize and an ephemeral key seals.
+    pub fn stealth_seal(signers: IndexSet<StealthSignerRequirement>) -> Self {
+        let mut signers = signers.into_iter();
+        match signers.next() {
+            Some(seal_signer) => Self::stealth_seal_with(seal_signer, signers.collect()),
+            None => Self {
+                seal: SealSource::Ephemeral,
+                authorizers: IndexSet::new(),
+            },
+        }
+    }
+
+    /// `seal_signer` seals with its one-time stealth key and each of `authorizers` authorizes against it. Use when the
+    /// sealing input is not the first one.
+    pub fn stealth_seal_with(
+        seal_signer: StealthSignerRequirement,
+        authorizers: IndexSet<StealthSignerRequirement>,
     ) -> Self {
         Self {
-            required_signers,
-            must_sign_with_account_key: false,
-            seal_signer,
+            seal: SealSource::StealthInput(seal_signer),
+            authorizers,
         }
     }
 
-    pub fn must_sign_with_account_key(&self) -> bool {
-        self.must_sign_with_account_key
+    pub fn seal(&self) -> &SealSource {
+        &self.seal
     }
 
-    pub fn can_sign_with_ephemeral_key(&self) -> bool {
-        !self.must_sign_with_account_key && self.required_signers.is_empty() && self.seal_signer.is_none()
+    pub fn into_parts(self) -> (SealSource, IndexSet<StealthSignerRequirement>) {
+        (self.seal, self.authorizers)
     }
 
-    /// Returns the seal signer to be used for the transaction.
-    /// If `must_sign_with_account_key()` is true, returns None.
-    /// If `must_sign_with_account_key()` is false, and `can_sign_with_ephemeral_key()` is true, returns None
-    /// If `must_sign_with_account_key()` is false, and `can_sign_with_ephemeral_key()` is false, returns the seal
-    /// signer if set, otherwise returns the first required signer.
-    pub fn seal_signer(&self) -> Option<&StealthSignerRequirement> {
-        self.must_sign_with_account_key
-            .not()
-            .then(|| self.seal_signer.as_ref().or_else(|| self.required_signers.first()))
-            .flatten()
-    }
-
-    pub fn other_signers(&self) -> impl Iterator<Item = &StealthSignerRequirement> {
-        // Skip the first signer if must_sign_with_account_key is true and seal signer is not set because that signer is
-        // used as the seal signer
-        let skip = usize::from(!self.must_sign_with_account_key && self.seal_signer.is_none());
-        self.required_signers.iter().skip(skip)
-    }
-
-    pub fn len(&self) -> usize {
-        self.required_signers.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.required_signers.is_empty()
+    /// The signers that must produce an authorization signature, each committing to the seal signer's public key.
+    pub fn authorizers(&self) -> impl ExactSizeIterator<Item = &StealthSignerRequirement> {
+        self.authorizers.iter()
     }
 }
 
@@ -275,71 +282,74 @@ mod tests {
         StealthSignerRequirement::new(addr, pk)
     }
 
+    fn signers<const N: usize>(seeds: [u8; N]) -> IndexSet<StealthSignerRequirement> {
+        seeds.into_iter().map(signer_from_seed).collect()
+    }
+
     mod signature_requirement_invariants {
         use super::*;
 
-        /// If `must_sign_with_account_key()` is true, returns None.
+        /// The account key seals and every stealth signer authorizes: none of them is promoted to seal signer.
         #[test]
-        fn invariant1() {
-            let signer1 = signer_from_seed(1);
-            let signer2 = signer_from_seed(2);
-            let mut required_signers = IndexSet::new();
-            required_signers.insert(signer1.clone());
-            required_signers.insert(signer2.clone());
+        fn account_key_seal_authorizes_every_signer() {
+            let spec = SignatureRequirements::account_key_seal_with(signers([1, 2]));
 
-            let spec = SignatureRequirements::new_must_sign_with_account_key(required_signers);
-            assert!(spec.must_sign_with_account_key());
-            assert!(!spec.can_sign_with_ephemeral_key());
-            assert_eq!(spec.seal_signer(), None);
-
-            let other_signers = spec.other_signers().collect::<Vec<_>>();
-            assert_eq!(other_signers, vec![&signer1, &signer2]);
+            assert_eq!(spec.seal(), &SealSource::AccountKey);
+            assert_eq!(spec.authorizers().collect::<Vec<_>>(), vec![
+                &signer_from_seed(1),
+                &signer_from_seed(2)
+            ]);
         }
 
-        /// If `must_sign_with_account_key()` is false, and `can_sign_with_ephemeral_key()` is false, returns the seal
-        /// signer if set, otherwise returns the first required signer.
+        /// With no stealth signers the account key is the only signature on the transaction.
         #[test]
-        fn invariant2() {
-            let signer1 = signer_from_seed(1);
-            let signer2 = signer_from_seed(2);
-            let mut required_signers = IndexSet::new();
-            required_signers.insert(signer1.clone());
-            required_signers.insert(signer2.clone());
+        fn account_key_seal_without_signers_has_no_authorizers() {
+            let spec = SignatureRequirements::account_key_seal();
 
-            let spec = SignatureRequirements::new_opt_with_seal_signer(required_signers, None);
-            assert!(!spec.must_sign_with_account_key());
-            assert!(!spec.can_sign_with_ephemeral_key());
-            let seal_signer = spec.seal_signer();
-            assert_eq!(seal_signer, Some(&signer1));
-
-            let other_signers = spec.other_signers().collect::<Vec<_>>();
-            assert_eq!(other_signers, vec![&signer2]);
-
-            let signer3 = signer_from_seed(3);
-            let mut required_signers = IndexSet::new();
-            required_signers.insert(signer1.clone());
-            required_signers.insert(signer3.clone());
-
-            let spec = SignatureRequirements::new_opt_with_seal_signer(required_signers, Some(signer2.clone()));
-            assert!(!spec.must_sign_with_account_key());
-            assert!(!spec.can_sign_with_ephemeral_key());
-            let seal_signer = spec.seal_signer();
-            assert_eq!(seal_signer, Some(&signer2));
-
-            let other_signers = spec.other_signers().collect::<Vec<_>>();
-            assert_eq!(other_signers, vec![&signer1, &signer3]);
+            assert_eq!(spec.seal(), &SealSource::AccountKey);
+            assert_eq!(spec.authorizers().len(), 0);
         }
 
-        /// If `must_sign_with_account_key()` is false, and `can_sign_with_ephemeral_key()` is true, returns None
+        /// The first stealth signer is promoted to seal signer; the rest authorize against it.
         #[test]
-        fn invariant3() {
-            // Case 1: seal signer is set
-            let spec = SignatureRequirements::new_opt_with_seal_signer(Default::default(), None);
-            assert!(!spec.must_sign_with_account_key());
-            assert!(spec.can_sign_with_ephemeral_key());
-            let seal_signer = spec.seal_signer();
-            assert_eq!(seal_signer, None);
-            assert_eq!(spec.other_signers().next(), None);
+        fn stealth_seal_promotes_the_first_signer() {
+            let spec = SignatureRequirements::stealth_seal(signers([1, 2, 3]));
+
+            assert_eq!(spec.seal(), &SealSource::StealthInput(signer_from_seed(1)));
+            assert_eq!(spec.authorizers().collect::<Vec<_>>(), vec![
+                &signer_from_seed(2),
+                &signer_from_seed(3)
+            ]);
+        }
+
+        /// A single stealth input seals and needs no authorization: the seal signature is its own.
+        #[test]
+        fn a_single_stealth_signer_seals_and_authorizes_nothing() {
+            let spec = SignatureRequirements::stealth_seal(signers([1]));
+
+            assert_eq!(spec.seal(), &SealSource::StealthInput(signer_from_seed(1)));
+            assert_eq!(spec.authorizers().len(), 0);
+        }
+
+        /// An explicitly chosen seal signer is not one of the authorizers.
+        #[test]
+        fn stealth_seal_with_an_explicit_seal_signer() {
+            let spec = SignatureRequirements::stealth_seal_with(signer_from_seed(2), signers([1, 3]));
+
+            assert_eq!(spec.seal(), &SealSource::StealthInput(signer_from_seed(2)));
+            assert_eq!(spec.authorizers().collect::<Vec<_>>(), vec![
+                &signer_from_seed(1),
+                &signer_from_seed(3)
+            ]);
+        }
+
+        /// Nothing to spend and no account access: an ephemeral key seals.
+        #[test]
+        fn no_signers_seals_ephemerally() {
+            let spec = SignatureRequirements::stealth_seal(IndexSet::new());
+
+            assert_eq!(spec.seal(), &SealSource::Ephemeral);
+            assert_eq!(spec.authorizers().len(), 0);
         }
     }
 }

--- a/crates/wallet/ootle-rs/src/transaction/ephemeral_signer.rs
+++ b/crates/wallet/ootle-rs/src/transaction/ephemeral_signer.rs
@@ -11,8 +11,9 @@ use tari_ootle_transaction::{Transaction, UnsealedTransaction};
 use tari_template_lib_types::crypto::RistrettoPublicKeyBytes;
 
 /// A transaction seal signer that uses an ephemeral secret.
-/// WARNING: This signer generates a cryptographically secure secret, signs a transaction and throws the secret away.
-/// You probably want to use another implementation e.g. OotleWallet
+/// WARNING: This signer generates a cryptographically secure secret and keeps it for its own lifetime. Every
+/// transaction it seals therefore carries the same seal public key and is linkable to the others, so a signer must not
+/// outlive the transaction it seals. You probably want to use another implementation e.g. OotleWallet
 ///
 /// This is primarily used in pure stealth transactions where no accounts/components are accessed, no inputs are being
 /// spent etc. and thus no specific signature is required.

--- a/crates/wallet/ootle-rs/src/transaction/ephemeral_signer.rs
+++ b/crates/wallet/ootle-rs/src/transaction/ephemeral_signer.rs
@@ -1,9 +1,14 @@
 //   Copyright 2026 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+use ootle_byte_type::ToByteType;
 use rand::{CryptoRng, Rng};
-use tari_crypto::{keys::SecretKey, ristretto::RistrettoSecretKey};
+use tari_crypto::{
+    keys::{PublicKey, SecretKey},
+    ristretto::{RistrettoPublicKey, RistrettoSecretKey},
+};
 use tari_ootle_transaction::{Transaction, UnsealedTransaction};
+use tari_template_lib_types::crypto::RistrettoPublicKeyBytes;
 
 /// A transaction seal signer that uses an ephemeral secret.
 /// WARNING: This signer generates a cryptographically secure secret, signs a transaction and throws the secret away.
@@ -26,7 +31,13 @@ impl EphemeralKeySigner {
         Self::random_with(&mut rand::rng())
     }
 
-    pub fn seal_transaction(self, transaction: UnsealedTransaction) -> Transaction {
+    /// The public key this signer seals with. An authorization made before the seal must commit to it, so it has to be
+    /// available without sealing.
+    pub fn public_key(&self) -> RistrettoPublicKeyBytes {
+        RistrettoPublicKey::from_secret_key(&self.key).to_byte_type()
+    }
+
+    pub fn seal_transaction(&self, transaction: UnsealedTransaction) -> Transaction {
         transaction.seal(&self.key)
     }
 }

--- a/crates/wallet/ootle-rs/src/transaction/signer.rs
+++ b/crates/wallet/ootle-rs/src/transaction/signer.rs
@@ -30,7 +30,19 @@ pub trait TransactionSigner {
 /// The seal signature is the last signature applied, proving that the transaction
 /// originator approved the final set of instructions and authorizations.
 #[async_trait]
-pub trait TransactionSealSigner {
+pub trait TransactionSealSigner: Sync {
+    /// The authorizations this signer contributes, produced before the transaction is sealed.
+    ///
+    /// Each one commits to the public key this signer will seal with, so only the seal signer can produce them —
+    /// which is why they are made here rather than by the caller. Defaults to none: a signer that seals with a key
+    /// the caller already knows has nothing to add.
+    async fn create_authorizations(
+        &self,
+        _unsigned: &UnsignedTransaction,
+    ) -> signer::Result<Vec<TransactionAuthorization>> {
+        Ok(Vec::new())
+    }
+
     /// Asynchronously sign (seal) an unsealed transaction.
     async fn seal_transaction(&self, transaction: UnsealedTransaction) -> signer::Result<Transaction>;
 }
@@ -38,6 +50,12 @@ pub trait TransactionSealSigner {
 /// Trait for signing transactions using derived stealth keys for confidential transactions.
 #[async_trait]
 pub trait TransactionStealthKeySigner {
+    /// The one-time public key this signer signs with for `public_nonce`, derived without producing a signature.
+    ///
+    /// Every authorization signature commits to the seal signer's public key, so when a stealth input seals, its
+    /// one-time key must be resolvable before any authorization is made.
+    async fn stealth_public_key(&self, public_nonce: &RistrettoPublicKey) -> signer::Result<RistrettoPublicKeyBytes>;
+
     async fn sign_authorization_with_stealth(
         &self,
         public_nonce: &RistrettoPublicKey,

--- a/crates/wallet/ootle-rs/src/transaction/signer.rs
+++ b/crates/wallet/ootle-rs/src/transaction/signer.rs
@@ -36,7 +36,7 @@ pub trait TransactionSealSigner: Sync {
     /// Each one commits to the public key this signer will seal with, so only the seal signer can produce them —
     /// which is why they are made here rather than by the caller. Defaults to none: a signer that seals with a key
     /// the caller already knows has nothing to add.
-    async fn create_authorizations(
+    async fn authorizations_for(
         &self,
         _unsigned: &UnsignedTransaction,
     ) -> signer::Result<Vec<TransactionAuthorization>> {

--- a/crates/wallet/ootle-rs/src/types/transaction/request.rs
+++ b/crates/wallet/ootle-rs/src/types/transaction/request.rs
@@ -61,14 +61,18 @@ impl<State> TransactionRequest<State> {
 }
 
 impl TransactionRequest<WithTx> {
+    /// The transaction with the caller's authorizations attached, but unsealed. Only [`build`](Self::build) can add
+    /// the seal signer's own authorizations, since those commit to the key it seals with.
     pub fn build_unsealed(self) -> UnsealedTransaction {
-        self.state.0.finish()
+        self.state
+            .0
+            .with_signatures(self.authorizations.into_iter().map(|a| a.into_signature()).collect())
     }
 
     pub async fn build(self, seal_signer: &dyn TransactionSealSigner) -> WalletResult<Transaction> {
         let unsigned = self.state.0;
         let mut authorizations = self.authorizations;
-        authorizations.extend(seal_signer.create_authorizations(&unsigned).await?);
+        authorizations.extend(seal_signer.authorizations_for(&unsigned).await?);
 
         let unsealed = unsigned.with_signatures(authorizations.into_iter().map(|a| a.into_signature()).collect());
         let final_tx = seal_signer.seal_transaction(unsealed).await?;

--- a/crates/wallet/ootle-rs/src/types/transaction/request.rs
+++ b/crates/wallet/ootle-rs/src/types/transaction/request.rs
@@ -66,8 +66,11 @@ impl TransactionRequest<WithTx> {
     }
 
     pub async fn build(self, seal_signer: &dyn TransactionSealSigner) -> WalletResult<Transaction> {
-        let builder = self.state.0;
-        let unsealed = builder.with_signatures(self.authorizations.into_iter().map(|a| a.into_signature()).collect());
+        let unsigned = self.state.0;
+        let mut authorizations = self.authorizations;
+        authorizations.extend(seal_signer.create_authorizations(&unsigned).await?);
+
+        let unsealed = unsigned.with_signatures(authorizations.into_iter().map(|a| a.into_signature()).collect());
         let final_tx = seal_signer.seal_transaction(unsealed).await?;
         Ok(final_tx)
     }

--- a/crates/wallet/ootle-rs/src/wallet/ootle.rs
+++ b/crates/wallet/ootle-rs/src/wallet/ootle.rs
@@ -186,6 +186,8 @@ impl OotleWallet {
         Ok(statement)
     }
 
+    /// An authorizer for one transaction. Call this per transaction rather than reusing the result: an ephemeral seal
+    /// draws its key here, so a shared authorizer seals every transaction with the same key and links them.
     pub fn stealth_authorizer(&self, required_signatures: SignatureRequirements) -> WalletStealthAuthorizer<'_, Self> {
         WalletStealthAuthorizer::new(self, required_signatures)
     }

--- a/crates/wallet/ootle-rs/src/wallet/ootle.rs
+++ b/crates/wallet/ootle-rs/src/wallet/ootle.rs
@@ -190,6 +190,20 @@ impl OotleWallet {
         WalletStealthAuthorizer::new(self, required_signatures)
     }
 
+    /// The one-time public key `address` signs a stealth input with, derived from the input's `public_nonce`.
+    /// See [`crate::transaction::TransactionStealthKeySigner::stealth_public_key`].
+    pub async fn stealth_public_key(
+        &self,
+        address: &Address,
+        public_nonce: &RistrettoPublicKey,
+    ) -> signer::Result<RistrettoPublicKeyBytes> {
+        let signer = self.key_providers.get(address).ok_or_else(|| {
+            signer::SignerError::other(format!("Signer for address {address} not found in wallet signers"))
+        })?;
+
+        signer.stealth_public_key(public_nonce).await
+    }
+
     pub async fn authorize_transaction_with_stealth_key(
         &self,
         address: &Address,

--- a/crates/wallet/ootle-rs/src/wallet/stealth.rs
+++ b/crates/wallet/ootle-rs/src/wallet/stealth.rs
@@ -1,105 +1,120 @@
 //   Copyright 2026 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::ops::Not;
-
 use async_trait::async_trait;
+use indexmap::IndexSet;
 use tari_ootle_transaction::{Transaction, TransactionSignature, UnsealedTransaction, UnsignedTransaction};
 use tari_template_lib_types::crypto::RistrettoPublicKeyBytes;
 
 use crate::{
     Address,
+    TransactionRequest,
     signer,
-    stealth::SignatureRequirements,
+    stealth::{SealSource, SignatureRequirements, StealthSignerRequirement},
     transaction::{TransactionSealSigner, ephemeral_signer::EphemeralKeySigner},
     wallet::{NetworkWallet, OotleWallet, TransactionAuthorization, WalletResult},
 };
 
+/// The seal key this authorizer will use, resolved from a [`SealSource`].
+///
+/// The ephemeral key is drawn when the authorizer is constructed rather than when the transaction is sealed, so that
+/// an authorization taken from [`WalletStealthAuthorizer::authorization_message`] commits to the key that actually
+/// ends up sealing.
+#[allow(clippy::large_enum_variant)]
+enum Seal {
+    AccountKey,
+    StealthInput(StealthSignerRequirement),
+    Ephemeral(EphemeralKeySigner),
+}
+
+impl From<SealSource> for Seal {
+    fn from(source: SealSource) -> Self {
+        match source {
+            SealSource::AccountKey => Self::AccountKey,
+            SealSource::StealthInput(signer) => Self::StealthInput(signer),
+            SealSource::Ephemeral => Self::Ephemeral(EphemeralKeySigner::random()),
+        }
+    }
+}
+
+/// Seals a stealth transaction and produces the stealth authorization signatures its inputs require.
+///
+/// Both halves live here because an authorization signs a message committing to the seal signer's public key: only
+/// whoever decides the seal key can produce them, and they must be attached before the seal signature is made over
+/// them.
 pub struct WalletStealthAuthorizer<'a, W: ?Sized> {
     wallet: &'a W,
-    required_signatures: SignatureRequirements,
+    seal: Seal,
+    authorizers: IndexSet<StealthSignerRequirement>,
 }
 
 impl<'a, W: ?Sized> WalletStealthAuthorizer<'a, W> {
     pub fn new(wallet: &'a W, required_signatures: SignatureRequirements) -> Self {
+        let (seal, authorizers) = required_signatures.into_parts();
         Self {
             wallet,
-            required_signatures,
+            seal: seal.into(),
+            authorizers,
         }
     }
 }
 
 impl WalletStealthAuthorizer<'_, OotleWallet> {
-    /// The public key that will seal the transaction: the wallet's default account key when an account-key seal is
-    /// required, otherwise the designated stealth seal signer. `None` when there is nothing to seal for (no inputs).
-    pub fn seal_signer(&self) -> Option<&RistrettoPublicKeyBytes> {
-        if self.required_signatures.must_sign_with_account_key() {
-            Some(self.wallet.default_address().account_public_key())
-        } else {
-            self.required_signatures
-                .seal_signer()
-                .map(|s| s.signer().account_public_key())
+    /// The public key that seals the transaction. A stealth seal derives the input owner's one-time key, so this
+    /// consults the owning key provider.
+    pub async fn seal_public_key(&self) -> signer::Result<RistrettoPublicKeyBytes> {
+        match &self.seal {
+            Seal::AccountKey => Ok(*self.wallet.default_address().account_public_key()),
+            Seal::StealthInput(signer) => {
+                self.wallet
+                    .stealth_public_key(signer.signer(), signer.public_nonce())
+                    .await
+            },
+            Seal::Ephemeral(signer) => Ok(signer.public_key()),
         }
     }
 
     /// The exact message every authorization signature for this transaction must sign. An external co-signer (or an
     /// adaptor pre-signer) produces its signature over these bytes; the resulting [`TransactionAuthorization`] is
-    /// attached via [`crate::TransactionRequest::add_authorization`]. Returns `None` when there is no seal signer to
-    /// bind the authorization to (no inputs to spend).
-    pub fn authorization_message(&self, unsigned: &UnsignedTransaction) -> Option<[u8; 64]> {
-        let seal_signer = self.seal_signer()?;
+    /// attached via [`crate::TransactionRequest::add_authorization`].
+    pub async fn authorization_message(&self, unsigned: &UnsignedTransaction) -> signer::Result<[u8; 64]> {
+        let seal_signer = self.seal_public_key().await?;
         let UnsignedTransaction::V1(unsigned_v1) = unsigned;
-        Some(TransactionSignature::create_message_v1(seal_signer, unsigned_v1))
-    }
-
-    pub async fn create_authorizations(
-        &self,
-        unsigned: &UnsignedTransaction,
-    ) -> signer::Result<Vec<TransactionAuthorization>> {
-        let Some(seal_signer) = self.seal_signer() else {
-            // There are no inputs to sign for
-            return Ok(vec![]);
-        };
-
-        let mut authorizations = Vec::with_capacity(self.required_signatures.len().saturating_sub(1));
-        for req in self.required_signatures.other_signers() {
-            let auth = self
-                .wallet
-                .authorize_transaction_with_stealth_key(req.signer(), req.public_nonce(), seal_signer, unsigned)
-                .await?;
-            authorizations.push(auth);
-        }
-        Ok(authorizations)
+        Ok(TransactionSignature::create_message_v1(&seal_signer, unsigned_v1))
     }
 }
 
 #[async_trait]
 impl TransactionSealSigner for WalletStealthAuthorizer<'_, OotleWallet> {
-    async fn seal_transaction(&self, transaction: UnsealedTransaction) -> signer::Result<Transaction> {
-        let stealth_seal_signer = self
-            .required_signatures
-            .must_sign_with_account_key()
-            .not()
-            .then(|| self.required_signatures.seal_signer())
-            .map(|s| s.or_else(|| self.required_signatures.other_signers().next()));
+    async fn create_authorizations(
+        &self,
+        unsigned: &UnsignedTransaction,
+    ) -> signer::Result<Vec<TransactionAuthorization>> {
+        if self.authorizers.is_empty() {
+            return Ok(Vec::new());
+        }
 
-        match stealth_seal_signer {
-            Some(Some(seal_signer)) => {
-                // Seal with a stealth key. This signature is required to spend an input.
+        let seal_signer = self.seal_public_key().await?;
+        let mut authorizations = Vec::with_capacity(self.authorizers.len());
+        for req in &self.authorizers {
+            let auth = self
+                .wallet
+                .authorize_transaction_with_stealth_key(req.signer(), req.public_nonce(), &seal_signer, unsigned)
+                .await?;
+            authorizations.push(auth);
+        }
+        Ok(authorizations)
+    }
+
+    async fn seal_transaction(&self, transaction: UnsealedTransaction) -> signer::Result<Transaction> {
+        match &self.seal {
+            Seal::AccountKey => self.wallet.seal_transaction(transaction).await,
+            Seal::StealthInput(signer) => {
                 self.wallet
-                    .seal_transaction_with_stealth_key(seal_signer.signer(), seal_signer.public_nonce(), &transaction)
+                    .seal_transaction_with_stealth_key(signer.signer(), signer.public_nonce(), &transaction)
                     .await
             },
-            Some(None) => {
-                // CASE: must_sign_with_account_key is false, but we have no inputs to spend (therefore no required
-                // signers) we can sign with "any" key (the transaction needs a seal signer). For privacy, we generate
-                // an ephemeral key rather than, say, using the wallet key.
-                Ok(EphemeralKeySigner::random().seal_transaction(transaction))
-            },
-            None => {
-                // Seal with the wallet's default key
-                self.wallet.seal_transaction(transaction).await
-            },
+            Seal::Ephemeral(signer) => Ok(signer.seal_transaction(transaction)),
         }
     }
 }
@@ -110,31 +125,165 @@ impl NetworkWallet for WalletStealthAuthorizer<'_, OotleWallet> {
     }
 
     async fn sign_transaction(&self, unsigned: UnsignedTransaction) -> WalletResult<Transaction> {
-        let authorizations = self.create_authorizations(&unsigned).await?;
-        let unsealed = unsigned.with_signatures(authorizations.into_iter().map(|a| a.into_signature()).collect());
+        TransactionRequest::new().with_transaction(unsigned).build(self).await
+    }
+}
 
-        let stealth_seal_signer = self
-            .required_signatures
-            .must_sign_with_account_key()
-            .not()
-            .then(|| self.required_signatures.seal_signer())
-            .map(|s| {
-                // We should either have must_sign_with_account_key = true or at least one signer
-                s.ok_or_else(|| {
-                    signer::SignerError::other("No signers found in required_signatures for stealth sealing")
-                })
-            })
-            .transpose()?;
+#[cfg(test)]
+mod tests {
+    use ootle_byte_type::ToByteType;
+    use tari_crypto::{
+        keys::{PublicKey, SecretKey},
+        ristretto::{RistrettoPublicKey, RistrettoSecretKey},
+    };
 
-        let tx = if let Some(seal_signer) = stealth_seal_signer {
-            // Seal with a stealth key
-            self.wallet
-                .seal_transaction_with_stealth_key(seal_signer.signer(), seal_signer.public_nonce(), &unsealed)
-                .await?
-        } else {
-            // Seal with the wallet's default key
-            self.wallet.seal_transaction(unsealed).await?
-        };
-        Ok(tx)
+    use super::*;
+    use crate::{
+        Network,
+        key_provider::PrivateKeyProvider,
+        transaction::{TransactionSigner, adaptor::sign_authorization},
+    };
+
+    /// A distinct sender public nonce, standing in for the one recorded on a spent UTXO.
+    fn public_nonce(seed: u8) -> RistrettoPublicKey {
+        let secret = RistrettoSecretKey::from_uniform_bytes(&[seed; 64]).expect("seed is the right length");
+        RistrettoPublicKey::from_secret_key(&secret)
+    }
+
+    fn wallet() -> (OotleWallet, Address) {
+        let provider = PrivateKeyProvider::random(Network::LocalNet);
+        let address = provider.address().clone();
+        (OotleWallet::from(provider), address)
+    }
+
+    /// The stealth inputs `seeds` describes, all owned by `address`.
+    fn signers<const N: usize>(address: &Address, seeds: [u8; N]) -> IndexSet<StealthSignerRequirement> {
+        seeds
+            .into_iter()
+            .map(|seed| StealthSignerRequirement::new(address.clone(), public_nonce(seed)))
+            .collect()
+    }
+
+    fn unsigned() -> UnsignedTransaction {
+        Transaction::builder(Network::LocalNet).build_unsigned()
+    }
+
+    /// Several stealth inputs owned by the same address: one seals with its one-time key and the rest authorize
+    /// against it. Every authorization must verify under the key that actually sealed.
+    #[tokio::test]
+    async fn stealth_authorizations_verify_against_the_sealing_one_time_key() {
+        let (wallet, address) = wallet();
+        let authorizer = wallet.stealth_authorizer(SignatureRequirements::stealth_seal(signers(&address, [1, 2, 3])));
+
+        let transaction = TransactionRequest::new()
+            .with_transaction(unsigned())
+            .build(&authorizer)
+            .await
+            .expect("sealing a multi-input stealth transfer must succeed");
+
+        // The two inputs that did not seal each contribute an authorization.
+        assert_eq!(transaction.signatures().len(), 2);
+        assert!(transaction.verify_all_signatures());
+
+        // The seal is the first input's one-time key, never the account key it derives from.
+        let expected_seal = wallet
+            .stealth_public_key(&address, &public_nonce(1))
+            .await
+            .expect("the wallet owns the sealing input");
+        assert_eq!(transaction.seal_signature().public_key(), &expected_seal);
+        assert_ne!(transaction.seal_signature().public_key(), address.account_public_key());
+    }
+
+    /// A single stealth input seals and authorizes nothing: the seal signature is its own spend authorization.
+    #[tokio::test]
+    async fn a_single_stealth_input_seals_without_authorizations() {
+        let (wallet, address) = wallet();
+        let authorizer = wallet.stealth_authorizer(SignatureRequirements::stealth_seal(signers(&address, [1])));
+
+        let transaction = TransactionRequest::new()
+            .with_transaction(unsigned())
+            .build(&authorizer)
+            .await
+            .expect("sealing a single-input stealth transfer must succeed");
+
+        assert!(transaction.signatures().is_empty());
+        assert!(transaction.verify_all_signatures());
+    }
+
+    /// When the account component is accessed the account key seals, and every stealth input authorizes against it.
+    #[tokio::test]
+    async fn account_key_seal_authorizes_every_stealth_input() {
+        let (wallet, address) = wallet();
+        let authorizer =
+            wallet.stealth_authorizer(SignatureRequirements::account_key_seal_with(signers(&address, [1, 2])));
+
+        let transaction = TransactionRequest::new()
+            .with_transaction(unsigned())
+            .build(&authorizer)
+            .await
+            .expect("sealing with the account key must succeed");
+
+        assert_eq!(transaction.signatures().len(), 2);
+        assert!(transaction.verify_all_signatures());
+        assert_eq!(transaction.seal_signature().public_key(), address.account_public_key());
+    }
+
+    /// An externally produced authorization signs `authorization_message`, so the key that message names must be the
+    /// key that ends up sealing — including the ephemeral one, which is drawn before the message is handed out.
+    #[tokio::test]
+    async fn an_external_authorization_verifies_against_every_seal_source() {
+        let (wallet, address) = wallet();
+        let requirements = [
+            SignatureRequirements::stealth_seal(signers(&address, [1, 2])),
+            SignatureRequirements::account_key_seal(),
+            SignatureRequirements::stealth_seal(IndexSet::new()),
+        ];
+
+        for requirement in requirements {
+            let authorizer = wallet.stealth_authorizer(requirement);
+            let unsigned = unsigned();
+
+            let secret = RistrettoSecretKey::random(&mut rand::rng());
+            let message = authorizer
+                .authorization_message(&unsigned)
+                .await
+                .expect("the seal key is resolvable before sealing");
+
+            let transaction = TransactionRequest::new()
+                .with_transaction(unsigned)
+                .add_authorization(sign_authorization(&secret, &message))
+                .build(&authorizer)
+                .await
+                .expect("sealing must succeed");
+
+            assert!(transaction.verify_all_signatures());
+            assert!(
+                transaction
+                    .signatures()
+                    .iter()
+                    .any(|sig| sig.public_key() == &RistrettoPublicKey::from_secret_key(&secret).to_byte_type()),
+                "the external authorization must be attached"
+            );
+        }
+    }
+
+    /// The ephemeral seal key is drawn per authorizer and is neither the account key nor reused.
+    #[tokio::test]
+    async fn an_ephemeral_seal_uses_a_fresh_key() {
+        let (wallet, address) = wallet();
+
+        let first = wallet
+            .stealth_authorizer(SignatureRequirements::stealth_seal(IndexSet::new()))
+            .seal_public_key()
+            .await
+            .expect("an ephemeral key needs no key provider");
+        let second = wallet
+            .stealth_authorizer(SignatureRequirements::stealth_seal(IndexSet::new()))
+            .seal_public_key()
+            .await
+            .expect("an ephemeral key needs no key provider");
+
+        assert_ne!(first, second);
+        assert_ne!(&first, address.account_public_key());
     }
 }

--- a/crates/wallet/ootle-rs/src/wallet/stealth.rs
+++ b/crates/wallet/ootle-rs/src/wallet/stealth.rs
@@ -42,6 +42,9 @@ impl From<SealSource> for Seal {
 /// Both halves live here because an authorization signs a message committing to the seal signer's public key: only
 /// whoever decides the seal key can produce them, and they must be attached before the seal signature is made over
 /// them.
+///
+/// Build one authorizer per transaction. An ephemeral seal draws its key once, when the authorizer is constructed, so
+/// reusing an authorizer seals every transaction with the same key and links them to each other.
 pub struct WalletStealthAuthorizer<'a, W: ?Sized> {
     wallet: &'a W,
     seal: Seal,
@@ -86,7 +89,7 @@ impl WalletStealthAuthorizer<'_, OotleWallet> {
 
 #[async_trait]
 impl TransactionSealSigner for WalletStealthAuthorizer<'_, OotleWallet> {
-    async fn create_authorizations(
+    async fn authorizations_for(
         &self,
         unsigned: &UnsignedTransaction,
     ) -> signer::Result<Vec<TransactionAuthorization>> {


### PR DESCRIPTION
Supersedes #2390, which fixed the message binding but left the same class of bug reachable through `authorization_message()` and did the derivation eagerly. This takes the same premise further and reworks the surrounding design.

## The bug

A stealth-sealed transaction seals with the one-time key `P` that `seal_transaction_with_stealth` derives from the spent input's sender nonce. `WalletStealthAuthorizer::seal_signer()` returned the owner's **account key `K`** instead. Since `UnsealedTransactionV1::verify_all_signatures` checks every authorization against `seal_signature().public_key()`, any transaction needing both a stealth seal and an authorization was rejected.

Two more defects kept that path from ever working — and hid each other:

2. **`TransactionRequest::build` only sealed.** It never asked the authorizer for the authorizations its inputs require, so they were silently dropped. This is the path both stealth examples use.
3. **`StealthTransferSpec::inputs_to_spend` was a `HashMap<Address, StealthInput>`.** A second input owned by the same address overwrote the first, so a multi-input transfer from one wallet was unbuildable.

Net effect: only the single-stealth-input shape — which needs zero authorizations — could be constructed at all, which is why this never showed up in testing.

## The fix

**Signature requirements are resolved once.** `must_sign_with_account_key` + `Option<seal_signer>` + `other_signers()`-with-a-skip becomes a `SealSource` (account key / stealth input / ephemeral) plus the authorizers that sign against it. Promoting the first input to seal signer happened in three places (the builder, `seal_signer()`, and `other_signers()`); it now happens once, at construction.

**The seal key is knowable before signing.** `TransactionStealthKeySigner::stealth_public_key` derives the one-time key without producing a signature. `LocalKeyProvider` derives it straight from `owner_stealth_dh_secret`. `LedgerSigner` reports it unsupported — `GetPublicKey` takes only `(account, index, key_type)`, so the device has no way to return `c + k` except alongside a signature it makes with it. Multi-input stealth on Ledger needs a new APDU; single-input (zero authorizations) is unaffected.

**Sealing and authorizing live behind one trait.** `TransactionSealSigner::create_authorizations` defaults to none, and `TransactionRequest::build` calls it. Only whoever chooses the seal key can produce signatures that commit to it, so the two steps cannot be separated by a caller. `NetworkWallet::sign_transaction` for the authorizer collapses to that same path, dropping a duplicated seal branch that also errored on the ephemeral case.

**The ephemeral key is drawn when the authorizer is built**, not at seal time, so an authorization taken from `authorization_message` commits to the key that actually seals. That case previously returned `None` and was unusable.

## Cases

Three, not two — the third is degenerate but real:

| | seals | authorizes |
|---|---|---|
| account component accessed (revealed input bucket) | account key `K` | every stealth input |
| stealth inputs only | first input's one-time key `P` | the remaining inputs |
| nothing spent, no account access | fresh ephemeral key | nothing |

## Tests

`stealth_authorizations_verify_against_the_sealing_one_time_key` is the regression test: three stealth inputs owned by one address, sealed via `TransactionRequest::build`, asserting `verify_all_signatures()` and that the seal key is `P` and not `K`. Reintroducing the old binding fails it (verified). Plus coverage for the single-input, account-key and ephemeral cases, external authorizations against all three seal sources, and `stealth_public_key` agreeing with the key the signing methods actually use.

`examples/stealth_transfer.rs` now splits the faucet funds across two outputs and spends both, so the example itself exercises the multi-input path.

## Notes

- `ootle-rs` is a published crate and this is a breaking API change: `SignatureRequirements`' constructors and accessors, `authorization_message` becoming `async` + `Result`, and the two new trait methods. Nothing else in the workspace depends on it.
- The pre-existing `src/lib.rs` doctest failure (missing trait imports in the module-level example) is unrelated and left alone.