### PR TITLE
ci: leave the shard aggregators cancelled, not failed, on a superseded run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,14 +255,22 @@ jobs:
   # without requiring branch protection rule changes.
   test:
     name: test
-    if: always()
+    # `!cancelled()` rather than `always()`: the aggregator must still run when a shard fails, but a run cancelled by
+    # `cancel-in-progress` must leave this check cancelled rather than failed.
+    if: ${{ !cancelled() }}
     needs: [ test-shards ]
     runs-on: [ ubuntu-latest ]
     steps:
       - name: check shard results
         run: |
-          if [[ "${{ needs.test-shards.result }}" != "success" ]]; then
-            echo "One or more test shards failed or were cancelled"
+          result="${{ needs.test-shards.result }}"
+          # A shard cancelled while the run as a whole was not means this run is superseded; the newer run reports.
+          if [[ "$result" == "cancelled" ]]; then
+            echo "::notice::Test shards were cancelled; a newer run supersedes this one"
+            exit 0
+          fi
+          if [[ "$result" != "success" ]]; then
+            echo "One or more test shards failed"
             exit 1
           fi
 
@@ -270,13 +278,18 @@ jobs:
   # rule. The full workspace is already compiled by the test shards on stable.
   check-stable:
     name: check stable
-    if: always()
+    if: ${{ !cancelled() }}
     needs: [ test-shards ]
     runs-on: [ ubuntu-latest ]
     steps:
       - name: check shard results
         run: |
-          if [[ "${{ needs.test-shards.result }}" != "success" ]]; then
+          result="${{ needs.test-shards.result }}"
+          if [[ "$result" == "cancelled" ]]; then
+            echo "::notice::Test shards were cancelled; a newer run supersedes this one"
+            exit 0
+          fi
+          if [[ "$result" != "success" ]]; then
             echo "Compilation check failed (test shards did not pass)"
             exit 1
           fi


### PR DESCRIPTION
## Description

The `test` and `check stable` required-status aggregators in `ci.yml` run under `if: always()`. When a push to an open PR triggers `cancel-in-progress`, the shards are cancelled but the aggregators still execute, and `needs.test-shards.result` is then `cancelled` — which the guard script treats identically to a failure:

```bash
if [[ "${{ needs.test-shards.result }}" != "success" ]]; then
  echo "One or more test shards failed or were cancelled"
  exit 1
fi
```

So both required checks report **red** on the superseded run, on every push to an open PR.

`if: ${{ !cancelled() }}` still runs the aggregator when a shard genuinely fails (which `success()` would not), but skips it when the run itself is cancelled, so the check follows the run's own state instead of contradicting it. GitHub offers no way for a job to mark *itself* cancelled; skipping is the closest equivalent, and branch protection treats a skipped required check as satisfied.

The explicit `cancelled` arm in the script covers the remaining case: a shard cancelled while the run as a whole was not (the newer run is the one that reports).

## Motivation and Context

Removes a persistent false-red on every open PR that gets a follow-up commit.

## How Has This Been Tested?

YAML parses clean. The behaviour change is observable on this PR itself — pushing a second commit while the first run is in flight should now leave `test` / `check stable` cancelled rather than failed.

## What process can a PR reviewer use to test or verify this change?

Push a trivial follow-up commit to this branch while its first CI run is still going, and confirm the superseded run's `test` and `check stable` checks are cancelled/skipped rather than failed.

## Breaking Changes

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
