### PR TITLE
feat(ledger): derive stealth one-time keys via GetPublicKey

### DIFF
--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -780,6 +780,53 @@ jobs:
           omitBodyDuringUpdate: true
           omitNameDuringUpdate: true
 
+  ledger-app:
+    name: Building the Ledger device app
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v7.0.1
+
+      # The device app versions independently of the workspace: it is installed on the device, not
+      # released alongside the binaries, so its own version identifies what a user is flashing.
+      - name: Declare Ledger app variables
+        shell: bash
+        run: |
+          echo "VSHA_SHORT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          LEDGER_APP_VERSION=$(awk -F ' = ' '$1 ~ /^version/ \
+            { gsub(/["]/, "", $2); printf("%s",$2); exit }' \
+            "$GITHUB_WORKSPACE/crates/wallet/ledger/app/Cargo.toml")
+          echo "LEDGER_APP_VERSION=${LEDGER_APP_VERSION}" >> $GITHUB_ENV
+
+      # Builds in the Ledger builder image; the embedded Rust toolchain and device SDKs live there.
+      - name: Build the device app for every target
+        run: ./crates/wallet/ledger/app/build-app.sh all
+
+      - name: Collect ELFs and checksum
+        shell: bash
+        run: |
+          set -euo pipefail
+          DIST="$GITHUB_WORKSPACE/dist-ledger"
+          mkdir -p "${DIST}"
+          for elf in "$GITHUB_WORKSPACE"/crates/wallet/ledger/app/target/*/release/ootle; do
+            device=$(basename "$(dirname "$(dirname "${elf}")")")
+            cp -v "${elf}" \
+              "${DIST}/${TS_FILENAME}_ledger_app-${LEDGER_APP_VERSION}-${VSHA_SHORT}-${device}.elf"
+          done
+          cd "${DIST}"
+          shasum --algorithm 256 *.elf \
+            >> "${TS_FILENAME}_ledger_app-${LEDGER_APP_VERSION}-${VSHA_SHORT}.sha256"
+          shasum --algorithm 256 --check "${TS_FILENAME}_ledger_app-${LEDGER_APP_VERSION}-${VSHA_SHORT}.sha256"
+          ls -alht
+
+      # Named with the `tari_ootle` prefix so `create-release` picks it up with the other artifacts.
+      - name: Artifact upload for the Ledger app
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ env.TS_FILENAME }}_ledger_app-${{ env.LEDGER_APP_VERSION }}-${{ env.VSHA_SHORT }}
+          path: "${{ github.workspace }}/dist-ledger/*"
+
   macOS-universal-assemble:
     name: macOS universal assemble
     needs: builds
@@ -985,7 +1032,7 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
 
     runs-on: ubuntu-latest
-    needs: [ builds, macOS-universal-assemble ]
+    needs: [ builds, macOS-universal-assemble, ledger-app ]
 
     env:
       TARI_NETWORK_DIR: ${{ needs.builds.outputs.TARI_NETWORK_DIR }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,30 @@ jobs:
       - name: run the license check
         run: ./scripts/file_license_check.sh
 
+  ledger-app:
+    # The Ledger device app declares its own `[workspace]`, so nothing else in CI compiles it — a
+    # change to `ootle_ledger_common` can break the firmware without any other job noticing.
+    name: ledger app
+    runs-on: [ ubuntu-latest ]
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v7.0.1
+
+      # Builds in the Ledger builder image (the embedded Rust toolchain and every device SDK live
+      # there); BAGL and NBGL targets exercise both device UI backends.
+      - name: build device app
+        run: ./crates/wallet/ledger/app/build-app.sh all
+
+      - name: app metadata
+        run: |
+          for elf in crates/wallet/ledger/app/target/*/release/ootle; do
+            echo "::group::${elf}"
+            size "${elf}"
+            readelf -p ledger.app_version "${elf}"
+            echo "::endgroup::"
+          done
+
   test-shards:
     name: test (${{ matrix.partition }})
     runs-on: [ ubuntu-latest ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7694,7 +7694,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-rs"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7765,7 +7765,7 @@ dependencies = [
 
 [[package]]
 name = "ootle_ledger_client"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -7789,7 +7789,7 @@ dependencies = [
 
 [[package]]
 name = "ootle_ledger_common"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "borsh",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,7 +172,7 @@ tari_utilities = "0.10"
 tari_hashing = "5.5.0"
 
 ## Ledger
-ootle_ledger_common = { path = "crates/wallet/ledger/common", version = "0.1.0" }
+ootle_ledger_common = { path = "crates/wallet/ledger/common", version = "0.2.0" }
 
 # networking crates
 proto_builder = { path = "networking/proto_builder" }

--- a/crates/wallet/ledger/app/Cargo.toml
+++ b/crates/wallet/ledger/app/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 [package]
 name = "ootle-ledger-app"
-version = "0.1.0"
+version = "0.2.0"
 description = "Ootle Ledger App"
 edition = "2024"
 authors = ["Tari Development Community"]

--- a/crates/wallet/ledger/app/build-app.sh
+++ b/crates/wallet/ledger/app/build-app.sh
@@ -16,7 +16,7 @@ usage() {
   echo ""
   echo "🦀 Ledger App Builder 🦀"
   echo ""
-  echo "Usage: $0 <target>"
+  echo "Usage: $0 <target...|all>"
   echo ""
   echo "📦 Supported targets:"
   for t in "${SUPPORTED_TARGETS[@]}"; do
@@ -25,7 +25,8 @@ usage() {
   echo ""
   echo "📖 Examples:"
   echo "   $0 nanosplus"
-  echo "   $0 nanox"
+  echo "   $0 nanox flex"
+  echo "   $0 all"
   echo ""
   exit 1
 }
@@ -35,45 +36,61 @@ if [ -z "$1" ]; then
   usage
 fi
 
-TARGET="$1"
+# `all` expands to every supported target.
+if [ "$1" = "all" ]; then
+  set -- "${SUPPORTED_TARGETS[@]}"
+fi
 
-# Validate target
-VALID=false
-for t in "${SUPPORTED_TARGETS[@]}"; do
-  if [ "$TARGET" = "$t" ]; then
-    VALID=true
-    break
+for TARGET in "$@"; do
+  VALID=false
+  for t in "${SUPPORTED_TARGETS[@]}"; do
+    if [ "$TARGET" = "$t" ]; then
+      VALID=true
+      break
+    fi
+  done
+
+  if [ "$VALID" = false ]; then
+    echo "❌ Error: Unknown target '$TARGET'."
+    usage
   fi
 done
 
-if [ "$VALID" = false ]; then
-  echo "❌ Error: Unknown target '$TARGET'."
-  usage
-fi
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-echo ""
-echo "🚀 Building Ledger app for target: $TARGET"
-echo "📁 Using source directory: $SCRIPT_DIR"
-echo ""
+# The Rust toolchain and every device SDK live in this image; the app cannot be built with the
+# host toolchain. Overridable so a caller can pin a digest.
+IMAGE="${LEDGER_APP_BUILDER_IMAGE:-ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder}"
 
-# NBGL targets (Stax/Flex) need the `nbgl` cargo feature, which enables the SDK's
-# `io_new` + `nano_nbgl`. BAGL targets (Nano S+/X) build with default features.
-EXTRA=""
-case "$TARGET" in
-  stax | flex) EXTRA="-- --features nbgl" ;;
-esac
+# A TTY is only available when a human runs this; CI has none and `docker run -t` would fail.
+DOCKER_TTY=()
+if [ -t 0 ] && [ -t 1 ]; then
+  DOCKER_TTY=(-it)
+fi
 
-# Mount the ledger workspace root (parent of this app crate) so the `../common` path
-# dependency resolves inside the container; build from the app crate directory.
-docker run --rm -it \
-  -v "$SCRIPT_DIR/..:/app" \
-  -w /app/app \
-  ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder \
-  bash -lc "cargo ledger build $TARGET $EXTRA"
+for TARGET in "$@"; do
+  echo ""
+  echo "🚀 Building Ledger app for target: $TARGET"
+  echo "📁 Using source directory: $SCRIPT_DIR"
+  echo ""
 
-echo ""
-echo "✅ Build complete for target: $TARGET"
-echo ""
+  # NBGL targets (Stax/Flex) need the `nbgl` cargo feature, which enables the SDK's
+  # `io_new` + `nano_nbgl`. BAGL targets (Nano S+/X) build with default features.
+  EXTRA=""
+  case "$TARGET" in
+    stax | flex) EXTRA="-- --features nbgl" ;;
+  esac
+
+  # Mount the ledger workspace root (parent of this app crate) so the `../common` path
+  # dependency resolves inside the container; build from the app crate directory.
+  docker run --rm "${DOCKER_TTY[@]}" \
+    -v "$SCRIPT_DIR/..:/app" \
+    -w /app/app \
+    "$IMAGE" \
+    bash -lc "cargo ledger build $TARGET $EXTRA"
+
+  echo ""
+  echo "✅ Build complete for target: $TARGET"
+  echo ""
+done
 

--- a/crates/wallet/ledger/app/src/handlers/get_public_key.rs
+++ b/crates/wallet/ledger/app/src/handlers/get_public_key.rs
@@ -1,7 +1,10 @@
 //   Copyright 2026 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use ootle_ledger_common::arg_types::{GetPublicKeyRequest, GetPublicKeyResponse};
+use ootle_ledger_common::{
+    OotleStatusWord,
+    arg_types::{GetPublicKeyRequest, GetPublicKeyResponse, KeyType},
+};
 use zeroize::Zeroizing;
 
 use crate::{
@@ -15,6 +18,11 @@ use crate::{
 pub fn get_public_key(_state_mut: &mut State, request: GetPublicKeyRequest) -> Result<GetPublicKeyResponse, AppStatus> {
     let k = Zeroizing::new(derive_from_bip32_key(request.account, request.index, request.key_type)?);
     let secret = match request.stealth {
+        // Stealth one-time keys are only defined over the account branch: a stealth output pays
+        // `c·G + K_account`, so tweaking any other branch derives a key that owns nothing.
+        Some(_) if !matches!(request.key_type, KeyType::Account) => {
+            return Err(AppStatus::OotleStatusWord(OotleStatusWord::BadRequest));
+        },
         Some(tweak) => Zeroizing::new(derive_stealth_secret(tweak.network, &k, &tweak.public_nonce)?),
         None => k,
     };

--- a/crates/wallet/ledger/app/src/handlers/get_public_key.rs
+++ b/crates/wallet/ledger/app/src/handlers/get_public_key.rs
@@ -2,12 +2,23 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use ootle_ledger_common::arg_types::{GetPublicKeyRequest, GetPublicKeyResponse};
+use zeroize::Zeroizing;
 
-use crate::{crypto::public_key_from_scalar, key_derive::derive_from_bip32_key, state::State, status::AppStatus};
+use crate::{
+    crypto::public_key_from_scalar,
+    hashing::derive_stealth_secret,
+    key_derive::derive_from_bip32_key,
+    state::State,
+    status::AppStatus,
+};
 
 pub fn get_public_key(_state_mut: &mut State, request: GetPublicKeyRequest) -> Result<GetPublicKeyResponse, AppStatus> {
-    let k = derive_from_bip32_key(request.account, request.index, request.key_type)?;
-    let pk = public_key_from_scalar(&k);
+    let k = Zeroizing::new(derive_from_bip32_key(request.account, request.index, request.key_type)?);
+    let secret = match request.stealth {
+        Some(tweak) => Zeroizing::new(derive_stealth_secret(tweak.network, &k, &tweak.public_nonce)?),
+        None => k,
+    };
+    let pk = public_key_from_scalar(&secret);
 
     Ok(GetPublicKeyResponse {
         public_key: pk.compress().0,

--- a/crates/wallet/ledger/app/src/hashing.rs
+++ b/crates/wallet/ledger/app/src/hashing.rs
@@ -12,7 +12,7 @@
 
 use alloc::format;
 
-use curve25519_dalek::{Scalar, ristretto::CompressedRistretto};
+use curve25519_dalek::{Scalar, ristretto::CompressedRistretto, traits::IsIdentity};
 use ledger_device_sdk::hash::{HashError, HashInit, blake2::Blake2b_512};
 use ootle_ledger_common::{
     OotleStatusWord,
@@ -102,6 +102,10 @@ pub fn derive_stealth_secret(
     let r = CompressedRistretto(*public_nonce)
         .decompress()
         .ok_or(AppStatus::OotleStatusWord(OotleStatusWord::BadRequest))?;
+    // The identity yields a DH point independent of the account key, so the resulting key belongs to no UTXO.
+    if r.is_identity() {
+        return Err(AppStatus::OotleStatusWord(OotleStatusWord::BadRequest));
+    }
     let dh = (account_secret * r).compress().0;
 
     let label = format!("{STEALTH_OWNER_LABEL}.n{network_byte}");

--- a/crates/wallet/ledger/client/Cargo.toml
+++ b/crates/wallet/ledger/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ootle_ledger_client"
-version = "0.3.0"
+version = "0.4.0"
 description = "Host client for the Tari Ootle Ledger app: on-device key derivation and transaction signing over any APDU transport"
 edition.workspace = true
 authors.workspace = true

--- a/crates/wallet/ledger/client/README.md
+++ b/crates/wallet/ledger/client/README.md
@@ -7,7 +7,8 @@ any [`ledger_transport::Exchange`](https://docs.rs/ledger-transport) APDU transp
 the app's instruction set:
 
 - app name and version queries,
-- on-device key derivation (`get_public_key`) — secrets never leave the device,
+- on-device key derivation (`get_public_key`), optionally tweaked to a stealth one-time key —
+  secrets never leave the device,
 - streamed transaction signing (`sign_transaction`) for both authorization ("add signer") and
   seal signatures, with optional stealth key derivation for confidential transfers.
 
@@ -41,7 +42,7 @@ use ootle_ledger_common::arg_types::KeyType;
 let client = LedgerClient::new(SpeculosTransport::new());
 
 let version = client.get_app_version().await?;
-let public_key = client.get_public_key(0, 0, KeyType::Account).await?;
+let public_key = client.get_public_key(0, 0, KeyType::Account, None).await?;
 # Ok(())
 # }
 ```

--- a/crates/wallet/ledger/client/src/client.rs
+++ b/crates/wallet/ledger/client/src/client.rs
@@ -15,6 +15,7 @@ use ootle_ledger_common::{
         SignTransactionHeader,
         SignTransactionResponse,
         SigningField,
+        StealthTweak,
     },
 };
 use tari_template_lib_types::crypto::RistrettoPublicKeyBytes;
@@ -74,16 +75,22 @@ impl<T: Exchange> LedgerClient<T> {
 
     /// Derive a key on-device from the `(account, index, key_type)` BIP-32 path parameters and
     /// return its public key. The secret never leaves the device.
+    ///
+    /// `stealth` is `Some` to obtain the stealth one-time key for a confidential transfer: the
+    /// returned key is `(c + k)·G`, the same key the device signs with when given the tweak's
+    /// public nonce in [`Self::sign_transaction`].
     pub async fn get_public_key(
         &self,
         account: u64,
         index: u64,
         key_type: KeyType,
+        stealth: Option<StealthTweak>,
     ) -> LedgerClientResult<RistrettoPublicKeyBytes, T::Error> {
         let req = GetPublicKeyRequest {
             account,
             index,
             key_type,
+            stealth,
         };
 
         let command = APDUCommand {
@@ -207,20 +214,20 @@ mod tests {
         let client = LedgerClient::new(speculos_transport());
 
         let version = client.get_app_version().await.unwrap();
-        assert_eq!(version, "0.1.0");
+        assert_eq!(version, "0.2.0");
 
         let app_name = client.get_app_name().await.unwrap();
         assert_eq!(app_name, "Tari Ootle");
 
-        let public_key = client.get_public_key(0, 0, KeyType::Transaction).await.unwrap();
+        let public_key = client.get_public_key(0, 0, KeyType::Transaction, None).await.unwrap();
         assert_eq!(public_key.len(), 32);
-        let other_pk = client.get_public_key(0, 0, KeyType::Transaction).await.unwrap();
+        let other_pk = client.get_public_key(0, 0, KeyType::Transaction, None).await.unwrap();
         assert_eq!(public_key, other_pk);
-        let other_pk = client.get_public_key(0, 1, KeyType::Transaction).await.unwrap();
+        let other_pk = client.get_public_key(0, 1, KeyType::Transaction, None).await.unwrap();
         assert_ne!(public_key, other_pk);
-        let other_pk = client.get_public_key(0, 0, KeyType::Account).await.unwrap();
+        let other_pk = client.get_public_key(0, 0, KeyType::Account, None).await.unwrap();
         assert_ne!(public_key, other_pk);
-        let other_pk = client.get_public_key(1, 0, KeyType::Transaction).await.unwrap();
+        let other_pk = client.get_public_key(1, 0, KeyType::Transaction, None).await.unwrap();
         assert_ne!(public_key, other_pk);
     }
 
@@ -272,7 +279,10 @@ mod tests {
         let (account, index) = (0u64, 0u64);
 
         // Any public key works as the seal-signer context for an authorization signature.
-        let seal_signer = client.get_public_key(account, index, KeyType::Account).await.unwrap();
+        let seal_signer = client
+            .get_public_key(account, index, KeyType::Account, None)
+            .await
+            .unwrap();
         let tx = sample_unsigned();
 
         let segments = TransactionSignature::signing_preimage_v1(&seal_signer, &tx);
@@ -341,7 +351,10 @@ mod tests {
 
         // The device's account public key, and a fresh sender ephemeral nonce (r, R) standing in for
         // the sender nonce of a received stealth UTXO being spent.
-        let account_pk_bytes = client.get_public_key(account, index, KeyType::Account).await.unwrap();
+        let account_pk_bytes = client
+            .get_public_key(account, index, KeyType::Account, None)
+            .await
+            .unwrap();
         let account_pk = RistrettoPublicKey::from_canonical_bytes(&account_pk_bytes[..]).unwrap();
         let r = RistrettoSecretKey::random(&mut rand::rng());
         let r_pub = RistrettoPublicKey::from_secret_key(&r);
@@ -388,6 +401,85 @@ mod tests {
         assert!(
             signature.verify_v1(&seal_signer, &tx),
             "device stealth signature did not verify"
+        );
+
+        // `GetPublicKey` must resolve the very key the device signs with, so callers can bind
+        // authorizations to the seal key before any signature is made.
+        let queried = client
+            .get_public_key(
+                account,
+                index,
+                KeyType::Account,
+                Some(StealthTweak {
+                    network: tx.network,
+                    public_nonce: nonce,
+                }),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            *queried, response.public_key,
+            "GetPublicKey disagrees with the signing key"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "Requires Speculos to be running with the ootle ledger app."]
+    async fn stealth_public_key_derivation() {
+        use ootle_network::Network;
+        use tari_crypto::{
+            keys::{PublicKey, SecretKey},
+            ristretto::{RistrettoPublicKey, RistrettoSecretKey},
+            tari_utilities::ByteArray,
+        };
+
+        let client = LedgerClient::new(speculos_transport());
+        let (account, index) = (0u64, 0u64);
+
+        let mut rng = rand::rng();
+        let nonce_of = |secret: &RistrettoSecretKey| {
+            let mut bytes = [0u8; 32];
+            bytes.copy_from_slice(RistrettoPublicKey::from_secret_key(secret).as_bytes());
+            bytes
+        };
+        let nonce = nonce_of(&RistrettoSecretKey::random(&mut rng));
+        let other_nonce = nonce_of(&RistrettoSecretKey::random(&mut rng));
+
+        let stealth_key = |network: Network, public_nonce: [u8; 32]| {
+            client.get_public_key(
+                account,
+                index,
+                KeyType::Account,
+                Some(StealthTweak {
+                    network: network.as_byte(),
+                    public_nonce,
+                }),
+            )
+        };
+
+        let key = stealth_key(Network::LocalNet, nonce).await.unwrap();
+        assert_eq!(
+            key,
+            stealth_key(Network::LocalNet, nonce).await.unwrap(),
+            "stealth key is not deterministic"
+        );
+        assert_ne!(
+            key,
+            stealth_key(Network::LocalNet, other_nonce).await.unwrap(),
+            "stealth key is not bound to the public nonce"
+        );
+        assert_ne!(
+            key,
+            stealth_key(Network::Igor, nonce).await.unwrap(),
+            "stealth key is not bound to the network"
+        );
+        assert_ne!(
+            key,
+            client
+                .get_public_key(account, index, KeyType::Account, None)
+                .await
+                .unwrap(),
+            "stealth key equals the untweaked account key"
         );
     }
 }

--- a/crates/wallet/ledger/client/tests/signing_recipe.rs
+++ b/crates/wallet/ledger/client/tests/signing_recipe.rs
@@ -326,9 +326,10 @@ fn stealth_recipe_matches_and_verifies() {
         "stealth authorization signature failed to verify"
     );
 
-    // (4) `GetPublicKey` with a stealth tweak must return exactly that key, so the seal key is
-    // known before any signature binds to it. Round-tripping the request through borsh exercises
-    // the bytes the device decodes.
+    // (4) The tweak a `GetPublicKey` request carries must survive the wire and, fed to the same
+    // derivation the signing path uses, reproduce the stealth address — that equality is what lets
+    // a caller resolve the seal key before any signature binds to it. (Whether the device handler
+    // applies the tweak at all is only observable on Speculos.)
     let request = GetPublicKeyRequest {
         account: 0,
         index: 0,
@@ -350,7 +351,6 @@ fn stealth_recipe_matches_and_verifies() {
     // (5) The tweak binds both of its parts: the same nonce on another network, and another nonce
     // on the same network, must each yield a different key.
     let other_network = Network::Igor;
-    assert_ne!(network.as_byte(), other_network.as_byte());
     assert_ne!(
         returned,
         public_key(&derive_stealth_secret(other_network.as_byte(), &k_scalar, &r_bytes)),

--- a/crates/wallet/ledger/client/tests/signing_recipe.rs
+++ b/crates/wallet/ledger/client/tests/signing_recipe.rs
@@ -278,6 +278,7 @@ fn seal_recipe_matches_and_verifies() {
 
 #[test]
 fn stealth_recipe_matches_and_verifies() {
+    use ootle_ledger_common::arg_types::{GetPublicKeyRequest, KeyType, StealthTweak};
     use ootle_network::Network;
     use tari_crypto::{
         keys::{PublicKey, SecretKey},
@@ -323,5 +324,44 @@ fn stealth_recipe_matches_and_verifies() {
     assert!(
         signature.verify_v1(&seal_signer, &tx),
         "stealth authorization signature failed to verify"
+    );
+
+    // (4) `GetPublicKey` with a stealth tweak must return exactly that key, so the seal key is
+    // known before any signature binds to it. Round-tripping the request through borsh exercises
+    // the bytes the device decodes.
+    let request = GetPublicKeyRequest {
+        account: 0,
+        index: 0,
+        key_type: KeyType::Account,
+        stealth: Some(StealthTweak {
+            network: network.as_byte(),
+            public_nonce: r_bytes,
+        }),
+    };
+    let decoded: GetPublicKeyRequest = borsh::from_slice(&borsh::to_vec(&request).unwrap()).unwrap();
+    let tweak = decoded.stealth.expect("stealth tweak survives the wire");
+    let returned = public_key(&derive_stealth_secret(tweak.network, &k_scalar, &tweak.public_nonce));
+    assert_eq!(
+        returned,
+        <[u8; 32]>::try_from(stealth_address.as_bytes()).unwrap(),
+        "GetPublicKey stealth key mismatch"
+    );
+
+    // (5) The tweak binds both of its parts: the same nonce on another network, and another nonce
+    // on the same network, must each yield a different key.
+    let other_network = Network::Igor;
+    assert_ne!(network.as_byte(), other_network.as_byte());
+    assert_ne!(
+        returned,
+        public_key(&derive_stealth_secret(other_network.as_byte(), &k_scalar, &r_bytes)),
+        "stealth key is not bound to the network"
+    );
+    let other_nonce =
+        <[u8; 32]>::try_from(RistrettoPublicKey::from_secret_key(&RistrettoSecretKey::random(&mut rng)).as_bytes())
+            .unwrap();
+    assert_ne!(
+        returned,
+        public_key(&derive_stealth_secret(network.as_byte(), &k_scalar, &other_nonce)),
+        "stealth key is not bound to the public nonce"
     );
 }

--- a/crates/wallet/ledger/common/Cargo.toml
+++ b/crates/wallet/ledger/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ootle_ledger_common"
-version = "0.1.0"
+version = "0.2.0"
 description = "Shared APDU protocol types for the Tari Ootle Ledger app and its host client"
 edition = "2024"
 authors = ["Tari Development Community"]

--- a/crates/wallet/ledger/common/README.md
+++ b/crates/wallet/ledger/common/README.md
@@ -21,6 +21,13 @@ All commands use APDU class byte `0x80`.
 | `GetPublicKey`    | `0x03` | `GetPublicKeyRequest` | `GetPublicKeyResponse`    |
 | `SignTransaction` | `0x04` | Streamed (see below)  | `SignTransactionResponse` |
 
+### `GetPublicKey`
+
+`GetPublicKeyRequest` names a derivation path and may carry a `StealthTweak` (network + the spent
+UTXO's sender public nonce). With the tweak the device returns the stealth one-time key `(c + k)·G`
+— the key it also signs with when the same nonce is given in a `SignTransaction` header — so a host
+can resolve the seal key of a stealth input before binding any signature to it.
+
 ### `SignTransaction` streaming
 
 A signing exchange streams the canonical transaction signing preimage to the device as a sequence

--- a/crates/wallet/ledger/common/src/arg_types.rs
+++ b/crates/wallet/ledger/common/src/arg_types.rs
@@ -39,12 +39,28 @@ impl KeyType {
     }
 }
 
+/// The tweak that turns a derived account key into a stealth one-time key: the spent UTXO's sender
+/// public nonce `R`, and the network the resulting key is bound to.
+///
+/// Both travel together because neither is meaningful alone — the tweak is
+/// `c = H_stealth_owner(network, k·R)`, so the same nonce yields a different key on each network.
+#[derive(BorshSerialize, BorshDeserialize)]
+pub struct StealthTweak {
+    pub network: u8,
+    pub public_nonce: [u8; 32],
+}
+
 /// Body of a `GetPublicKey` request: the derivation path of the key to return.
+///
+/// When `stealth` is set the device returns the stealth one-time key `(c + k)·G` for that tweak
+/// rather than the derived key `k·G` itself. This is the key a stealth input signs with, so it must
+/// be resolvable before any signature binds to it.
 #[derive(BorshSerialize, BorshDeserialize)]
 pub struct GetPublicKeyRequest {
     pub account: u64,
     pub index: u64,
     pub key_type: KeyType,
+    pub stealth: Option<StealthTweak>,
 }
 
 /// Response to `GetPublicKey`: the compressed Ristretto public key for the requested path.

--- a/crates/wallet/ootle-rs/Cargo.toml
+++ b/crates/wallet/ootle-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ootle-rs"
-version = "0.17.0"
+version = "0.18.0"
 description = "A Rust library for interacting with the Tari Ootle network."
 edition.workspace = true
 authors.workspace = true
@@ -21,7 +21,7 @@ tari_ootle_address = { workspace = true }
 tari_template_builtin = { workspace = true }
 
 # Ledger hardware-wallet signer (feature-gated).
-ootle_ledger_client = { path = "../ledger/client", version = "0.3.0", optional = true }
+ootle_ledger_client = { path = "../ledger/client", version = "0.4.0", optional = true }
 ootle_ledger_common = { workspace = true, optional = true }
 
 async-trait = { workspace = true }

--- a/crates/wallet/ootle-rs/src/signer/ledger.rs
+++ b/crates/wallet/ootle-rs/src/signer/ledger.rs
@@ -18,7 +18,7 @@
 
 use async_trait::async_trait;
 use ootle_ledger_client::{Exchange, LedgerClient, LedgerClientError};
-use ootle_ledger_common::arg_types::{KeyType, SignMode, SigningField};
+use ootle_ledger_common::arg_types::{KeyType, SignMode, SigningField, StealthTweak};
 use tari_crypto::{ristretto::RistrettoPublicKey, tari_utilities::ByteArray};
 use tari_ootle_address::OotleAddress;
 use tari_ootle_transaction::{
@@ -58,11 +58,11 @@ where
     /// `(account, index)` and derive the wallet [`Address`].
     pub async fn connect(client: LedgerClient<T>, network: Network, account: u64, index: u64) -> signer::Result<Self> {
         let account_pk = client
-            .get_public_key(account, index, KeyType::Account)
+            .get_public_key(account, index, KeyType::Account, None)
             .await
             .map_err(map_client_err)?;
         let view_only_pk = client
-            .get_public_key(account, index, KeyType::ViewOnlyKey)
+            .get_public_key(account, index, KeyType::ViewOnlyKey, None)
             .await
             .map_err(map_client_err)?;
         let address = OotleAddress::new(network, view_only_pk, account_pk);
@@ -155,13 +155,19 @@ where
     T: Exchange + Send + Sync,
     T::Error: core::fmt::Display + Send + Sync,
 {
-    async fn stealth_public_key(&self, _public_nonce: &RistrettoPublicKey) -> signer::Result<RistrettoPublicKeyBytes> {
-        // `GetPublicKey` derives from (account, index, key_type) only; the device has no request that takes a sender
-        // public nonce, so `c + k` is only ever returned alongside a signature it makes with it.
-        Err(SignerError::other(
-            "the Ledger device cannot derive a stealth public key without signing, so it cannot seal a stealth \
-             transfer that also needs authorization signatures",
-        ))
+    async fn stealth_public_key(&self, public_nonce: &RistrettoPublicKey) -> signer::Result<RistrettoPublicKeyBytes> {
+        self.client
+            .get_public_key(
+                self.account,
+                self.index,
+                KeyType::Account,
+                Some(StealthTweak {
+                    network: self.address.network().as_byte(),
+                    public_nonce: nonce_bytes(public_nonce),
+                }),
+            )
+            .await
+            .map_err(map_client_err)
     }
 
     async fn sign_authorization_with_stealth(

--- a/crates/wallet/ootle-rs/src/signer/ledger.rs
+++ b/crates/wallet/ootle-rs/src/signer/ledger.rs
@@ -118,6 +118,20 @@ where
             .map_err(|_| SignerError::other("device returned malformed signature bytes"))?;
         Ok((public_key, signature))
     }
+
+    /// A stealth key is bound to a network, and the two APDUs take that network from different
+    /// places: `GetPublicKey` from this signer's address, signing from the transaction's own
+    /// `Network` field. They must agree, or the key resolved up front is not the key the device
+    /// signs with and every authorization commits to the wrong seal signer.
+    fn check_stealth_network(&self, tx_network: u8) -> signer::Result<()> {
+        let network = self.address.network().as_byte();
+        if tx_network != network {
+            return Err(SignerError::other(format!(
+                "cannot sign a transaction for network {tx_network} with a stealth key derived on network {network}",
+            )));
+        }
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -177,6 +191,7 @@ where
         tx: &UnsignedTransaction,
     ) -> signer::Result<TransactionAuthorization> {
         let UnsignedTransaction::V1(unsigned) = tx;
+        self.check_stealth_network(unsigned.network)?;
         let segments = TransactionSignature::signing_preimage_v1(seal_signer, unsigned);
         let (public_key, signature) = self
             .stream(SignMode::AddSigner, Some(nonce_bytes(public_nonce)), segments)
@@ -190,6 +205,7 @@ where
         message: &UnsealedTransaction,
     ) -> signer::Result<TransactionSealSignature> {
         let UnsealedTransaction::V1(unsealed) = message;
+        self.check_stealth_network(unsealed.unsigned_transaction().network)?;
         let segments = TransactionSealSignature::signing_preimage_v1(unsealed);
         let (public_key, signature) = self
             .stream(SignMode::Seal, Some(nonce_bytes(public_nonce)), segments)
@@ -237,5 +253,72 @@ fn to_wire(field: PreimageField) -> SigningField {
         PreimageField::DryRun => SigningField::DryRun,
         PreimageField::BlobHashes => SigningField::BlobHashes,
         PreimageField::Signatures => SigningField::Signatures,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ootle_ledger_client::ledger_transport::{APDUAnswer, APDUCommand, async_trait as transport_async_trait};
+    use tari_crypto::{
+        keys::{PublicKey, SecretKey},
+        ristretto::RistrettoSecretKey,
+    };
+    use tari_ootle_transaction::{Transaction as TransactionBuilderEntry, UnsealedTransactionV1};
+
+    use super::*;
+
+    /// A transport that fails the test if the device is contacted: the network guard must reject
+    /// before any APDU is sent.
+    struct NoDevice;
+
+    #[transport_async_trait]
+    impl Exchange for NoDevice {
+        type AnswerType = Vec<u8>;
+        type Error = std::io::Error;
+
+        async fn exchange<I>(&self, _command: &APDUCommand<I>) -> Result<APDUAnswer<Self::AnswerType>, Self::Error>
+        where I: core::ops::Deref<Target = [u8]> + Send + Sync {
+            panic!("the device must not be contacted for a transaction on the wrong network");
+        }
+    }
+
+    fn signer_on(network: Network) -> LedgerSigner<NoDevice> {
+        let mut rng = rand::rng();
+        let mut key = || {
+            RistrettoPublicKeyBytes::from_bytes(
+                RistrettoPublicKey::from_secret_key(&RistrettoSecretKey::random(&mut rng)).as_bytes(),
+            )
+            .unwrap()
+        };
+        let address = OotleAddress::new(network, key(), key());
+        LedgerSigner::with_address(LedgerClient::new(NoDevice), address, 0, 0)
+    }
+
+    /// The stealth key `GetPublicKey` returns is derived under the signer's network, while the device
+    /// derives the key it signs with from the transaction's own `Network` field. Signing a transaction
+    /// from another network would silently sign with a different key than the one the caller bound its
+    /// authorizations to.
+    #[tokio::test]
+    async fn signing_a_transaction_from_another_network_is_rejected() {
+        let signer = signer_on(Network::Igor);
+        let tx = TransactionBuilderEntry::builder(Network::LocalNet).build_unsigned();
+        let nonce = RistrettoPublicKey::from_secret_key(&RistrettoSecretKey::random(&mut rand::rng()));
+
+        let err = signer
+            .sign_authorization_with_stealth(&nonce, &RistrettoPublicKeyBytes::default(), &tx)
+            .await
+            .expect_err("a transaction from another network must not be signed");
+        assert!(err.to_string().contains("network"), "unexpected error: {err}");
+
+        let unsealed = UnsealedTransaction::V1(UnsealedTransactionV1::new(
+            match tx {
+                UnsignedTransaction::V1(unsigned) => unsigned,
+            },
+            vec![],
+        ));
+        signer
+            .seal_transaction_with_stealth(&nonce, &unsealed)
+            .await
+            .expect_err("a transaction from another network must not be sealed");
     }
 }


### PR DESCRIPTION
## Description

Adds a stealth tweak to the Ledger `GetPublicKey` request so the device can return a stealth
one-time key without signing, unblocking multi-input stealth spends on Ledger.

A stealth input seals with the one-time key `(c + k)·G` derived from the spent UTXO's sender public
nonce, so — since #2403 — that key must be resolvable *before* any authorization signature binds to
it. `GetPublicKeyRequest` carried only `(account, index, key_type)`, so the device could only ever
return `c + k` alongside a signature it made with it, and `LedgerSigner::stealth_public_key`
returned an "unsupported" error. That blocked every stealth spend of two or more inputs, and any
script-path input needing an externally supplied co-signature. Single-input key-path spends were
unaffected — they need no authorizations.

`GetPublicKeyRequest` gains `stealth: Option<StealthTweak { network, public_nonce }>`. This mirrors
how `SignTransactionHeader` already carries `stealth_public_nonce`: key derivation gains a
parameter rather than the protocol gaining an instruction, so `Instruction`, `GetPublicKeyResponse`
and both device dispatch tables are untouched. Network and nonce travel together because the tweak
is `c = H_stealth_owner(network, k·R)` — a nonce without a network cannot be derived, and a network
without a nonce has nothing to bind.

The signing path deliberately keeps taking its network from the streamed `SigningField::Network`:
that value is the one displayed and signed, and a second copy in the header could disagree with it.
`GetPublicKey` signs nothing, so carrying the network in its request is safe. The host side keeps
the two consistent — see the guard below.

No firmware is deployed, so this is a clean wire change: **no version gating, capability probing or
compatibility shims.**

### Guards on the new path

- The device rejects a tweak on any branch other than `KeyType::Account`. A stealth output pays
  `c·G + K_account`, so tweaking another branch would derive a key that owns nothing.
- `derive_stealth_secret` rejects the identity as the sender public nonce: `k·R` would then be
  independent of the account key, yielding a well-formed key belonging to no UTXO.
- `LedgerSigner` refuses to sign a stealth transaction whose network differs from the address the
  stealth key was derived under. The two APDUs read the network from different places, so a
  mismatch would resolve one key up front and sign with another — failing only after the user had
  approved every signature.

### Versions

Device app `0.1.0` → `0.2.0`. `GetPublicKeyRequest` gaining a field is breaking for
`ootle_ledger_common` (→ `0.2.0`) and `ootle_ledger_client` (→ `0.4.0`); `ootle-rs` → `0.18.0`
re-exposes both. Per `scripts/crate_versioning.py impact ootle_ledger_common --breaking`.

## Motivation and Context

Follow-up to #2403, which fixed stealth authorization signatures to commit to the key that actually
seals the transaction and left `LedgerSigner` unable to satisfy the new
`TransactionStealthKeySigner::stealth_public_key`.

An alternative needing zero firmware change — sealing with a host-generated ephemeral key and
having all N inputs authorize — was rejected: it costs a permanent extra signature (10 µT plus
~96 bytes of weight) on the common single-input transfer, taking it from 1 signature to 2. It
remains the fallback if firmware rollout stalls.

## How Has This Been Tested?

- `cargo test -p ootle_ledger_client` — the host reference test now covers the stealth request's
  borsh round-trip and asserts the tweak binds to both the network and the nonce. Verified by
  mutation (pinning the network byte turns the network-binding assertion red).
- `cargo test -p ootle-rs --features ledger` — new unit test proves the network guard rejects
  before any APDU is sent (mutation-verified: without the guard the mock transport is contacted).
- Speculos, nanox, running the rebuilt app: all five integration tests pass, including a new
  `stealth_public_key_derivation` (deterministic, bound to nonce and network, never the untweaked
  account key) and an assertion in `sign_stealth_roundtrip` that `GetPublicKey` returns exactly the
  key the device signs with. The two device-side rejections were confirmed by raw APDU.
- Device app builds for nanosplus, nanox, stax and flex — all reporting `0.2.0`. Note the app is
  outside the cargo workspace and has no CI job, so it must be built explicitly.

Not yet exercised end-to-end against a running network with a physical device.

## What process can a PR reviewer use to test or verify this change?

Build the app (`crates/wallet/ledger/app/build-app.sh nanox`), run it under Speculos, then
`cargo test -p ootle_ledger_client --features speculos-transport -- --ignored --test-threads=1`.
The emulator serialises APDUs, so the tests must not run in parallel.

<!-- Checklist -->
## Breaking Changes

- [ ] None
- [ ] Requires data directory to be deleted
- [x] Other - Please specify

The Ledger app must be updated to `0.2.0`: `GetPublicKeyRequest` gained a field and the device
decodes request bodies strictly, so a 0.4.0 client against 0.1.x firmware fails every
`get_public_key`.
