### PR TITLE
chore(deps)!: update minicbor 2.3.0 and drop the local 128-bit codecs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1733,7 +1733,7 @@ dependencies = [
 
 [[package]]
 name = "consensus_tests"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "fern",
  "futures 0.3.31",
@@ -2744,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "db-inspector"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -5128,7 +5128,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "integration_tests"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "config",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-messaging"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "futures-bounded 0.2.4",
@@ -6074,7 +6074,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-substream"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "libp2p",
  "prometheus-client",
@@ -6653,18 +6653,18 @@ dependencies = [
 
 [[package]]
 name = "minicbor"
-version = "2.2.2"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b7a5041e12946f8b7d3f5a9d96383a19d694b9335457c522be7815b9abafb02"
+checksum = "c12b4033ffaa92fbf9df03df38d19324f52bad130dd223f811734a8006dd2d69"
 dependencies = [
  "minicbor-derive",
 ]
 
 [[package]]
 name = "minicbor-derive"
-version = "0.19.4"
+version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9303a7d70578b101a21b3043ade4ab825c59063bbcd89af1066729399b79c6"
+checksum = "84f5ad8dfe10176465fe33f19ecfcf08783ba66630fdb40b2e4542547c1046f0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7712,7 +7712,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-rs"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7743,7 +7743,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -7754,7 +7754,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm-core"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -7775,7 +7775,7 @@ dependencies = [
 
 [[package]]
 name = "ootle_byte_type"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "tari_crypto",
  "tari_template_lib_types",
@@ -7783,7 +7783,7 @@ dependencies = [
 
 [[package]]
 name = "ootle_ledger_client"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -7814,7 +7814,7 @@ dependencies = [
 
 [[package]]
 name = "ootle_sdk_core"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "blake2 0.10.6",
  "hex",
@@ -7840,7 +7840,7 @@ dependencies = [
 
 [[package]]
 name = "ootle_sdk_ffi_c"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "cbindgen",
  "hex",
@@ -7851,7 +7851,7 @@ dependencies = [
 
 [[package]]
 name = "ootle_serde"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -8835,7 +8835,7 @@ dependencies = [
 
 [[package]]
 name = "proto_builder"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "prost-build 0.14.3",
  "sha2 0.10.9",
@@ -10676,7 +10676,7 @@ dependencies = [
 
 [[package]]
 name = "sqlite_message_logger"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "chrono",
  "diesel",
@@ -11024,7 +11024,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node_client"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "futures-util",
  "log",
@@ -11045,7 +11045,7 @@ dependencies = [
 
 [[package]]
 name = "tari_bor"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "borsh",
  "indexmap 2.13.0",
@@ -11255,7 +11255,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -11280,7 +11280,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "borsh",
  "minicbor",
@@ -11383,7 +11383,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "blake2 0.10.6",
  "bytes",
@@ -11416,7 +11416,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11446,7 +11446,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_manager"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "log",
@@ -11466,7 +11466,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_oracles"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",
@@ -11512,7 +11512,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -11588,7 +11588,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_client"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "bounded-vec",
@@ -11617,7 +11617,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_lib"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "log",
@@ -11715,7 +11715,7 @@ dependencies = [
 
 [[package]]
 name = "tari_networking"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11753,7 +11753,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_address"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bech32",
  "ootle-network",
@@ -11769,7 +11769,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_app_utilities"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11810,7 +11810,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11839,7 +11839,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_p2p"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "libp2p-identity 0.2.14",
@@ -11863,7 +11863,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -11892,7 +11892,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage_sqlite"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -11913,7 +11913,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_template_build"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "syn 2.0.117",
  "tari_ootle_template_metadata",
@@ -11924,7 +11924,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_template_metadata"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "borsh",
  "cargo_toml 0.22.3",
@@ -11945,7 +11945,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_template_provider"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "dashmap 5.5.3",
@@ -11962,7 +11962,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "borsh",
  "hex",
@@ -11988,7 +11988,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction_validation"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -12004,7 +12004,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_cli"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -12034,7 +12034,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_crypto"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "argon2 0.5.3",
  "blake2 0.10.6",
@@ -12064,7 +12064,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12126,7 +12126,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk_tests"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "digest 0.10.7",
  "ootle_byte_type",
@@ -12148,7 +12148,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_storage_sqlite"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -12172,7 +12172,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",
@@ -12243,7 +12243,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd_client"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "hex",
  "ootle_serde",
@@ -12299,7 +12299,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_framework"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "bitflags 2.13.0",
@@ -12323,7 +12323,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_macros"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12332,7 +12332,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_state_sync"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12414,7 +12414,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_store_rocksdb"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12446,7 +12446,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_tree"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "indexmap 2.13.0",
  "log",
@@ -12475,7 +12475,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "libp2p",
  "libp2p-messaging",
@@ -12487,7 +12487,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm_daemon"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12531,7 +12531,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_abi"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "hashbrown 0.13.2",
  "minicbor",
@@ -12543,7 +12543,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_builtin"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "minicbor",
@@ -12556,7 +12556,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "borsh",
  "minicbor",
@@ -12570,7 +12570,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib_types"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "bnum",
  "borsh",
@@ -12588,7 +12588,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_macros"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "indoc",
  "proc-macro2",
@@ -12600,7 +12600,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_test_tooling"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "cargo_toml 0.22.3",
@@ -12716,7 +12716,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_manifest"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "proc-macro2",
  "serde_json",
@@ -12751,7 +12751,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -12814,7 +12814,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_client"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "indexmap 2.13.0",
  "multiaddr 0.18.3",
@@ -12838,7 +12838,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_rpc"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12862,7 +12862,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_rollback"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12899,7 +12899,7 @@ dependencies = [
 
 [[package]]
 name = "tari_watcher"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -12928,7 +12928,7 @@ dependencies = [
 
 [[package]]
 name = "tariswap_bench"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13611,7 +13611,7 @@ dependencies = [
 
 [[package]]
 name = "traffic-sim"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13635,7 +13635,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_generator"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -13656,7 +13656,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_submitter"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "clap 4.5.54",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.38.0"
+version = "0.39.0"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-ootle"
@@ -97,59 +97,59 @@ tari_ootle_app_utilities = { path = "applications/tari_ootle_app_utilities" }
 
 # core crates
 tari_consensus = { path = "crates/consensus" }
-tari_ootle_address = { path = "crates/ootle_address", version = "0.8" }
+tari_ootle_address = { path = "crates/ootle_address", version = "0.9" }
 ootle-network = { path = "crates/ootle_network", version = "0.2" }
-tari_engine = { path = "crates/engine", version = "0.38" }
+tari_engine = { path = "crates/engine", version = "0.39" }
 tari_ootle_p2p = { path = "crates/p2p" }
 tari_ootle_storage = { path = "crates/storage" }
 tari_ootle_storage_sqlite = { path = "crates/storage_sqlite" }
-tari_ootle_wallet_crypto = { path = "crates/wallet/crypto", version = "0.39.0" }
-tari_ootle_wallet_sdk = { path = "crates/wallet/sdk", version = "0.38" }
+tari_ootle_wallet_crypto = { path = "crates/wallet/crypto", version = "0.40.0" }
+tari_ootle_wallet_sdk = { path = "crates/wallet/sdk", version = "0.39" }
 tari_ootle_wallet_sdk_services = { path = "crates/wallet/sdk_services" }
-tari_ootle_wallet_storage_sqlite = { path = "crates/wallet/storage_sqlite", version = "0.38" }
+tari_ootle_wallet_storage_sqlite = { path = "crates/wallet/storage_sqlite", version = "0.39" }
 tari_epoch_manager = { path = "crates/epoch_manager" }
 tari_epoch_oracles = { path = "crates/epoch_oracles" }
 tari_indexer_lib = { path = "crates/indexer_lib" }
 tari_rpc_state_sync = { path = "crates/rpc_state_sync" }
 tari_state_store_rocksdb = { path = "crates/state_store_rocksdb" }
 tari_state_tree = { path = "crates/state_tree" }
-tari_template_test_tooling = { path = "crates/template_test_tooling", version = "0.38" }
-tari_transaction_manifest = { path = "crates/transaction_manifest", version = "0.38" }
+tari_template_test_tooling = { path = "crates/template_test_tooling", version = "0.39" }
+tari_transaction_manifest = { path = "crates/transaction_manifest", version = "0.39" }
 tari_validator_node_rpc = { path = "crates/validator_node_rpc" }
 sqlite_message_logger = { path = "networking/sqlite_message_logger" }
 tari_base_node_client = { path = "clients/base_node_client" }
-tari_indexer_client = { path = "clients/tari_indexer_client", default-features = false, version = "0.37" }
+tari_indexer_client = { path = "clients/tari_indexer_client", default-features = false, version = "0.38" }
 tari_networking = { path = "networking/core" }
 tari_rpc_framework = { path = "networking/rpc_framework" }
 tari_rpc_macros = { path = "networking/rpc_macros" }
 tari_swarm = { path = "networking/swarm" }
 tari_validator_node_client = { path = "clients/validator_node_client" }
-tari_validator_rollback = { path = "utilities/validator_rollback", version = "0.38" }
-tari_ootle_walletd_client = { path = "clients/wallet_daemon_client", version = "0.38" }
+tari_validator_rollback = { path = "utilities/validator_rollback", version = "0.39" }
+tari_ootle_walletd_client = { path = "clients/wallet_daemon_client", version = "0.39" }
 transaction_generator = { path = "utilities/transaction_generator" }
 
 # Dependency crates on crates.io (update versions here as well when updating the workspace version)
-tari_consensus_types = { path = "crates/consensus_types", version = "0.38" }
-tari_ootle_common_types = { path = "crates/common_types", version = "0.38" }
-tari_engine_types = { path = "crates/engine_types", version = "0.38" }
-tari_template_builtin = { path = "crates/template_builtin", version = "0.38" }
-tari_ootle_transaction = { path = "crates/transaction", version = "0.38" }
+tari_consensus_types = { path = "crates/consensus_types", version = "0.39" }
+tari_ootle_common_types = { path = "crates/common_types", version = "0.39" }
+tari_engine_types = { path = "crates/engine_types", version = "0.39" }
+tari_template_builtin = { path = "crates/template_builtin", version = "0.39" }
+tari_ootle_transaction = { path = "crates/transaction", version = "0.39" }
 tari_ootle_transaction_validation = { path = "crates/transaction_validation" }
 
 # Template lib
-tari_ootle_template_build = { path = "crates/template_build", version = "0.9" }
-tari_ootle_template_metadata = { path = "crates/template_metadata", version = "0.9" }
+tari_ootle_template_build = { path = "crates/template_build", version = "0.10" }
+tari_ootle_template_metadata = { path = "crates/template_metadata", version = "0.10" }
 tari_ootle_template_provider = { path = "crates/template_provider" }
-tari_template_lib = { version = "0.29", path = "crates/template_lib" }
-tari_template_lib_types = { version = "0.29", path = "crates/template_lib_types", default-features = false }
-tari_template_abi = { version = "0.18", path = "crates/template_abi", default-features = false }
-tari_template_macros = { version = "0.21", path = "crates/template_macros" }
-tari_bor = { version = "0.14.2", path = "crates/tari_bor", default-features = false }
+tari_template_lib = { version = "0.30", path = "crates/template_lib" }
+tari_template_lib_types = { version = "0.30", path = "crates/template_lib_types", default-features = false }
+tari_template_abi = { version = "0.19", path = "crates/template_abi", default-features = false }
+tari_template_macros = { version = "0.22", path = "crates/template_macros" }
+tari_bor = { version = "0.15.0", path = "crates/tari_bor", default-features = false }
 
-ootle_byte_type = { path = "crates/ootle_byte_type", version = "0.10" }
-ootle_serde = { path = "crates/ootle_serde", version = "0.3" }
-ootle-wasm-core = { path = "crates/ootle_wasm/core", version = "0.38" }
-ootle_sdk_core = { path = "crates/ootle_sdk_core", version = "0.38" }
+ootle_byte_type = { path = "crates/ootle_byte_type", version = "0.11" }
+ootle_serde = { path = "crates/ootle_serde", version = "0.4" }
+ootle-wasm-core = { path = "crates/ootle_wasm/core", version = "0.39" }
+ootle_sdk_core = { path = "crates/ootle_sdk_core", version = "0.39" }
 
 # external minotari/tari dependencies
 minotari_app_grpc = "5.6.0"
@@ -199,7 +199,7 @@ memmap2 = "0.9"
 bnum = "0.13.0"
 bech32 = "0.11.0"
 bounded-vec = "0.9.0"
-minicbor = { version = "2.2", default-features = false, features = ["alloc", "derive"] }
+minicbor = { version = "2.3", default-features = false, features = ["alloc", "derive"] }
 clap = "3.2.25"
 chacha20poly1305 = "0.10.1"
 config = "0.14.0"

--- a/clients/tari_indexer_client/Cargo.toml
+++ b/clients/tari_indexer_client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_indexer_client"
 description = "Tari indexer client library"
-version = "0.37.0"
+version = "0.38.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/clients/wallet_daemon_client/Cargo.toml
+++ b/clients/wallet_daemon_client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_walletd_client"
 description = "Tari wallet daemon client library"
-version = "0.38.0"
+version = "0.39.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/consensus_types/src/types/accumulated_data.rs
+++ b/crates/consensus_types/src/types/accumulated_data.rs
@@ -8,10 +8,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, BorshSerialize, Encode, Decode, CborLen)]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub struct ShardGroupAccumulatedData {
-    // minicbor 2.2 has no Encode/Decode for u128; bridge via tari_bor's u128 adapter until
-    // upstream PR https://github.com/twittner/minicbor/pull/63 lands.
     #[n(0)]
-    #[cbor(with = "tari_bor::adapters::u128_codec")]
     pub total_exhaust_burn: u128,
 }
 
@@ -19,6 +16,25 @@ impl From<ShardGroupAccumulatedData> for tari_sidechain::ShardGroupAccumulatedDa
     fn from(value: ShardGroupAccumulatedData) -> Self {
         Self {
             total_exhaust_burn: value.total_exhaust_burn,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `total_exhaust_burn` crosses the `u64::MAX` boundary where minicbor switches between a
+    /// plain CBOR integer and an RFC 8949 bignum, and `CborLen` has to agree with the encoder on
+    /// both sides of it.
+    #[test]
+    fn total_exhaust_burn_roundtrips_across_the_bignum_boundary() {
+        for total_exhaust_burn in [0, 1, u128::from(u64::MAX), u128::from(u64::MAX) + 1, u128::MAX] {
+            let data = ShardGroupAccumulatedData { total_exhaust_burn };
+            let bytes = minicbor::to_vec(data).unwrap();
+            assert_eq!(bytes.len(), minicbor::len(data));
+            let decoded: ShardGroupAccumulatedData = minicbor::decode(&bytes).unwrap();
+            assert_eq!(decoded.total_exhaust_burn, total_exhaust_burn);
         }
     }
 }

--- a/crates/engine/tests/templates/nft/basic_nft/Cargo.toml
+++ b/crates/engine/tests/templates/nft/basic_nft/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 
 [dependencies]
 tari_template_lib = { path = "../../../../../template_lib" }
-minicbor = { version = "2.2", default-features = false, features = ["alloc", "derive"] }
+minicbor = { version = "2.3", default-features = false, features = ["alloc", "derive"] }
 
 
 [lib]

--- a/crates/engine/tests/templates/nft/emoji_id/Cargo.toml
+++ b/crates/engine/tests/templates/nft/emoji_id/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 
 [dependencies]
 tari_template_lib = { path = "../../../../../template_lib" }
-minicbor = { version = "2.2", default-features = false, features = ["alloc", "derive"] }
+minicbor = { version = "2.3", default-features = false, features = ["alloc", "derive"] }
 
 [lib]
 crate-type = ["cdylib"]

--- a/crates/engine/tests/templates/nft/nft_list/Cargo.toml
+++ b/crates/engine/tests/templates/nft/nft_list/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 
 [dependencies]
 tari_template_lib = { path = "../../../../../template_lib" }
-minicbor = { version = "2.2", default-features = false, features = ["alloc", "derive"] }
+minicbor = { version = "2.3", default-features = false, features = ["alloc", "derive"] }
 
 [lib]
 crate-type = ["cdylib"]

--- a/crates/engine/tests/templates/nft/tickets/Cargo.toml
+++ b/crates/engine/tests/templates/nft/tickets/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 
 [dependencies]
 tari_template_lib = { path = "../../../../../template_lib" }
-minicbor = { version = "2.2", default-features = false, features = ["alloc", "derive"] }
+minicbor = { version = "2.3", default-features = false, features = ["alloc", "derive"] }
 
 [lib]
 crate-type = ["cdylib"]

--- a/crates/engine/tests/templates/no_std/src/lib.rs
+++ b/crates/engine/tests/templates/no_std/src/lib.rs
@@ -32,9 +32,6 @@ mod template {
 
     #[derive(Debug, Default)]
     pub struct NoStdCounter {
-        // u64 rather than u128: minicbor 2.2 does not impl Encode/Decode for u128/i128 and the
-        // workspace's bignum bridge (`Value::Integer(i128)` via `serde_bridge`) doesn't apply to
-        // bare template struct fields. The test exists to exercise no_std + allocator, not 128-bit.
         value: u64,
     }
 

--- a/crates/engine/tests/templates/template_upgrade/v2/Cargo.toml
+++ b/crates/engine/tests/templates/template_upgrade/v2/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 
 [dependencies]
 tari_template_lib = { path = "../../../../../template_lib" }
-minicbor = { version = "2.2", default-features = false, features = ["alloc", "derive"] }
+minicbor = { version = "2.3", default-features = false, features = ["alloc", "derive"] }
 
 [lib]
 crate-type = ["cdylib"]

--- a/crates/ootle_address/Cargo.toml
+++ b/crates/ootle_address/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_address"
 description = "Tari Ootle address using bech32 encoding"
-version = "0.8.0"
+version = "0.9.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/ootle_byte_type/Cargo.toml
+++ b/crates/ootle_byte_type/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ootle_byte_type"
-version = "0.10.0"
+version = "0.11.0"
 description = "Conversion traits that define conversions to/from light-weight byte types"
 edition.workspace = true
 authors.workspace = true

--- a/crates/ootle_serde/Cargo.toml
+++ b/crates/ootle_serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ootle_serde"
-version = "0.3.0"
+version = "0.4.0"
 description = "serde utilities for Tari Ootle"
 edition.workspace = true
 authors.workspace = true

--- a/crates/ootle_wasm/wasm/Cargo.toml
+++ b/crates/ootle_wasm/wasm/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../NPM_README.md"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-ootle-wasm-core = { path = "../core", version = "0.38" }
+ootle-wasm-core = { path = "../core", version = "0.39" }
 wasm-bindgen = "0.2"
 # getrandom is pulled in transitively via `rand` and `tari_bulletproofs_plus`. The wasm32-unknown-unknown
 # target requires explicit feature opt-in for both major versions used in the graph.

--- a/crates/tari_bor/Cargo.toml
+++ b/crates/tari_bor/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_bor"
 description = "The binary object representation (BOR) crate provides a binary encoding for template/engine data types"
-version = "0.14.2"
+version = "0.15.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true
@@ -24,8 +24,9 @@ borsh = ["dep:borsh"]
 std = ["minicbor/std", "serde?/std", "borsh?/std"]
 alloc = ["minicbor/alloc", "serde?/alloc"]
 # The `serde` feature also enables the local `serde_codec` module (a fork of `minicbor-serde`
-# with u128/i128 support) so the `adapters::serde_bridge` module — which lets foreign
-# serde-only types ride inside minicbor-encoded structs — is available wherever serde is.
+# that accepts a CBOR byte string where serde asks for a sequence) so the `adapters::serde_bridge`
+# module — which lets foreign serde-only types ride inside minicbor-encoded structs — is available
+# wherever serde is.
 serde = ["dep:serde"]
 ts = ["dep:ts-rs"]
 indexmap = ["dep:indexmap"]

--- a/crates/tari_bor/src/adapters.rs
+++ b/crates/tari_bor/src/adapters.rs
@@ -231,91 +231,9 @@ pub mod indexmap_codec {
     }
 }
 
-/// `#[cbor(with = "u128_codec")]` adapter for fields of type `u128`.
-///
-/// minicbor 2.2 has no built-in `Encode`/`Decode` for `u128` (upstream PR
-/// <https://github.com/twittner/minicbor/pull/63> is in flight). Until that lands, this adapter
-/// encodes the value using the RFC 8949 §3.4.3 positive-bignum tag — tag `2` wrapping a CBOR
-/// byte string of the big-endian magnitude with leading zero bytes stripped (canonical form).
-///
-/// Switching to the upstream `Encode for u128` once it ships should be wire-compatible: it will
-/// produce the same canonical form for values that don't fit in `u64`. (Values that *do* fit in
-/// `u64` will likely be emitted as a plain CBOR integer rather than a tagged bignum, so this is
-/// not a forever-stable wire format — call it out in the migration when the time comes.)
-pub mod u128_codec {
-    use minicbor::{CborLen, Decoder, Encoder, data::Tag};
-
-    const TAG_POSITIVE_BIGNUM: u64 = 2;
-
-    fn canonical_bytes(v: u128) -> ([u8; 16], usize) {
-        let bytes = v.to_be_bytes();
-        // unwrap_or(15) handles v == 0: encode as a single zero byte rather than an empty bstr,
-        // since RFC 8949 bignums must be non-empty.
-        let first = bytes.iter().position(|&b| b != 0).unwrap_or(15);
-        (bytes, first)
-    }
-
-    pub fn encode<C, W>(v: &u128, e: &mut Encoder<W>, _ctx: &mut C) -> Result<(), minicbor::encode::Error<W::Error>>
-    where W: minicbor::encode::Write {
-        let (bytes, first) = canonical_bytes(*v);
-        e.tag(Tag::new(TAG_POSITIVE_BIGNUM))?;
-        e.bytes(&bytes[first..])?;
-        Ok(())
-    }
-
-    pub fn decode<'b, C>(d: &mut Decoder<'b>, _ctx: &mut C) -> Result<u128, minicbor::decode::Error> {
-        let tag: u64 = d.tag()?.into();
-        if tag != TAG_POSITIVE_BIGNUM {
-            return Err(minicbor::decode::Error::message(
-                "u128_codec: expected positive-bignum tag (2)",
-            ));
-        }
-        let bytes = d.bytes()?;
-        if bytes.len() > 16 {
-            return Err(minicbor::decode::Error::message("u128_codec: bignum exceeds 128 bits"));
-        }
-        let mut buf = [0u8; 16];
-        buf[16 - bytes.len()..].copy_from_slice(bytes);
-        Ok(u128::from_be_bytes(buf))
-    }
-
-    pub fn cbor_len<C>(v: &u128, ctx: &mut C) -> usize {
-        let (_, first) = canonical_bytes(*v);
-        let n = 16 - first;
-        // Tag header + bstr header (1 byte: payload length 1..=16 fits below the 24-element threshold) + payload.
-        <Tag as CborLen<C>>::cbor_len(&Tag::new(TAG_POSITIVE_BIGNUM), ctx) + 1 + n
-    }
-
-    #[cfg(test)]
-    mod tests {
-        use minicbor::{Decoder, Encoder};
-
-        use super::*;
-
-        fn roundtrip(v: u128) {
-            let mut buf = Vec::new();
-            let mut e = Encoder::new(&mut buf);
-            encode(&v, &mut e, &mut ()).unwrap();
-            assert_eq!(buf.len(), cbor_len(&v, &mut ()), "cbor_len mismatch for {v}");
-            let mut d = Decoder::new(&buf);
-            let got = decode::<()>(&mut d, &mut ()).unwrap();
-            assert_eq!(got, v);
-        }
-
-        #[test]
-        fn boundary_values() {
-            roundtrip(0);
-            roundtrip(1);
-            roundtrip(u128::from(u64::MAX));
-            roundtrip(u128::from(u64::MAX) + 1);
-            roundtrip(u128::MAX);
-        }
-    }
-}
-
 /// Bridges any `serde::Serialize`/`serde::Deserialize` type into minicbor's `#[cbor(with = ...)]`
-/// system via our local [`crate::serde_codec`] module (a fork of `minicbor-serde` with `u128`
-/// and `i128` support added).
+/// system via our local [`crate::serde_codec`] module (a fork of `minicbor-serde` that also
+/// accepts a CBOR byte string where serde asks for a sequence).
 ///
 /// Use this on fields whose type is foreign (orphan-rule blocked) and only implements serde —
 /// most commonly the consensus proofs from `tari_sidechain`. The subtree is encoded as

--- a/crates/tari_bor/src/serde_codec.rs
+++ b/crates/tari_bor/src/serde_codec.rs
@@ -1,23 +1,17 @@
 //   Copyright 2026 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-//! Local fork of [`minicbor-serde`](https://docs.rs/minicbor-serde) with `u128` / `i128` support
-//! added on both the encode and decode sides.
+//! Local fork of [`minicbor-serde`](https://docs.rs/minicbor-serde) that additionally accepts a
+//! CBOR byte string wherever serde asks for a sequence.
 //!
-//! Upstream's `Serializer` and `Deserializer` don't implement `serialize_u128`/`serialize_i128`
-//! or `deserialize_u128`/`deserialize_i128`, so any serde-bridged struct that names a `u128` or
-//! `i128` field fails to round-trip. The relevant upstream change is in flight at
-//! <https://github.com/twittner/minicbor/pull/63>; when it lands (and a `minicbor-serde` release
-//! picks it up), this module can be deleted and call sites switched back to `minicbor_serde`.
+//! serde's blanket `Deserialize for Vec<u8>` (and `Cow<'_, [u8]>`, which routes through it) calls
+//! `deserialize_seq` even when the encoded form is a CBOR `bstr`. Upstream only handles a CBOR
+//! array there, so foreign serde-only types that serialize bytes as `bstr` — the consensus proofs
+//! in `tari_sidechain`, for example — fail to round-trip through `adapters::serde_bridge`. See
+//! [`Deserializer::deserialize_seq`].
 //!
-//! The wire format is intentionally identical to `minicbor-serde`'s for every type it already
-//! supports — only the 128-bit integer arms are new. Those use the RFC 8949 §3.4.3 bignum form:
-//!   - `u128`  → tag `2`  ("positive bignum") + bstr of big-endian magnitude (leading zeros stripped; a single `0x00`
-//!     byte for the value `0`).
-//!   - `i128`  → tag `2` for non-negative, tag `3` ("negative bignum", encoding `-1 - n`) for negative values, payload
-//!     as above.
-//!
-//! Code structure mirrors upstream so the eventual diff to drop this fork is mechanical.
+//! The wire format is otherwise identical to `minicbor-serde`'s, so code structure mirrors
+//! upstream to keep the diff small.
 
 #![cfg(feature = "serde")]
 
@@ -28,7 +22,7 @@ use core::fmt;
 use minicbor::{
     Decoder,
     Encoder,
-    data::{Tag, Type},
+    data::{IanaTag, Type},
     decode,
     encode::{self, Write},
 };
@@ -48,8 +42,6 @@ use serde::{
     },
 };
 
-const TAG_POSITIVE_BIGNUM: u64 = 2;
-const TAG_NEGATIVE_BIGNUM: u64 = 3;
 const BREAK: u8 = 0xff;
 
 // ============================================================================
@@ -125,30 +117,8 @@ pub fn from_slice<'de, T: Deserialize<'de>>(b: &'de [u8]) -> Result<T, DecodeErr
 }
 
 // ============================================================================
-// 128-bit helpers (the reason this fork exists)
+// Helpers
 // ============================================================================
-
-fn encode_u128<W: Write>(e: &mut Encoder<W>, v: u128) -> Result<(), encode::Error<W::Error>> {
-    let bytes = v.to_be_bytes();
-    let first = bytes.iter().position(|&b| b != 0).unwrap_or(15);
-    e.tag(Tag::new(TAG_POSITIVE_BIGNUM))?;
-    e.bytes(&bytes[first..])?;
-    Ok(())
-}
-
-fn encode_i128<W: Write>(e: &mut Encoder<W>, v: i128) -> Result<(), encode::Error<W::Error>> {
-    if v >= 0 {
-        return encode_u128(e, v as u128);
-    }
-    // RFC 8949 §3.4.3: negative bignum encodes -1 - n. So for v < 0, the encoded magnitude is
-    // (-1 - v) as an unsigned bignum.
-    let magnitude = (-1i128 - v) as u128;
-    let bytes = magnitude.to_be_bytes();
-    let first = bytes.iter().position(|&b| b != 0).unwrap_or(15);
-    e.tag(Tag::new(TAG_NEGATIVE_BIGNUM))?;
-    e.bytes(&bytes[first..])?;
-    Ok(())
-}
 
 /// Concatenate the chunks of an indefinite-length CBOR byte string into a single `Vec<u8>`,
 /// pre-sized so the output buffer is allocated exactly once. Collecting the chunk references
@@ -162,56 +132,6 @@ fn collect_indef_bytes(d: &mut Decoder<'_>) -> Result<Vec<u8>, decode::Error> {
         buf.extend_from_slice(chunk);
     }
     Ok(buf)
-}
-
-fn read_bignum_payload(d: &mut Decoder<'_>) -> Result<u128, decode::Error> {
-    let bytes = d.bytes()?;
-    if bytes.len() > 16 {
-        return Err(decode::Error::message("bignum payload exceeds 128 bits"));
-    }
-    let mut buf = [0u8; 16];
-    buf[16 - bytes.len()..].copy_from_slice(bytes);
-    Ok(u128::from_be_bytes(buf))
-}
-
-fn decode_u128(d: &mut Decoder<'_>) -> Result<u128, decode::Error> {
-    // Accept a plain CBOR unsigned integer too, since RFC 8949 lets bignums skip the tag when the
-    // value fits in u64.
-    let ty = d.datatype()?;
-    match ty {
-        Type::U8 | Type::U16 | Type::U32 | Type::U64 => Ok(u128::from(d.u64()?)),
-        Type::Tag => {
-            let tag: u64 = d.tag()?.into();
-            if tag != TAG_POSITIVE_BIGNUM {
-                return Err(decode::Error::message("u128: expected positive-bignum tag (2)"));
-            }
-            read_bignum_payload(d)
-        },
-        other => Err(decode::Error::type_mismatch(other).with_message("u128: unexpected CBOR type")),
-    }
-}
-
-fn decode_i128(d: &mut Decoder<'_>) -> Result<i128, decode::Error> {
-    let ty = d.datatype()?;
-    match ty {
-        Type::U8 | Type::U16 | Type::U32 | Type::U64 => Ok(i128::from(d.u64()?)),
-        Type::I8 | Type::I16 | Type::I32 | Type::I64 => Ok(i128::from(d.i64()?)),
-        Type::Tag => {
-            let tag: u64 = d.tag()?.into();
-            let magnitude = read_bignum_payload(d)?;
-            match tag {
-                TAG_POSITIVE_BIGNUM => i128::try_from(magnitude)
-                    .map_err(|_| decode::Error::message("i128: positive bignum overflows i128")),
-                TAG_NEGATIVE_BIGNUM => {
-                    let signed = i128::try_from(magnitude)
-                        .map_err(|_| decode::Error::message("i128: negative bignum overflows i128"))?;
-                    Ok(-1i128 - signed)
-                },
-                _ => Err(decode::Error::message("i128: unexpected bignum tag")),
-            }
-        },
-        other => Err(decode::Error::type_mismatch(other).with_message("i128: unexpected CBOR type")),
-    }
 }
 
 // ============================================================================
@@ -287,7 +207,8 @@ where <W as Write>::Error: core::error::Error + 'static
     }
 
     fn serialize_i128(self, v: i128) -> Result<(), Self::Error> {
-        encode_i128(&mut self.encoder, v).map_err(Into::into)
+        self.encoder.i128(v)?;
+        Ok(())
     }
 
     fn serialize_u8(self, v: u8) -> Result<(), Self::Error> {
@@ -311,7 +232,8 @@ where <W as Write>::Error: core::error::Error + 'static
     }
 
     fn serialize_u128(self, v: u128) -> Result<(), Self::Error> {
-        encode_u128(&mut self.encoder, v).map_err(Into::into)
+        self.encoder.u128(v)?;
+        Ok(())
     }
 
     fn serialize_f32(self, v: f32) -> Result<(), Self::Error> {
@@ -651,12 +573,14 @@ impl<'de> de::Deserializer<'de> for &mut Deserializer<'de> {
             },
             Type::Array | Type::ArrayIndef => self.deserialize_seq(visitor),
             Type::Map | Type::MapIndef => self.deserialize_map(visitor),
+            Type::Int => self.deserialize_i128(visitor),
             Type::Tag => {
-                // Could be a bignum (positive or negative). decode_i128 handles both
-                // TAG_POSITIVE_BIGNUM and TAG_NEGATIVE_BIGNUM; anything else is currently
-                // unsupported, matching upstream.
-                let v = decode_i128(&mut self.decoder)?;
-                visitor.visit_i128(v)
+                let tag = self.decoder.probe().tag()?;
+                match tag.try_into() {
+                    Ok(IanaTag::PosBignum) => self.deserialize_u128(visitor),
+                    Ok(IanaTag::NegBignum) => self.deserialize_i128(visitor),
+                    _ => Err(decode::Error::tag_mismatch(tag).at(self.decoder.position()).into()),
+                }
             },
             Type::BytesIndef => visitor.visit_byte_buf(collect_indef_bytes(&mut self.decoder)?),
             Type::StringIndef => {
@@ -669,7 +593,7 @@ impl<'de> de::Deserializer<'de> for &mut Deserializer<'de> {
                 }
                 visitor.visit_string(buf)
             },
-            t @ (Type::F16 | Type::Undefined | Type::Int | Type::Simple | Type::Break | Type::Unknown(_)) => {
+            t @ (Type::F16 | Type::Undefined | Type::Simple | Type::Break | Type::Unknown(_)) => {
                 Err(decode::Error::type_mismatch(t)
                     .with_message("unexpected type")
                     .at(self.decoder.position())
@@ -699,8 +623,7 @@ impl<'de> de::Deserializer<'de> for &mut Deserializer<'de> {
     }
 
     fn deserialize_i128<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
-        let v = decode_i128(&mut self.decoder)?;
-        visitor.visit_i128(v)
+        visitor.visit_i128(self.decoder.i128()?)
     }
 
     fn deserialize_u8<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
@@ -720,8 +643,7 @@ impl<'de> de::Deserializer<'de> for &mut Deserializer<'de> {
     }
 
     fn deserialize_u128<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
-        let v = decode_u128(&mut self.decoder)?;
-        visitor.visit_u128(v)
+        visitor.visit_u128(self.decoder.u128()?)
     }
 
     fn deserialize_f32<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {

--- a/crates/template_abi/Cargo.toml
+++ b/crates/template_abi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_template_abi"
 description = "Defines the low-level Tari engine ABI for WASM targets"
-version = "0.18.0"
+version = "0.19.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_build/Cargo.toml
+++ b/crates/template_build/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_template_build"
 description = "Build-time metadata generation for Tari Ootle templates"
-version = "0.9.0"
+version = "0.10.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_builtin/Cargo.toml
+++ b/crates/template_builtin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_template_builtin"
 description = "Tari Ootle built-in templates"
-version = "0.38.0"
+version = "0.39.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_lib/Cargo.toml
+++ b/crates/template_lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_template_lib"
 description = "Tari template library provides abstrations that interface with the Tari validator engine"
-version = "0.29.0"
+version = "0.30.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_lib_types/Cargo.toml
+++ b/crates/template_lib_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_template_lib_types"
-version = "0.29.0"
+version = "0.30.0"
 edition.workspace = true
 authors.workspace = true
 description = "Tari template library types"

--- a/crates/template_macros/Cargo.toml
+++ b/crates/template_macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_template_macros"
 description = "Tari template macro"
-version = "0.21.0"
+version = "0.22.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_metadata/Cargo.toml
+++ b/crates/template_metadata/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_template_metadata"
 description = "Template metadata types, serialization, and hashing for Tari Ootle templates"
-version = "0.9.0"
+version = "0.10.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/transaction_manifest/src/value.rs
+++ b/crates/transaction_manifest/src/value.rs
@@ -74,12 +74,9 @@ pub fn lit_to_arg(lit: &Lit) -> Result<InstructionArg, ManifestError> {
             "" => Ok(call_arg!(i.base10_parse::<i64>()?)),
             // 128-bit integer literals are emitted as `tari_bor::Value::Integer(i128)` and on the
             // wire become a CBOR integer (Value's encoder accepts the i64::MIN..=u64::MAX range
-            // and errors at submission time for anything wider). This unblocks templates whose
-            // arg type is `tari_bor::Value` — they can read back via `Value::as_integer()`.
-            // Templates that take native `u128` / `i128` parameters still won't decode, because
-            // minicbor 2.2 has no `Decode` impl for those types (upstream PR
-            // <https://github.com/twittner/minicbor/pull/63> is pending); use the adapters in
-            // `tari_bor::adapters::{u128_codec, i128_codec}` on those fields in the meantime.
+            // and errors at submission time for anything wider). Templates taking native `u128` /
+            // `i128` parameters decode that form too, so both they and templates whose arg type is
+            // `tari_bor::Value` (read back via `Value::as_integer()`) accept these literals.
             "u128" => {
                 let parsed = i.base10_parse::<u128>()?;
                 let as_i128 = i128::try_from(parsed).map_err(|_| {

--- a/crates/wallet/crypto/Cargo.toml
+++ b/crates/wallet/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_ootle_wallet_crypto"
-version = "0.39.0"
+version = "0.40.0"
 description = "Cryptographic utilities and types for Tari Ootle wallet"
 edition.workspace = true
 authors.workspace = true

--- a/crates/wallet/ledger/client/Cargo.toml
+++ b/crates/wallet/ledger/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ootle_ledger_client"
-version = "0.4.0"
+version = "0.5.0"
 description = "Host client for the Tari Ootle Ledger app: on-device key derivation and transaction signing over any APDU transport"
 edition.workspace = true
 authors.workspace = true

--- a/crates/wallet/ootle-rs/Cargo.toml
+++ b/crates/wallet/ootle-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ootle-rs"
-version = "0.18.0"
+version = "0.19.0"
 description = "A Rust library for interacting with the Tari Ootle network."
 edition.workspace = true
 authors.workspace = true
@@ -21,7 +21,7 @@ tari_ootle_address = { workspace = true }
 tari_template_builtin = { workspace = true }
 
 # Ledger hardware-wallet signer (feature-gated).
-ootle_ledger_client = { path = "../ledger/client", version = "0.4.0", optional = true }
+ootle_ledger_client = { path = "../ledger/client", version = "0.5.0", optional = true }
 ootle_ledger_common = { workspace = true, optional = true }
 
 async-trait = { workspace = true }

--- a/crates/wallet/sdk/Cargo.toml
+++ b/crates/wallet/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_wallet_sdk"
 description = "The Tari wallet library"
-version = "0.38.0"
+version = "0.39.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/wallet/storage_sqlite/Cargo.toml
+++ b/crates/wallet/storage_sqlite/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_wallet_storage_sqlite"
 description = "The Tari wallet SQLite storage library"
-version = "0.38.0"
+version = "0.39.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## Description

minicbor 2.3.0 ships native `Encode`/`Decode`/`CborLen` impls for `u128`/`i128`, so the workspace's stand-in codecs are no longer needed.

- Bump `minicbor` 2.2 → 2.3 (workspace + the WASM test templates).
- Delete `tari_bor::adapters::u128_codec`. `ShardGroupAccumulatedData::total_exhaust_burn` uses the derived impl now.
- `tari_bor::serde_codec` delegates its 128-bit arms to `Encoder::{u128,i128}` / `Decoder::{u128,i128}`, and picks up upstream's `Type::Int` and per-tag bignum dispatch in `deserialize_any`. The fork stays only for its byte-string-as-sequence handling in `deserialize_seq`, which upstream `minicbor-serde` still doesn't do — that's what lets `tari_sidechain`'s serde-only proofs round-trip through `adapters::serde_bridge`.
- Drop the stale comments that pointed at the pending upstream PR.

## Wire format

Breaking for 128-bit integers, and asymmetrically so. The removed codecs always emitted an RFC 8949 bignum; minicbor emits a plain CBOR integer for values in the CBOR integer range (`-2^64 ..= 2^64-1`) and a bignum only beyond it:

| value | old (`u128_codec`) | new (minicbor 2.3) |
|---|---|---|
| `0` | `c24100` | `00` |
| `1_000_000` | `c2430f4240` | `1a000f4240` |
| `u64::MAX` | `c248ffffffffffffffff` | `1bffffffffffffffff` |
| `u64::MAX + 1` | `c249010000000000000000` | identical |
| `u128::MAX` | `c250` + `ff`×16 | identical |

`ShardGroupAccumulatedData::total_exhaust_burn` is the only 128-bit field in any encoded type in the workspace, and its blast radius is narrow:

- **Not hashed.** `BlockHeader::calculate_hash` feeds `BlockHeaderHashFieldsV1` to `hashing::block_hasher().chain(&fields)`, and `chain` is `chain<T: BorshSerialize>` — the preimage is Borsh, not CBOR. Block IDs, signatures and merkle roots are unchanged, so no chain split and no re-validation failure on historical blocks.
- **Not gossiped as CBOR.** Consensus messages and block sync are protobuf, and the conversion splits the `u128` into `total_exhaust_burn_msb`/`_lsb` (`crates/p2p/src/conversions/consensus.rs:1113`). The CBOR encoding never crosses the network.
- **Persistence only.** The RocksDB column families are minicbor-encoded, so this is where the bytes change.

A rolling upgrade needs no coordination and the existing database needs no migration: new code decodes old rows, since minicbor's `u128` decoder accepts the untagged integer and the tag-2 bignum alike. The one hazard is **downgrade** — an older binary running against a database that a newer one has written will hit `u128_codec::decode`'s leading `d.tag()?` and fail with `expected tag`.

## Version bumps

Per `scripts/crate_versioning.py impact tari_bor --breaking`: workspace `0.38.0` → `0.39.0`, plus minor bumps for the tier-1/2 crates that re-expose the changed types (`tari_bor` → `0.15.0`, `tari_template_lib` → `0.30.0`, etc.).

## Motivation and Context

Removes ~180 lines of hand-rolled bignum encoding now covered upstream, and makes native `u128`/`i128` usable in template struct fields and parameters without an adapter.

## How Has This Been Tested?

- `cargo check --workspace --all-targets` and `cargo clippy --workspace --all-targets` clean.
- `cargo test --workspace --lib` passes; `tari_bor`'s `--all-features` suite covers the `u128`/`i128` serde boundary values.
- New `ShardGroupAccumulatedData` test round-trips `total_exhaust_burn` across the `u64::MAX` bignum boundary and asserts `CborLen` agrees with the encoder on both sides.

## What process can a PR reviewer use to test or verify this change?

Check out the branch and run `cargo test -p tari_bor --all-features` and `cargo test -p tari_consensus_types`.

