### PR TITLE
fix(engine)!: charge storage for the transaction receipt and drop its logs

### DIFF
--- a/applications/tari_indexer/src/storage_sqlite/store_factory.rs
+++ b/applications/tari_indexer/src/storage_sqlite/store_factory.rs
@@ -354,7 +354,6 @@ mod tests {
             diff_summary: Default::default(),
             fee_withdrawals: [].into(),
             events: [].into(),
-            logs: [].into(),
             fee_receipt: FeeReceiptBuilder::default().with_total_fees_paid(123).build(),
             epoch: Epoch(1),
             intent_commitment: Default::default(),

--- a/applications/tari_indexer/web_ui/src/routes/TransactionReceipts/components/TransactionReceiptDetails.tsx
+++ b/applications/tari_indexer/web_ui/src/routes/TransactionReceipts/components/TransactionReceiptDetails.tsx
@@ -26,7 +26,6 @@ import { CURRENCY } from "../../../utils/constants";
 import { formatCurrency } from "../../../utils/helpers";
 import EventsContent from "../../Transaction/components/EventsContent";
 import FeeReceipt from "../../Transaction/components/FeeReceipt";
-import LogsContent from "../../Transaction/components/LogsContent";
 import SubstateChanges from "./SubstateChanges";
 
 function TransactionReceiptDetails({ address }: { address: string }) {
@@ -41,7 +40,7 @@ function TransactionReceiptDetails({ address }: { address: string }) {
     setExpandedPanels((prev) => (isExpanded ? [...prev, panel] : prev.filter((p) => p !== panel)));
   };
 
-  const expandAll = () => setExpandedPanels(["p1", "p2", "p3", "p4", "p5"]);
+  const expandAll = () => setExpandedPanels(["p1", "p3", "p4", "p5"]);
   const collapseAll = () => setExpandedPanels([]);
 
   const receipt = data?.receipt;
@@ -128,17 +127,6 @@ function TransactionReceiptDetails({ address }: { address: string }) {
                   </AccordionSummary>
                   <AccordionDetails>
                     <EventsContent data={receipt.events} />
-                  </AccordionDetails>
-                </Accordion>
-              )}
-
-              {receipt.logs.length > 0 && (
-                <Accordion expanded={expandedPanels.includes("p2")} onChange={handleChange("p2")}>
-                  <AccordionSummary>
-                    <Typography variant="h5">Logs ({receipt.logs.length})</Typography>
-                  </AccordionSummary>
-                  <AccordionDetails>
-                    <LogsContent data={receipt.logs} />
                   </AccordionDetails>
                 </Accordion>
               )}

--- a/bindings/src/types/TransactionReceipt.ts
+++ b/bindings/src/types/TransactionReceipt.ts
@@ -5,7 +5,6 @@ import type { Event } from "./Event";
 import type { FeeReceipt } from "./FeeReceipt";
 import type { FinalizeOutcome } from "./FinalizeOutcome";
 import type { Hash32 } from "./Hash32";
-import type { LogEntry } from "./LogEntry";
 import type { ValidatorFeeWithdrawal } from "./ValidatorFeeWithdrawal";
 
 export type TransactionReceipt = {
@@ -13,7 +12,6 @@ export type TransactionReceipt = {
   diff_summary: DiffSummary;
   fee_withdrawals: Array<ValidatorFeeWithdrawal>;
   events: Array<Event>;
-  logs: Array<LogEntry>;
   fee_receipt: FeeReceipt;
   epoch: Epoch;
   intent_commitment: Hash32;

--- a/crates/consensus_tests/src/support/transaction.rs
+++ b/crates/consensus_tests/src/support/transaction.rs
@@ -136,7 +136,6 @@ pub fn create_execution_result_for_transaction(
                 diff_summary: Default::default(),
                 fee_withdrawals: Default::default(),
                 events: Default::default(),
-                logs: Default::default(),
                 fee_receipt: create_test_fee_receipt(fee),
                 epoch: Epoch::zero(),
                 intent_commitment: transaction.calculate_intent_commitment(),

--- a/crates/engine/src/fees/fee_module.rs
+++ b/crates/engine/src/fees/fee_module.rs
@@ -131,6 +131,17 @@ impl<TStore: StateReader> RuntimeModule<TStore> for FeeModule {
             Ok::<_, RuntimeModuleError>((counter.get(), base_bytes, premium))
         })?;
 
+        // Finalization persists the transaction receipt on top of the mutated substates. It carries
+        // the transaction's events, so leaving it out of the tally would make that payload — the
+        // largest caller-controlled contribution to permanent state after the substates themselves —
+        // free.
+        let receipt_bytes = track
+            .transaction_receipt_size()
+            .map_err(|e| RuntimeModuleError::Runtime(e.to_string()))?;
+        let total_storage = total_storage
+            .checked_add(receipt_bytes)
+            .ok_or_else(|| RuntimeModuleError::Overflow("Overflow accumulating storage bytes".to_string()))?;
+
         let cost = self
             .fee_table
             .per_byte_storage_cost()
@@ -153,9 +164,12 @@ impl<TStore: StateReader> RuntimeModule<TStore> for FeeModule {
             track.add_fee_charge(FeeSource::TemplatePublish, template_publish_cost);
         }
 
+        // The receipt occupies a slot of its own — it is always newly created, since it is addressed
+        // by a transaction id that can only be finalized once.
         let new_substate_count = track
             .count_newly_created_substates()
-            .map_err(|e| RuntimeModuleError::Runtime(e.to_string()))?;
+            .map_err(|e| RuntimeModuleError::Runtime(e.to_string()))?
+            .saturating_add(1);
         let create_cost = (new_substate_count as u64)
             .checked_mul(self.fee_table.per_substate_create_cost())
             .ok_or_else(|| RuntimeModuleError::Overflow("Overflow calculating substate create cost".to_string()))?;

--- a/crates/engine/src/runtime/tracker.rs
+++ b/crates/engine/src/runtime/tracker.rs
@@ -451,6 +451,12 @@ impl<TStore: StateReader> StateTracker<TStore> {
         self.write_with(|state| f(state.mutated_substates()))
     }
 
+    /// The storage footprint of the transaction receipt, which finalization persists in addition to
+    /// the substates seen by [`Self::with_substates_to_persist`].
+    pub fn transaction_receipt_size(&mut self) -> Result<usize, RuntimeError> {
+        self.write_with(|state| state.transaction_receipt_size())
+    }
+
     /// Counts substates in the to-persist set that did not previously exist in the state store.
     /// Used by the fee module to charge a slot-allocation premium on top of per-byte storage.
     pub fn count_newly_created_substates(&self) -> Result<usize, RuntimeError> {

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -1162,6 +1162,21 @@ impl<TStore: StateReader> WorkingState<TStore> {
         self.last_instruction_output = Some(output);
     }
 
+    /// The storage footprint of the transaction receipt this state will finalize into.
+    ///
+    /// The receipt is persisted like any other substate but is only built once fees are settled, so
+    /// it cannot be measured alongside the substates in [`Self::mutated_substates`] — it is bounded
+    /// here instead. See [`TransactionReceipt::encoded_size_upper_bound`] for what the bound covers.
+    pub fn transaction_receipt_size(&mut self) -> Result<usize, RuntimeError> {
+        let epoch = self.get_current_epoch()?;
+        Ok(TransactionReceipt::encoded_size_upper_bound(
+            &self.events,
+            &self.validator_fee_withdrawals,
+            self.store.mutated_substates().keys(),
+            epoch,
+        ))
+    }
+
     pub fn finalize_transaction_receipt(
         &mut self,
         outcome: FinalizeOutcome,
@@ -1174,7 +1189,6 @@ impl<TStore: StateReader> WorkingState<TStore> {
             diff_summary: DiffSummary::from_diff(diff, epoch),
             fee_withdrawals: diff.validator_fee_withdrawals().to_vec().into_boxed_slice(),
             events: self.events.clone().into_boxed_slice(),
-            logs: self.logs.clone().into_boxed_slice(),
             fee_receipt,
             epoch,
             intent_commitment: self.intent_commitment,

--- a/crates/engine/tests/account.rs
+++ b/crates/engine/tests/account.rs
@@ -195,7 +195,7 @@ fn gasless() {
 
     test.execute_expect_success(
         Transaction::builder_localnet()
-            .pay_fee_from_component(fee_account, 1000u64)
+            .pay_fee_from_component(fee_account, 2000u64)
             .call_method(user_account, "withdraw", args![TARI_TOKEN, 100])
             .put_last_instruction_output_on_workspace("b")
             .call_method(user2_account, "deposit", args![Workspace("b")])

--- a/crates/engine/tests/fees.rs
+++ b/crates/engine/tests/fees.rs
@@ -86,7 +86,7 @@ fn deposit_from_faucet_then_pay() {
                 builder
                     // Faucet deposits free coins into the account
                     .call_method(xtr_faucet_component(), "take", args![account])
-                    .call_method(account, "pay_fee", args![1000])
+                    .call_method(account, "pay_fee", args![3000])
             })
             .call_function(test.get_template_address("State"), "new", args![])
             .build_and_seal(&private_key),
@@ -124,7 +124,7 @@ fn another_account_pays_partially_for_fees() {
             // Faucet pays a little
             .pay_fee_from_component(account_fee, Amount::from(FAUCET_CAP))
             // Account pays the rest
-            .pay_fee_from_component(account_fee2, Amount::from(1000u64))
+            .pay_fee_from_component(account_fee2, Amount::from(3000u64))
             .call_method(xtr_faucet_component(), "take", args![account])
             // NOTE: the test harness provides the virtual proofs as provided, so the transaction signer does not matter
             .build_and_seal(test.secret_key()),
@@ -228,11 +228,14 @@ fn fail_partial_paid_fees() {
     );
 
     let total_fees = result.finalize.fee_receipt.fee_breakdown().get_total();
-    // The fee charged exceeds the fee paid (so the transaction is rejected), but should not be far above it
-    // since execution stops as soon as fees are determined insufficient.
+    // The fee charged exceeds the fee paid, so the transaction is rejected. Execution stops as soon
+    // as the fees are determined insufficient, so the *execution* charges stay close to what was
+    // paid. Storage is excluded: it is charged at finalization for the substates and the receipt
+    // that a fee-intent commit still persists, whenever execution gave up.
+    let storage = result.finalize.fee_receipt.fee_breakdown().get(FeeSource::Storage);
     assert!(
-        total_fees > FEE_PAID && total_fees < FEE_PAID * 3,
-        "total fees: {total_fees}"
+        total_fees > FEE_PAID && total_fees - storage < FEE_PAID * 3,
+        "total fees: {total_fees}, of which storage: {storage}"
     );
     let reason = result.expect_failure();
     assert!(

--- a/crates/engine_types/src/fees.rs
+++ b/crates/engine_types/src/fees.rs
@@ -73,6 +73,22 @@ impl FeeReceipt {
         FeeReceiptBuilder::default()
     }
 
+    /// The widest form this type can encode to: every amount at full varint width and a breakdown
+    /// entry for every [`FeeSource`]. Bounds the encoded size of a receipt whose fees are not yet
+    /// settled — see `TransactionReceipt::encoded_size_upper_bound`.
+    pub fn widest() -> Self {
+        let mut cost_breakdown = FeeBreakdown::default();
+        for source in FeeSource::ALL {
+            cost_breakdown.add(source, u64::MAX);
+        }
+        Self {
+            total_fee_payment: u64::MAX,
+            total_fees_paid: u64::MAX,
+            total_fee_overcharge: u64::MAX,
+            cost_breakdown,
+        }
+    }
+
     pub fn to_cost_breakdown(&self) -> FeeCostBreakdown {
         FeeCostBreakdown {
             total_fees_charged: self.total_fees_charged(),
@@ -209,6 +225,24 @@ pub enum FeeSource {
     NativeExecution = 10,
 }
 
+impl FeeSource {
+    /// Every variant. `fee_source_all_is_exhaustive` fails to compile if a variant is added without
+    /// being listed here.
+    pub const ALL: [Self; 11] = [
+        Self::Initial,
+        Self::RuntimeCall,
+        Self::Storage,
+        Self::TransactionWeight,
+        Self::SignatureVerification,
+        Self::TemplateLoad,
+        Self::SubstateCreate,
+        Self::WasmExecution,
+        Self::TemplatePublish,
+        Self::ExhaustBurn,
+        Self::NativeExecution,
+    ];
+}
+
 #[derive(
     Debug,
     Clone,
@@ -260,4 +294,47 @@ pub struct FeeCostBreakdown {
     pub total_fees_charged: u64,
     pub required_fees: u64,
     pub breakdown: FeeBreakdown,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fee_source_all_is_exhaustive() {
+        for source in FeeSource::ALL {
+            // An added variant fails to compile here until it is listed in `FeeSource::ALL`.
+            match source {
+                FeeSource::Initial |
+                FeeSource::RuntimeCall |
+                FeeSource::Storage |
+                FeeSource::TransactionWeight |
+                FeeSource::SignatureVerification |
+                FeeSource::TemplateLoad |
+                FeeSource::SubstateCreate |
+                FeeSource::WasmExecution |
+                FeeSource::TemplatePublish |
+                FeeSource::ExhaustBurn |
+                FeeSource::NativeExecution => {},
+            }
+        }
+    }
+
+    #[test]
+    fn widest_bounds_every_other_receipt() {
+        let widest = minicbor::len(FeeReceipt::widest());
+
+        let mut breakdown = FeeBreakdown::default();
+        breakdown.add(FeeSource::Initial, 1000);
+        breakdown.add(FeeSource::Storage, u64::MAX);
+        let realistic = FeeReceipt::builder()
+            .with_total_fee_payment(u64::MAX)
+            .with_total_fees_paid(u64::MAX)
+            .with_total_fee_overcharge(u64::MAX)
+            .with_cost_breakdown(breakdown)
+            .build();
+
+        assert!(minicbor::len(&realistic) <= widest);
+        assert!(minicbor::len(FeeReceipt::default()) <= widest);
+    }
 }

--- a/crates/engine_types/src/substate_hasher.rs
+++ b/crates/engine_types/src/substate_hasher.rs
@@ -138,8 +138,6 @@ impl borsh::BorshSerialize for TransactionReceiptHashMessage<'_> {
         BorshSerialize::serialize(&self.receipt.fee_withdrawals, writer)?;
         let events = hash(&self.receipt.events);
         BorshSerialize::serialize(&events, writer)?;
-        let logs = hash(&self.receipt.logs);
-        BorshSerialize::serialize(&logs, writer)?;
         BorshSerialize::serialize(&self.receipt.fee_receipt, writer)?;
         BorshSerialize::serialize(&self.receipt.epoch, writer)?;
         // Serialized in full: the commitment is already 32 bytes, so part-hashing it saves nothing.

--- a/crates/engine_types/src/transaction_receipt.rs
+++ b/crates/engine_types/src/transaction_receipt.rs
@@ -4,6 +4,7 @@
 use std::{fmt, fmt::Display, str::FromStr};
 
 use serde::{Deserialize, Serialize};
+use tari_bor::adapters::boxed_slice;
 use tari_template_lib::types::Hash32;
 
 use crate::{
@@ -11,7 +12,6 @@ use crate::{
     ValidatorFeeWithdrawal,
     events::Event,
     fees::FeeReceipt,
-    logs::LogEntry,
     substate::{SubstateDiff, SubstateId, hash_substate},
 };
 
@@ -31,11 +31,8 @@ pub struct TransactionReceipt {
     #[cbor(with = "tari_bor::adapters::boxed_slice")]
     pub events: Box<[Event]>,
     #[n(4)]
-    #[cbor(with = "tari_bor::adapters::boxed_slice")]
-    pub logs: Box<[LogEntry]>,
-    #[n(5)]
     pub fee_receipt: FeeReceipt,
-    #[n(6)]
+    #[n(5)]
     pub epoch: Epoch,
     /// Commitment to the transaction's intent: every field the signers authorized (network, fee
     /// instructions, instructions, inputs, epoch bounds, flags and blob commitments), excluding the
@@ -47,7 +44,7 @@ pub struct TransactionReceipt {
     /// projection minus the signatures, so whoever holds the transaction can link it to this
     /// receipt without revealing who authorized it. It identifies the intent, not the signers:
     /// transactions differing only in who signed them share a commitment.
-    #[n(7)]
+    #[n(6)]
     pub intent_commitment: Hash32,
 }
 
@@ -64,10 +61,6 @@ impl TransactionReceipt {
         &self.fee_withdrawals
     }
 
-    pub fn logs(&self) -> &[LogEntry] {
-        &self.logs
-    }
-
     pub fn events(&self) -> &[Event] {
         &self.events
     }
@@ -82,6 +75,49 @@ impl TransactionReceipt {
 
     pub fn intent_commitment(&self) -> Hash32 {
         self.intent_commitment
+    }
+
+    /// An upper bound on the encoded size of the receipt that finalization will persist, computed
+    /// from the parts that are already fixed when storage fees are charged.
+    ///
+    /// The receipt is the one persisted substate whose bytes cannot be counted alongside the rest:
+    /// it is built after fees are settled, and it embeds the [`FeeReceipt`] that the charge derived
+    /// from this bound feeds into. Measuring it exactly would require a fixed point, so the two
+    /// parts that are not yet known are replaced by worst-case stand-ins — a fee receipt whose
+    /// amounts all encode at full varint width, and a max-width version on each diff-summary entry.
+    /// Everything else (`events`, `fee_withdrawals`, `epoch`, `intent_commitment`) is measured as it
+    /// will actually be encoded.
+    ///
+    /// `upped` is the substates that will appear in the [`DiffSummary`] — one entry each. Fee
+    /// settlement can still add a handful of substates (validator fee pools, the refund vault)
+    /// after the charge is computed, and those entries are not counted; the shortfall is bounded by
+    /// the committee size rather than by anything the transaction controls.
+    pub fn encoded_size_upper_bound<'a>(
+        events: &[Event],
+        fee_withdrawals: &[ValidatorFeeWithdrawal],
+        upped: impl Iterator<Item = &'a SubstateId>,
+        epoch: Epoch,
+    ) -> usize {
+        let diff_summary = DiffSummary {
+            upped: upped
+                .map(|substate_id| UpSubstate {
+                    substate_id: substate_id.clone(),
+                    version: u32::MAX,
+                    value_hash: Hash32::from_array([0xff; Hash32::LENGTH]),
+                })
+                .collect(),
+        };
+
+        let ctx = &mut ();
+        let mut len = minicbor::len(&diff_summary);
+        len += boxed_slice::cbor_len(events, ctx);
+        len += boxed_slice::cbor_len(fee_withdrawals, ctx);
+        len += minicbor::len(FeeReceipt::widest());
+        len += minicbor::len(epoch);
+        len += minicbor::len(Hash32::from_array([0xff; Hash32::LENGTH]));
+        // The outcome discriminant and the array header wrapping the receipt's fields.
+        len += minicbor::len(FinalizeOutcome::Commit) + 1;
+        len
     }
 }
 
@@ -183,4 +219,97 @@ pub struct UpSubstate {
     pub version: u32,
     #[n(2)]
     pub value_hash: Hash32,
+}
+
+#[cfg(test)]
+mod tests {
+    use tari_template_lib::types::{ComponentAddress, Metadata, ObjectKey};
+
+    use super::*;
+
+    fn substate_id(seed: u8) -> SubstateId {
+        SubstateId::Component(ComponentAddress::new(ObjectKey::from_array([seed; ObjectKey::LENGTH])))
+    }
+
+    fn event(topic: &str) -> Event {
+        let mut payload = Metadata::new();
+        payload.insert("amount", "1000000");
+        Event::new(
+            Some(substate_id(0x02)),
+            Hash32::from_array([0x03; Hash32::LENGTH]),
+            topic.to_string(),
+            payload,
+        )
+    }
+
+    /// The bound must never come in under the receipt that finalization actually persists, or the
+    /// storage charge would let some of its bytes through unpriced. It must also stay close, or a
+    /// transaction pays for space it never uses. Adding a field to `TransactionReceipt` fails to
+    /// compile here until the bound accounts for it.
+    fn assert_bounds(receipt: &TransactionReceipt, upped: &[SubstateId]) {
+        let TransactionReceipt {
+            outcome: _,
+            diff_summary,
+            fee_withdrawals,
+            events,
+            fee_receipt: _,
+            epoch,
+            intent_commitment: _,
+        } = receipt;
+        assert_eq!(diff_summary.upped.len(), upped.len());
+
+        let bound = TransactionReceipt::encoded_size_upper_bound(events, fee_withdrawals, upped.iter(), *epoch);
+        let actual = minicbor::len(receipt);
+
+        assert!(bound >= actual, "bound {bound} is under the actual size {actual}");
+        // The slack is the worst-case fee receipt and the max-width versions, both fixed-size.
+        assert!(bound - actual < 256, "bound {bound} overshoots {actual} by too much");
+    }
+
+    fn receipt(events: Vec<Event>, upped: &[SubstateId]) -> TransactionReceipt {
+        TransactionReceipt {
+            outcome: FinalizeOutcome::Commit,
+            diff_summary: DiffSummary {
+                upped: upped
+                    .iter()
+                    .map(|substate_id| UpSubstate {
+                        substate_id: substate_id.clone(),
+                        version: 1,
+                        value_hash: Hash32::from_array([0x04; Hash32::LENGTH]),
+                    })
+                    .collect(),
+            },
+            fee_withdrawals: Box::new([]),
+            events: events.into_boxed_slice(),
+            fee_receipt: FeeReceipt::default(),
+            epoch: Epoch(1),
+            intent_commitment: Hash32::from_array([0x05; Hash32::LENGTH]),
+        }
+    }
+
+    #[test]
+    fn bound_holds_for_an_empty_receipt() {
+        assert_bounds(&receipt(vec![], &[]), &[]);
+    }
+
+    #[test]
+    fn bound_holds_with_events_and_upped_substates() {
+        let upped = [substate_id(0x01), substate_id(0x02), substate_id(0x03)];
+        assert_bounds(
+            &receipt(vec![event("std.deposit"), event("custom.thing")], &upped),
+            &upped,
+        );
+    }
+
+    #[test]
+    fn bound_grows_with_the_event_payload() {
+        let small = receipt(vec![event("a")], &[]);
+        let large = receipt(vec![event(&"a".repeat(4096))], &[]);
+
+        let bound_of = |r: &TransactionReceipt| {
+            TransactionReceipt::encoded_size_upper_bound(&r.events, &r.fee_withdrawals, [].iter(), r.epoch)
+        };
+        assert!(bound_of(&large) - bound_of(&small) >= 4000);
+        assert_bounds(&large, &[]);
+    }
 }

--- a/crates/transaction/src/v1/intent.rs
+++ b/crates/transaction/src/v1/intent.rs
@@ -159,7 +159,6 @@ mod tests {
             diff_summary: Default::default(),
             fee_withdrawals: Default::default(),
             events: Default::default(),
-            logs: Default::default(),
             fee_receipt: Default::default(),
             epoch: Epoch(1),
             intent_commitment: commitment,

--- a/crates/wallet/ootle-rs/examples/fungible_transfer.rs
+++ b/crates/wallet/ootle-rs/examples/fungible_transfer.rs
@@ -174,13 +174,6 @@ async fn print_fancy_results(pending_tx: &PendingTransaction) {
     println!("🔹 Outcome: {:?}", receipt.outcome);
     println!("🔹 Fees Paid: {}", receipt.fee_receipt.total_fees_paid());
 
-    if !receipt.logs.is_empty() {
-        println!("\n🪵 Logs:");
-        for log in receipt.logs {
-            println!("  - {}", log);
-        }
-    }
-
     if !receipt.events.is_empty() {
         println!("\n🎉 Events:");
         for event in receipt.events {

--- a/crates/wallet/ootle-rs/examples/stealth_transfer.rs
+++ b/crates/wallet/ootle-rs/examples/stealth_transfer.rs
@@ -207,13 +207,6 @@ async fn print_fancy_results(label: &str, pending_tx: &PendingTransaction) -> Tr
         fee_receipt.total_refunded()
     );
 
-    if !receipt.logs.is_empty() {
-        println!("\n🪵 Logs:");
-        for log in receipt.logs() {
-            println!("  - {}", log);
-        }
-    }
-
     if !receipt.events.is_empty() {
         println!("\n🎉 Events:");
         for event in receipt.events() {


### PR DESCRIPTION
## Problem

The transaction receipt is persisted like any other substate — it is never downed, and it is streamed to every syncing node ([`block_sync_task.rs:324-340`](https://github.com/tari-project/tari-ootle/blob/development/applications/tari_validator_node/src/p2p/rpc/block_sync_task.rs)) — but nothing charged for its bytes.

`FeeModule::on_before_finalize` prices the substates in `mutated_substates`, and the receipt only joins the diff afterwards, in `tracker.finalize`. It therefore escaped both the per-byte storage charge and the per-substate create charge. Since `emit_log` costs a flat `per_module_call_cost` (1 µT on testnet) regardless of message size, the engine limits (`max_logs: 256`, `max_log_size_bytes: 32 KiB`) put **8 MiB of permanent, replicated, unpriced state within reach of any transaction for 256 µT**.

## Charge for the receipt

`on_before_finalize` now adds the receipt's encoded size to the storage tally and counts its slot in the create charge.

The size cannot be measured exactly at that point: the receipt embeds the `FeeReceipt` that this very charge feeds into, so an exact figure would need a fixed point. `TransactionReceipt::encoded_size_upper_bound` instead measures the parts already fixed at charge time (events, fee withdrawals, epoch, intent commitment) and substitutes worst-case stand-ins for the two that are not — `FeeReceipt::widest()` and a max-width version on each diff-summary entry. It never comes in under the receipt that is actually persisted; unit tests hold the overshoot below 256 bytes.

## Remove `logs` from the receipt

Logs are `println!` for template authors, not contract semantics — events already carry the indexable, subscribable record, and forcing debug output through events would pollute what indexers consume without shrinking anything.

Logs remain on `FinalizeResult`, so **the wallet CLI, dry runs, the SDK's `LogSummary` and the indexer's transaction-result endpoint are unaffected**. Two consumers did read them off the persisted receipt and now show events only:

- `ootle-rs`'s `PendingTransaction::get_receipt()` — the `fungible_transfer` and `stealth_transfer` examples
- the indexer web UI's receipt page (the Transaction page still renders `finalize.logs`)

## Breaking

`TransactionReceipt` drops `logs` and renumbers the CBOR indices after it, and the log digest leaves the receipt hash. Existing receipts do not decode and their substate hashes differ — this needs a network reset.

## Known follow-up: the reject path over-charges

Every finalize-time charge is computed against the *live* state, but on the reject path the diff that gets persisted comes from the fee checkpoint. `Storage`, `SubstateCreate` and `TemplatePublish` are all priced over substates that are then discarded, and `ExhaustBurn` inherits the inflation since it is derived from `total_fee_charges()`.

This predates the PR — the per-substate storage charge has always behaved this way — but pricing the receipt amplifies it, because the bound scales with the discarded state's substate count and events. In `fail_partial_paid_fees` that is ~1000 µT of storage against a ~160 µT receipt.

Fixing it properly means running the finalize-time charges twice — provisionally against the live state to gate the commit/reject decision, then authoritatively against the state actually persisted — which needs `set` rather than `add` semantics on the finalize-time fee sources and a hook fired after state selection (splitting `tracker.finalize`, since the tracker does not own the modules). Left out of this PR to keep it reviewable.

## Testing

`tari_engine` (all suites), `engine_types`, `transaction`, `ootle_sdk_core` including golden vectors, `storage`, `tari_bor` and `consensus_tests` pass. Three fee tests needed real updates: two paid fixed `max_fee`s now short of the requirement, and `fail_partial_paid_fees` asserted total fees stay near the amount paid, which now excludes storage.
