### PR TITLE
fix(engine)!: account for confidential commitments in total_supply

### DIFF
--- a/bindings/src/index.ts
+++ b/bindings/src/index.ts
@@ -150,7 +150,7 @@ export * from "./types/StealthOutputView";
 export * from "./types/StealthOutputsStatement";
 export * from "./types/StealthTransferStatement";
 export * from "./types/StealthUnspentOutput";
-export * from "./types/StealthValueProof";
+export * from "./types/CommitmentValueProof";
 export * from "./types/Substate";
 export * from "./types/SubstateAddress";
 export * from "./types/SubstateCreated";

--- a/bindings/src/types/CommitmentValueProof.ts
+++ b/bindings/src/types/CommitmentValueProof.ts
@@ -6,7 +6,7 @@ import type { ValueKnowledgeProof } from "./ValueKnowledgeProof";
  * Proof of knowledge of the opening to a commitment and that the commitment commits to a specific value.
  * Currently used when burning UTXOs to allow the total supply to be adjusted.
  */
-export type StealthValueProof = {
+export type CommitmentValueProof = {
   /**
    * The claimed value to prove
    */

--- a/crates/engine/src/runtime/error.rs
+++ b/crates/engine/src/runtime/error.rs
@@ -171,10 +171,9 @@ pub enum RuntimeError {
         commitment: PedersenCommitmentBytes,
     },
     #[error(
-        "The proven values of the confidential commitments of resource {resource_address} sum to more than the \
-         maximum amount"
+        "The amounts being minted or destroyed for resource {resource_address} sum to more than the maximum amount"
     )]
-    CommitmentValueSumOverflow { resource_address: ResourceAddress },
+    ValueSumOverflow { resource_address: ResourceAddress },
     #[error("Bucket {bucket_id} was dropped but was not empty")]
     BucketNotEmpty { bucket_id: BucketId },
     #[error("Item at id {id} does not exist on the workspace (existing ids: {})", .existing_ids.display())]

--- a/crates/engine/src/runtime/error.rs
+++ b/crates/engine/src/runtime/error.rs
@@ -52,6 +52,7 @@ use tari_template_lib::{
         TemplateAddress,
         TransactionReceiptAddress,
         VaultId,
+        crypto::PedersenCommitmentBytes,
     },
 };
 
@@ -151,6 +152,23 @@ pub enum RuntimeError {
         resource_address: ResourceAddress,
         current_supply: Amount,
         amount: Amount,
+    },
+    #[error(
+        "Resource supply would underflow: resource {resource_address}, current supply {current_supply}, amount \
+         {amount}"
+    )]
+    ResourceSupplyWouldUnderflow {
+        resource_address: ResourceAddress,
+        current_supply: Amount,
+        amount: Amount,
+    },
+    #[error(
+        "Commitment {commitment} of resource {resource_address} requires a value proof because the resource tracks \
+         total supply"
+    )]
+    MissingValueProofForCommitment {
+        resource_address: ResourceAddress,
+        commitment: PedersenCommitmentBytes,
     },
     #[error("Bucket {bucket_id} was dropped but was not empty")]
     BucketNotEmpty { bucket_id: BucketId },

--- a/crates/engine/src/runtime/error.rs
+++ b/crates/engine/src/runtime/error.rs
@@ -170,6 +170,11 @@ pub enum RuntimeError {
         resource_address: ResourceAddress,
         commitment: PedersenCommitmentBytes,
     },
+    #[error(
+        "The proven values of the confidential commitments of resource {resource_address} sum to more than the \
+         maximum amount"
+    )]
+    CommitmentValueSumOverflow { resource_address: ResourceAddress },
     #[error("Bucket {bucket_id} was dropped but was not empty")]
     BucketNotEmpty { bucket_id: BucketId },
     #[error("Item at id {id} does not exist on the workspace (existing ids: {})", .existing_ids.display())]

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -489,7 +489,11 @@ impl<TStore: StateReader + Clone + 'static, TTemplateProvider: TemplateProvider<
         has_view_key: bool,
         is_total_supply_tracking_enabled: bool,
     ) -> Result<(), RuntimeError> {
-        let MintArg::Confidential { statement, .. } = mint_arg else {
+        let MintArg::Confidential {
+            statement,
+            value_proofs,
+        } = mint_arg
+        else {
             return Ok(());
         };
 
@@ -499,9 +503,17 @@ impl<TStore: StateReader + Clone + 'static, TTemplateProvider: TemplateProvider<
                 has_view_key,
             ))?;
 
-        if is_total_supply_tracking_enabled && statement.output.is_some() {
-            self.tracker
-                .charge_native_execution(tari_engine_types::limits::NativeExecutionPoints::PER_VALUE_PROOF)?;
+        if is_total_supply_tracking_enabled {
+            // One proof is verified per minted commitment; the price depends on each proof's variant.
+            let points = statement
+                .output
+                .iter()
+                .filter_map(|output| value_proofs.get(&output.commitment))
+                .map(crypto::value_proof_native_points)
+                .fold(0u64, u64::saturating_add);
+            if points > 0 {
+                self.tracker.charge_native_execution(points)?;
+            }
         }
 
         Ok(())
@@ -2936,25 +2948,27 @@ where
                     self.invoke_resource_access_hook(auth_hook, auth_caller, ResourceAuthAction::Burn)?;
                 }
 
-                // The hook may have altered the bucket, so the commitments are counted after it runs: the charge
-                // must cover the proofs actually verified below, not those held when the hook was scheduled.
-                let num_value_proofs = self.tracker.write_with(|state_mut| {
+                // The hook may have altered the bucket, so the commitments are read after it runs: the charge must
+                // cover the proofs actually verified below, not those held when the hook was scheduled.
+                let value_proof_points = self.tracker.write_with(|state_mut| {
                     let bucket = state_mut.get_bucket(bucket_id)?;
-                    // A value proof is verified per held commitment, and only when supply tracking is enabled.
-                    let num_commitments = if tracks_supply {
-                        bucket.number_of_confidential_commitments()
-                    } else {
-                        0
-                    };
-                    Ok::<_, RuntimeError>(num_commitments)
+                    if !tracks_supply {
+                        return Ok::<_, RuntimeError>(0);
+                    }
+                    // One proof is verified per unlocked commitment; the price depends on each proof's variant.
+                    let points = bucket
+                        .get_confidential_commitments()
+                        .into_iter()
+                        .flatten()
+                        .filter_map(|commitment| arg.value_proofs.get(commitment))
+                        .map(crypto::value_proof_native_points)
+                        .fold(0u64, u64::saturating_add);
+                    Ok(points)
                 })?;
 
                 // Charge the value proofs' native verification against the payment-funded allowance before they run.
-                if num_value_proofs > 0 {
-                    self.tracker.charge_native_execution(
-                        tari_engine_types::limits::NativeExecutionPoints::PER_VALUE_PROOF
-                            .saturating_mul(num_value_proofs as u64),
-                    )?;
+                if value_proof_points > 0 {
+                    self.tracker.charge_native_execution(value_proof_points)?;
                 }
 
                 self.tracker.write_with(|state| {

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -2948,10 +2948,12 @@ where
                     self.invoke_resource_access_hook(auth_hook, auth_caller, ResourceAuthAction::Burn)?;
                 }
 
-                // The hook may have altered the bucket, so the commitments are read after it runs: the charge must
-                // cover the proofs actually verified below, not those held when the hook was scheduled.
+                // The hook may have altered the bucket, so it is re-inspected after the hook runs and before
+                // anything is charged: a hook that locked funds makes the burn fail, and the charge must cover the
+                // proofs actually verified below rather than those held when the hook was scheduled.
                 let value_proof_points = self.tracker.write_with(|state_mut| {
                     let bucket = state_mut.get_bucket(bucket_id)?;
+                    Self::check_bucket_is_burnable(bucket_id, bucket)?;
                     if !tracks_supply {
                         return Ok::<_, RuntimeError>(0);
                     }
@@ -2973,9 +2975,8 @@ where
 
                 self.tracker.write_with(|state| {
                     let bucket = state.take_bucket(bucket_id)?;
-                    Self::check_bucket_is_burnable(bucket_id, &bucket)?;
 
-                    state.burn_bucket(bucket, &resource_lock, &arg.value_proofs)?;
+                    state.burn_bucket(bucket_id, bucket, &resource_lock, &arg.value_proofs)?;
 
                     state.unlock_substate(resource_lock)?;
 

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -31,6 +31,7 @@ use tari_engine_types::{
     commit_result::{FinalizeResult, RejectReason},
     component::Component,
     confidential::{ClaimBurnOutputData, ClaimedOutputTombstone, MinotariBurnClaimProof},
+    crypto,
     crypto::OutputBody,
     entity_id_provider::EntityIdProvider,
     events::Event,
@@ -68,6 +69,7 @@ use tari_template_lib::{
         BucketGetAmountArg,
         BucketRef,
         BuiltinTemplateAction,
+        BurnBucketArg,
         BurnStealthUtxoArg,
         CallAction,
         CallFunctionArg,
@@ -81,6 +83,7 @@ use tari_template_lib::{
         FreezeResourceArg,
         GenerateRandomAction,
         InvokeResult,
+        MintArg,
         MintResourceArg,
         NonFungibleAction,
         PayFeeArg,
@@ -462,6 +465,33 @@ impl<TStore: StateReader + Clone + 'static, TTemplateProvider: TemplateProvider<
             function: function.to_string(),
             details: e.to_string(),
         })
+    }
+
+    /// Charges the native verification cost of a confidential mint against the payment-funded allowance before any
+    /// of its proof crypto runs. The charged work must match what `WorkingState::mint_resource` goes on to verify:
+    /// the value proof is only checked when the resource tracks supply and the statement mints a commitment.
+    fn charge_confidential_mint(
+        &mut self,
+        mint_arg: &MintArg,
+        has_view_key: bool,
+        is_total_supply_tracking_enabled: bool,
+    ) -> Result<(), RuntimeError> {
+        let MintArg::Confidential { statement, .. } = mint_arg else {
+            return Ok(());
+        };
+
+        self.tracker
+            .charge_native_execution(tari_engine_types::confidential::statement_native_points(
+                statement,
+                has_view_key,
+            ))?;
+
+        if is_total_supply_tracking_enabled && statement.output.is_some() {
+            self.tracker
+                .charge_native_execution(tari_engine_types::limits::NativeExecutionPoints::PER_VALUE_PROOF)?;
+        }
+
+        Ok(())
     }
 
     fn check_resource_auth_hook(&mut self, hook: &AuthHook) -> Result<(), RuntimeError> {
@@ -1393,12 +1423,12 @@ where
 
                 // Charge the initial mint's native verification cost against the payment-funded
                 // allowance before its proof crypto runs.
-                if let Some(tari_template_lib::args::MintArg::Confidential { statement }) = arg.mint_arg.as_ref() {
-                    self.tracker
-                        .charge_native_execution(tari_engine_types::confidential::statement_native_points(
-                            statement,
-                            arg.view_key.is_some(),
-                        ))?;
+                if let Some(mint_arg) = arg.mint_arg.as_ref() {
+                    self.charge_confidential_mint(
+                        mint_arg,
+                        arg.view_key.is_some(),
+                        arg.is_total_supply_tracking_enabled,
+                    )?;
                 }
 
                 self.tracker.write_with(|state_mut| {
@@ -1503,7 +1533,7 @@ where
                         })?;
                 let mint_resource: MintResourceArg = args.assert_one_arg()?;
 
-                let (resource_lock, maybe_auth_hook, auth_caller, has_view_key) =
+                let (resource_lock, maybe_auth_hook, auth_caller, has_view_key, tracks_supply) =
                     self.tracker.write_with(|state_mut| {
                         let resource_lock = state_mut.write_lock_substate(SubstateId::Resource(resource_address))?;
 
@@ -1517,7 +1547,14 @@ where
 
                         let auth_caller = state_mut.get_auth_caller()?;
                         let has_view_key = resource.view_key().is_some();
-                        Ok::<_, RuntimeError>((resource_lock, resource.auth_hook().cloned(), auth_caller, has_view_key))
+                        let tracks_supply = resource.is_supply_tracking_enabled();
+                        Ok::<_, RuntimeError>((
+                            resource_lock,
+                            resource.auth_hook().cloned(),
+                            auth_caller,
+                            has_view_key,
+                            tracks_supply,
+                        ))
                     })?;
 
                 if let Some(auth_hook) = maybe_auth_hook {
@@ -1526,13 +1563,7 @@ where
 
                 // Charge the mint's native verification cost against the payment-funded allowance
                 // before its proof crypto runs.
-                if let tari_template_lib::args::MintArg::Confidential { statement } = &mint_resource.mint_arg {
-                    self.tracker
-                        .charge_native_execution(tari_engine_types::confidential::statement_native_points(
-                            statement,
-                            has_view_key,
-                        ))?;
-                }
+                self.charge_confidential_mint(&mint_resource.mint_arg, has_view_key, tracks_supply)?;
 
                 self.tracker.write_with(|state_mut| {
                     let mint_arg = mint_resource.mint_arg;
@@ -2084,7 +2115,7 @@ where
                             .output
                             .as_ref()
                             .and_then(|o| o.output.viewable_balance.as_ref());
-                        let value = stealth::validate_value_proof(
+                        let value = crypto::validate_value_proof(
                             &commitment,
                             maybe_view_key.as_ref(),
                             elgamal_proof,
@@ -2094,8 +2125,7 @@ where
                         if value.is_positive() {
                             let resource_lock =
                                 state_mut.write_lock_substate(SubstateId::Resource(resource_address))?;
-                            let resource_mut = state_mut.get_resource_mut(&resource_lock)?;
-                            resource_mut.decrease_total_supply(value);
+                            state_mut.decrease_total_supply(&resource_lock, value)?;
                             state_mut.unlock_substate(resource_lock)?;
                         }
                     } else {
@@ -2860,26 +2890,50 @@ where
                     reason: "Burn bucket action requires a bucket id".to_string(),
                 })?;
 
-                let (resource_lock, maybe_auth_hook, auth_caller) = self.tracker.write_with(|state_mut| {
-                    let bucket = state_mut.get_bucket(bucket_id)?;
+                let arg: BurnBucketArg = args.assert_one_arg()?;
 
-                    let resource_lock =
-                        state_mut.write_lock_substate(SubstateId::Resource(*bucket.resource_address()))?;
+                let (resource_lock, maybe_auth_hook, auth_caller, num_value_proofs) =
+                    self.tracker.write_with(|state_mut| {
+                        let bucket = state_mut.get_bucket(bucket_id)?;
+                        let num_commitments = bucket.number_of_confidential_commitments();
 
-                    let resource = state_mut.get_resource(&resource_lock)?;
+                        let resource_lock =
+                            state_mut.write_lock_substate(SubstateId::Resource(*bucket.resource_address()))?;
 
-                    state_mut.authorization().check_resource_access_rules(
-                        ResourceAuthAction::Burn,
-                        resource.as_ownership(),
-                        resource.access_rules(),
-                    )?;
+                        let resource = state_mut.get_resource(&resource_lock)?;
 
-                    let auth_caller = state_mut.get_auth_caller()?;
-                    Ok::<_, RuntimeError>((resource_lock, resource.auth_hook().cloned(), auth_caller))
-                })?;
+                        state_mut.authorization().check_resource_access_rules(
+                            ResourceAuthAction::Burn,
+                            resource.as_ownership(),
+                            resource.access_rules(),
+                        )?;
+
+                        // A value proof is verified per held commitment, and only when supply tracking is enabled.
+                        let num_value_proofs = if resource.is_supply_tracking_enabled() {
+                            num_commitments
+                        } else {
+                            0
+                        };
+
+                        let auth_caller = state_mut.get_auth_caller()?;
+                        Ok::<_, RuntimeError>((
+                            resource_lock,
+                            resource.auth_hook().cloned(),
+                            auth_caller,
+                            num_value_proofs,
+                        ))
+                    })?;
 
                 if let Some(auth_hook) = maybe_auth_hook {
                     self.invoke_resource_access_hook(auth_hook, auth_caller, ResourceAuthAction::Burn)?;
+                }
+
+                // Charge the value proofs' native verification against the payment-funded allowance before they run.
+                if num_value_proofs > 0 {
+                    self.tracker.charge_native_execution(
+                        tari_engine_types::limits::NativeExecutionPoints::PER_VALUE_PROOF
+                            .saturating_mul(num_value_proofs as u64),
+                    )?;
                 }
 
                 self.tracker.write_with(|state| {
@@ -2892,11 +2946,8 @@ where
                             locked_amount: bucket.locked_amount(),
                         });
                     }
-                    let burnt_amount = bucket.unlocked_amount();
-                    state.burn_bucket(bucket)?;
 
-                    let resource_mut = state.get_resource_mut(&resource_lock)?;
-                    resource_mut.decrease_total_supply(burnt_amount);
+                    state.burn_bucket(bucket, &resource_lock, &arg.value_proofs)?;
 
                     state.unlock_substate(resource_lock)?;
 
@@ -3319,7 +3370,11 @@ where
             let address = ClaimedOutputTombstoneAddress::from_commitment(claim.commitment);
             state_mut.new_substate(address, ClaimedOutputTombstone { value: claim.value })?;
 
-            // 3. Create the stealth UTXO
+            // 3. Create the stealth UTXO.
+            // This mints value with no `increase_total_supply` counterpart, which is sound only because the genesis
+            // TARI resource both disables supply tracking and denies `Burn` (see `get_stealth_tari_resource`).
+            // Enabling either would need an increase here to balance the decrease that
+            // `ResourceAction::StealthUtxoBurn` applies when the UTXO is burnt.
             let address = UtxoAddress::new(TARI_TOKEN, claim.commitment.into());
             let utxo = Utxo::new(UtxoOutput {
                 output: OutputBody {

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -28,6 +28,7 @@ use tari_crypto::{ristretto::RistrettoPublicKey, tari_utilities::ByteArray};
 use tari_engine_types::{
     Utxo,
     UtxoOutput,
+    bucket::Bucket,
     commit_result::{FinalizeResult, RejectReason},
     component::Component,
     confidential::{ClaimBurnOutputData, ClaimedOutputTombstone, MinotariBurnClaimProof},
@@ -465,6 +466,18 @@ impl<TStore: StateReader + Clone + 'static, TTemplateProvider: TemplateProvider<
             function: function.to_string(),
             details: e.to_string(),
         })
+    }
+
+    /// It is invalid to burn a bucket that has locked funds (e.g. by a proof). Burning downs only the unlocked
+    /// commitments, so a locked one would be left live with nothing referencing it.
+    fn check_bucket_is_burnable(bucket_id: BucketId, bucket: &Bucket) -> Result<(), RuntimeError> {
+        if bucket.has_locked_funds() {
+            return Err(RuntimeError::InvalidOpDepositLockedBucket {
+                bucket_id,
+                locked_amount: bucket.locked_amount(),
+            });
+        }
+        Ok(())
     }
 
     /// Charges the native verification cost of a confidential mint against the payment-funded allowance before any
@@ -2892,10 +2905,12 @@ where
 
                 let arg: BurnBucketArg = args.assert_one_arg()?;
 
-                let (resource_lock, maybe_auth_hook, auth_caller, num_value_proofs) =
+                let (resource_lock, maybe_auth_hook, auth_caller, tracks_supply) =
                     self.tracker.write_with(|state_mut| {
                         let bucket = state_mut.get_bucket(bucket_id)?;
-                        let num_commitments = bucket.number_of_confidential_commitments();
+                        // Reject a burn that cannot succeed before the auth hook runs or anything is charged for it.
+                        // This is re-checked after the hook, which may lock funds itself.
+                        Self::check_bucket_is_burnable(bucket_id, bucket)?;
 
                         let resource_lock =
                             state_mut.write_lock_substate(SubstateId::Resource(*bucket.resource_address()))?;
@@ -2908,25 +2923,31 @@ where
                             resource.access_rules(),
                         )?;
 
-                        // A value proof is verified per held commitment, and only when supply tracking is enabled.
-                        let num_value_proofs = if resource.is_supply_tracking_enabled() {
-                            num_commitments
-                        } else {
-                            0
-                        };
-
                         let auth_caller = state_mut.get_auth_caller()?;
                         Ok::<_, RuntimeError>((
                             resource_lock,
                             resource.auth_hook().cloned(),
                             auth_caller,
-                            num_value_proofs,
+                            resource.is_supply_tracking_enabled(),
                         ))
                     })?;
 
                 if let Some(auth_hook) = maybe_auth_hook {
                     self.invoke_resource_access_hook(auth_hook, auth_caller, ResourceAuthAction::Burn)?;
                 }
+
+                // The hook may have altered the bucket, so the commitments are counted after it runs: the charge
+                // must cover the proofs actually verified below, not those held when the hook was scheduled.
+                let num_value_proofs = self.tracker.write_with(|state_mut| {
+                    let bucket = state_mut.get_bucket(bucket_id)?;
+                    // A value proof is verified per held commitment, and only when supply tracking is enabled.
+                    let num_commitments = if tracks_supply {
+                        bucket.number_of_confidential_commitments()
+                    } else {
+                        0
+                    };
+                    Ok::<_, RuntimeError>(num_commitments)
+                })?;
 
                 // Charge the value proofs' native verification against the payment-funded allowance before they run.
                 if num_value_proofs > 0 {
@@ -2938,14 +2959,7 @@ where
 
                 self.tracker.write_with(|state| {
                     let bucket = state.take_bucket(bucket_id)?;
-                    // It is invalid to burn a bucket that has locked funds (e.g. via a proof). Burning downs only
-                    // the unlocked commitments, so a locked one would be left live with nothing referencing it.
-                    if bucket.has_locked_funds() {
-                        return Err(RuntimeError::InvalidOpDepositLockedBucket {
-                            bucket_id,
-                            locked_amount: bucket.locked_amount(),
-                        });
-                    }
+                    Self::check_bucket_is_burnable(bucket_id, &bucket)?;
 
                     state.burn_bucket(bucket, &resource_lock, &arg.value_proofs)?;
 

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -634,7 +634,7 @@ impl<TStore: StateReader> WorkingState<TStore> {
                 )?;
                 proven_value
                     .checked_add(value)
-                    .ok_or(RuntimeError::CommitmentValueSumOverflow { resource_address })
+                    .ok_or(RuntimeError::ValueSumOverflow { resource_address })
             })
     }
 
@@ -754,7 +754,7 @@ impl<TStore: StateReader> WorkingState<TStore> {
                 )?;
                 destroyed_amount = destroyed_amount
                     .checked_add(proven_value)
-                    .ok_or(RuntimeError::CommitmentValueSumOverflow { resource_address })?;
+                    .ok_or(RuntimeError::ValueSumOverflow { resource_address })?;
             } else {
                 self.spend_confidential_outputs(resource_address, commitments)?;
             }
@@ -909,7 +909,7 @@ impl<TStore: StateReader> WorkingState<TStore> {
                         )?;
                         minted_commitment_value = minted_commitment_value
                             .checked_add(value)
-                            .ok_or(RuntimeError::CommitmentValueSumOverflow { resource_address })?;
+                            .ok_or(RuntimeError::ValueSumOverflow { resource_address })?;
                     }
                 }
 
@@ -947,7 +947,7 @@ impl<TStore: StateReader> WorkingState<TStore> {
             let minted_amount = resource_container
                 .unlocked_amount()
                 .checked_add(minted_commitment_value)
-                .ok_or(RuntimeError::CommitmentValueSumOverflow { resource_address })?;
+                .ok_or(RuntimeError::ValueSumOverflow { resource_address })?;
             if !resource_mut.increase_total_supply(minted_amount) {
                 return Err(RuntimeError::ResourceSupplyWouldOverflow {
                     resource_address,

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -587,9 +587,23 @@ impl<TStore: StateReader> WorkingState<TStore> {
         &mut self,
         resource_address: ResourceAddress,
         commitments: I,
-    ) -> Result<(), RuntimeError> {
-        self.spend_confidential_outputs_internal(resource_address, commitments, None)
-            .map(|_| ())
+    ) -> Result<Vec<(PedersenCommitmentBytes, ConfidentialOutput)>, RuntimeError> {
+        commitments
+            .into_iter()
+            .map(|commitment| {
+                let address = ConfidentialOutputAddress::new(resource_address, commitment);
+                let lock_id = self.store.try_lock(address.clone().into(), LockFlag::Write)?;
+                let output = self.store.down_confidential_output(lock_id)?;
+                self.store.try_unlock(lock_id)?;
+                if output.is_frozen() {
+                    return Err(ResourceError::InvalidSpend {
+                        details: format!("Confidential output {} is frozen", address),
+                    }
+                    .into());
+                }
+                Ok((commitment, output))
+            })
+            .collect()
     }
 
     /// Downs each commitment's [`ConfidentialOutput`] substate, verifying the caller's value proof for it and
@@ -602,51 +616,26 @@ impl<TStore: StateReader> WorkingState<TStore> {
         value_proofs: &BTreeMap<PedersenCommitmentBytes, CommitmentValueProof>,
         view_key: Option<&RistrettoPublicKey>,
     ) -> Result<Amount, RuntimeError> {
-        self.spend_confidential_outputs_internal(resource_address, commitments, Some((value_proofs, view_key)))
-    }
-
-    fn spend_confidential_outputs_internal<I: IntoIterator<Item = PedersenCommitmentBytes>>(
-        &mut self,
-        resource_address: ResourceAddress,
-        commitments: I,
-        value_proofs: Option<(
-            &BTreeMap<PedersenCommitmentBytes, CommitmentValueProof>,
-            Option<&RistrettoPublicKey>,
-        )>,
-    ) -> Result<Amount, RuntimeError> {
-        let mut proven_value = Amount::ZERO;
-        for commitment in commitments {
-            let address = ConfidentialOutputAddress::new(resource_address, commitment);
-            let lock_id = self.store.try_lock(address.clone().into(), LockFlag::Write)?;
-            let output = self.store.down_confidential_output(lock_id)?;
-            self.store.try_unlock(lock_id)?;
-            if output.is_frozen() {
-                return Err(ResourceError::InvalidSpend {
-                    details: format!("Confidential output {} is frozen", address),
-                }
-                .into());
-            }
-
-            let Some((value_proofs, view_key)) = value_proofs else {
-                continue;
-            };
-            let value_proof = value_proofs
-                .get(&commitment)
-                .ok_or(RuntimeError::MissingValueProofForCommitment {
-                    resource_address,
-                    commitment,
-                })?;
-            let value = crypto::validate_value_proof(
-                &commitment,
-                view_key,
-                output.output().viewable_balance.as_ref(),
-                value_proof,
-            )?;
-            proven_value = proven_value
-                .checked_add(value)
-                .ok_or(RuntimeError::CommitmentValueSumOverflow { resource_address })?;
-        }
-        Ok(proven_value)
+        self.spend_confidential_outputs(resource_address, commitments)?
+            .into_iter()
+            .try_fold(Amount::ZERO, |proven_value, (commitment, output)| {
+                let value_proof =
+                    value_proofs
+                        .get(&commitment)
+                        .ok_or(RuntimeError::MissingValueProofForCommitment {
+                            resource_address,
+                            commitment,
+                        })?;
+                let value = crypto::validate_value_proof(
+                    &commitment,
+                    view_key,
+                    output.output().viewable_balance.as_ref(),
+                    value_proof,
+                )?;
+                proven_value
+                    .checked_add(value)
+                    .ok_or(RuntimeError::CommitmentValueSumOverflow { resource_address })
+            })
     }
 
     /// Applies the substate-level effects of a confidential mint/withdraw: downs the spent input substates and
@@ -722,14 +711,7 @@ impl<TStore: StateReader> WorkingState<TStore> {
             return Ok(());
         }
         let resource_address = *bucket.resource_address();
-        let resource = self.get_resource(resource_lock)?;
-        let is_total_supply_tracking_enabled = resource.is_supply_tracking_enabled();
-        let maybe_view_key = resource
-            .to_view_key_public_key()
-            .map_err(|e| RuntimeError::InvariantError {
-                function: "burn_bucket",
-                details: format!("Resource contained a malformed view key: {e}. This should never happen!"),
-            })?;
+        let is_total_supply_tracking_enabled = self.get_resource(resource_lock)?.is_supply_tracking_enabled();
 
         let burnt_amount = bucket.unlocked_amount();
         // Confidential outputs are held by id in the bucket; downing them destroys the value.
@@ -755,6 +737,15 @@ impl<TStore: StateReader> WorkingState<TStore> {
         let mut destroyed_amount = burnt_amount;
         if let Some(commitments) = confidential_commitments {
             if is_total_supply_tracking_enabled {
+                // Decompressing the view key costs a point decompression, so it is only done once a proof is
+                // actually going to be verified against it.
+                let maybe_view_key = self
+                    .get_resource(resource_lock)?
+                    .to_view_key_public_key()
+                    .map_err(|e| RuntimeError::InvariantError {
+                        function: "burn_bucket",
+                        details: format!("Resource contained a malformed view key: {e}. This should never happen!"),
+                    })?;
                 let proven_value = self.spend_confidential_outputs_with_value_proofs(
                     resource_address,
                     commitments,

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -644,11 +644,7 @@ impl<TStore: StateReader> WorkingState<TStore> {
             )?;
             proven_value = proven_value
                 .checked_add(value)
-                .ok_or(RuntimeError::ResourceSupplyWouldOverflow {
-                    resource_address,
-                    current_supply: proven_value,
-                    amount: value,
-                })?;
+                .ok_or(RuntimeError::CommitmentValueSumOverflow { resource_address })?;
         }
         Ok(proven_value)
     }
@@ -765,14 +761,9 @@ impl<TStore: StateReader> WorkingState<TStore> {
                     value_proofs,
                     maybe_view_key.as_ref(),
                 )?;
-                destroyed_amount =
-                    destroyed_amount
-                        .checked_add(proven_value)
-                        .ok_or(RuntimeError::ResourceSupplyWouldOverflow {
-                            resource_address,
-                            current_supply: burnt_amount,
-                            amount: proven_value,
-                        })?;
+                destroyed_amount = destroyed_amount
+                    .checked_add(proven_value)
+                    .ok_or(RuntimeError::CommitmentValueSumOverflow { resource_address })?;
             } else {
                 self.spend_confidential_outputs(resource_address, commitments)?;
             }
@@ -925,13 +916,9 @@ impl<TStore: StateReader> WorkingState<TStore> {
                             body.viewable_balance.as_ref(),
                             value_proof,
                         )?;
-                        minted_commitment_value = minted_commitment_value.checked_add(value).ok_or(
-                            RuntimeError::ResourceSupplyWouldOverflow {
-                                resource_address,
-                                current_supply: minted_commitment_value,
-                                amount: value,
-                            },
-                        )?;
+                        minted_commitment_value = minted_commitment_value
+                            .checked_add(value)
+                            .ok_or(RuntimeError::CommitmentValueSumOverflow { resource_address })?;
                     }
                 }
 
@@ -968,16 +955,13 @@ impl<TStore: StateReader> WorkingState<TStore> {
             // The minted amount is the revealed funds plus the value of any minted commitments
             let minted_amount = resource_container
                 .unlocked_amount()
-                .checked_add(minted_commitment_value);
-            let overflows = match minted_amount {
-                Some(amount) => !resource_mut.increase_total_supply(amount),
-                None => true,
-            };
-            if overflows {
+                .checked_add(minted_commitment_value)
+                .ok_or(RuntimeError::CommitmentValueSumOverflow { resource_address })?;
+            if !resource_mut.increase_total_supply(minted_amount) {
                 return Err(RuntimeError::ResourceSupplyWouldOverflow {
                     resource_address,
                     current_supply,
-                    amount: minted_amount.unwrap_or(Amount::MAX),
+                    amount: minted_amount,
                 });
             }
         }

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -703,10 +703,20 @@ impl<TStore: StateReader> WorkingState<TStore> {
     /// holds the commitment.
     pub fn burn_bucket(
         &mut self,
+        bucket_id: BucketId,
         bucket: Bucket,
         resource_lock: &LockedSubstate,
         value_proofs: &BTreeMap<PedersenCommitmentBytes, CommitmentValueProof>,
     ) -> Result<(), RuntimeError> {
+        // Burning downs only the unlocked commitments, so a locked one would be left live with nothing referencing
+        // it. Callers reject this earlier to avoid charging for a burn that cannot succeed; the check lives here so
+        // that it holds for every caller.
+        if bucket.has_locked_funds() {
+            return Err(RuntimeError::InvalidOpDepositLockedBucket {
+                bucket_id,
+                locked_amount: bucket.locked_amount(),
+            });
+        }
         if bucket.is_empty() {
             return Ok(());
         }

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -3,7 +3,7 @@
 
 use std::{
     cmp,
-    collections::{BTreeSet, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     mem,
 };
 
@@ -18,6 +18,7 @@ use tari_engine_types::{
     bucket::Bucket,
     component::Component,
     confidential_output::ConfidentialOutput,
+    crypto,
     events::Event,
     fees::{FeeReceipt, FeeSource},
     id_provider::{IdProvider, ObjectIds},
@@ -58,7 +59,7 @@ use tari_template_lib::{
         access_rules::ResourceAuthAction,
         confidential::ConfidentialWithdrawProof,
         constants::{PUBLIC_IDENTITY_RESOURCE_ADDRESS, STEALTH_TARI_RESOURCE_ADDRESS},
-        crypto::PedersenCommitmentBytes,
+        crypto::{CommitmentValueProof, PedersenCommitmentBytes},
         metadata,
         stealth::{SpendAuthorization, StealthInput, StealthTransferStatement},
     },
@@ -587,6 +588,33 @@ impl<TStore: StateReader> WorkingState<TStore> {
         resource_address: ResourceAddress,
         commitments: I,
     ) -> Result<(), RuntimeError> {
+        self.spend_confidential_outputs_internal(resource_address, commitments, None)
+            .map(|_| ())
+    }
+
+    /// Downs each commitment's [`ConfidentialOutput`] substate, verifying the caller's value proof for it and
+    /// returning the total value proven. Requiring a proof here — where the commitments are enumerated — is what
+    /// makes it impossible to destroy a commitment's value without accounting for it.
+    pub fn spend_confidential_outputs_with_value_proofs<I: IntoIterator<Item = PedersenCommitmentBytes>>(
+        &mut self,
+        resource_address: ResourceAddress,
+        commitments: I,
+        value_proofs: &BTreeMap<PedersenCommitmentBytes, CommitmentValueProof>,
+        view_key: Option<&RistrettoPublicKey>,
+    ) -> Result<Amount, RuntimeError> {
+        self.spend_confidential_outputs_internal(resource_address, commitments, Some((value_proofs, view_key)))
+    }
+
+    fn spend_confidential_outputs_internal<I: IntoIterator<Item = PedersenCommitmentBytes>>(
+        &mut self,
+        resource_address: ResourceAddress,
+        commitments: I,
+        value_proofs: Option<(
+            &BTreeMap<PedersenCommitmentBytes, CommitmentValueProof>,
+            Option<&RistrettoPublicKey>,
+        )>,
+    ) -> Result<Amount, RuntimeError> {
+        let mut proven_value = Amount::ZERO;
         for commitment in commitments {
             let address = ConfidentialOutputAddress::new(resource_address, commitment);
             let lock_id = self.store.try_lock(address.clone().into(), LockFlag::Write)?;
@@ -598,8 +626,31 @@ impl<TStore: StateReader> WorkingState<TStore> {
                 }
                 .into());
             }
+
+            let Some((value_proofs, view_key)) = value_proofs else {
+                continue;
+            };
+            let value_proof = value_proofs
+                .get(&commitment)
+                .ok_or(RuntimeError::MissingValueProofForCommitment {
+                    resource_address,
+                    commitment,
+                })?;
+            let value = crypto::validate_value_proof(
+                &commitment,
+                view_key,
+                output.output().viewable_balance.as_ref(),
+                value_proof,
+            )?;
+            proven_value = proven_value
+                .checked_add(value)
+                .ok_or(RuntimeError::ResourceSupplyWouldOverflow {
+                    resource_address,
+                    current_supply: proven_value,
+                    amount: value,
+                })?;
         }
-        Ok(())
+        Ok(proven_value)
     }
 
     /// Applies the substate-level effects of a confidential mint/withdraw: downs the spent input substates and
@@ -627,11 +678,64 @@ impl<TStore: StateReader> WorkingState<TStore> {
         Ok(())
     }
 
-    pub fn burn_bucket(&mut self, bucket: Bucket) -> Result<(), RuntimeError> {
+    /// Decreases the total supply of the locked resource, rejecting the transaction rather than wrapping if the
+    /// decrease would underflow. Callers must only call this for a resource with supply tracking enabled.
+    pub fn decrease_total_supply(
+        &mut self,
+        resource_lock: &LockedSubstate,
+        amount: Amount,
+    ) -> Result<(), RuntimeError> {
+        let resource_address =
+            resource_lock
+                .substate_id()
+                .as_resource_address()
+                .ok_or_else(|| RuntimeError::InvariantError {
+                    function: "decrease_total_supply",
+                    details: "LockedSubstate substate_id is not a ResourceAddress".to_string(),
+                })?;
+        let resource_mut = self.get_resource_mut(resource_lock)?;
+        if resource_mut.decrease_total_supply(amount) {
+            return Ok(());
+        }
+        Err(RuntimeError::ResourceSupplyWouldUnderflow {
+            resource_address,
+            current_supply: resource_mut
+                .total_supply()
+                .expect("Resource supply tracking is enabled"),
+            amount,
+        })
+    }
+
+    /// Destroys `bucket` and its contents, decreasing the resource's total supply by the value destroyed.
+    ///
+    /// `resource_lock` must be a write lock on the bucket's resource. When the resource tracks total supply,
+    /// `value_proofs` must prove the value of every confidential commitment the bucket holds: a commitment's value
+    /// is not visible to `unlocked_amount`, so without a proof the engine cannot know how much the burn destroys.
+    ///
+    /// A holder who knows the masks can prove a commitment directly. A holder who does not — a recaller, say — can
+    /// only prove one through the resource's view key, so commitments recalled from a resource without a view key
+    /// cannot be burnt at all. The supply figure stays correct either way: the value still exists, held by whoever
+    /// holds the commitment.
+    pub fn burn_bucket(
+        &mut self,
+        bucket: Bucket,
+        resource_lock: &LockedSubstate,
+        value_proofs: &BTreeMap<PedersenCommitmentBytes, CommitmentValueProof>,
+    ) -> Result<(), RuntimeError> {
         if bucket.is_empty() {
             return Ok(());
         }
         let resource_address = *bucket.resource_address();
+        let resource = self.get_resource(resource_lock)?;
+        let is_total_supply_tracking_enabled = resource.is_supply_tracking_enabled();
+        let maybe_view_key = resource
+            .to_view_key_public_key()
+            .map_err(|e| RuntimeError::InvariantError {
+                function: "burn_bucket",
+                details: format!("Resource contained a malformed view key: {e}. This should never happen!"),
+            })?;
+
+        let burnt_amount = bucket.unlocked_amount();
         // Confidential outputs are held by id in the bucket; downing them destroys the value.
         let confidential_commitments = bucket.get_confidential_commitments().cloned();
         // Burn Non-fungibles (if resource is nf). Fungibles are burnt by removing the bucket from the tracker state
@@ -652,8 +756,30 @@ impl<TStore: StateReader> WorkingState<TStore> {
             self.unlock_substate(locked_nft)?;
         }
 
+        let mut destroyed_amount = burnt_amount;
         if let Some(commitments) = confidential_commitments {
-            self.spend_confidential_outputs(resource_address, commitments)?;
+            if is_total_supply_tracking_enabled {
+                let proven_value = self.spend_confidential_outputs_with_value_proofs(
+                    resource_address,
+                    commitments,
+                    value_proofs,
+                    maybe_view_key.as_ref(),
+                )?;
+                destroyed_amount =
+                    destroyed_amount
+                        .checked_add(proven_value)
+                        .ok_or(RuntimeError::ResourceSupplyWouldOverflow {
+                            resource_address,
+                            current_supply: burnt_amount,
+                            amount: proven_value,
+                        })?;
+            } else {
+                self.spend_confidential_outputs(resource_address, commitments)?;
+            }
+        }
+
+        if is_total_supply_tracking_enabled {
+            self.decrease_total_supply(resource_lock, destroyed_amount)?;
         }
 
         Ok(())
@@ -721,6 +847,10 @@ impl<TStore: StateReader> WorkingState<TStore> {
             resource.is_supply_tracking_enabled()
         };
 
+        // The value minted into commitments. `ResourceContainer::unlocked_amount` cannot see it, so it is tracked
+        // separately and added to the supply increase below.
+        let mut minted_commitment_value = Amount::ZERO;
+
         let resource_container = match mint_arg {
             MintArg::Fungible { amount } => {
                 if amount.is_negative() {
@@ -760,7 +890,10 @@ impl<TStore: StateReader> WorkingState<TStore> {
 
                 ResourceContainer::non_fungible(resource_address, token_ids)
             },
-            MintArg::Confidential { statement } => {
+            MintArg::Confidential {
+                statement,
+                value_proofs,
+            } => {
                 let resource = self.get_resource(locked_resource)?;
                 debug!(
                     target: LOG_TARGET,
@@ -774,6 +907,34 @@ impl<TStore: StateReader> WorkingState<TStore> {
                     })?;
                 let (container, created_outputs) =
                     ResourceContainer::mint_confidential(resource_address, *statement, maybe_view_key.as_ref())?;
+
+                // Every commitment the mint creates must be proven, so that the supply increase covers all of the
+                // value minted no matter how many outputs the statement turns out to produce.
+                if is_total_supply_tracking_enabled {
+                    for (commitment, body) in &created_outputs {
+                        let value_proof =
+                            value_proofs
+                                .get(commitment)
+                                .ok_or(RuntimeError::MissingValueProofForCommitment {
+                                    resource_address,
+                                    commitment: *commitment,
+                                })?;
+                        let value = crypto::validate_value_proof(
+                            commitment,
+                            maybe_view_key.as_ref(),
+                            body.viewable_balance.as_ref(),
+                            value_proof,
+                        )?;
+                        minted_commitment_value = minted_commitment_value.checked_add(value).ok_or(
+                            RuntimeError::ResourceSupplyWouldOverflow {
+                                resource_address,
+                                current_supply: minted_commitment_value,
+                                amount: value,
+                            },
+                        )?;
+                    }
+                }
+
                 for (commitment, body) in created_outputs {
                     let address = ConfidentialOutputAddress::new(resource_address, commitment);
                     self.new_substate(SubstateId::ConfidentialOutput(address), ConfidentialOutput::new(body))?;
@@ -801,14 +962,22 @@ impl<TStore: StateReader> WorkingState<TStore> {
         // to the substate diff)
         if is_total_supply_tracking_enabled {
             let resource_mut = self.get_resource_mut(locked_resource)?;
-            // Increase the total supply of the resource
-            if !resource_mut.increase_total_supply(resource_container.unlocked_amount()) {
+            let current_supply = resource_mut
+                .total_supply()
+                .expect("Resource supply tracking is enabled");
+            // The minted amount is the revealed funds plus the value of any minted commitments
+            let minted_amount = resource_container
+                .unlocked_amount()
+                .checked_add(minted_commitment_value);
+            let overflows = match minted_amount {
+                Some(amount) => !resource_mut.increase_total_supply(amount),
+                None => true,
+            };
+            if overflows {
                 return Err(RuntimeError::ResourceSupplyWouldOverflow {
                     resource_address,
-                    current_supply: resource_mut
-                        .total_supply()
-                        .expect("Resource supply tracking is enabled"),
-                    amount: resource_container.unlocked_amount(),
+                    current_supply,
+                    amount: minted_amount.unwrap_or(Amount::MAX),
                 });
             }
         }

--- a/crates/engine/tests/burn.rs
+++ b/crates/engine/tests/burn.rs
@@ -2,8 +2,8 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use tari_ootle_transaction::{Transaction, args};
-use tari_template_lib::types::{Amount, ComponentAddress};
-use tari_template_test_tooling::{TemplateTest, support::confidential::generate_confidential_output_statement};
+use tari_template_lib::types::{Amount, ComponentAddress, confidential::ConfidentialOutputStatement};
+use tari_template_test_tooling::TemplateTest;
 
 const CRATE_PATH: &str = env!("CARGO_MANIFEST_DIR");
 
@@ -12,8 +12,9 @@ fn it_burns_all_resource_types() {
     let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/burn"]);
     let recall_template = test.get_template_address("Burn");
 
-    let (mut initial_supply, _mask, _) = generate_confidential_output_statement(1000, None);
-    initial_supply.output_revealed_amount = Amount::from(1000u64);
+    // Revealed-only, so that `burn_all` needs no value proofs. Burning commitments is covered by the confidential
+    // tests.
+    let initial_supply = ConfidentialOutputStatement::mint_revealed(1000u64);
 
     let result = test.execute_expect_success(
         Transaction::builder_localnet()

--- a/crates/engine/tests/confidential.rs
+++ b/crates/engine/tests/confidential.rs
@@ -1,6 +1,8 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+use std::collections::BTreeMap;
+
 use ootle_byte_type::ToByteType;
 use tari_crypto::{
     keys::PublicKey as _,
@@ -22,7 +24,7 @@ use tari_template_lib::{
         ComponentAddress,
         ConfidentialOutputAddress,
         confidential::{ConfidentialOutputStatement, ConfidentialWithdrawProof},
-        crypto::RistrettoPublicKeyBytes,
+        crypto::{CommitmentValueProof, PedersenCommitmentBytes, RistrettoPublicKeyBytes},
     },
 };
 use tari_template_test_tooling::{
@@ -33,10 +35,12 @@ use tari_template_test_tooling::{
         confidential::{
             generate_confidential_output_statement,
             generate_confidential_proof_with_view_key,
+            generate_reveal_proof,
             generate_withdraw_proof,
             generate_withdraw_proof_with_inputs,
             generate_withdraw_proof_with_view_key,
         },
+        value_proof::generate_value_proof_mask_knowledge,
     },
 };
 use tari_transaction_manifest::ManifestValue;
@@ -44,8 +48,31 @@ use tari_utilities::ByteArray;
 
 const CRATE_PATH: &str = env!("CARGO_MANIFEST_DIR");
 
+/// Generates a mint statement for `amount` along with the mask and the value proofs the engine requires to
+/// account for the minted commitment in the resource's total supply.
+fn mint_statement(
+    amount: u64,
+    view_key: Option<&RistrettoPublicKey>,
+) -> (ConfidentialOutputStatement, RistrettoSecretKey, ValueProofs) {
+    let (statement, mask, _change) = match view_key {
+        Some(vk) => generate_confidential_proof_with_view_key(amount, None, vk),
+        None => generate_confidential_output_statement(amount, None),
+    };
+    (statement, mask.clone(), value_proofs_for(amount, &mask))
+}
+
+type ValueProofs = BTreeMap<PedersenCommitmentBytes, CommitmentValueProof>;
+
+/// The single-commitment proof map for a commitment of `amount` under `mask`.
+fn value_proofs_for(amount: u64, mask: &RistrettoSecretKey) -> ValueProofs {
+    let amount = Amount::from(amount);
+    let commitment = commit_amount(mask, amount).unwrap().to_byte_type();
+    BTreeMap::from([(commitment, generate_value_proof_mask_knowledge(amount, mask))])
+}
+
 fn setup(
     initial_supply: ConfidentialOutputStatement,
+    value_proofs: ValueProofs,
     view_key: Option<&RistrettoPublicKey>,
 ) -> (TemplateTest, ComponentAddress, SubstateId) {
     let mut template_test = TemplateTest::new(CRATE_PATH, vec![
@@ -53,17 +80,23 @@ fn setup(
         "tests/templates/confidential/utilities",
     ]);
 
-    let faucet: ComponentAddress = view_key
-        .map(|vk| {
+    let faucet: ComponentAddress = match view_key {
+        Some(vk) => {
             let vk = RistrettoPublicKeyBytes::from_bytes(vk.as_bytes()).unwrap();
             template_test.call_function(
                 "ConfidentialFaucet",
                 "mint_with_view_key",
-                args![initial_supply, vk],
+                args![initial_supply, vk, value_proofs],
                 vec![],
             )
-        })
-        .unwrap_or_else(|| template_test.call_function("ConfidentialFaucet", "mint", args![initial_supply], vec![]));
+        },
+        None => template_test.call_function(
+            "ConfidentialFaucet",
+            "mint",
+            args![initial_supply, value_proofs],
+            vec![],
+        ),
+    };
 
     let resx = template_test.get_previous_output_address(SubstateType::Resource);
 
@@ -72,24 +105,47 @@ fn setup(
 
 #[test]
 fn mint_initial_commitment() {
-    let (confidential_proof, _mask, _change) = generate_confidential_output_statement(100, None);
-    let (test, _faucet, faucet_resx) = setup(confidential_proof, None);
+    let (confidential_proof, _mask, value_proofs) = mint_statement(100, None);
+    let (test, _faucet, faucet_resx) = setup(confidential_proof, value_proofs, None);
 
     let resource = test
         .read_only_state_store()
         .get_resource(&faucet_resx.as_resource_address().unwrap())
         .unwrap();
-    // TODO: confidential total_supply tracking only tracks revealed funds
-    assert_eq!(resource.total_supply(), Some(Amount::from(0u64)));
+    assert_eq!(resource.total_supply(), Some(Amount::from(100u64)));
+}
+
+/// Minting a commitment on a supply-tracking resource is rejected unless the mint proves its value, otherwise the
+/// minted value would not be counted towards the supply.
+#[test]
+fn minting_a_commitment_without_a_value_proof_is_rejected() {
+    let (confidential_proof, _mask, value_proofs) = mint_statement(100, None);
+    let (mut test, faucet, faucet_resx) = setup(confidential_proof, value_proofs, None);
+    let owner = test.owner_proof();
+
+    let (mint_proof, mint_mask, _value_proofs) = mint_statement(42, None);
+    let commitment = commit_amount(&mint_mask, Amount::from(42u64)).unwrap().to_byte_type();
+
+    let reason = test.execute_expect_failure(
+        Transaction::builder_localnet()
+            .call_method(faucet, "mint_more", args![mint_proof, ValueProofs::new()])
+            .build_and_seal(test.secret_key()),
+        vec![owner],
+    );
+
+    assert_reject_reason(reason, RuntimeError::MissingValueProofForCommitment {
+        resource_address: faucet_resx.as_resource_address().unwrap(),
+        commitment,
+    });
 }
 
 #[test]
 fn mint_more_later() {
-    let (confidential_proof, _mask, _change) = generate_confidential_output_statement(0, None);
-    let (mut template_test, faucet, _faucet_resx) = setup(confidential_proof, None);
+    let (confidential_proof, _mask, value_proofs) = mint_statement(0, None);
+    let (mut template_test, faucet, _faucet_resx) = setup(confidential_proof, value_proofs, None);
 
-    let (confidential_proof, mask, _change) = generate_confidential_output_statement(100, None);
-    template_test.call_method::<()>(faucet, "mint_more", args![confidential_proof], vec![]);
+    let (confidential_proof, mask, value_proofs) = mint_statement(100, None);
+    template_test.call_method::<()>(faucet, "mint_more", args![confidential_proof, value_proofs], vec![]);
 
     let (user_account, user_proof, user_key) = template_test.create_empty_account();
 
@@ -107,8 +163,8 @@ fn mint_more_later() {
 #[allow(clippy::too_many_lines)]
 #[test]
 fn transfer_confidential_amounts_between_accounts() {
-    let (confidential_proof, faucet_mask, _change) = generate_confidential_output_statement(100_000, None);
-    let (mut template_test, faucet, faucet_resx) = setup(confidential_proof, None);
+    let (confidential_proof, faucet_mask, value_proofs) = mint_statement(100_000, None);
+    let (mut template_test, faucet, faucet_resx) = setup(confidential_proof, value_proofs, None);
 
     // Create an account
     let (account1, owner1, _k) = template_test.create_funded_account();
@@ -196,8 +252,8 @@ fn transfer_confidential_amounts_between_accounts() {
 
 #[test]
 fn transfer_confidential_fails_with_invalid_balance() {
-    let (confidential_proof, faucet_mask, _change) = generate_confidential_output_statement(100_000, None);
-    let (mut template_test, faucet, _faucet_resx) = setup(confidential_proof, None);
+    let (confidential_proof, faucet_mask, value_proofs) = mint_statement(100_000, None);
+    let (mut template_test, faucet, _faucet_resx) = setup(confidential_proof, value_proofs, None);
 
     // Create an account
     let (account1, _owner1, _k) = template_test.create_funded_account();
@@ -228,8 +284,8 @@ fn transfer_confidential_fails_with_invalid_balance() {
 
 #[test]
 fn reveal_confidential_and_transfer() {
-    let (confidential_proof, faucet_mask, _change) = generate_confidential_output_statement(100_000, None);
-    let (mut test, faucet, faucet_resx) = setup(confidential_proof, None);
+    let (confidential_proof, faucet_mask, value_proofs) = mint_statement(100_000, None);
+    let (mut test, faucet, faucet_resx) = setup(confidential_proof, value_proofs, None);
 
     // Create an account
     let (account1, owner1, _k) = test.create_funded_account();
@@ -305,8 +361,8 @@ fn reveal_confidential_and_transfer() {
 
 #[test]
 fn attempt_to_reveal_with_unbalanced_proof() {
-    let (confidential_proof, faucet_mask, _change) = generate_confidential_output_statement(100_000, None);
-    let (mut template_test, faucet, faucet_resx) = setup(confidential_proof, None);
+    let (confidential_proof, faucet_mask, value_proofs) = mint_statement(100_000, None);
+    let (mut template_test, faucet, faucet_resx) = setup(confidential_proof, value_proofs, None);
 
     // Create an account
     let (account1, owner1, _k) = template_test.create_funded_account();
@@ -358,8 +414,8 @@ fn attempt_to_reveal_with_unbalanced_proof() {
 
 #[test]
 fn multi_commitment_join() {
-    let (confidential_proof, faucet_mask, _change) = generate_confidential_output_statement(100_000, None);
-    let (mut template_test, faucet, faucet_resx) = setup(confidential_proof, None);
+    let (confidential_proof, faucet_mask, value_proofs) = mint_statement(100_000, None);
+    let (mut template_test, faucet, faucet_resx) = setup(confidential_proof, value_proofs, None);
 
     // Create an account
     let (account1, owner1, _k) = template_test.create_funded_account();
@@ -431,8 +487,8 @@ fn multi_commitment_join() {
 
 #[test]
 fn mint_and_transfer_revealed() {
-    let (confidential_proof, _mask, _change) = generate_confidential_output_statement(100, None);
-    let (mut test, faucet, faucet_resx) = setup(confidential_proof, None);
+    let (confidential_proof, _mask, value_proofs) = mint_statement(100, None);
+    let (mut test, faucet, faucet_resx) = setup(confidential_proof, value_proofs, None);
 
     let faucet_resx = faucet_resx.as_resource_address().unwrap();
 
@@ -462,8 +518,8 @@ fn mint_and_transfer_revealed() {
 
 #[test]
 fn mint_revealed_with_invalid_proof() {
-    let (confidential_proof, _mask, _change) = generate_confidential_output_statement(100, None);
-    let (mut test, faucet, _faucet_resx) = setup(confidential_proof, None);
+    let (confidential_proof, _mask, value_proofs) = mint_statement(100, None);
+    let (mut test, faucet, _faucet_resx) = setup(confidential_proof, value_proofs, None);
 
     let reason = test.execute_expect_failure(
         Transaction::builder_localnet()
@@ -500,11 +556,11 @@ where
 #[test]
 fn mint_with_view_key() {
     let (view_key_secret, ref view_key) = RistrettoPublicKey::random_keypair(&mut rand::rng());
-    let (confidential_proof, _mask, _change) = generate_confidential_proof_with_view_key(123, None, view_key);
-    let (mut test, faucet, _faucet_resx) = setup(confidential_proof, Some(view_key));
+    let (confidential_proof, _mask, value_proofs) = mint_statement(123, Some(view_key));
+    let (mut test, faucet, _faucet_resx) = setup(confidential_proof, value_proofs, Some(view_key));
 
-    let (confidential_proof, mask, _change) = generate_confidential_proof_with_view_key(100, None, view_key);
-    test.call_method::<()>(faucet, "mint_more", args![confidential_proof], vec![]);
+    let (confidential_proof, mask, value_proofs) = mint_statement(100, Some(view_key));
+    test.call_method::<()>(faucet, "mint_more", args![confidential_proof, value_proofs], vec![]);
 
     let (user_account, user_proof, user_key) = test.create_empty_account();
 
@@ -555,8 +611,8 @@ fn mint_with_view_key() {
 
 #[test]
 fn freeze_then_attempt_spend() {
-    let (confidential_proof, mask, _change) = generate_confidential_output_statement(100, None);
-    let (mut test, faucet, faucet_resx) = setup(confidential_proof, None);
+    let (confidential_proof, mask, value_proofs) = mint_statement(100, None);
+    let (mut test, faucet, faucet_resx) = setup(confidential_proof, value_proofs, None);
 
     let commitment = commit_amount(&mask, Amount::from(100u64)).unwrap().to_byte_type();
     let frozen_address = ConfidentialOutputAddress::new(faucet_resx.as_resource_address().unwrap(), commitment);
@@ -608,8 +664,8 @@ fn freeze_then_attempt_spend() {
 /// with its value already spent.
 #[test]
 fn unfreeze_and_spend_in_one_transaction_downs_the_output() {
-    let (confidential_proof, mask, _change) = generate_confidential_output_statement(100, None);
-    let (mut test, faucet, faucet_resx) = setup(confidential_proof, None);
+    let (confidential_proof, mask, value_proofs) = mint_statement(100, None);
+    let (mut test, faucet, faucet_resx) = setup(confidential_proof, value_proofs, None);
 
     let commitment = commit_amount(&mask, Amount::from(100u64)).unwrap().to_byte_type();
     let output_address = ConfidentialOutputAddress::new(faucet_resx.as_resource_address().unwrap(), commitment);
@@ -653,14 +709,17 @@ fn unfreeze_and_spend_in_one_transaction_downs_the_output() {
 /// no longer keyed by a per-vault map.
 #[test]
 fn minting_a_duplicate_commitment_is_rejected() {
-    let (confidential_proof, _mask, _change) = generate_confidential_output_statement(100, None);
-    let (mut test, faucet, faucet_resx) = setup(confidential_proof, None);
+    let (confidential_proof, _mask, value_proofs) = mint_statement(100, None);
+    let (mut test, faucet, faucet_resx) = setup(confidential_proof, value_proofs, None);
 
-    let (mint_proof, mint_mask, _change) = generate_confidential_output_statement(42, None);
+    let (mint_proof, mint_mask, mint_value_proofs) = mint_statement(42, None);
     let owner = test.owner_proof();
     test.execute_expect_success(
         Transaction::builder_localnet()
-            .call_method(faucet, "mint_more", args![mint_proof.clone()])
+            .call_method(faucet, "mint_more", args![
+                mint_proof.clone(),
+                mint_value_proofs.clone()
+            ])
             .build_and_seal(test.secret_key()),
         vec![owner.clone()],
     );
@@ -669,7 +728,7 @@ fn minting_a_duplicate_commitment_is_rejected() {
     let address = ConfidentialOutputAddress::new(faucet_resx.as_resource_address().unwrap(), commitment);
     let reason = test.execute_expect_failure(
         Transaction::builder_localnet()
-            .call_method(faucet, "mint_more", args![mint_proof])
+            .call_method(faucet, "mint_more", args![mint_proof, mint_value_proofs])
             .build_and_seal(test.secret_key()),
         vec![owner],
     );
@@ -683,8 +742,8 @@ fn minting_a_duplicate_commitment_is_rejected() {
 /// standalone checks: one withdraw over `max_withdraws_per_transaction` rejects the whole transaction.
 #[test]
 fn a_transaction_over_the_withdraw_cap_is_rejected() {
-    let (confidential_proof, _mask, _change) = generate_confidential_output_statement(100, None);
-    let (mut test, faucet, _faucet_resx) = setup(confidential_proof, None);
+    let (confidential_proof, _mask, value_proofs) = mint_statement(100, None);
+    let (mut test, faucet, _faucet_resx) = setup(confidential_proof, value_proofs, None);
     let owner = test.owner_proof();
 
     let max_withdraws = CONFIDENTIAL_LIMITS.max_withdraws_per_transaction;
@@ -709,4 +768,101 @@ fn a_transaction_over_the_withdraw_cap_is_rejected() {
         reason,
         ArgumentValidationError::MaxConfidentialWithdrawsPerTransactionExceeded { max_withdraws },
     );
+}
+
+fn read_total_supply(test: &TemplateTest, resource: &SubstateId) -> Option<Amount> {
+    test.read_only_state_store()
+        .get_resource(&resource.as_resource_address().unwrap())
+        .unwrap()
+        .total_supply()
+}
+
+/// Value minted into a commitment counts towards `total_supply`, revealing it is supply-neutral, and burning
+/// the revealed bucket removes it again.
+#[test]
+fn minting_and_burning_a_commitment_tracks_total_supply() {
+    let (confidential_proof, mask, value_proofs) = mint_statement(500, None);
+    let (mut test, faucet, faucet_resx) = setup(confidential_proof, value_proofs, None);
+    let owner = test.owner_proof();
+    let utilities = test.get_template_address("ConfidentialUtilities");
+
+    assert_eq!(read_total_supply(&test, &faucet_resx), Some(Amount::from(500u64)));
+
+    // Move the whole 500 out of the commitment and into revealed funds.
+    let reveal_proof = generate_reveal_proof(&mask, 500);
+    test.execute_expect_success(
+        Transaction::builder_localnet()
+            .call_method(faucet, "take_free_coins", args![reveal_proof])
+            .put_last_instruction_output_on_workspace("coins")
+            .call_function(utilities, "burn_bucket", args![Workspace("coins")])
+            .build_and_seal(test.secret_key()),
+        vec![owner],
+    );
+
+    assert_eq!(read_total_supply(&test, &faucet_resx), Some(Amount::ZERO));
+}
+
+/// A bucket still holding commitments has an amount the engine cannot see, so burning it while supply
+/// tracking is enabled requires a value proof for each commitment.
+#[test]
+fn burning_a_bucket_holding_commitments_without_a_value_proof_is_rejected() {
+    let (confidential_proof, mask, value_proofs) = mint_statement(500, None);
+    let (mut test, faucet, faucet_resx) = setup(confidential_proof, value_proofs, None);
+    let owner = test.owner_proof();
+    let utilities = test.get_template_address("ConfidentialUtilities");
+
+    let withdraw_proof = generate_withdraw_proof(&mask, 500, None, 0u64);
+    let commitment = commit_amount(&withdraw_proof.output_mask, Amount::from(500u64))
+        .unwrap()
+        .to_byte_type();
+    let reason = test.execute_expect_failure(
+        Transaction::builder_localnet()
+            .call_method(faucet, "take_free_coins", args![withdraw_proof.proof])
+            .put_last_instruction_output_on_workspace("coins")
+            .call_function(utilities, "burn_bucket", args![Workspace("coins")])
+            .build_and_seal(test.secret_key()),
+        vec![owner],
+    );
+
+    assert_reject_reason(reason, RuntimeError::MissingValueProofForCommitment {
+        resource_address: faucet_resx.as_resource_address().unwrap(),
+        commitment,
+    });
+}
+
+/// Given a value proof per commitment, a bucket holding commitments burns and the resource's total supply drops
+/// by the value destroyed. This is the path a holder who knows the masks takes instead of revealing first.
+#[test]
+fn burning_a_bucket_holding_commitments_with_value_proofs_decreases_total_supply() {
+    let (confidential_proof, mask, value_proofs) = mint_statement(500, None);
+    let (mut test, faucet, faucet_resx) = setup(confidential_proof, value_proofs, None);
+    let owner = test.owner_proof();
+    let utilities = test.get_template_address("ConfidentialUtilities");
+
+    assert_eq!(read_total_supply(&test, &faucet_resx), Some(Amount::from(500u64)));
+
+    // Split the 500 into a 200 output and 300 change, then burn the 200 output commitment.
+    let withdraw_proof = generate_withdraw_proof(&mask, 200, Some(300), 0u64);
+    let burnt = Amount::from(200u64);
+    let commitment = commit_amount(&withdraw_proof.output_mask, burnt)
+        .unwrap()
+        .to_byte_type();
+    let value_proofs = BTreeMap::from([(
+        commitment,
+        generate_value_proof_mask_knowledge(burnt, &withdraw_proof.output_mask),
+    )]);
+
+    test.execute_expect_success(
+        Transaction::builder_localnet()
+            .call_method(faucet, "take_free_coins", args![withdraw_proof.proof])
+            .put_last_instruction_output_on_workspace("coins")
+            .call_function(utilities, "burn_bucket_with_value_proofs", args![
+                Workspace("coins"),
+                value_proofs
+            ])
+            .build_and_seal(test.secret_key()),
+        vec![owner],
+    );
+
+    assert_eq!(read_total_supply(&test, &faucet_resx), Some(Amount::from(300u64)));
 }

--- a/crates/engine/tests/confidential.rs
+++ b/crates/engine/tests/confidential.rs
@@ -40,7 +40,7 @@ use tari_template_test_tooling::{
             generate_withdraw_proof_with_inputs,
             generate_withdraw_proof_with_view_key,
         },
-        value_proof::generate_value_proof_mask_knowledge,
+        value_proof::{generate_value_proof_mask_knowledge, value_proofs_for_commitment},
     },
 };
 use tari_transaction_manifest::ManifestValue;
@@ -58,17 +58,10 @@ fn mint_statement(
         Some(vk) => generate_confidential_proof_with_view_key(amount, None, vk),
         None => generate_confidential_output_statement(amount, None),
     };
-    (statement, mask.clone(), value_proofs_for(amount, &mask))
+    (statement, mask.clone(), value_proofs_for_commitment(amount, &mask))
 }
 
 type ValueProofs = BTreeMap<PedersenCommitmentBytes, CommitmentValueProof>;
-
-/// The single-commitment proof map for a commitment of `amount` under `mask`.
-fn value_proofs_for(amount: u64, mask: &RistrettoSecretKey) -> ValueProofs {
-    let amount = Amount::from(amount);
-    let commitment = commit_amount(mask, amount).unwrap().to_byte_type();
-    BTreeMap::from([(commitment, generate_value_proof_mask_knowledge(amount, mask))])
-}
 
 fn setup(
     initial_supply: ConfidentialOutputStatement,

--- a/crates/engine/tests/recall.rs
+++ b/crates/engine/tests/recall.rs
@@ -4,14 +4,13 @@
 use std::collections::BTreeMap;
 
 use ootle_byte_type::ToByteType;
-use tari_engine_types::crypto::commit_amount;
 use tari_ootle_transaction::{Transaction, args};
 use tari_template_lib::types::{Amount, ComponentAddress, NonFungibleId, ResourceAddress, VaultId};
 use tari_template_test_tooling::{
     TemplateTest,
     support::{
         confidential::{generate_confidential_output_statement, generate_withdraw_proof},
-        value_proof::generate_value_proof_mask_knowledge,
+        value_proof::value_proofs_for_commitment,
     },
 };
 
@@ -25,11 +24,7 @@ fn it_recalls_all_resource_types() {
 
     let (mut initial_supply, mask, _) = generate_confidential_output_statement(1000, None);
     initial_supply.output_revealed_amount = Amount::from(1000u64);
-    let commitment = commit_amount(&mask, Amount::from(1000u64)).unwrap().to_byte_type();
-    let value_proofs = BTreeMap::from([(
-        commitment,
-        generate_value_proof_mask_knowledge(Amount::from(1000u64), &mask),
-    )]);
+    let value_proofs = value_proofs_for_commitment(1000u64, &mask);
 
     let result = test.execute_expect_success(
         Transaction::builder_localnet()

--- a/crates/engine/tests/recall.rs
+++ b/crates/engine/tests/recall.rs
@@ -4,11 +4,15 @@
 use std::collections::BTreeMap;
 
 use ootle_byte_type::ToByteType;
+use tari_engine_types::crypto::commit_amount;
 use tari_ootle_transaction::{Transaction, args};
 use tari_template_lib::types::{Amount, ComponentAddress, NonFungibleId, ResourceAddress, VaultId};
 use tari_template_test_tooling::{
     TemplateTest,
-    support::confidential::{generate_confidential_output_statement, generate_withdraw_proof},
+    support::{
+        confidential::{generate_confidential_output_statement, generate_withdraw_proof},
+        value_proof::generate_value_proof_mask_knowledge,
+    },
 };
 
 const CRATE_PATH: &str = env!("CARGO_MANIFEST_DIR");
@@ -21,10 +25,15 @@ fn it_recalls_all_resource_types() {
 
     let (mut initial_supply, mask, _) = generate_confidential_output_statement(1000, None);
     initial_supply.output_revealed_amount = Amount::from(1000u64);
+    let commitment = commit_amount(&mask, Amount::from(1000u64)).unwrap().to_byte_type();
+    let value_proofs = BTreeMap::from([(
+        commitment,
+        generate_value_proof_mask_knowledge(Amount::from(1000u64), &mask),
+    )]);
 
     let result = test.execute_expect_success(
         Transaction::builder_localnet()
-            .call_function(recall_template, "new", args![initial_supply])
+            .call_function(recall_template, "new", args![initial_supply, value_proofs])
             .build_and_seal(test.secret_key()),
         vec![],
     );

--- a/crates/engine/tests/resource.rs
+++ b/crates/engine/tests/resource.rs
@@ -1,9 +1,16 @@
 //   Copyright 2024 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+use std::collections::BTreeMap;
+
+use ootle_byte_type::ToByteType;
+use tari_engine_types::crypto::commit_amount;
 use tari_ootle_transaction::args;
-use tari_template_lib::types::{ComponentAddress, Metadata, ResourceAddress};
-use tari_template_test_tooling::{TemplateTest, support::confidential::generate_confidential_output_statement};
+use tari_template_lib::types::{Amount, ComponentAddress, Metadata, ResourceAddress};
+use tari_template_test_tooling::{
+    TemplateTest,
+    support::{confidential::generate_confidential_output_statement, value_proof::generate_value_proof_mask_knowledge},
+};
 
 const CRATE_PATH: &str = env!("CARGO_MANIFEST_DIR");
 
@@ -25,8 +32,11 @@ fn non_fungible_join() {
 fn confidential_join() {
     let mut test = TemplateTest::new(CRATE_PATH, vec!["tests/templates/resource"]);
     let component: ComponentAddress = test.call_function("ResourceTest", "new", args![], vec![]);
-    let (output, _, _) = generate_confidential_output_statement(1000, None);
-    test.call_method::<()>(component, "confidential_join", args![output], vec![]);
+    let (output, mask, _) = generate_confidential_output_statement(1000, None);
+    let amount = Amount::from(1000u64);
+    let commitment = commit_amount(&mask, amount).unwrap().to_byte_type();
+    let value_proofs = BTreeMap::from([(commitment, generate_value_proof_mask_knowledge(amount, &mask))]);
+    test.call_method::<()>(component, "confidential_join", args![output, value_proofs], vec![]);
 }
 
 #[test]

--- a/crates/engine/tests/resource.rs
+++ b/crates/engine/tests/resource.rs
@@ -1,15 +1,11 @@
 //   Copyright 2024 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::collections::BTreeMap;
-
-use ootle_byte_type::ToByteType;
-use tari_engine_types::crypto::commit_amount;
 use tari_ootle_transaction::args;
-use tari_template_lib::types::{Amount, ComponentAddress, Metadata, ResourceAddress};
+use tari_template_lib::types::{ComponentAddress, Metadata, ResourceAddress};
 use tari_template_test_tooling::{
     TemplateTest,
-    support::{confidential::generate_confidential_output_statement, value_proof::generate_value_proof_mask_knowledge},
+    support::{confidential::generate_confidential_output_statement, value_proof::value_proofs_for_commitment},
 };
 
 const CRATE_PATH: &str = env!("CARGO_MANIFEST_DIR");
@@ -33,9 +29,7 @@ fn confidential_join() {
     let mut test = TemplateTest::new(CRATE_PATH, vec!["tests/templates/resource"]);
     let component: ComponentAddress = test.call_function("ResourceTest", "new", args![], vec![]);
     let (output, mask, _) = generate_confidential_output_statement(1000, None);
-    let amount = Amount::from(1000u64);
-    let commitment = commit_amount(&mask, amount).unwrap().to_byte_type();
-    let value_proofs = BTreeMap::from([(commitment, generate_value_proof_mask_knowledge(amount, &mask))]);
+    let value_proofs = value_proofs_for_commitment(1000u64, &mask);
     test.call_method::<()>(component, "confidential_join", args![output, value_proofs], vec![]);
 }
 

--- a/crates/engine/tests/stealth.rs
+++ b/crates/engine/tests/stealth.rs
@@ -36,6 +36,7 @@ use tari_template_test_tooling::{
         spec::OutputAuthSpec,
         stealth,
         stealth::{NO_INPUTS, StealthSecretTransferData},
+        value_proof,
     },
     wallet_crypto::{MaskAndValue, viewable_balance_proof::generate_elgamal_value_proof},
 };
@@ -706,7 +707,7 @@ fn burn_then_attempt_spend() {
         .map(|(mask, amount)| {
             let commitment = get_commitment_factory().commit_value(mask, amount);
             let utxo_id = UtxoId::from(commitment.to_byte_type());
-            let proof = stealth::generate_value_proof_mask_knowledge(amount.into(), mask);
+            let proof = value_proof::generate_value_proof_mask_knowledge(amount.into(), mask);
             (utxo_id, proof)
         })
         .collect::<Vec<_>>();
@@ -818,8 +819,8 @@ fn burn_rejects_elgamal_value_proof_for_a_false_value() {
             .build_and_seal(test.secret_key()),
         vec![owner],
     );
-    assert_reject_reason(reason, ResourceError::UtxoBurnFailed {
-        id: utxo_id,
+    assert_reject_reason(reason, ResourceError::InvalidValueProof {
+        commitment: commitment_bytes,
         details: "Invalid Elgamal encrypted value proof (s.R != K_r + e.D)".to_string(),
     });
 

--- a/crates/engine/tests/templates/confidential/faucet/Cargo.toml
+++ b/crates/engine/tests/templates/confidential/faucet/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+tari_template_abi = { path = "../../../../../template_abi" }
 tari_template_lib = { path = "../../../../../template_lib" }
 
 

--- a/crates/engine/tests/templates/confidential/faucet/src/lib.rs
+++ b/crates/engine/tests/templates/confidential/faucet/src/lib.rs
@@ -20,6 +20,7 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use tari_template_abi::rust::collections::BTreeMap;
 use tari_template_lib::prelude::*;
 
 #[template]
@@ -31,10 +32,14 @@ mod faucet_template {
     }
 
     impl ConfidentialFaucet {
-        pub fn mint(confidential_proof: ConfidentialOutputStatement) -> Component<Self> {
+        pub fn mint(
+            confidential_proof: ConfidentialOutputStatement,
+            value_proofs: BTreeMap<PedersenCommitmentBytes, crypto::CommitmentValueProof>,
+        ) -> Component<Self> {
             let coins = ResourceBuilder::confidential()
                 .mintable(rule!(allow_all), OWNER)
-                .initial_supply(confidential_proof);
+                .burnable(rule!(allow_all), OWNER)
+                .initial_supply_with_value_proofs(confidential_proof, value_proofs);
 
             Component::new(Self {
                 vault: Vault::from_bucket(coins),
@@ -46,11 +51,13 @@ mod faucet_template {
         pub fn mint_with_view_key(
             confidential_proof: ConfidentialOutputStatement,
             view_key: RistrettoPublicKeyBytes,
+            value_proofs: BTreeMap<PedersenCommitmentBytes, crypto::CommitmentValueProof>,
         ) -> Component<Self> {
             let coins = ResourceBuilder::confidential()
                 .mintable(rule!(allow_all), OWNER)
+                .burnable(rule!(allow_all), OWNER)
                 .with_view_key(view_key)
-                .initial_supply(confidential_proof);
+                .initial_supply_with_value_proofs(confidential_proof, value_proofs);
 
             Component::new(Self {
                 vault: Vault::from_bucket(coins),
@@ -61,19 +68,23 @@ mod faucet_template {
 
         pub fn mint_revealed(&mut self, amount: Amount) {
             let proof = ConfidentialOutputStatement::mint_revealed(amount);
-            let bucket = ResourceManager::get(self.vault.resource_address()).mint_confidential(proof);
+            let bucket = ResourceManager::get(self.vault.resource_address()).mint_confidential(proof, BTreeMap::new());
             self.vault.deposit(bucket);
         }
 
         pub fn mint_revealed_with_bad_range_proof(&mut self, amount: Amount) {
             let mut proof = ConfidentialOutputStatement::mint_revealed(amount);
             proof.range_proof = crypto::RangeProofBytes::try_from(vec![1, 2, 3]).unwrap();
-            let bucket = ResourceManager::get(self.vault.resource_address()).mint_confidential(proof);
+            let bucket = ResourceManager::get(self.vault.resource_address()).mint_confidential(proof, BTreeMap::new());
             self.vault.deposit(bucket);
         }
 
-        pub fn mint_more(&mut self, proof: ConfidentialOutputStatement) {
-            let bucket = ResourceManager::get(self.vault.resource_address()).mint_confidential(proof);
+        pub fn mint_more(
+            &mut self,
+            proof: ConfidentialOutputStatement,
+            value_proofs: BTreeMap<PedersenCommitmentBytes, crypto::CommitmentValueProof>,
+        ) {
+            let bucket = ResourceManager::get(self.vault.resource_address()).mint_confidential(proof, value_proofs);
             self.vault.deposit(bucket);
         }
 

--- a/crates/engine/tests/templates/confidential/utilities/Cargo.toml
+++ b/crates/engine/tests/templates/confidential/utilities/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+tari_template_abi = { path = "../../../../../template_abi" }
 tari_template_lib = { path = "../../../../../template_lib" }
 
 

--- a/crates/engine/tests/templates/confidential/utilities/src/lib.rs
+++ b/crates/engine/tests/templates/confidential/utilities/src/lib.rs
@@ -20,6 +20,7 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use tari_template_abi::rust::collections::BTreeMap;
 use tari_template_lib::prelude::*;
 
 // A stateless utility template: it exposes only pure free functions over confidential buckets and
@@ -36,5 +37,18 @@ mod ConfidentialUtilities {
     /// Joins two buckets into one, returning a new bucket containing the combined value of the same resource.
     pub fn join_buckets(bucket1: Bucket, bucket2: Bucket) -> Bucket {
         bucket1.join(bucket2)
+    }
+
+    /// Destroys a bucket and its contents.
+    pub fn burn_bucket(bucket: Bucket) {
+        bucket.burn();
+    }
+
+    /// Destroys a bucket and its contents, proving the value of each commitment it holds.
+    pub fn burn_bucket_with_value_proofs(
+        bucket: Bucket,
+        value_proofs: BTreeMap<PedersenCommitmentBytes, crypto::CommitmentValueProof>,
+    ) {
+        bucket.burn_with_value_proofs(value_proofs);
     }
 }

--- a/crates/engine/tests/templates/fungible/Cargo.toml
+++ b/crates/engine/tests/templates/fungible/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+tari_template_abi = { path = "../../../../template_abi" }
 tari_template_lib = { path = "../../../../template_lib" }
 
 

--- a/crates/engine/tests/templates/fungible/src/lib.rs
+++ b/crates/engine/tests/templates/fungible/src/lib.rs
@@ -20,6 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use tari_template_abi::rust::collections::BTreeMap;
 use tari_template_lib::prelude::*;
 
 #[template]
@@ -41,8 +42,11 @@ mod template {
             let fungible = ResourceBuilder::public_fungible()
                 .mintable(rule!(allow_all), OWNER)
                 .initial_supply(supply);
+            // Supply tracking is off so that the tests can mint past `Amount::MAX` in total and exercise the
+            // vault's own overflow handling.
             let confidential = ResourceBuilder::confidential()
                 .mintable(rule!(allow_all), OWNER)
+                .disable_total_supply_tracking()
                 .initial_supply(ConfidentialOutputStatement::mint_revealed(supply));
 
             Component::new(Self {
@@ -60,7 +64,7 @@ mod template {
         }
 
         pub fn confidential_mint_more(&self, output: ConfidentialOutputStatement) {
-            let commitments = ResourceManager::get(self.confidential.resource_address()).mint_confidential(output);
+            let commitments = ResourceManager::get(self.confidential.resource_address()).mint_confidential(output, BTreeMap::new());
             self.confidential.deposit(commitments);
         }
 

--- a/crates/engine/tests/templates/recall/Cargo.toml
+++ b/crates/engine/tests/templates/recall/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+tari_template_abi = { path = "../../../../template_abi" }
 tari_template_lib = { path = "../../../../template_lib" }
 
 [lib]

--- a/crates/engine/tests/templates/recall/src/lib.rs
+++ b/crates/engine/tests/templates/recall/src/lib.rs
@@ -1,5 +1,6 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
+use tari_template_abi::rust::collections::BTreeMap;
 use tari_template_lib::prelude::*;
 
 #[template]
@@ -18,6 +19,7 @@ mod template {
     impl Recall {
         pub fn new(
             confidential_supply: ConfidentialOutputStatement,
+            confidential_value_proofs: BTreeMap<PedersenCommitmentBytes, crypto::CommitmentValueProof>,
         ) -> (
             Component<Self>,
             ResourceAddress,
@@ -38,7 +40,7 @@ mod template {
 
             let confidential = ResourceBuilder::confidential()
                 .recallable(rule!(allow_all), OWNER)
-                .initial_supply(confidential_supply);
+                .initial_supply_with_value_proofs(confidential_supply, confidential_value_proofs);
             let confidential_resource = confidential.resource_address();
 
             let stealth = ResourceBuilder::stealth()

--- a/crates/engine/tests/templates/resource/Cargo.toml
+++ b/crates/engine/tests/templates/resource/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+tari_template_abi = { path = "../../../../template_abi" }
 tari_template_lib = { path = "../../../../template_lib" }
 
 

--- a/crates/engine/tests/templates/resource/src/lib.rs
+++ b/crates/engine/tests/templates/resource/src/lib.rs
@@ -20,6 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use tari_template_abi::rust::collections::BTreeMap;
 use tari_template_lib::prelude::*;
 
 #[template]
@@ -66,8 +67,13 @@ mod template {
             self.non_fungible.deposit(joined);
         }
 
-        pub fn confidential_join(&self, output: ConfidentialOutputStatement) {
-            let commitments = ResourceManager::get(self.confidential.resource_address()).mint_confidential(output);
+        pub fn confidential_join(
+            &self,
+            output: ConfidentialOutputStatement,
+            value_proofs: BTreeMap<PedersenCommitmentBytes, crypto::CommitmentValueProof>,
+        ) {
+            let commitments = ResourceManager::get(self.confidential.resource_address())
+                .mint_confidential(output, value_proofs);
             let b1 = self.confidential.withdraw(10u32);
             let b2 = self.confidential.withdraw(900u32);
             let joined = b1.join(b2);

--- a/crates/engine/tests/templates/stealth/src/lib.rs
+++ b/crates/engine/tests/templates/stealth/src/lib.rs
@@ -5,7 +5,7 @@ use tari_template_lib::prelude::*;
 
 #[template]
 mod template {
-    use tari_template_lib::prelude::crypto::StealthValueProof;
+    use tari_template_lib::prelude::crypto::CommitmentValueProof;
 
     use super::*;
 
@@ -141,7 +141,7 @@ mod template {
             self.manager.unfreeze_utxos(utxos);
         }
 
-        pub fn burn_utxos(&self, utxos: Vec<(UtxoId, StealthValueProof)>) {
+        pub fn burn_utxos(&self, utxos: Vec<(UtxoId, CommitmentValueProof)>) {
             for (utxo, proof) in utxos {
                 self.manager.burn_utxo(utxo, Some(proof));
             }

--- a/crates/engine_types/src/crypto/mod.rs
+++ b/crates/engine_types/src/crypto/mod.rs
@@ -8,9 +8,11 @@ pub mod messages;
 mod output;
 pub mod range_proof;
 mod value_lookup;
+mod value_proof;
 
 pub use covenant::*;
 pub use elgamal::*;
 pub use helpers::*;
 pub use output::*;
 pub use value_lookup::*;
+pub use value_proof::*;

--- a/crates/engine_types/src/crypto/value_proof.rs
+++ b/crates/engine_types/src/crypto/value_proof.rs
@@ -9,8 +9,13 @@ use tari_crypto::{
 };
 use tari_template_lib::types::{
     Amount,
-    UtxoId,
-    crypto::{PedersenCommitmentBytes, RistrettoPublicKeyBytes, Scalar32Bytes, StealthValueProof, ValueKnowledgeProof},
+    crypto::{
+        CommitmentValueProof,
+        PedersenCommitmentBytes,
+        RistrettoPublicKeyBytes,
+        Scalar32Bytes,
+        ValueKnowledgeProof,
+    },
 };
 
 use crate::{
@@ -18,52 +23,40 @@ use crate::{
     resource_container::ResourceError,
 };
 
+/// Verifies that `commitment_bytes` commits to `proof.value` and returns that value.
+///
+/// This is the only way the engine can learn the value hidden in a commitment, so it is required wherever a
+/// commitment enters or leaves a supply-tracking resource.
 pub fn validate_value_proof(
     commitment_bytes: &PedersenCommitmentBytes,
     view_key: Option<&RistrettoPublicKey>,
     elgamal_verifiable_balance: Option<&ElgamalVerifiableBalanceBytes>,
-    proof: &StealthValueProof,
+    proof: &CommitmentValueProof,
 ) -> Result<Amount, ResourceError> {
-    if proof.value.is_negative() {
-        return Err(ResourceError::UtxoBurnFailed {
-            id: UtxoId::from(*commitment_bytes),
-            details: "Value proof amount cannot be negative".to_string(),
-        });
-    }
+    let invalid = |details: String| ResourceError::InvalidValueProof {
+        commitment: *commitment_bytes,
+        details,
+    };
 
-    let commitment: PedersenCommitment =
-        commitment_bytes
-            .try_from_byte_type()
-            .map_err(|e| ResourceError::UtxoBurnFailed {
-                id: UtxoId::from(*commitment_bytes),
-                details: format!("Invalid commitment bytes: {}", e),
-            })?;
+    let commitment: PedersenCommitment = commitment_bytes
+        .try_from_byte_type()
+        .map_err(|e| invalid(format!("Invalid commitment bytes: {e}")))?;
 
     match proof.knowledge_proof {
         ValueKnowledgeProof::Commitment { mask_knowledge_proof } => {
             let Some(commit_amount) = commit_amount(&RistrettoSecretKey::default(), proof.value) else {
-                return Err(ResourceError::UtxoBurnFailed {
-                    id: UtxoId::from(*commitment_bytes),
-                    details: "Value proof amount is too large".to_string(),
-                });
+                return Err(invalid("Value proof amount is too large".to_string()));
             };
             let public_mask = commitment.as_public_key() - commit_amount.as_public_key();
 
-            let sig: RistrettoSchnorr =
-                mask_knowledge_proof
-                    .try_from_byte_type()
-                    .map_err(|e| ResourceError::UtxoBurnFailed {
-                        id: UtxoId::from(*commitment_bytes),
-                        details: format!("Invalid mask knowledge proof bytes: {}", e),
-                    })?;
+            let sig: RistrettoSchnorr = mask_knowledge_proof
+                .try_from_byte_type()
+                .map_err(|e| invalid(format!("Invalid mask knowledge proof bytes: {e}")))?;
 
             let message = messages::value_proof_message(commitment_bytes, &proof.value);
 
             if !sig.verify(&public_mask, message) {
-                return Err(ResourceError::UtxoBurnFailed {
-                    id: UtxoId::from(*commitment_bytes),
-                    details: "Invalid mask knowledge proof".to_string(),
-                });
+                return Err(invalid("Invalid mask knowledge proof".to_string()));
             }
         },
         ValueKnowledgeProof::ElgamalEncrypted {
@@ -98,19 +91,19 @@ fn validate_elgamal_knowledge_proof(
     // Viewable balances encrypt a u64 value, so a larger claimed value can never be honest. This also keeps
     // the bound consistent with the Commitment variant, which inherits it from `commit_amount`.
     if value > u64::MAX {
-        return Err(ResourceError::UtxoBurnFailed {
-            id: UtxoId::from(*commitment_bytes),
+        return Err(ResourceError::InvalidValueProof {
+            commitment: *commitment_bytes,
             details: "Value proof amount is too large".to_string(),
         });
     }
 
-    let elgamal = elgamal_verifiable_balance.ok_or_else(|| ResourceError::UtxoBurnFailed {
-        id: UtxoId::from(*commitment_bytes),
+    let elgamal = elgamal_verifiable_balance.ok_or_else(|| ResourceError::InvalidValueProof {
+        commitment: *commitment_bytes,
         details: "Utxo does not have a viewable balance".to_string(),
     })?;
 
-    let view_key = view_key.ok_or_else(|| ResourceError::UtxoBurnFailed {
-        id: UtxoId::from(*commitment_bytes),
+    let view_key = view_key.ok_or_else(|| ResourceError::InvalidValueProof {
+        commitment: *commitment_bytes,
         details: "Resource does not have a view key".to_string(),
     })?;
 
@@ -118,8 +111,8 @@ fn validate_elgamal_knowledge_proof(
         elgamal
             .encrypted
             .try_from_byte_type()
-            .map_err(|e| ResourceError::UtxoBurnFailed {
-                id: UtxoId::from(*commitment_bytes),
+            .map_err(|e| ResourceError::InvalidValueProof {
+                commitment: *commitment_bytes,
                 details: format!("Invalid encrypted balance bytes: {}", e),
             })?;
 
@@ -127,31 +120,32 @@ fn validate_elgamal_knowledge_proof(
         elgamal
             .public_nonce
             .try_from_byte_type()
-            .map_err(|e| ResourceError::UtxoBurnFailed {
-                id: UtxoId::from(*commitment_bytes),
+            .map_err(|e| ResourceError::InvalidValueProof {
+                commitment: *commitment_bytes,
                 details: format!("Invalid ElGamal public nonce bytes: {}", e),
             })?;
 
     let public_nonce_g: RistrettoPublicKey =
         public_nonce_g
             .try_from_byte_type()
-            .map_err(|e| ResourceError::UtxoBurnFailed {
-                id: UtxoId::from(*commitment_bytes),
+            .map_err(|e| ResourceError::InvalidValueProof {
+                commitment: *commitment_bytes,
                 details: format!("Invalid public nonce (G) bytes: {}", e),
             })?;
 
     let public_nonce_r: RistrettoPublicKey =
         public_nonce_r
             .try_from_byte_type()
-            .map_err(|e| ResourceError::UtxoBurnFailed {
-                id: UtxoId::from(*commitment_bytes),
+            .map_err(|e| ResourceError::InvalidValueProof {
+                commitment: *commitment_bytes,
                 details: format!("Invalid public nonce (R) bytes: {}", e),
             })?;
 
-    let s_p = RistrettoSecretKey::from_canonical_bytes(s_p.as_bytes()).map_err(|e| ResourceError::UtxoBurnFailed {
-        id: UtxoId::from(*commitment_bytes),
-        details: format!("Invalid scalar s_p bytes: {}", e),
-    })?;
+    let s_p =
+        RistrettoSecretKey::from_canonical_bytes(s_p.as_bytes()).map_err(|e| ResourceError::InvalidValueProof {
+            commitment: *commitment_bytes,
+            details: format!("Invalid scalar s_p bytes: {}", e),
+        })?;
 
     let challenge = messages::elgamal_value_proof64(
         commitment_bytes,
@@ -167,8 +161,8 @@ fn validate_elgamal_knowledge_proof(
 
     // Check s.G ?= K_g + e.P
     if RistrettoPublicKey::from_secret_key(&s_p) != public_nonce_g + &e * view_key {
-        return Err(ResourceError::UtxoBurnFailed {
-            id: UtxoId::from(*commitment_bytes),
+        return Err(ResourceError::InvalidValueProof {
+            commitment: *commitment_bytes,
             details: "Invalid Elgamal encrypted value proof (s.G != K_g + e.P)".to_string(),
         });
     }
@@ -180,8 +174,8 @@ fn validate_elgamal_knowledge_proof(
 
     // Check s.R ?= K_r + e.D
     if &s_p * &elgamal_public_nonce != public_nonce_r + &e * d {
-        return Err(ResourceError::UtxoBurnFailed {
-            id: UtxoId::from(*commitment_bytes),
+        return Err(ResourceError::InvalidValueProof {
+            commitment: *commitment_bytes,
             details: "Invalid Elgamal encrypted value proof (s.R != K_r + e.D)".to_string(),
         });
     }
@@ -193,7 +187,7 @@ fn validate_elgamal_knowledge_proof(
 mod tests {
     use ootle_byte_type::ToByteType;
     use tari_crypto::keys::SecretKey;
-    use tari_template_lib::types::crypto::{StealthValueProof, ValueKnowledgeProof};
+    use tari_template_lib::types::crypto::{CommitmentValueProof, ValueKnowledgeProof};
 
     use super::*;
 
@@ -209,7 +203,7 @@ mod tests {
         let message = messages::value_proof_message(&commitment_bytes, &value);
         let sig = RistrettoSchnorr::sign(&mask, message, &mut rng).unwrap();
 
-        let proof = StealthValueProof {
+        let proof = CommitmentValueProof {
             value,
             knowledge_proof: ValueKnowledgeProof::Commitment {
                 mask_knowledge_proof: sig.to_byte_type(),
@@ -235,7 +229,7 @@ mod tests {
         let message = messages::value_proof_message(&commitment_bytes, &other_value);
         let sig = RistrettoSchnorr::sign(&mask, message, &mut rng).unwrap();
 
-        let proof = StealthValueProof {
+        let proof = CommitmentValueProof {
             value: other_value,
             knowledge_proof: ValueKnowledgeProof::Commitment {
                 mask_knowledge_proof: sig.to_byte_type(),
@@ -245,7 +239,7 @@ mod tests {
         // Validate the proof
         let err = validate_value_proof(&commitment_bytes, None, None, &proof).unwrap_err();
         match err {
-            ResourceError::UtxoBurnFailed { details, .. } => {
+            ResourceError::InvalidValueProof { details, .. } => {
                 assert_eq!(details, "Invalid mask knowledge proof");
             },
             _ => panic!("Unexpected error type {err}"),
@@ -299,7 +293,7 @@ mod tests {
             utxo: &ViewableUtxo,
             claimed_value: Amount,
             witness: &RistrettoSecretKey,
-        ) -> StealthValueProof {
+        ) -> CommitmentValueProof {
             let mut rng = rand::rng();
             let k = RistrettoSecretKey::random(&mut rng);
             let public_nonce_g = RistrettoPublicKey::from_secret_key(&k);
@@ -317,7 +311,7 @@ mod tests {
             let e = RistrettoSecretKey::from_uniform_bytes(&challenge).unwrap();
             let s_p = &k + &e * witness;
 
-            StealthValueProof {
+            CommitmentValueProof {
                 value: claimed_value,
                 knowledge_proof: ValueKnowledgeProof::ElgamalEncrypted {
                     public_nonce_g: public_nonce_g.to_byte_type(),
@@ -397,7 +391,7 @@ mod tests {
             )
             .unwrap_err();
             match err {
-                ResourceError::UtxoBurnFailed { details, .. } => {
+                ResourceError::InvalidValueProof { details, .. } => {
                     assert_eq!(details, "Value proof amount is too large");
                 },
                 _ => panic!("Unexpected error type {err}"),

--- a/crates/engine_types/src/crypto/value_proof.rs
+++ b/crates/engine_types/src/crypto/value_proof.rs
@@ -23,6 +23,17 @@ use crate::{
     resource_container::ResourceError,
 };
 
+/// The native-execution metering points [`validate_value_proof`] costs for `proof`, which depends on the variant:
+/// the ElGamal DLEQ verifies two Schnorr-style equations where the mask-knowledge variant verifies one. Must stay
+/// in lock-step with what [`validate_value_proof`] actually verifies.
+pub fn value_proof_native_points(proof: &CommitmentValueProof) -> u64 {
+    use crate::limits::NativeExecutionPoints as P;
+    match proof.knowledge_proof {
+        ValueKnowledgeProof::Commitment { .. } => P::PER_VALUE_PROOF,
+        ValueKnowledgeProof::ElgamalEncrypted { .. } => P::PER_ELGAMAL_VALUE_PROOF,
+    }
+}
+
 /// Verifies that `commitment_bytes` commits to `proof.value` and returns that value.
 ///
 /// This is the only way the engine can learn the value hidden in a commitment, so it is required wherever a

--- a/crates/engine_types/src/limits.rs
+++ b/crates/engine_types/src/limits.rs
@@ -88,6 +88,9 @@ impl NativeExecutionPoints {
     /// same primitives as [`Self::PER_STATEMENT`]) and a bounded kernel-MMR inclusion proof
     /// (Blake2b hashes, microseconds). Priced as the statement cost with headroom.
     pub const PER_CLAIM_BURN: u64 = 3_200_000;
+    /// One ElGamal (DLEQ) value proof. It verifies two Schnorr-style equations over four decompressed
+    /// points rather than one, so it is priced at double the mask-knowledge variant.
+    pub const PER_ELGAMAL_VALUE_PROOF: u64 = 1_200_000;
     /// One stealth/confidential input commitment: decompress + point aggregation (~4.8µs measured).
     /// Substate access is charged separately by the fee module.
     pub const PER_INPUT: u64 = 42_000;
@@ -102,8 +105,8 @@ impl NativeExecutionPoints {
     /// Fixed per-statement cost: balance-proof Schnorr verification, bulletproof base cost and
     /// basic validations (~0.24ms measured).
     pub const PER_STATEMENT: u64 = 2_100_000;
-    /// One UTXO value proof (supply-tracked burns): a Schnorr verification plus commitment
-    /// arithmetic (~60µs class), priced with headroom.
+    /// One mask-knowledge value proof (supply-tracked mints and burns): a Schnorr verification plus
+    /// commitment arithmetic (~60µs class), priced with headroom.
     pub const PER_VALUE_PROOF: u64 = 600_000;
 }
 

--- a/crates/engine_types/src/resource.rs
+++ b/crates/engine_types/src/resource.rs
@@ -176,9 +176,6 @@ impl Resource {
     /// Increases the total supply. This is a no-op if total supply tracking is disabled.
     /// Returns `true` if the total supply was successfully increased or supply tracking is disabled, or `false` if it
     /// would overflow.
-    ///
-    /// ## Panics
-    /// Panics if the amount is not positive
     pub fn increase_total_supply(&mut self, amount: Amount) -> bool {
         let Some(supply_mut) = self.total_supply.as_mut() else {
             // Total supply tracking is disabled, this call succeeded
@@ -195,14 +192,20 @@ impl Resource {
     }
 
     /// Decreases the total supply. This is a no-op if total supply tracking is disabled.
-    ///
-    /// ## Panics
-    /// Panics if the amount is not positive or if the amount is greater than the total supply.
-    pub fn decrease_total_supply(&mut self, amount: Amount) {
-        if let Some(supply_mut) = self.total_supply.as_mut() {
-            *supply_mut = supply_mut.checked_sub(amount).expect(
-                "Invariant violation in decrease_total_supply: decrease total supply by more than total supply",
-            );
+    /// Returns `true` if the total supply was successfully decreased or supply tracking is disabled, or `false` if it
+    /// would underflow. [`Amount`] is unsigned, so an underflow must be rejected rather than wrapped.
+    #[must_use]
+    pub fn decrease_total_supply(&mut self, amount: Amount) -> bool {
+        let Some(supply_mut) = self.total_supply.as_mut() else {
+            // Total supply tracking is disabled, this call succeeded
+            return true;
+        };
+        match supply_mut.checked_sub(amount) {
+            Some(new_supply) => {
+                *supply_mut = new_supply;
+                true
+            },
+            None => false,
         }
     }
 

--- a/crates/engine_types/src/resource_container.rs
+++ b/crates/engine_types/src/resource_container.rs
@@ -981,4 +981,9 @@ pub enum ResourceError {
     },
     #[error("UTXO {id} failed to burn: {details}")]
     UtxoBurnFailed { id: UtxoId, details: String },
+    #[error("Invalid value proof for commitment {commitment}: {details}")]
+    InvalidValueProof {
+        commitment: PedersenCommitmentBytes,
+        details: String,
+    },
 }

--- a/crates/engine_types/src/stealth/mod.rs
+++ b/crates/engine_types/src/stealth/mod.rs
@@ -6,11 +6,9 @@ mod condition_tree;
 mod hashlock;
 mod outputs;
 mod transfer;
-mod value_proof;
 
 pub use condition_structure::*;
 pub use condition_tree::*;
 pub use hashlock::*;
 pub use outputs::*;
 pub use transfer::*;
-pub use value_proof::*;

--- a/crates/template_lib/src/args/types.rs
+++ b/crates/template_lib/src/args/types.rs
@@ -41,7 +41,7 @@ use tari_template_lib_types::{
     access_rules::{AccessRule, ComponentAccessRules, ResourceAccessRules, ResourceAuthAction},
     bytes::Bytes,
     confidential::{ConfidentialOutputStatement, ConfidentialWithdrawProof},
-    crypto::StealthValueProof,
+    crypto::CommitmentValueProof,
     stealth::StealthTransferStatement,
 };
 
@@ -268,6 +268,11 @@ pub enum MintArg {
     Confidential {
         #[n(0)]
         statement: Box<ConfidentialOutputStatement>,
+        /// Proves the value of each commitment the statement mints, keyed by commitment. One is required per
+        /// commitment when the resource tracks total supply, since the engine cannot otherwise learn the minted
+        /// value. Entries for commitments the statement does not mint are ignored.
+        #[n(1)]
+        value_proofs: BTreeMap<PedersenCommitmentBytes, CommitmentValueProof>,
     },
     #[n(3)]
     Stealth {
@@ -946,7 +951,18 @@ pub struct BurnStealthUtxoArg {
     #[n(0)]
     pub utxo_id: UtxoId,
     #[n(1)]
-    pub value_proof: Option<StealthValueProof>,
+    pub value_proof: Option<CommitmentValueProof>,
+}
+
+/// Arguments for [`BucketAction::Burn`].
+#[derive(Clone, Debug, Default, Encode, Decode, CborLen)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct BurnBucketArg {
+    /// Proves the value of each confidential commitment the bucket holds, keyed by commitment. One is required per
+    /// commitment when the resource tracks total supply, since the engine cannot otherwise learn how much value the
+    /// burn destroys. Entries for commitments the bucket does not hold are ignored.
+    #[n(0)]
+    pub value_proofs: BTreeMap<PedersenCommitmentBytes, CommitmentValueProof>,
 }
 
 // -------------------------------- SpendContext -------------------------------- //

--- a/crates/template_lib/src/models/bucket.rs
+++ b/crates/template_lib/src/models/bucket.rs
@@ -24,19 +24,20 @@ use tari_bor::BorTag;
 use tari_template_abi::{
     EngineOp,
     call_engine,
-    rust::{fmt, prelude::*},
+    rust::{collections::BTreeMap, fmt, prelude::*},
 };
 use tari_template_lib_types::{
     BinaryTag,
     NonFungibleId,
     ResourceAddress,
     confidential::ConfidentialWithdrawProof,
+    crypto::{CommitmentValueProof, PedersenCommitmentBytes},
     stealth::StealthTransferStatement,
 };
 
 use super::{NonFungible, Proof};
 use crate::{
-    args::{BucketAction, BucketGetAmountArg, BucketInvokeArg, BucketRef, InvokeResult},
+    args::{BucketAction, BucketGetAmountArg, BucketInvokeArg, BucketRef, BurnBucketArg, InvokeResult},
     resource::ResourceManager,
     types::{Amount, ResourceType},
 };
@@ -152,12 +153,25 @@ impl Bucket {
     }
 
     /// Destroy all the tokens that this bucket holds.
-    /// It will panic if the caller does not have the appropriate permission to burn the resource.
+    ///
+    /// It will panic if the caller does not have the appropriate permission to burn the resource, or if the bucket
+    /// holds confidential commitments on a resource that tracks total supply — those need
+    /// [`Self::burn_with_value_proofs`].
     pub fn burn(&self) {
+        self.burn_with_value_proofs(BTreeMap::new())
+    }
+
+    /// Destroy all the tokens that this bucket holds, proving the value of each confidential commitment it holds so
+    /// that the resource's total supply can be decreased by the value destroyed.
+    ///
+    /// A proof per commitment is required when the resource tracks total supply; otherwise `value_proofs` may be
+    /// empty. It will panic if a proof is missing or invalid, or if the caller does not have the appropriate
+    /// permission to burn the resource.
+    pub fn burn_with_value_proofs(&self, value_proofs: BTreeMap<PedersenCommitmentBytes, CommitmentValueProof>) {
         let resp: InvokeResult = call_engine(EngineOp::BucketInvoke, &BucketInvokeArg {
             bucket_ref: BucketRef::Ref(self.id),
             action: BucketAction::Burn,
-            args: invoke_args![],
+            args: invoke_args![BurnBucketArg { value_proofs }],
         });
 
         resp.decode().expect("Bucket Burn returned invalid result")

--- a/crates/template_lib/src/resource/builder/confidential.rs
+++ b/crates/template_lib/src/resource/builder/confidential.rs
@@ -1,6 +1,6 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
-use tari_template_abi::rust::prelude::*;
+use tari_template_abi::rust::{collections::BTreeMap, prelude::*};
 use tari_template_lib_types::{
     AuthHook,
     ComponentAddress,
@@ -18,7 +18,10 @@ use crate::{
     error_variants::ERR_AUTH_HOOK_FN_NAME_LEN,
     models::{Bucket, ResourceAddressAllocation},
     resource::ResourceManager,
-    types::{ResourceType, crypto::RistrettoPublicKeyBytes},
+    types::{
+        ResourceType,
+        crypto::{CommitmentValueProof, PedersenCommitmentBytes, RistrettoPublicKeyBytes},
+    },
 };
 
 /// Implements the builder pattern for Confidential resources.
@@ -270,9 +273,27 @@ impl ConfidentialResourceBuilder {
 
     /// Sets up how many tokens are going to be minted on resource creation
     /// This builds the resource and returns a bucket containing the initial supply.
+    ///
+    /// Equivalent to calling `initial_supply_with_value_proofs(initial_supply_proof, BTreeMap::new())`. Unless total
+    /// supply tracking is disabled, this only permits an initial supply of revealed funds.
     pub fn initial_supply(self, initial_supply_proof: ConfidentialOutputStatement) -> Bucket {
+        self.initial_supply_with_value_proofs(initial_supply_proof, BTreeMap::new())
+    }
+
+    /// Sets up how many tokens are going to be minted on resource creation, along with a proof of the value of each
+    /// commitment the statement mints, keyed by commitment.
+    ///
+    /// A proof per minted commitment is required when total supply tracking is enabled (the default), because the
+    /// engine cannot otherwise learn the minted value.
+    /// This builds the resource and returns a bucket containing the initial supply.
+    pub fn initial_supply_with_value_proofs(
+        self,
+        initial_supply_proof: ConfidentialOutputStatement,
+        value_proofs: BTreeMap<PedersenCommitmentBytes, CommitmentValueProof>,
+    ) -> Bucket {
         let mint_arg = MintArg::Confidential {
             statement: Box::new(initial_supply_proof),
+            value_proofs,
         };
 
         let (_, bucket) = self.build_internal(Some(mint_arg));

--- a/crates/template_lib/src/resource/manager.rs
+++ b/crates/template_lib/src/resource/manager.rs
@@ -58,7 +58,7 @@ use tari_template_lib_types::{
     VaultId,
     access_rules::{AccessRule, ResourceAccessRules, ResourceAuthAction},
     confidential::ConfidentialOutputStatement,
-    crypto::StealthValueProof,
+    crypto::CommitmentValueProof,
     stealth::StealthTransferStatement,
 };
 
@@ -256,6 +256,8 @@ impl ResourceManager {
     /// * `statement` – A [`ConfidentialOutputStatement`] containing the zero-knowledge statement and associated
     ///   metadata. This includes the output and change statements, a range statement, and revealed amounts for output
     ///   and change.
+    /// * `value_proofs` – Proves the value of each commitment the statement mints, keyed by commitment. One is required
+    ///   per minted commitment if the resource tracks total supply.
     ///
     /// # Returns
     ///
@@ -266,17 +268,23 @@ impl ResourceManager {
     /// This method will panic if:
     /// - The resource is not of type [`ResourceType::Confidential`]
     /// - The provided statement is invalid or malformed
+    /// - The resource tracks total supply and a minted commitment has no valid proof in `value_proofs`
     /// - The caller lacks the required minting permissions, as defined by the resource's [`ResourceAccessRules`]
     ///
     /// # Example
     ///
     /// ```rust,ignore
-    /// let bucket = resource_manager.mint_confidential(statement);
+    /// let bucket = resource_manager.mint_confidential(statement, value_proofs);
     /// ```
-    pub fn mint_confidential(&self, statement: ConfidentialOutputStatement) -> Bucket {
+    pub fn mint_confidential(
+        &self,
+        statement: ConfidentialOutputStatement,
+        value_proofs: BTreeMap<PedersenCommitmentBytes, CommitmentValueProof>,
+    ) -> Bucket {
         self.mint_internal(MintResourceArg {
             mint_arg: MintArg::Confidential {
                 statement: Box::new(statement),
+                value_proofs,
             },
         })
     }
@@ -1033,11 +1041,11 @@ impl ResourceManager {
     }
 
     /// Burns the stealth UTXO, permanently removing them from circulation.
-    /// If total supply tracking is enabled for the resource, a valid `StealthValueProof` is required.
+    /// If total supply tracking is enabled for the resource, a valid `CommitmentValueProof` is required.
     /// NOTE: that this essentially limits burns to the UTXO owner or the secret view key holder regardless of the
     /// access rules (i.e. if burns are limited to an "admin" badge, the admin can only burn funds if they have the
     /// secret view key or burn their own funds). This is a limitation of the current protocol.
-    pub fn burn_utxo(&self, utxo_id: UtxoId, value_proof: Option<StealthValueProof>) {
+    pub fn burn_utxo(&self, utxo_id: UtxoId, value_proof: Option<CommitmentValueProof>) {
         let resp: InvokeResult = call_engine(EngineOp::ResourceInvoke, &ResourceInvokeArg {
             resource_ref: self.resource_address.into(),
             action: ResourceAction::StealthUtxoBurn,

--- a/crates/template_lib_types/src/crypto/value_proof.rs
+++ b/crates/template_lib_types/src/crypto/value_proof.rs
@@ -9,11 +9,13 @@ use crate::{
 };
 
 /// Proof of knowledge of the opening to a commitment and that the commitment commits to a specific value.
-/// Currently used when burning UTXOs to allow the total supply to be adjusted.
+///
+/// Used wherever a resource's total supply must account for a value that is otherwise hidden in a commitment:
+/// burning a stealth UTXO, and minting a confidential commitment.
 #[derive(Debug, Clone, Encode, Decode, CborLen)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
-pub struct StealthValueProof {
+pub struct CommitmentValueProof {
     /// The claimed value to prove
     #[n(0)]
     pub value: Amount,

--- a/crates/template_test_tooling/src/support/confidential.rs
+++ b/crates/template_test_tooling/src/support/confidential.rs
@@ -76,6 +76,23 @@ fn generate_confidential_proof_internal(
     (proof, mask, change.map(|_| change_mask))
 }
 
+/// Generates a withdraw proof that spends a single commitment entirely into revealed funds, leaving no output
+/// commitment behind.
+pub fn generate_reveal_proof(input_mask: &RistrettoSecretKey, input_value: u64) -> ConfidentialWithdrawProof {
+    confidential::create_withdraw_proof(
+        &[MaskAndValue {
+            value: input_value,
+            mask: input_mask.clone(),
+        }],
+        Amount::zero(),
+        None,
+        Amount::from(input_value),
+        None,
+        Amount::zero(),
+    )
+    .unwrap()
+}
+
 pub struct ConfidentialWithdrawProofOutput {
     pub output_mask: RistrettoSecretKey,
     pub change_mask: Option<RistrettoSecretKey>,

--- a/crates/template_test_tooling/src/support/mod.rs
+++ b/crates/template_test_tooling/src/support/mod.rs
@@ -5,5 +5,6 @@ pub mod assert_error;
 pub mod confidential;
 pub mod spec;
 pub mod stealth;
+pub mod value_proof;
 
 pub use tari_ootle_wallet_crypto::GenerateValueLookup;

--- a/crates/template_test_tooling/src/support/stealth.rs
+++ b/crates/template_test_tooling/src/support/stealth.rs
@@ -6,15 +6,14 @@ use std::iter;
 use ootle_byte_type::ToByteType;
 use tari_crypto::{
     keys::{PublicKey, SecretKey},
-    ristretto::{RistrettoPublicKey, RistrettoSchnorr, RistrettoSecretKey},
+    ristretto::{RistrettoPublicKey, RistrettoSecretKey},
 };
-use tari_engine_types::crypto::{commit_amount, messages};
 use tari_ootle_wallet_crypto::{MaskAndValue, OutputWitness, StealthInputWitness, StealthOutputWitness, stealth};
 use tari_template_lib::types::{
     Amount,
     EncryptedData,
     bytes::Bytes,
-    crypto::{RistrettoPublicKeyBytes, StealthValueProof, UtxoTag, ValueKnowledgeProof},
+    crypto::{RistrettoPublicKeyBytes, UtxoTag},
     stealth::{SpendAuthorization, SpendCondition, StealthOutputsStatement, StealthTransferStatement},
 };
 
@@ -284,19 +283,5 @@ where
         output_masks: outputs.into_iter().map(|m| m.witness.mask).collect(),
         output_auths,
         statement: transfer,
-    }
-}
-
-pub fn generate_value_proof_mask_knowledge(value: Amount, mask: &RistrettoSecretKey) -> StealthValueProof {
-    let commitment = commit_amount(mask, value).unwrap();
-    let commitment_bytes = commitment.to_byte_type();
-    let message = messages::value_proof_message(&commitment_bytes, &value);
-    let sig = RistrettoSchnorr::sign(mask, message, &mut rand::rng()).expect("Signing cannot fail");
-
-    StealthValueProof {
-        value,
-        knowledge_proof: ValueKnowledgeProof::Commitment {
-            mask_knowledge_proof: sig.to_byte_type(),
-        },
     }
 }

--- a/crates/template_test_tooling/src/support/value_proof.rs
+++ b/crates/template_test_tooling/src/support/value_proof.rs
@@ -1,0 +1,26 @@
+//   Copyright 2025 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use ootle_byte_type::ToByteType;
+use tari_crypto::ristretto::{RistrettoSchnorr, RistrettoSecretKey};
+use tari_engine_types::crypto::{commit_amount, messages};
+use tari_template_lib::types::{
+    Amount,
+    crypto::{CommitmentValueProof, ValueKnowledgeProof},
+};
+
+/// Proves the value of a commitment by knowledge of its mask. For the view-key path, build the DLEQ proof with
+/// `tari_ootle_wallet_crypto::generate_elgamal_value_proof` instead.
+pub fn generate_value_proof_mask_knowledge(value: Amount, mask: &RistrettoSecretKey) -> CommitmentValueProof {
+    let commitment = commit_amount(mask, value).unwrap();
+    let commitment_bytes = commitment.to_byte_type();
+    let message = messages::value_proof_message(&commitment_bytes, &value);
+    let sig = RistrettoSchnorr::sign(mask, message, &mut rand::rng()).expect("Signing cannot fail");
+
+    CommitmentValueProof {
+        value,
+        knowledge_proof: ValueKnowledgeProof::Commitment {
+            mask_knowledge_proof: sig.to_byte_type(),
+        },
+    }
+}

--- a/crates/template_test_tooling/src/support/value_proof.rs
+++ b/crates/template_test_tooling/src/support/value_proof.rs
@@ -1,13 +1,28 @@
 //   Copyright 2025 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+use std::collections::BTreeMap;
+
 use ootle_byte_type::ToByteType;
 use tari_crypto::ristretto::{RistrettoSchnorr, RistrettoSecretKey};
 use tari_engine_types::crypto::{commit_amount, messages};
 use tari_template_lib::types::{
     Amount,
-    crypto::{CommitmentValueProof, ValueKnowledgeProof},
+    crypto::{CommitmentValueProof, PedersenCommitmentBytes, ValueKnowledgeProof},
 };
+
+/// The proof map the engine requires to mint or burn a single commitment of `amount` under `mask`, keyed by the
+/// commitment as the engine sees it.
+pub fn value_proofs_for_commitment<A: Into<Amount>>(
+    amount: A,
+    mask: &RistrettoSecretKey,
+) -> BTreeMap<PedersenCommitmentBytes, CommitmentValueProof> {
+    let amount = amount.into();
+    let commitment = commit_amount(mask, amount)
+        .expect("value_proofs_for_commitment: amount exceeds u64::MAX")
+        .to_byte_type();
+    BTreeMap::from([(commitment, generate_value_proof_mask_knowledge(amount, mask))])
+}
 
 /// Proves the value of a commitment by knowledge of its mask. For the view-key path, build the DLEQ proof with
 /// `tari_ootle_wallet_crypto::generate_elgamal_value_proof` instead.

--- a/crates/wallet/crypto/src/viewable_balance_proof.rs
+++ b/crates/wallet/crypto/src/viewable_balance_proof.rs
@@ -10,7 +10,7 @@ use tari_crypto::{
 use tari_engine_types::crypto::{ElgamalVerifiableBalance, get_commitment_factory, messages};
 use tari_template_lib_types::{
     Amount,
-    crypto::{PedersenCommitmentBytes, Scalar32Bytes, StealthValueProof, ValueKnowledgeProof},
+    crypto::{CommitmentValueProof, PedersenCommitmentBytes, Scalar32Bytes, ValueKnowledgeProof},
     stealth::{ViewableBalanceProof, ViewableBalanceProofMessageFields},
 };
 use tari_utilities::ByteArray;
@@ -116,7 +116,7 @@ pub fn generate_elgamal_viewable_balance_proof_seeded(
     })
 }
 
-/// Generates a [`StealthValueProof`] for the value encrypted in a UTXO's viewable balance. The prover is the
+/// Generates a [`CommitmentValueProof`] for the value encrypted in a UTXO's viewable balance. The prover is the
 /// view-key holder: the proof is a Chaum-Pedersen DLEQ demonstrating knowledge of the view private key `p` such
 /// that `P = p.G` and `E - v.G = p.R`, which holds only when `v` is the value encrypted for the view key.
 pub fn generate_elgamal_value_proof(
@@ -124,7 +124,7 @@ pub fn generate_elgamal_value_proof(
     value: u64,
     commitment: &PedersenCommitmentBytes,
     verifiable_balance: &ElgamalVerifiableBalance,
-) -> StealthValueProof {
+) -> CommitmentValueProof {
     let mut rng = rand::rng();
     let value = Amount::from(value);
     let view_key = RistrettoPublicKey::from_secret_key(view_private_key);
@@ -148,7 +148,7 @@ pub fn generate_elgamal_value_proof(
     // s = k + e.p
     let s_p = &k + &e * view_private_key;
 
-    StealthValueProof {
+    CommitmentValueProof {
         value,
         knowledge_proof: ValueKnowledgeProof::ElgamalEncrypted {
             public_nonce_g: public_nonce_g.to_byte_type(),

--- a/docs/developer-docs/src/content/docs/guides/stealth-resources.mdx
+++ b/docs/developer-docs/src/content/docs/guides/stealth-resources.mdx
@@ -505,9 +505,13 @@ This has implications for minting and burning:
 - **Minting** always produces a revealed amount returned as a `Bucket`. The minted value is public because the
   engine needs to update the total supply. You then use a stealth transfer to convert the bucket into
   stealth UTXOs.
-- **Burning** a stealth UTXO requires a `StealthValueProof` when supply tracking is enabled. This proof reveals
+- **Burning** a stealth UTXO requires a `CommitmentValueProof` when supply tracking is enabled. This proof reveals
   the value of the UTXO being burnt so that the total supply can be decremented. This effectively limits burns to
-  the UTXO owner or the holder of the secret view key, since only they can construct the proof.
+  the UTXO owner (who proves knowledge of the commitment mask) or the holder of the secret view key (who proves
+  the value against the encrypted viewable balance), since only they can construct the proof.
+- The same applies to **burning a bucket** that holds confidential commitments: use
+  `Bucket::burn_with_value_proofs` with one `CommitmentValueProof` per commitment, and to **minting**
+  commitments via `mint_confidential`, which requires a proof for each commitment the statement mints.
 
 If your resource does not need total supply tracking, you can disable it to save on fees and avoid
 revealing values during burns:
@@ -520,7 +524,7 @@ ResourceBuilder::stealth()
 ```
 
 <Aside type="note">
-When total supply tracking is disabled, `burn_utxo` can be called without a `StealthValueProof`
+When total supply tracking is disabled, `burn_utxo` can be called without a `CommitmentValueProof`
 (pass `None`), and the burnt value remains hidden.
 </Aside>
 


### PR DESCRIPTION
## Description

`Resource::total_supply` was mis-accounted for `Confidential` resources. Supply tracking is enabled by default for them (`resource/builder/confidential.rs`), so this was the default configuration rather than an opt-in edge case.

Both sides of the accounting went through `ResourceContainer::unlocked_amount()`, which for `Confidential` returns the **revealed amount only** — commitments are invisible to it:

- mint — `working_state.rs` → `increase_total_supply(resource_container.unlocked_amount())`
- burn — `impl.rs`, `BucketAction::Burn` → `decrease_total_supply(bucket.unlocked_amount())`

That would be merely incomplete-but-self-consistent, except value crosses the revealed ⇄ confidential boundary freely inside `ResourceContainer::withdraw_confidential` with no supply call at all. Two consequences:

**Silent over-reporting.** Mint a commitment worth 1000, burn the bucket holding it → the decrement is 0. The value is destroyed and `total_supply` keeps reporting it, permanently.

**Underflow panic.** Mint a commitment worth 500 with 0 revealed (`total_supply += 0`), convert it to revealed via `output_revealed_amount`, burn the resulting bucket → `decrease_total_supply(500)` against a tracked supply of 0. `Amount` is an unsigned `u128` and `decrease_total_supply` called `.expect()` on the `checked_sub`, so this panicked rather than wrapping.

The blast radius of that panic is the whole process: the validator node installs a panic hook that exits on a panic in *any* thread (`applications/tari_validator_node/src/main.rs`, "This makes a panic in any thread 'crash' the system instead of silently continuing"). Since execution is deterministic, one such transaction takes down every node that executes it. Burning does require passing the resource's `Burn` access rule, so it is not open to arbitrary callers on every resource — but `rule!(allow_all)` is a common choice.

## Approach

`total_supply` now means **revealed + confidential**, which is what `Stealth` already does: `UtxoAction::Burn` requires a `StealthValueProof` whenever supply tracking is enabled, verifies it, and decrements by the recovered value. The primitive existed; it just wasn't wired to the confidential paths.

- **Mint** — `MintArg::Confidential` carries a proof per minted commitment, keyed by commitment, required when the resource tracks total supply since the engine cannot otherwise learn the minted value. Every created output is iterated rather than assuming a single one, so the accounting does not depend on `mint_confidential`'s change-rejection invariant holding. Verification is charged against the payment-funded allowance (`PER_VALUE_PROOF`) before the crypto runs, matching the stealth burn.

- **Burn** — `BucketAction::Burn` takes a `BurnBucketArg` carrying a value proof per commitment, and the supply is decreased by the revealed funds plus the proven commitment value. The proofs are verified inside `spend_confidential_outputs`, where the commitments are already enumerated, so a commitment cannot be destroyed without its value being accounted for whichever path reaches it. Revealing a commitment first is still supply-neutral and remains a valid alternative for a holder who knows the masks.

  One case stays impossible by construction: a commitment recalled from a resource with no view key. The recaller has no mask, so nobody but the original owner can prove its value. `total_supply` remains correct — the value still exists, held by whoever holds the commitment — but it cannot be destroyed.

- **Underflow** — `decrease_total_supply` returns `false` instead of `.expect()`ing, mirroring `increase_total_supply`. Both call sites raise the new `RuntimeError::ResourceSupplyWouldUnderflow`, turning a node crash into a transaction rejection. Worth having independently of the accounting change.

`StealthValueProof` is renamed to `CommitmentValueProof` and `validate_value_proof` moved from `engine_types::stealth` to `engine_types::crypto` — it is no longer stealth-specific, and leaving a stealth-named type on the confidential mint path would be misleading. Its error is now a generic `ResourceError::InvalidValueProof` rather than the UTXO-specific `UtxoBurnFailed`. Mechanical, ~20 call sites; happy to split it out if you'd rather review it separately.

## Breaking changes

- `MintArg::Confidential` gains a `value_proofs` field: a `BTreeMap<PedersenCommitmentBytes, CommitmentValueProof>`.
- `BucketAction::Burn` gains a `BurnBucketArg` argument carrying the same map.
- `ResourceManager::mint_confidential` and `ConfidentialResourceBuilder::initial_supply_with_value_proofs` take the map. `initial_supply` remains, and without tracking disabled only accepts a revealed initial supply.
- `Bucket::burn()` keeps its signature but now sends a `BurnBucketArg`; `Bucket::burn_with_value_proofs` burns commitments on a supply-tracking resource.
- `StealthValueProof` → `CommitmentValueProof` (`bindings/src/types/` renamed to match).

These are wire-format changes, not just Rust API changes: an old-encoding `MintArg::Confidential` decodes with an empty `value_proofs` and is rejected at runtime, as is an old `BucketAction::Burn` with no argument. Accepted deliberately — a testnet reset is planned, so no migration path is provided.

## Test plan

- `mint_initial_commitment` asserted `total_supply == 0` after minting a commitment worth 100, carrying a `// TODO: confidential total_supply tracking only tracks revealed funds`. It now asserts 100 and the TODO is gone.
- `minting_and_burning_a_commitment_tracks_total_supply` — mint 500 into a commitment (supply 500), reveal it (supply unchanged — the conversion is neutral), burn the revealed bucket (supply 0). This is the case that used to panic.
- `burning_a_bucket_holding_commitments_without_a_value_proof_is_rejected` and `burning_a_bucket_holding_commitments_with_value_proofs_decreases_total_supply` — cover both sides of the new burn rule.
- `minting_a_commitment_without_a_value_proof_is_rejected` — the mint-side equivalent.
- `generate_reveal_proof` added to the test tooling: the existing `generate_withdraw_proof` helpers always emit an output commitment, even for a zero output amount, so they cannot express "spend this commitment entirely into revealed funds".
- Value-proof helpers moved from `support::stealth` to a new `support::value_proof`.

`cargo test -p tari_engine` passes in full. `cargo check --workspace --all-targets` is clean.

Two notes on the test changes:

- `it_does_not_overflow_when_minting_more_then_amount_max_confidential_tokens` deliberately mints past `Amount::MAX`, which correct accounting now rejects as a supply overflow before the vault can be exercised. Supply tracking is disabled on the `Fungible` test template's confidential resource so the test keeps covering the vault-level overflow it was written for.
- `it_burns_all_resource_types` minted a confidential supply that was both revealed 1000 *and* a commitment worth 1000, then burned the lot — Symptom A in miniature. Its confidential initial supply is now revealed-only, and the commitment-burn path is covered by the new dedicated test.

## Versioning

Not done here. `scripts/crate_versioning.py impact tari_template_lib_types --breaking` asks for a workspace rollup to 0.40.0 plus minor bumps on 14 independent crates. The two most recent breaking commits on `development` (#2414, #2410) don't carry those bumps, so this looks batched at release time — say if you'd like it in this PR instead.


## Review follow-ups

- **Value proofs required structurally, not positionally.** Burn verification lives in `spend_confidential_outputs`, the function that enumerates and downs the commitments, so the only code path able to destroy a commitment is the one that demands a proof for it. The mint iterates every created output. Neither side depends on a caller remembering a check, nor on an invariant enforced elsewhere.
- **`claim_burn` asymmetry** — documented at the mint site. It rests on two guards, not one: the genesis TARI resource disables supply tracking *and* denies `Burn`.
- **Migration** — no path provided; see breaking changes above.
- **ElGamal value proof forgeability** — fixed separately in #2425. This branch needs a rebase once that lands, since it changes `validate_value_proof`'s signature and reorders the stealth burn arm.
