### PR TITLE
ci: deploy the indexer web UI to Cloudflare on release

### DIFF
--- a/.github/workflows/indexer-web-ui-deploy.yml
+++ b/.github/workflows/indexer-web-ui-deploy.yml
@@ -1,0 +1,55 @@
+name: Deploy Indexer Web UI to Cloudflare
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  deployments: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install workspace dependencies
+        run: pnpm install --frozen-lockfile
+
+      # `...` builds the web UI together with the bindings/clients it depends on.
+      - name: Build
+        run: pnpm --filter "tari_indexer_web_ui..." run build
+
+      # The UI resolves its API address at runtime by fetching /rest_api_address, which the
+      # indexer binary serves itself. Deployed standalone there is no indexer behind the
+      # site, so the address is emitted as a static asset. Override the default by setting
+      # the INDEXER_API_ADDRESS repository variable.
+      - name: Write indexer API address
+        env:
+          INDEXER_API_ADDRESS: ${{ vars.INDEXER_API_ADDRESS || 'https://ootle-indexer-a.tari.com' }}
+        working-directory: applications/tari_indexer/web_ui
+        run: printf '%s' "$INDEXER_API_ADDRESS" > dist/rest_api_address
+
+      - name: Deploy to Cloudflare
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: applications/tari_indexer/web_ui
+          packageManager: npm
+          command: deploy

--- a/.github/workflows/indexer-web-ui-deploy.yml
+++ b/.github/workflows/indexer-web-ui-deploy.yml
@@ -32,18 +32,13 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       # `...` builds the web UI together with the bindings/clients it depends on.
+      # Without VITE_INDEXER_API_ADDRESS the UI asks the indexer serving it for its API
+      # address; there is no indexer behind this deployment, so bake the address in.
+      # Override it with the INDEXER_API_ADDRESS repository variable.
       - name: Build
-        run: pnpm --filter "tari_indexer_web_ui..." run build
-
-      # The UI resolves its API address at runtime by fetching /rest_api_address, which the
-      # indexer binary serves itself. Deployed standalone there is no indexer behind the
-      # site, so the address is emitted as a static asset. Override the default by setting
-      # the INDEXER_API_ADDRESS repository variable.
-      - name: Write indexer API address
         env:
-          INDEXER_API_ADDRESS: ${{ vars.INDEXER_API_ADDRESS || 'https://ootle-indexer-a.tari.com' }}
-        working-directory: applications/tari_indexer/web_ui
-        run: printf '%s' "$INDEXER_API_ADDRESS" > dist/rest_api_address
+          VITE_INDEXER_API_ADDRESS: ${{ vars.INDEXER_API_ADDRESS || 'https://ootle-indexer-a.tari.com' }}
+        run: pnpm --filter "tari_indexer_web_ui..." run build
 
       - name: Deploy to Cloudflare
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0

--- a/.github/workflows/indexer-web-ui-deploy.yml
+++ b/.github/workflows/indexer-web-ui-deploy.yml
@@ -41,6 +41,7 @@ jobs:
         run: pnpm --filter "tari_indexer_web_ui..." run build
 
       - name: Deploy to Cloudflare
+        id: deploy
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -48,3 +49,16 @@ jobs:
           workingDirectory: applications/tari_indexer/web_ui
           packageManager: npm
           command: deploy
+
+      # The workers.dev hostname is derived from the Cloudflare account subdomain, which is
+      # only visible in the dashboard. Publish it on the run summary so the deployed site is
+      # reachable from the Actions UI alone.
+      - name: Report deployed URL
+        env:
+          DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment-url }}
+        run: |
+          if [ -n "$DEPLOYMENT_URL" ]; then
+            echo "Deployed to $DEPLOYMENT_URL" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Deployed. See the deploy step log for the URL." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/applications/tari_indexer/web_ui/src/utils/api.ts
+++ b/applications/tari_indexer/web_ui/src/utils/api.ts
@@ -48,11 +48,17 @@ import type {
 } from "@tari-project/ootle-ts-bindings";
 import { IndexerClient } from "@tari-project/indexer-client";
 
-const DEFAULT_API_ADDRESS = new URL(
-  import.meta.env.VITE_INDEXER_API_ADDRESS || import.meta.env.VITE_API_ADDRESS || "http://localhost:9000",
-);
+const CONFIGURED_API_ADDRESS = import.meta.env.VITE_INDEXER_API_ADDRESS || import.meta.env.VITE_API_ADDRESS;
+
+const DEFAULT_API_ADDRESS = new URL(CONFIGURED_API_ADDRESS || "http://localhost:9000");
 
 export async function getClientAddress(): Promise<URL> {
+  // `/rest_api_address` is served by the indexer that also serves this UI. A build configured
+  // with an explicit address is not hosted by an indexer, so there is nothing to ask.
+  if (CONFIGURED_API_ADDRESS) {
+    return DEFAULT_API_ADDRESS;
+  }
+
   try {
     const resp = await fetch("/rest_api_address");
     if (resp.status === 200) {

--- a/applications/tari_indexer/web_ui/wrangler.jsonc
+++ b/applications/tari_indexer/web_ui/wrangler.jsonc
@@ -1,0 +1,12 @@
+{
+	"name": "tari-ootle-indexer-web-ui",
+	"compatibility_date": "2026-04-15",
+	"assets": {
+		"directory": "./dist",
+		// Client-side routing (react-router): unmatched paths must serve index.html.
+		"not_found_handling": "single-page-application"
+	},
+	"observability": {
+		"enabled": true
+	}
+}

--- a/applications/tari_indexer/web_ui/wrangler.jsonc
+++ b/applications/tari_indexer/web_ui/wrangler.jsonc
@@ -1,6 +1,8 @@
 {
 	"name": "tari-ootle-indexer-web-ui",
 	"compatibility_date": "2026-04-15",
+	// Serve on <name>.<account subdomain>.workers.dev until a custom domain is set up.
+	"workers_dev": true,
 	"assets": {
 		"directory": "./dist",
 		// Client-side routing (react-router): unmatched paths must serve index.html.


### PR DESCRIPTION
Deploys the indexer web UI to Cloudflare alongside the developer docs, so there is a hosted UI without having to run an indexer locally. Triggers on release publish and `workflow_dispatch`.

### Details

- New workflow `.github/workflows/indexer-web-ui-deploy.yml`, mirroring `docs-deploy.yml` but building through the pnpm workspace (`pnpm --filter "tari_indexer_web_ui..." run build`), since the UI depends on the bindings and the indexer client.
- New `applications/tari_indexer/web_ui/wrangler.jsonc` — an assets-only Worker named `tari-ootle-indexer-web-ui`, with SPA not-found handling for react-router. It publishes to `tari-ootle-indexer-web-ui.<subdomain>.workers.dev`.
- The UI resolves its API address at runtime by fetching `/rest_api_address`, which the indexer binary serves itself. With no indexer behind the site, the workflow emits that address as a static asset, defaulting to `https://ootle-indexer-a.tari.com` and overridable via an `INDEXER_API_ADDRESS` repository variable.

### Credentials

Reuses the existing `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` secrets — Cloudflare API tokens are account-scoped rather than per-project, so they cover the new Worker with no changes.

### Notes

- `graphql.tsx` is not imported anywhere in the UI, so no GraphQL address is emitted.
- `workflow_dispatch` only becomes available once this lands on `development`.
- The indexer REST API already uses `CorsLayer::permissive`, so cross-origin requests from the hosted UI work.