### PR TITLE
feat(mempool): validate blob references at ingress

### DIFF
--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -79,6 +79,7 @@ use tari_ootle_template_provider::MemoryCacheTemplateProvider;
 use tari_ootle_transaction::{Network, Transaction};
 use tari_ootle_transaction_validation::{
     BasicValidations,
+    BlobReferenceValidator,
     EpochRangeValidator,
     PublishTemplateLimitValidator,
     SignatureLimitValidator,
@@ -522,6 +523,9 @@ pub fn create_mempool_transaction_validator<TProvider: TemplateProvider>(
     TransactionNetworkValidator::new(network)
         .and_then(TransactionDryRunValidator)
         .and_then(BasicValidations::new())
+        // Blob payloads must be exactly what the instructions reference: bad indices would only
+        // fail at execution, and unreferenced blobs would never fail at all.
+        .and_then(BlobReferenceValidator::new())
         // Cheap structural check — reject over-weight transactions before verifying signatures.
         .and_then(TransactionWeightValidator::new(max_transaction_weight))
         // Reject transactions whose aggregate stealth-transfer work exceeds the per-transaction caps before

--- a/crates/transaction_validation/src/blob_references.rs
+++ b/crates/transaction_validation/src/blob_references.rs
@@ -1,0 +1,141 @@
+// Copyright 2026 The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
+use log::warn;
+use tari_ootle_transaction::Transaction;
+
+use crate::{TransactionValidationError, Validator};
+
+const LOG_TARGET: &str = "tari::ootle::mempool::validators::blob_references";
+
+/// Rejects transactions whose blob list does not correspond exactly to what the instructions
+/// reference: every `BlobIndex` must be in bounds, and every blob must be referenced.
+///
+/// Out-of-bounds indices are otherwise only caught during execution, wasting the mempool, gossip
+/// and consensus work spent on a transaction that can never succeed. Unreferenced blobs are never
+/// caught at all: their bytes are gossiped, stored and retained by every node while contributing
+/// nothing to execution, so a transaction can carry arbitrary payload up to the weight cap.
+///
+/// Both are deterministic properties of the transaction itself, so every honest node reaches the
+/// same verdict.
+#[derive(Debug, Clone, Default)]
+pub struct BlobReferenceValidator;
+
+impl BlobReferenceValidator {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Validator<Transaction> for BlobReferenceValidator {
+    type Context = ();
+    type Error = TransactionValidationError;
+
+    fn validate(&self, _context: &(), transaction: &Transaction) -> Result<(), Self::Error> {
+        if let Err(source) = transaction.validate_blob_references() {
+            let transaction_id = transaction.calculate_id();
+            warn!(target: LOG_TARGET, "BlobReferenceValidator - FAIL: {transaction_id}: {source}");
+            return Err(TransactionValidationError::InvalidBlobReferences { transaction_id, source });
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indexmap::IndexSet;
+    use tari_ootle_transaction::{
+        Blob,
+        Blobs,
+        Instruction,
+        Network,
+        TransactionSealSignature,
+        TransactionSignature,
+        UnsealedTransactionV1,
+        UnsignedTransactionV1,
+        args::InstructionArg,
+    };
+    use tari_template_lib::types::{
+        FunctionName,
+        TemplateAddress,
+        crypto::{RistrettoPublicKeyBytes, SchnorrSignatureBytes},
+    };
+
+    use super::*;
+
+    fn publish_template(binary: u8) -> Instruction {
+        Instruction::PublishTemplate {
+            binary,
+            metadata_hash: None,
+        }
+    }
+
+    fn call_function(args: Vec<InstructionArg>) -> Instruction {
+        Instruction::CallFunction {
+            address: TemplateAddress::from_array([0; 32]),
+            function: FunctionName::try_from("f").unwrap(),
+            args,
+        }
+    }
+
+    fn tx(blobs: Vec<Blob>, instructions: Vec<Instruction>) -> Transaction {
+        let mut unsigned = UnsignedTransactionV1::new(
+            Network::LocalNet.as_byte(),
+            vec![],
+            instructions,
+            IndexSet::new(),
+            None,
+            None,
+            false,
+        );
+        unsigned.blobs = Blobs::from_vec(blobs);
+        Transaction::new(
+            UnsealedTransactionV1::new(unsigned, vec![TransactionSignature::new(
+                RistrettoPublicKeyBytes::zero(),
+                SchnorrSignatureBytes::zero(),
+            )])
+            .into(),
+            TransactionSealSignature::new(RistrettoPublicKeyBytes::zero(), SchnorrSignatureBytes::zero()),
+        )
+    }
+
+    fn validate(transaction: &Transaction) -> Result<(), TransactionValidationError> {
+        BlobReferenceValidator::new().validate(&(), transaction)
+    }
+
+    #[test]
+    fn accepts_a_transaction_with_no_blobs() {
+        validate(&tx(vec![], vec![call_function(vec![])])).unwrap();
+    }
+
+    #[test]
+    fn accepts_every_blob_being_referenced() {
+        let transaction = tx(vec![Blob::from(vec![1]), Blob::from(vec![2])], vec![
+            publish_template(0),
+            call_function(vec![InstructionArg::blob(1)]),
+        ]);
+        validate(&transaction).unwrap();
+    }
+
+    #[test]
+    fn rejects_an_out_of_bounds_blob_index() {
+        let err = validate(&tx(vec![Blob::from(vec![1])], vec![publish_template(1)])).unwrap_err();
+        assert!(
+            matches!(err, TransactionValidationError::InvalidBlobReferences { .. }),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_an_unreferenced_blob() {
+        let transaction = tx(vec![Blob::from(vec![1]), Blob::from(vec![2])], vec![publish_template(
+            0,
+        )]);
+        let err = validate(&transaction).unwrap_err();
+        assert!(
+            matches!(err, TransactionValidationError::InvalidBlobReferences { .. }),
+            "unexpected error: {err}"
+        );
+    }
+}

--- a/crates/transaction_validation/src/builder.rs
+++ b/crates/transaction_validation/src/builder.rs
@@ -5,6 +5,7 @@ use tari_ootle_transaction::{Network, Transaction};
 
 use crate::{
     BasicValidations,
+    BlobReferenceValidator,
     PublishTemplateLimitValidator,
     SignatureLimitValidator,
     StealthTransactionLimitsValidator,
@@ -16,8 +17,8 @@ use crate::{
 };
 
 /// Builds the structural (context-free) mempool validations suitable for any transaction entry
-/// point: network match, basic well-formedness, the per-transaction weight cap, and signature
-/// verification.
+/// point: network match, basic well-formedness, blob references, the per-transaction weight cap,
+/// and signature verification.
 ///
 /// These never depend on lagging runtime state (epoch, template existence), so they cannot
 /// false-reject and are safe to run at the indexer before forwarding to validator committees. The
@@ -29,6 +30,7 @@ pub fn create_structural_transaction_validator(
 ) -> impl Validator<Transaction, Context = (), Error = TransactionValidationError> {
     TransactionNetworkValidator::new(network)
         .and_then(BasicValidations::new())
+        .and_then(BlobReferenceValidator::new())
         .and_then(TransactionWeightValidator::new(max_transaction_weight))
         .and_then(StealthTransactionLimitsValidator::new())
         .and_then(PublishTemplateLimitValidator::new())

--- a/crates/transaction_validation/src/error.rs
+++ b/crates/transaction_validation/src/error.rs
@@ -4,7 +4,7 @@
 use tari_networking::NetworkingError;
 use tari_ootle_common_types::Epoch;
 use tari_ootle_storage::{StorageError, consensus_models::TransactionPoolError};
-use tari_ootle_transaction::{Network, TransactionId};
+use tari_ootle_transaction::{BlobValidationError, Network, TransactionId};
 use tari_template_lib::types::TemplateAddress;
 
 #[derive(thiserror::Error, Debug)]
@@ -76,6 +76,11 @@ pub enum TransactionValidationError {
         max: usize,
         actual: usize,
     },
+    #[error("Transaction {transaction_id} has invalid blob references: {source}")]
+    InvalidBlobReferences {
+        transaction_id: TransactionId,
+        source: BlobValidationError,
+    },
 }
 
 impl TransactionValidationError {
@@ -122,7 +127,8 @@ impl TransactionValidationError {
             Self::TransactionExceedsMaxWeight { .. } |
             Self::ExceedsStealthTransactionLimit { .. } |
             Self::TooManyPublishTemplateInstructions { .. } |
-            Self::TooManySignatures { .. } => true,
+            Self::TooManySignatures { .. } |
+            Self::InvalidBlobReferences { .. } => true,
         }
     }
 }
@@ -188,6 +194,10 @@ mod tests {
                 transaction_id: tx_id(),
                 max: 1,
                 actual: 2,
+            },
+            TransactionValidationError::InvalidBlobReferences {
+                transaction_id: tx_id(),
+                source: BlobValidationError::UnreferencedBlob { index: 0 },
             },
         ];
         for err in structural {

--- a/crates/transaction_validation/src/lib.rs
+++ b/crates/transaction_validation/src/lib.rs
@@ -15,6 +15,8 @@ pub use error::*;
 
 mod basic;
 pub use basic::*;
+mod blob_references;
+pub use blob_references::*;
 mod dry_run;
 pub use dry_run::*;
 mod epoch_range;


### PR DESCRIPTION
## Description

A transaction's blob list was never validated against what its instructions actually reference.

`Transaction::validate_blob_references` already implements both halves of the check — every `BlobIndex` in bounds, and every blob referenced by some instruction — but its only callers are the wallet daemon handlers, i.e. client-side before signing. Nothing enforced it on transactions arriving from the network.

This adds `BlobReferenceValidator`, which runs that check at ingress:

- `create_mempool_transaction_validator` (validator node) — also covers consensus, since `TariBlockTransactionValidator` wraps the mempool chain
- `create_structural_transaction_validator` — the context-free chain the indexer runs before forwarding to committees

It sits after `BasicValidations` and before the weight and signature validators, so a malformed blob list is rejected before signature verification hashes every blob payload.

Failures surface as `TransactionValidationError::InvalidBlobReferences`, classified `is_sender_fault() == true`: both failure modes are deterministic properties of the transaction itself, so every honest node reaches the same verdict and the sending peer is answerable for it.

## Motivation and Context

Two gaps, neither of them caught before execution:

- **Out-of-bounds index** — only failed at execution time (`TransactionErrorKind::BlobIndexOutOfBounds`), after the mempool, gossip and consensus work had already been spent on a transaction that can never succeed.
- **Unreferenced blob** — never caught at all. The bytes are gossiped, stored and retained by every node while contributing nothing to execution, so a transaction could carry arbitrary padding up to the weight cap. Weight pricing bounds the size but nothing rejects the payload.

Blob payload *integrity* was already covered — the signing domain binds `blobs.hashes()`, so tampered bytes fail signature verification. This PR closes the structural side.

Instruction coverage is complete against the current instruction set: only `PublishTemplate.binary` and `InstructionArg::Blob` carry blob indices, and both are collected by `Instruction::referenced_blob_ids`.

## How Has This Been Tested?

New unit tests in `blob_references.rs`: no blobs, all blobs referenced, out-of-bounds index, unreferenced blob. Added the new variant to the existing `is_sender_fault` exhaustiveness test.

`cargo test -p tari_ootle_transaction_validation` passes (27 tests); `cargo check -p tari_validator_node -p tari_indexer` is clean.

## What process can a PR reviewer use to test or verify this change?

Read `create_mempool_transaction_validator` and `create_structural_transaction_validator` to confirm the validator is in both chains and ordered before signature verification. The unit tests cover both rejection paths directly.

<!-- Checklist -->
## Breaking Changes

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
