### PR TITLE
feat(ootle-wasm): expose script-path witness construction for spending PayTo::Conditions outputs

### DIFF
--- a/crates/ootle_wasm/core/src/stealth/inputs.rs
+++ b/crates/ootle_wasm/core/src/stealth/inputs.rs
@@ -9,10 +9,12 @@
 //! without hand-crafting JSON.
 
 use tari_crypto::{ristretto::RistrettoSecretKey, tari_utilities::ByteArray};
+use tari_ootle_wallet_crypto::stealth::script_path_witness_with_data;
 use tari_template_lib_types::{
     Amount,
+    bytes::Bytes,
     crypto::PedersenCommitmentBytes,
-    stealth::{StealthInput, StealthInputsStatement},
+    stealth::{SpendCondition, StealthInput, StealthInputsStatement},
 };
 
 use crate::{
@@ -50,6 +52,53 @@ pub fn build_stealth_inputs_statement(
         revealed_amount: Amount::from_u64(revealed_amount_microtari),
     };
     Ok(serde_json::to_string(&statement)?)
+}
+
+/// Build a `StealthInputsStatement` JSON from a JSON array of [`StealthInput`], each carrying its own
+/// per-input `SpendWitness` (key path or script path), and a revealed amount.
+///
+/// Unlike [`build_stealth_inputs_statement`], which only ever builds key-path inputs from raw commitment
+/// bytes, this accepts a caller-supplied witness per input — the only way to spend an output committed
+/// with `PayTo::Conditions` (e.g. claiming or refunding an HTLC-style hashlock/timelock output). Build
+/// each script-path input's witness with [`build_script_path_witness`] first; a plain key-path input can
+/// still be included in the same call as `{"commitment": <hex>, "witness": "KeyPath"}`.
+pub fn build_stealth_inputs_statement_from_inputs(
+    inputs_json: &str,
+    revealed_amount_microtari: u64,
+) -> Result<String, OotleWasmError> {
+    let inputs: Vec<StealthInput> = serde_json::from_str(inputs_json)?;
+    let statement = StealthInputsStatement {
+        inputs,
+        revealed_amount: Amount::from_u64(revealed_amount_microtari),
+    };
+    Ok(serde_json::to_string(&statement)?)
+}
+
+/// Build a script-path [`SpendWitness`](tari_template_lib_types::stealth::SpendWitness) revealing `leaf`
+/// from the committed `conditions` set, optionally supplying a witness `data` blob the leaf's predicate
+/// interprets (e.g. a hashlock preimage). Returns a JSON object:
+/// `{ "witness": <SpendWitness>, "condition_root": <Hash32> }`.
+///
+/// `conditions_json` is the JSON array of [`SpendCondition`] leaves exactly as passed to
+/// `createStealthOutputWitness`'s `PayTo::Conditions`; `leaf_json` is the single leaf being revealed. The
+/// returned `condition_root` must match the `Script` root recorded in the output's `SpendAuthorization` at
+/// creation time — record it against the spent input (see [`build_stealth_inputs_statement_from_inputs`]'s
+/// caller-supplied witness).
+///
+/// Pass an empty `data` slice for a leaf whose predicate needs no spender-supplied data (e.g. a plain
+/// timelock).
+pub fn build_script_path_witness(
+    conditions_json: &str,
+    leaf_json: &str,
+    data: &[u8],
+) -> Result<String, OotleWasmError> {
+    let conditions: Vec<SpendCondition> = serde_json::from_str(conditions_json)?;
+    let leaf: SpendCondition = serde_json::from_str(leaf_json)?;
+    let (witness, condition_root) = script_path_witness_with_data(&conditions, &leaf, Bytes::from(data.to_vec()))
+        .map_err(|e| OotleWasmError::Stealth(e.to_string()))?;
+    Ok(serde_json::to_string(
+        &serde_json::json!({ "witness": witness, "condition_root": condition_root }),
+    )?)
 }
 
 /// Aggregate the commitment masks of stealth inputs into a single 32-byte Ristretto scalar.
@@ -141,5 +190,99 @@ mod tests {
             field: "masks_concat",
             ..
         }));
+    }
+
+    /// Two-leaf HTLC-shaped condition tree: a hashlock claim leaf and a timelock refund leaf.
+    fn htlc_conditions_json(hash_hex: &str) -> String {
+        format!(
+            r#"[[{{"Builtin":{{"HashLock":{{"hash":"{hash_hex}","alg":"Sha256"}}}}}}],[{{"Builtin":{{"AfterEpoch":1000}}}}]]"#
+        )
+    }
+
+    #[test]
+    fn script_path_witness_reveals_the_claim_leaf() {
+        let hash_hex = hex::encode([7u8; 32]);
+        let conditions_json = htlc_conditions_json(&hash_hex);
+        let claim_leaf_json = format!(r#"[{{"Builtin":{{"HashLock":{{"hash":"{hash_hex}","alg":"Sha256"}}}}}}]"#);
+        let preimage = [7u8; 32];
+
+        let result = build_script_path_witness(&conditions_json, &claim_leaf_json, &preimage).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        let witness = &parsed["witness"];
+        assert!(
+            witness.get("ScriptPath").is_some(),
+            "expected a ScriptPath witness, got {witness}"
+        );
+        assert_eq!(
+            witness["ScriptPath"]["data"].as_str().map(|s| s.to_string()),
+            Some(hex::encode(preimage))
+        );
+    }
+
+    #[test]
+    fn script_path_witness_condition_root_matches_output_side_pay_to_conditions() {
+        use tari_template_lib_types::stealth::SpendCondition;
+
+        let hash_hex = hex::encode([9u8; 32]);
+        let conditions_json = htlc_conditions_json(&hash_hex);
+        let claim_leaf_json = format!(r#"[{{"Builtin":{{"HashLock":{{"hash":"{hash_hex}","alg":"Sha256"}}}}}}]"#);
+
+        let result = build_script_path_witness(&conditions_json, &claim_leaf_json, &[]).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        let root_from_witness = parsed["condition_root"].as_str().unwrap().to_string();
+
+        // Independently recompute the root the way output creation (PayTo::Conditions) does. These
+        // MUST agree: a mismatch here means a script-path-authorized output could be created under one
+        // root and never spendable under the witness this function produces -- a fund-loss bug, not a
+        // cosmetic one.
+        let conditions: Vec<SpendCondition> = serde_json::from_str(&conditions_json).unwrap();
+        let expected_root = tari_ootle_wallet_crypto::stealth::validated_condition_root(&conditions).unwrap();
+        assert_eq!(root_from_witness, expected_root.to_string());
+    }
+
+    #[test]
+    fn script_path_witness_rejects_a_leaf_not_in_the_committed_set() {
+        let hash_hex = hex::encode([1u8; 32]);
+        let conditions_json = htlc_conditions_json(&hash_hex);
+        let foreign_leaf_json = r#"[{"Builtin":{"AfterEpoch":999999}}]"#;
+
+        let err = build_script_path_witness(&conditions_json, foreign_leaf_json, &[]).unwrap_err();
+        assert!(matches!(err, OotleWasmError::Stealth(_)));
+    }
+
+    #[test]
+    fn statement_from_inputs_carries_a_script_path_witness_through() {
+        let hash_hex = hex::encode([3u8; 32]);
+        let conditions_json = htlc_conditions_json(&hash_hex);
+        let claim_leaf_json = format!(r#"[{{"Builtin":{{"HashLock":{{"hash":"{hash_hex}","alg":"Sha256"}}}}}}]"#);
+        let witness_result = build_script_path_witness(&conditions_json, &claim_leaf_json, &[3u8; 32]).unwrap();
+        let witness_value: serde_json::Value = serde_json::from_str(&witness_result).unwrap();
+
+        let commitment_hex = hex::encode([5u8; 32]);
+        let inputs_json = format!(
+            r#"[{{"commitment":"{commitment_hex}","witness":{witness}}}]"#,
+            witness = witness_value["witness"]
+        );
+
+        let statement_json = build_stealth_inputs_statement_from_inputs(&inputs_json, 0).unwrap();
+        let statement: StealthInputsStatement = serde_json::from_str(&statement_json).unwrap();
+        assert_eq!(statement.inputs.len(), 1);
+        assert!(
+            serde_json::to_value(&statement.inputs[0].witness)
+                .unwrap()
+                .get("ScriptPath")
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn statement_from_inputs_defaults_missing_witness_to_key_path() {
+        let commitment_hex = hex::encode([2u8; 32]);
+        let inputs_json = format!(r#"[{{"commitment":"{commitment_hex}"}}]"#);
+        let statement_json = build_stealth_inputs_statement_from_inputs(&inputs_json, 500).unwrap();
+        let statement: StealthInputsStatement = serde_json::from_str(&statement_json).unwrap();
+        assert_eq!(statement.inputs.len(), 1);
+        assert_eq!(serde_json::to_value(&statement.inputs[0].witness).unwrap(), "KeyPath");
+        assert_eq!(statement.revealed_amount, Amount::from_u64(500));
     }
 }

--- a/crates/ootle_wasm/wasm/src/lib.rs
+++ b/crates/ootle_wasm/wasm/src/lib.rs
@@ -321,6 +321,44 @@ pub fn build_stealth_inputs_statement(
         .map_err(|e| JsError::new(&e.to_string()))
 }
 
+/// Build a `StealthInputsStatement` JSON from a JSON array of per-input `{commitment, witness}` pairs
+/// and a revealed amount.
+///
+/// Unlike `buildStealthInputsStatement`, which only builds key-path inputs from raw commitment bytes,
+/// this accepts a caller-supplied `witness` per input -- the only way to spend an output committed with
+/// `PayTo::Conditions` (e.g. claiming or refunding an HTLC-style hashlock/timelock output). Build each
+/// script-path input's witness with `buildScriptPathWitness` first; a plain key-path input can still be
+/// included in the same call, either with `"witness":"KeyPath"` or by omitting `witness` entirely
+/// (defaults to key path).
+///
+/// `inputs_json` shape: `[{ "commitment": <hex 32 bytes>, "witness"?: <SpendWitness> }, ...]`.
+#[wasm_bindgen(js_name = "buildStealthInputsStatementFromInputs")]
+pub fn build_stealth_inputs_statement_from_inputs(
+    inputs_json: &str,
+    revealed_amount_microtari: u64,
+) -> Result<String, JsError> {
+    ootle_wasm_core::stealth::inputs::build_stealth_inputs_statement_from_inputs(inputs_json, revealed_amount_microtari)
+        .map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Build a script-path `SpendWitness` revealing `leaf` from the committed `conditions` set, optionally
+/// supplying a witness `data` blob the leaf's predicate interprets (e.g. a hashlock preimage). Returns a
+/// JSON object: `{ "witness": <SpendWitness>, "condition_root": <Hash32> }`.
+///
+/// `conditions_json` is the JSON array of `SpendCondition` leaves exactly as passed to
+/// `createStealthOutputWitness`'s `PayTo::Conditions` when the output was created; `leaf_json` is the
+/// single leaf being revealed. The returned `condition_root` must match the `Script` root recorded in
+/// that output's `SpendAuthorization` -- record it against the spent input via
+/// `buildStealthInputsStatementFromInputs`.
+///
+/// Pass an empty `data` array for a leaf whose predicate needs no spender-supplied data (e.g. a plain
+/// timelock refund).
+#[wasm_bindgen(js_name = "buildScriptPathWitness")]
+pub fn build_script_path_witness(conditions_json: &str, leaf_json: &str, data: &[u8]) -> Result<String, JsError> {
+    ootle_wasm_core::stealth::inputs::build_script_path_witness(conditions_json, leaf_json, data)
+        .map_err(|e| JsError::new(&e.to_string()))
+}
+
 /// Aggregate the commitment masks of stealth inputs into a single 32-byte Ristretto scalar.
 ///
 /// `masks_concat` is the concatenated bytes of all input masks (32 bytes per mask, so the input


### PR DESCRIPTION
## Summary

`createStealthOutputWitness`'s `pay_to_json` already accepts a full `PayTo` -- including `Conditions`, an HTLC-style hashlock/timelock MAST tree -- because `pay_to_output_authorization` handles every `PayTo` variant generically. This isn't obvious from the wasm binding's own doc comment, which only documents `"StealthPublicKey"` and `{"AccessRule": ...}`; I confirmed the `Conditions` variant works today against the published `0.38.0` build by constructing a real hashlock+timelock condition tree and inspecting the returned `auth` field (produces a real `SpendAuthorization::Script` root).

What's actually missing is the *spend* side: there was no way to build a `SpendWitness::ScriptPath` (revealing a leaf + Merkle inclusion proof + optional witness data, e.g. a hashlock preimage) from the wasm crate at all, even though the underlying crypto already exists and is already used by `tari_walletd` -- `script_path_witness_with_data` (`tari_ootle_wallet_crypto::stealth`) and `StealthInput::with_witness` (`tari_template_lib_types::stealth`) are both real, tested, unexported-from-wasm functions.

## Changes

Two purely-additive `#[wasm_bindgen]` exports, no existing export touched:

- **`buildScriptPathWitness(conditions_json, leaf_json, data)`** -- wraps `script_path_witness_with_data`. Returns `{ "witness": <SpendWitness>, "condition_root": <Hash32> }`.
- **`buildStealthInputsStatementFromInputs(inputs_json, revealed_amount_microtari)`** -- like the existing `buildStealthInputsStatement`, but takes a JSON array of `{commitment, witness}` so a caller can attach a script-path witness per input instead of the existing function's hardcoded key-path (`StealthInput::new`).

## Motivation

Came out of a conversation about wiring HTLC-based atomic-swap support into a browser-extension wallet (`tari-wallet-extension`, entirely client-side, no `tari_walletd`). Output creation already worked; this was the missing half. Related to the walletd-side proof of concept in #2343 and the `create_stealth_transfer_statement` handler merged in #2386 -- same underlying capability, exposed for a client that has no daemon to delegate to.

## Testing

- 6 new unit tests in `crates/ootle_wasm/core/src/stealth/inputs.rs`, including a cross-check that the condition root computed on the spend side (`buildScriptPathWitness`) matches the root independently computed the way output creation does (`validated_condition_root`) -- the property that actually matters for fund safety, since a mismatch there means an output could be created under one root and never spendable under the witness this produces.
- Full existing test suites for both touched crates (`ootle-wasm-core`, `tari_ootle_wallet_crypto`) still pass: 46 tests, 0 failures.
- `cargo clippy -p ootle-wasm-core -p ootle-wasm --all-targets`: clean.
- `cargo +nightly-2025-12-05 fmt --all`: applied.
- Built the actual wasm package (`bash crates/ootle_wasm/build.sh nodejs release`) and ran a real end-to-end Node.js test against the compiled binary: create an HTLC-conditioned output via `createStealthOutputWitness`, build a claim witness via the new `buildScriptPathWitness`, confirm the two independently-arrived-at condition roots match exactly, and confirm the preimage witness data survives into the resulting `StealthInputsStatement` via `buildStealthInputsStatementFromInputs`. All checks passed.

## Scope

Wasm bindings only. No change to `tari_walletd`, transaction validation, submission, or any signing/sealing path -- this only builds the witness JSON a caller (or a higher-level SDK like `@tari-project/ootle`) would still pass through the existing `addTransactionSigner`/`sealTransaction` flow, unchanged.