### PR TITLE
fix(wallet): report the fee actually paid as a transaction's final_fee

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12066,7 +12066,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12134,6 +12134,7 @@ dependencies = [
  "digest 0.10.7",
  "ootle_byte_type",
  "rand 0.10.1",
+ "tari_consensus_types",
  "tari_crypto",
  "tari_engine_types",
  "tari_indexer_client",
@@ -12147,6 +12148,8 @@ dependencies = [
  "tari_template_lib",
  "tari_transaction_components",
  "tempfile",
+ "time",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/wallet/sdk/Cargo.toml
+++ b/crates/wallet/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_wallet_sdk"
 description = "The Tari wallet library"
-version = "0.40.0"
+version = "0.40.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/wallet/sdk/src/apis/transaction.rs
+++ b/crates/wallet/sdk/src/apis/transaction.rs
@@ -291,8 +291,9 @@ where
                         self.commit_diff(tx, diff)?;
                     }
 
-                    let final_fee =
-                        execution_result.as_ref().map(|e| e.finalize.fee_receipt.required_fees());
+                    let final_fee = execution_result
+                        .as_ref()
+                        .map(|e| e.finalize.fee_receipt.total_fees_paid());
 
                     tx.transactions_update(
                         WalletTransactionUpdate::new(transaction_id)

--- a/crates/wallet/sdk_tests/Cargo.toml
+++ b/crates/wallet/sdk_tests/Cargo.toml
@@ -14,6 +14,7 @@ tari_transaction_components = { workspace = true }
 tari_ootle_wallet_storage_sqlite = { workspace = true }
 
 tari_crypto = { workspace = true, features = ["borsh"] }
+tari_consensus_types = { workspace = true }
 tari_engine_types = { workspace = true }
 tari_ootle_common_types = { workspace = true }
 tari_ootle_wallet_crypto = { workspace = true, features = ["serde"] }
@@ -27,3 +28,5 @@ ootle_byte_type = { workspace = true }
 tempfile = { workspace = true }
 digest = { workspace = true }
 rand = { workspace = true }
+time = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/wallet/sdk_tests/tests/support/harness.rs
+++ b/crates/wallet/sdk_tests/tests/support/harness.rs
@@ -1,7 +1,7 @@
 //   Copyright 2025 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::{collections::HashMap, convert::Infallible, future::Future, str::FromStr};
+use std::{collections::HashMap, convert::Infallible, future::Future, marker::PhantomData, str::FromStr};
 
 use ootle_byte_type::ToByteType;
 use tari_crypto::tari_utilities::SafePassword;
@@ -57,29 +57,37 @@ use tari_template_lib::types::{
     crypto::PedersenCommitmentBytes,
 };
 
-pub struct TestSdkSpec;
+pub struct TestSdkSpec<TNetwork = PanicNetworkInterface>(PhantomData<TNetwork>);
 
-impl WalletSdkSpec for TestSdkSpec {
+impl<TNetwork: WalletNetworkInterface> WalletSdkSpec for TestSdkSpec<TNetwork> {
     type KeyStore = LocalKeyStore;
-    type NetworkInterface = PanicNetworkInterface;
+    type NetworkInterface = TNetwork;
     type Store = SqliteWalletStore;
 }
 
-pub struct Test {
+pub type Test = TestWithNetwork<PanicNetworkInterface>;
+
+pub struct TestWithNetwork<TNetwork: WalletNetworkInterface> {
     store: SqliteWalletStore,
-    sdk: WalletSdk<TestSdkSpec>,
+    sdk: WalletSdk<TestSdkSpec<TNetwork>>,
     _temp: tempfile::TempDir,
 }
 
 impl Test {
     pub fn new() -> Self {
+        Self::with_network(PanicNetworkInterface)
+    }
+}
+
+impl<TNetwork: WalletNetworkInterface> TestWithNetwork<TNetwork> {
+    pub fn with_network(network: TNetwork) -> Self {
         let temp = tempfile::tempdir().unwrap();
         let store = SqliteWalletStore::try_open(temp.path().join("data/wallet.sqlite")).unwrap();
         store.run_migrations().unwrap();
 
         let mut sdk = WalletSdk::initialize_with_local_key_store(
             store.clone(),
-            PanicNetworkInterface,
+            network,
             WalletSdkConfig {
                 network: Network::LocalNet,
                 override_keyring_password: Some(SafePassword::from_str("SuuuCh Sekret W0W").unwrap()),
@@ -186,12 +194,108 @@ impl Test {
             .unwrap_or_default()
     }
 
-    pub fn sdk(&self) -> &WalletSdk<TestSdkSpec> {
+    pub fn sdk(&self) -> &WalletSdk<TestSdkSpec<TNetwork>> {
         &self.sdk
     }
 
     pub fn store(&self) -> &SqliteWalletStore {
         &self.store
+    }
+}
+
+/// Network interface that answers `query_transaction_result` with a canned result and panics on every other call.
+#[derive(Debug, Clone)]
+pub struct CannedTransactionResultInterface {
+    result: TransactionQueryResult,
+}
+
+impl CannedTransactionResultInterface {
+    pub fn new(result: TransactionQueryResult) -> Self {
+        Self { result }
+    }
+}
+
+impl WalletNetworkInterface for CannedTransactionResultInterface {
+    type Error = PanicError;
+
+    #[allow(clippy::diverging_sub_expression)]
+    async fn query_substate(
+        &self,
+        _address: &SubstateId,
+        _version: Option<u32>,
+        _local_search_only: bool,
+    ) -> Result<SubstateQueryResult, Self::Error> {
+        panic!("CannedTransactionResultInterface called")
+    }
+
+    async fn get_substates(&self, _: Vec<SubstateId>) -> Result<HashMap<SubstateId, Substate>, Self::Error> {
+        panic!("CannedTransactionResultInterface called")
+    }
+
+    #[allow(clippy::diverging_sub_expression)]
+    async fn submit_transaction(&self, _transaction: Transaction) -> Result<TransactionId, Self::Error> {
+        panic!("CannedTransactionResultInterface called")
+    }
+
+    async fn submit_transaction_envelope(
+        &self,
+        _transaction: TransactionEnvelope,
+    ) -> Result<TransactionId, Self::Error> {
+        panic!("CannedTransactionResultInterface called")
+    }
+
+    #[allow(clippy::diverging_sub_expression)]
+    async fn submit_dry_run_transaction(
+        &self,
+        _transaction: Transaction,
+    ) -> Result<TransactionQueryResult, Self::Error> {
+        panic!("CannedTransactionResultInterface called")
+    }
+
+    async fn query_transaction_result(
+        &self,
+        _transaction_id: TransactionId,
+    ) -> Result<TransactionQueryResult, Self::Error> {
+        Ok(self.result.clone())
+    }
+
+    async fn fetch_template_definition(&self, _template_address: TemplateAddress) -> Result<TemplateDef, Self::Error> {
+        panic!("CannedTransactionResultInterface called")
+    }
+
+    async fn stream_stealth_utxo_updates(
+        &self,
+        _from_epoch: Epoch,
+        _resource_address: ResourceAddress,
+        _shard_state_versions: Vec<(Shard, StateVersion)>,
+        _unspent_only: bool,
+    ) -> Result<UtxoUpdateStream<Self::Error>, Self::Error> {
+        panic!("CannedTransactionResultInterface called")
+    }
+
+    async fn list_watched_substates(
+        &self,
+        _template_address: Option<TemplateAddress>,
+        _limit: Option<u64>,
+        _offset: Option<u64>,
+    ) -> Result<Vec<WatchedSubstateItem>, Self::Error> {
+        panic!("CannedTransactionResultInterface called")
+    }
+
+    async fn get_unspent_utxos(
+        &self,
+        _resource_address: ResourceAddress,
+        _tag_and_nonce_pairs: Vec<TagAndPublicNoncePair>,
+    ) -> Result<Vec<(UtxoId, Utxo)>, Self::Error> {
+        panic!("CannedTransactionResultInterface called")
+    }
+
+    async fn get_current_epoch(&self) -> Result<Epoch, Self::Error> {
+        panic!("CannedTransactionResultInterface called")
+    }
+
+    async fn wait_until_ready(&self) -> Result<(), Self::Error> {
+        Ok(())
     }
 }
 

--- a/crates/wallet/sdk_tests/tests/transaction_api.rs
+++ b/crates/wallet/sdk_tests/tests/transaction_api.rs
@@ -1,0 +1,143 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+mod support;
+
+use std::time::Duration;
+
+use tari_consensus_types::Decision;
+use tari_crypto::ristretto::RistrettoSecretKey;
+use tari_engine_types::{
+    commit_result::{AbortReason, ExecuteResult, FinalizeResult, RejectReason, TransactionResult},
+    fees::{FeeBreakdown, FeeReceipt, FeeSource},
+    substate::SubstateDiff,
+};
+use tari_ootle_transaction::{Transaction, TransactionId, args};
+use tari_ootle_wallet_sdk::{
+    models::TransactionStatus,
+    network::{TransactionFinalizedResult, TransactionQueryResult},
+    storage::{WalletStoreWriter, WriteableWalletStore},
+};
+use time::{OffsetDateTime, PrimitiveDateTime};
+
+use crate::support::{CannedTransactionResultInterface, Test, TestWithNetwork};
+
+fn now() -> PrimitiveDateTime {
+    let now = OffsetDateTime::now_utc();
+    PrimitiveDateTime::new(now.date(), now.time())
+}
+
+fn build_transaction() -> Transaction {
+    Transaction::builder_localnet()
+        .allocate_component_address("component")
+        .put_last_instruction_output_on_workspace("bucket")
+        .call_method("component", "new", args!["bucket"])
+        .build_and_seal(&RistrettoSecretKey::from(1))
+}
+
+/// A fee-only accept where the fee intent could not cover everything charged: 1000 was paid up front and all of it
+/// was consumed, but the execution charged 2548.
+fn underpaid_fee_receipt() -> FeeReceipt {
+    let mut cost_breakdown = FeeBreakdown::default();
+    cost_breakdown.add(FeeSource::Initial, 2548);
+
+    FeeReceipt::builder()
+        .with_total_fee_payment(1000)
+        .with_total_fees_paid(1000)
+        .with_cost_breakdown(cost_breakdown)
+        .build()
+}
+
+fn finalized_result(transaction_id: TransactionId, fee_receipt: FeeReceipt) -> TransactionQueryResult {
+    let finalize = FinalizeResult::new(
+        transaction_id.into_array().into(),
+        vec![],
+        vec![],
+        TransactionResult::AcceptFeeRejectRest(
+            SubstateDiff::new(),
+            RejectReason::ExecutionFailure("out of fees".to_string()),
+        ),
+        fee_receipt,
+    );
+
+    TransactionQueryResult {
+        transaction_id,
+        result: TransactionFinalizedResult::Finalized {
+            final_decision: Decision::Commit,
+            execution_result: Some(Box::new(ExecuteResult {
+                finalize,
+                execution_time: Duration::from_secs(1),
+                execute_epoch: None,
+                wasm_execution_points: 0,
+                native_execution_points: 0,
+            })),
+            execution_time: Duration::from_secs(1),
+            finalized_time: now(),
+            abort_details: None,
+        },
+    }
+}
+
+#[tokio::test]
+async fn final_fee_is_what_was_paid_not_what_was_required() {
+    let transaction = build_transaction();
+    let transaction_id = transaction.calculate_id();
+    let fee_receipt = underpaid_fee_receipt();
+    // `required_fees()` is a dry run estimate for a later submit, never what a settled transaction cost, so the two
+    // must be distinguishable here.
+    assert_ne!(fee_receipt.total_fees_paid(), fee_receipt.required_fees());
+
+    let test = TestWithNetwork::with_network(CannedTransactionResultInterface::new(finalized_result(
+        transaction_id,
+        fee_receipt.clone(),
+    )));
+    test.store()
+        .with_write_tx(|tx| tx.transactions_insert(&transaction, None, &[Test::test_account_address()], false))
+        .unwrap();
+
+    let finalized = test
+        .sdk()
+        .transaction_api()
+        .check_and_store_finalized_transaction(transaction_id)
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(finalized.status, TransactionStatus::OnlyFeeAccepted);
+    assert_eq!(finalized.final_fee, Some(fee_receipt.total_fees_paid()));
+}
+
+#[tokio::test]
+async fn final_fee_is_zero_for_a_rejected_transaction() {
+    let transaction = build_transaction();
+    let transaction_id = transaction.calculate_id();
+
+    let mut query_result = finalized_result(transaction_id, FeeReceipt::default());
+    let TransactionFinalizedResult::Finalized {
+        final_decision,
+        execution_result,
+        ..
+    } = &mut query_result.result
+    else {
+        unreachable!()
+    };
+    *final_decision = Decision::Abort(AbortReason::InsufficientFeesPaid);
+    execution_result.as_mut().unwrap().finalize.result =
+        TransactionResult::Reject(RejectReason::ExecutionFailure("nope".to_string()));
+
+    let test = TestWithNetwork::with_network(CannedTransactionResultInterface::new(query_result));
+    test.store()
+        .with_write_tx(|tx| tx.transactions_insert(&transaction, None, &[Test::test_account_address()], false))
+        .unwrap();
+
+    let finalized = test
+        .sdk()
+        .transaction_api()
+        .check_and_store_finalized_transaction(transaction_id)
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(finalized.status, TransactionStatus::Rejected);
+    assert_eq!(finalized.final_fee, Some(0));
+}


### PR DESCRIPTION
## Problem

`TransactionApi::check_and_store_finalized_transaction` set a wallet transaction's `final_fee` from `FeeReceipt::required_fees()`.

`required_fees()` is `total_fees_charged() + 1`, documented in `crates/engine_types/src/fees.rs` as *"the minimum fee required to submit a transaction based on a dry run result"* — the `+1` is a rounding allowance for the dry-run → submit path. It is not what a settled transaction cost.

This is visible whenever the fee intent could not cover everything charged. A testnet `OnlyFeeAccepted` transaction reported `final_fee: 2549` against a receipt of `total_fee_payment: 1000, total_fees_paid: 1000` — reading as a 2549 µT overcharge that never happened; nothing was overcharged, the wallet was showing the wrong field. Reproduced identically on a local swarm. A rejected transaction, whose receipt is the default, reported `1`.

## Fix

Store `total_fees_paid()` — what was actually deducted. That is what every consumer of the field already means by it:

- `applications/tari_wallet_cli/src/command/transaction.rs` prints `Fee: {final_fee} ({refunded} refunded)`
- `applications/tari_walletd/src/handlers/nfts.rs` returns `fee: final_fee` and `fee_refunded: max_fee - final_fee`
- `crates/wallet/sdk_services/src/transaction_service/service.rs` feeds it into `TransactionFinalizedEvent.final_fee`

The dry-run branch in `submit_dry_run_transaction` is deliberately left alone — it genuinely wants `required_fees()`, since it is an estimate for a later submit.

Rejected transactions fall out correctly: a `Reject` carries a default `FeeReceipt`, so `total_fees_paid()` is 0 — nothing was committed and nothing charged.

## Scope

- Storage and types are untouched. `final_fee` stays `Option<u64>` — no migration, no TS binding change.
- `tari_ootle_wallet_sdk` gets a patch bump (0.40.0 → 0.40.1) per `scripts/crate_versioning.py impact`. Dependents pick it up via their `^0.40` constraints; no other crate needs to move.

## Considered and rejected

Surfacing the *required* fee somewhere for a transaction that ran short, so a user can see the gap. The reject reason already carries `"Required fees X but Y paid"`, so a second home for it would just be a second thing to keep consistent.

## Tests

New `crates/wallet/sdk_tests/tests/transaction_api.rs` drives `check_and_store_finalized_transaction` against a canned network result:

- a fee-only accept charging 2548 against 1000 paid — asserts `final_fee == 1000` (was `2549`)
- a rejected transaction — asserts `final_fee == 0` (was `1`)

Both fail on `development` and pass here. The test harness is now generic over the network interface (`TestWithNetwork<N>`, with `Test` aliasing the existing panicking one), plus a `CannedTransactionResultInterface` that answers `query_transaction_result` and panics on everything else.