### PR TITLE
feat(wallet-webui): show indexer liveness in the app bar

### DIFF
--- a/applications/tari_walletd/web_ui/src/components/IndexerLivenessPill.tsx
+++ b/applications/tari_walletd/web_ui/src/components/IndexerLivenessPill.tsx
@@ -1,0 +1,175 @@
+//  Copyright 2026. The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import Box from "@mui/material/Box";
+import Chip from "@mui/material/Chip";
+import Tooltip from "@mui/material/Tooltip";
+import { useTheme } from "@mui/material/styles";
+import useAuthStore from "@store/authStore";
+import { indexerGetNetworkInfo, settingsGet } from "@utils/json_rpc";
+import { useEffect, useRef, useState } from "react";
+
+/// How often the configured indexer is re-probed.
+const POLL_INTERVAL_MS = 15_000;
+
+/// Consecutive failures tolerated before the pill goes red. One failed probe leaves the pill
+/// unknown so a single dropped request does not read as an outage.
+const FAILURES_BEFORE_DISCONNECTED = 2;
+
+/// "connecting" is a request in flight with no verdict yet; "unknown" is no verdict and nothing in
+/// flight, which is also where a probe that failed once lands.
+type Liveness = "connected" | "connecting" | "unknown" | "disconnected";
+
+interface Status {
+  liveness: Liveness;
+  epoch: bigint | number | null;
+  indexerUrl: string | null;
+  detail: string | null;
+}
+
+const LABELS: Record<Liveness, string> = {
+  connected: "Connected",
+  connecting: "Connecting…",
+  unknown: "Unknown",
+  disconnected: "Disconnected",
+};
+
+/**
+ * Liveness of the indexer this wallet is configured to use, as a coloured pill.
+ *
+ * Probes the same endpoint the indexer settings tab uses, reading the URL from `settings.get` so
+ * that changing the indexer takes effect here without a reload. The probe goes browser → indexer
+ * directly, so it reflects whether *this* page can reach the indexer.
+ *
+ * `settings.get` is authenticated, so the pill is inert until the user is logged in — probing
+ * before then would only ever report the authentication failure as an indexer outage.
+ */
+function IndexerLivenessPill() {
+  const theme = useTheme();
+  const loggedIn = useAuthStore((state) => state.loggedIn);
+  const [status, setStatus] = useState<Status>({
+    liveness: "unknown",
+    epoch: null,
+    indexerUrl: null,
+    detail: null,
+  });
+  // Counted across polls rather than held in state, so a re-probe does not re-render the pill
+  // before it has a verdict.
+  const consecutiveFailures = useRef(0);
+
+  useEffect(() => {
+    if (!loggedIn) {
+      // A logged out session carries no probe history into the next one.
+      consecutiveFailures.current = 0;
+      setStatus({ liveness: "unknown", epoch: null, indexerUrl: null, detail: null });
+      return;
+    }
+
+    let cancelled = false;
+
+    const probe = async () => {
+      try {
+        const settings = await settingsGet();
+        if (cancelled) return;
+        const indexerUrl = settings.indexer_url;
+        if (!indexerUrl) {
+          throw new Error("No indexer URL is configured");
+        }
+        // Announced only when there is no verdict to keep showing, so a poll from an established
+        // state does not flicker through "Connecting…" every interval.
+        setStatus((prev) => (prev.liveness === "unknown" ? { ...prev, liveness: "connecting", indexerUrl } : prev));
+        const info = await indexerGetNetworkInfo(indexerUrl);
+        if (cancelled) return;
+        consecutiveFailures.current = 0;
+        setStatus({
+          liveness: "connected",
+          epoch: info.epoch,
+          indexerUrl,
+          detail: null,
+        });
+      } catch (e) {
+        if (cancelled) return;
+        consecutiveFailures.current += 1;
+        const detail = e instanceof Error ? e.message : "Cannot reach the indexer";
+        setStatus((prev) => ({
+          ...prev,
+          liveness: consecutiveFailures.current >= FAILURES_BEFORE_DISCONNECTED ? "disconnected" : "unknown",
+          detail,
+        }));
+      }
+    };
+
+    void probe();
+    const timer = setInterval(() => void probe(), POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [loggedIn]);
+
+  if (!loggedIn) {
+    return null;
+  }
+
+  const colour = {
+    connected: theme.palette.success.main,
+    connecting: theme.palette.info.main,
+    unknown: theme.palette.text.disabled,
+    disconnected: theme.palette.error.main,
+  }[status.liveness];
+
+  const tooltip = [
+    status.indexerUrl ? `Indexer: ${status.indexerUrl}` : "No indexer configured",
+    status.liveness === "connected" && status.epoch != null ? `Epoch: ${status.epoch.toString()}` : null,
+    status.detail,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+
+  return (
+    <Tooltip title={tooltip} arrow>
+      <Chip
+        size="small"
+        variant="outlined"
+        label={LABELS[status.liveness]}
+        icon={
+          <Box
+            component="span"
+            sx={{
+              width: 8,
+              height: 8,
+              borderRadius: "50%",
+              backgroundColor: colour,
+              marginLeft: "8px !important",
+            }}
+          />
+        }
+        sx={{
+          borderColor: colour,
+          color: theme.palette.text.secondary,
+        }}
+      />
+    </Tooltip>
+  );
+}
+
+export default IndexerLivenessPill;

--- a/applications/tari_walletd/web_ui/src/theme/LayoutMain.tsx
+++ b/applications/tari_walletd/web_ui/src/theme/LayoutMain.tsx
@@ -25,6 +25,7 @@ import "@tari-project/ootle-web-ui-theming/overrides.ts";
 import { breadcrumbRoutes } from "@/App";
 import Logo from "@assets/Logo";
 import Breadcrumbs from "@components/Breadcrumbs";
+import IndexerLivenessPill from "@components/IndexerLivenessPill";
 import MenuItems from "@components/MenuItems";
 import { Check } from "@mui/icons-material";
 import MenuOpenOutlinedIcon from "@mui/icons-material/MenuOpenOutlined";
@@ -179,6 +180,7 @@ export default function Layout() {
               >
                 <Logo fill={theme.palette.text.primary} />
               </Link>
+              <IndexerLivenessPill />
               {/*<Stack direction="row" spacing={1}>*/}
               {/*  {loggedIn ? <WalletConnectLink /> : null}*/}
               {/*</Stack>*/}


### PR DESCRIPTION
## Description

Adds a coloured pill next to the logo in the wallet web UI app bar reporting whether the page can reach the configured indexer.

- The indexer URL is read from `settings.get` on every poll, so switching indexers in Settings takes effect without a reload.
- The probe goes browser → indexer directly (`networkInfo`), so it reflects whether *this page* can reach the indexer, not whether the wallet daemon can.
- Tooltip carries the indexer URL, the current epoch when connected, and the failure detail otherwise.

### States

| State | Colour | Meaning |
| --- | --- | --- |
| Unknown | grey | No verdict and no request in flight — before the first probe, and where a probe that has failed once lands. |
| Connecting… | blue | The indexer URL is known and a request is in flight, with no verdict yet. |
| Connected | green | The indexer replied. |
| Disconnected | red | Two consecutive probes failed (30s), so a single dropped request doesn't read as an outage. |

`Connecting…` is announced only when there is no verdict to keep showing, so a steady Connected or Disconnected pill doesn't flicker through it on every 15s poll.

## Auth gating

The pill is mounted in `LayoutMain`, which is the parent route element in `App.tsx`, so it renders while `GuardedRoute` is still showing the auth dialog. `settings.get` is an authenticated call, so the probe is gated on the auth store's `loggedIn`. Without that gate, every probe on the login screen throws, the pill settles on "Disconnected" with the auth error in its tooltip as if the indexer were down, and the page keeps issuing failing authenticated RPCs every 15s.

While logged out the component renders nothing and clears its probe history, so a fresh login starts from a clean slate rather than inheriting a stale verdict.

`LayoutMain`'s own `settings.get` — the one that loads the advanced UI feature flags — is gated the same way for the same reason. `App.tsx` already guards its copy of that call on the authenticated state, so the login screen now issues no authenticated RPCs at all.

## Motivation and Context

There was no indication in the UI when the wallet's configured indexer was unreachable — requests just failed one by one with no shared explanation.

## How Has This Been Tested?

`tsc --noEmit` on `tari_ootle_wallet_web_ui` passes. Each state was driven in a browser against the dev server and captured: Connected against a live indexer, Connecting… against an indexer that never answers, Unknown after one failed probe, Disconnected after two, and the login screen with no pill and no `settings.get` issued over more than two poll intervals.

## What process can a PR reviewer use to test or verify this change?

Run the wallet daemon and web UI, confirm no `settings.get` requests are issued while the auth dialog is up, log in and confirm the pill goes Connecting… then green with the epoch, then stop the indexer and confirm it goes grey then red within 30s.

## Breaking Changes

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other