### PR TITLE
fix(wallet-webui): don't load UI feature flags before the user is logged in

### DIFF
--- a/applications/tari_walletd/web_ui/src/theme/LayoutMain.tsx
+++ b/applications/tari_walletd/web_ui/src/theme/LayoutMain.tsx
@@ -113,10 +113,13 @@ export default function Layout() {
   const setAdvancedUiFeatures = useSettingsStore((s) => s.setAdvancedUiFeatures);
 
   useEffect(() => {
+    if (!loggedIn) {
+      return;
+    }
     settingsGet().then((res) => {
       setAdvancedUiFeatures(res.advanced_ui_features);
     });
-  }, [setAdvancedUiFeatures]);
+  }, [loggedIn, setAdvancedUiFeatures]);
 
   const handleClose = () => {
     setPopup({ visible: false });


### PR DESCRIPTION
## Description

Gates `LayoutMain`'s `settings.get` on the auth store's `loggedIn`.

`LayoutMain` is the parent route element in `App.tsx`, so it mounts while `GuardedRoute` is still showing the auth dialog. `settings.get` is an authenticated call, so on the login screen it throws and the advanced UI feature flags are never set from it.

`App.tsx` already guards its copy of the same call on the authenticated state, and #2429 gated the indexer liveness pill's probe the same way. This is the last authenticated RPC the login screen still issues.

## Motivation and Context

Follow-up to #2429. Verifying that PR involved watching the daemon's RPC log while sitting on the auth dialog, which showed this call going out and failing.

## How Has This Been Tested?

`tsc --noEmit` on `tari_ootle_wallet_web_ui` passes. Driven in a browser against the dev server: with the daemon refusing authentication, the login screen now issues no `settings.get` at all over more than two of the pill's poll intervals; after logging in the flags load as before.

## What process can a PR reviewer use to test or verify this change?

Run the wallet daemon and web UI and watch the daemon's request log while the auth dialog is up — no `settings.get` should appear until after login.

## Breaking Changes

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other