### PR TITLE
fix(walletd): wait for the local NFT records before answering a transfer

### DIFF
--- a/applications/tari_walletd/src/handlers/nfts.rs
+++ b/applications/tari_walletd/src/handlers/nfts.rs
@@ -390,7 +390,7 @@ pub async fn handle_transfer(
         .transaction_service()
         .submit_transaction_with_opts(
             transaction,
-            Some(TransactionContext::with_accounts(linked_accounts)),
+            Some(TransactionContext::with_accounts(linked_accounts.clone())),
             None,
         )
         .await?;
@@ -412,6 +412,19 @@ pub async fn handle_transfer(
         finalized.transaction_id,
         finalized.final_fee
     );
+
+    // `wait_for_result` returns on the finalize event that the account monitor also consumes to update the
+    // local vault and NFT records, so those records are not yet current here. Refreshing each account the
+    // transfer touched serialises behind the monitor's work, so a caller that re-reads `nfts.list` or the
+    // account balances on return sees the post-transfer state.
+    for account_address in linked_accounts {
+        if let Err(err) = context.account_monitor().refresh_account(account_address).await {
+            warn!(
+                target: LOG_TARGET,
+                "Failed to refresh account {} after NFT transfer {}: {}", account_address, tx_id, err
+            );
+        }
+    }
 
     Ok(TransferNftResponse {
         transaction_id: tx_id,

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/NFTList.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/NFTList.tsx
@@ -150,9 +150,9 @@ export default function NFTList(props: NftListProps) {
   const DisplayNFTs = () => {
     return viewMode === "grid" ? (
       <Grid container spacing={3}>
-        {displayedNfts.map((nft: NonFungibleToken, i) => (
+        {displayedNfts.map((nft: NonFungibleToken) => (
           <NftCard
-            key={i}
+            key={nftKey(nft)}
             nft={nft}
             selected={selectedMap.has(nftKey(nft))}
             selectDisabled={isSelectDisabled(nft)}
@@ -173,9 +173,9 @@ export default function NFTList(props: NftListProps) {
             </TableRow>
           </TableHead>
           <TableBody>
-            {displayedNfts.map((nft: NonFungibleToken, i) => (
+            {displayedNfts.map((nft: NonFungibleToken) => (
               <NftRow
-                key={i}
+                key={nftKey(nft)}
                 nft={nft}
                 selected={selectedMap.has(nftKey(nft))}
                 selectDisabled={isSelectDisabled(nft)}


### PR DESCRIPTION
## Description

Transferring an NFT to another account left it in the sender's NFT tab until the page was reloaded. The stale read comes from the wallet daemon, not the UI — though the UI is what makes it permanent.

### The race

`handle_transfer` waits for the transaction with `wait_for_result`, which returns on the `TransactionFinalized` broadcast event. `AccountMonitor::run` is a separate task subscribed to that *same* broadcast; its `TransactionFinalized` arm calls `scanner.process_result`, and that is the only thing that removes the transferred IDs from the local NFT records (`refresh_vault` → `update_vault_nfts` → `remove_nft` over `removed_nft_ids`). So the RPC response and the DB write are two tasks reacting to one event, and `nfts.list` can still return the NFTs the caller just sent away.

`handle_mint_faucet`, in the same file, already orders itself against the monitor by using `wait_for_result_and_account`, which additionally waits for `AccountChangedOnChain` — the event the scanner emits *after* `process_result` completes. Minting was consistent; transferring was not. That asymmetry is the bug.

### Why the UI never recovered

`useNFTsList` sets `staleTime: 30000`, `refetchOnMount: false`, `refetchOnWindowFocus: false`, `refetchInterval: false`. The transfer mutation's `onSettled` invalidation is the list's only refresh path, and it fires at exactly the racy moment — so one lost race sticks for the lifetime of the page. (Reopening the send dialog happens to fix the display, because that dialog calls `refetchNfts()` unconditionally on mount.)

## Changes

- `handle_transfer` awaits an account-monitor refresh of the accounts the transfer touched before responding — the existing `linked_accounts` set (source, fee payer, and the target when it is one of the wallet's own accounts), already computed for `TransactionContext`. A refresh failure is logged, not propagated: the transfer itself succeeded.
- NFT grid cards and table rows are keyed by `resource_address:nft_id` instead of array index, so a card's `SendNft` dialog state stays attached to its own NFT when the list changes underneath it.

### Why not `wait_for_result_and_account`

It would be the tighter primitive, but it is not safe here: the fee payer account may differ from the source account, so on a fee-only accept (fees charged, body rejected) nothing emits `AccountChangedOnChain` for the source account and the helper would loop until the broadcast channel closed. Requesting the refresh explicitly after the finalize and reject checks cannot hang.

The refresh request serialises correctly in either interleaving. The monitor's `select!` awaits `on_event` to completion before taking the next request, so if it picks up the finalize event first, our refresh is queued behind the NFT removal; if it picks up our request first, `refresh_account` re-reads the account from the network, which has the finalized state.

## Motivation and Context

Reported as NFTs remaining in the sender's NFT tab after a transfer.

## How Has This Been Tested?

`cargo check -p tari_ootle_walletd --all-targets` is clean. The reasoning above is traced from the code paths; the race was not reproduced against a running daemon, so a manual check of the reported flow (transfer an NFT to a second account, confirm the sender's NFT tab drops it without a reload) is worth doing before merge.

The two web UI edits are `key` props only; the worktree has no `node_modules`, so no `tsc` run — `nftKey(nft)` returns `string` and the dropped parameter was the unused map index.

## What process can a PR reviewer use to test or verify this change?

Transfer an NFT from the default account to a second account in the wallet UI and confirm it disappears from the sender's NFT tab without reloading, and appears in the recipient's.

<!-- markdownlint-disable-file MD041 -->
## Breaking Changes

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify
