### PR TITLE
feat(engine)!: allow 16 stealth outputs per transfer statement

### DIFF
--- a/crates/engine/examples/native_points_calibrate.rs
+++ b/crates/engine/examples/native_points_calibrate.rs
@@ -87,7 +87,7 @@ const NATIVE_TRIALS: usize = 100;
 
 /// Output counts the per-output marginal is fitted over. Powers of two so an aggregated bulletproof
 /// never pays a padding step mid-range.
-const OUTPUT_COUNTS: [usize; 4] = [1, 2, 4, 8];
+const OUTPUT_COUNTS: [usize; 5] = [1, 2, 4, 8, 16];
 /// Input counts for the per-input marginal.
 const INPUT_COUNTS: [usize; 2] = [100, 1000];
 

--- a/crates/engine/tests/stealth.rs
+++ b/crates/engine/tests/stealth.rs
@@ -486,32 +486,28 @@ fn many_outputs_in_one_transfer() {
     use std::{iter, time::Instant};
 
     use tari_engine_types::limits;
-    let outputs = [1000];
-    let mint = stealth::generate_mint_statement(outputs, 0u64, None);
+    // The whole minted amount is spent into equal outputs, so it must divide exactly by the output count or the
+    // balance proof will not sum.
+    const VALUE_PER_OUTPUT: u64 = 125;
+    let max_outputs = limits::STEALTH_LIMITS.max_outputs;
+    let total = VALUE_PER_OUTPUT * u64::try_from(max_outputs).unwrap();
+    let mint = stealth::generate_mint_statement([total], 0u64, None);
     let (_faucet, faucet_resx) = setup(&mut test, &mint, None);
 
     let timer = Instant::now();
 
-    assert_eq!(
-        1000 % limits::STEALTH_LIMITS.max_outputs,
-        0,
-        "Balance proof will fail due to rounding. Adjust the test amount to be a multiple of the limit"
-    );
     let transfer_from_faucet = stealth::generate_transfer_data(
         [MaskAndValue {
             mask: mint.output_masks[0].clone(),
-            value: 1000,
+            value: total,
         }],
         0u64,
-        iter::repeat_n(
-            u64::try_from(1000 / limits::STEALTH_LIMITS.max_outputs).unwrap(),
-            limits::STEALTH_LIMITS.max_outputs,
-        ),
+        iter::repeat_n(VALUE_PER_OUTPUT, max_outputs),
         0,
     );
 
-    // Release mode: ± 23s on M1 Mac, 3.7s on Ryzen 5950x (single thread, total test time 6.1s) for 500 outputs. Current
-    // limit is 8 TODO: verification time (depending on hardware) of 2-10+ seconds is still a problem, determine
+    // Release mode: ± 23s on M1 Mac, 3.7s on Ryzen 5950x (single thread, total test time 6.1s) for 500 outputs.
+    // TODO: verification time (depending on hardware) of 2-10+ seconds is still a problem, determine
     // what the upper bound for utxos should be. Parts of the verification could be parallelized (helps, assuming
     // some minimum CPU spec for a VN). Note that generation in Debug mode took 16 minutes on Ryzen 5950x !
     eprintln!("Generated transfer in {:.2?}", timer.elapsed());
@@ -530,7 +526,7 @@ fn many_outputs_in_one_transfer() {
         .up_iter()
         .filter_map(|(_, substate)| substate.substate_value().as_utxo())
         .collect::<Vec<_>>();
-    assert_eq!(utxos.len(), 8);
+    assert_eq!(utxos.len(), max_outputs);
 }
 
 pub fn try_brute_force_stealth_balance<L>(

--- a/crates/engine_types/src/crypto/helpers.rs
+++ b/crates/engine_types/src/crypto/helpers.rs
@@ -22,7 +22,9 @@ pub const ZERO_SECRET_KEY: RistrettoSecretKey = unsafe { std::mem::transmute([0u
 // Note that the BP-plus implementation currently does not support bit lengths over 64
 const BP_BIT_LENGTH: usize = u64::BITS as usize;
 
-pub const MAX_LAZY_BP_AGG_FACTORS: usize = 8;
+/// Largest bulletproof aggregation factor a statement may use. Must be a power of two and must have a matching
+/// service below, since a proof over `n` commitments is verified at `n.next_power_of_two()`.
+pub const MAX_LAZY_BP_AGG_FACTORS: usize = 16;
 
 lazy_static! {
     /// Static reference to the default commitment factory. Each instance of CommitmentFactory requires a number of heap allocations.
@@ -36,6 +38,8 @@ lazy_static! {
         BulletproofsPlusService::init(BP_BIT_LENGTH, 4, ExtendedPedersenCommitmentFactory::default()).unwrap();
     static ref RANGE_PROOF_AGG_8_SERVICE: BulletproofsPlusService =
         BulletproofsPlusService::init(BP_BIT_LENGTH, 8, ExtendedPedersenCommitmentFactory::default()).unwrap();
+    static ref RANGE_PROOF_AGG_16_SERVICE: BulletproofsPlusService =
+        BulletproofsPlusService::init(BP_BIT_LENGTH, 16, ExtendedPedersenCommitmentFactory::default()).unwrap();
 }
 
 pub fn get_static_range_proof_service(aggregation_factor: usize) -> &'static BulletproofsPlusService {
@@ -44,8 +48,9 @@ pub fn get_static_range_proof_service(aggregation_factor: usize) -> &'static Bul
         2 => &RANGE_PROOF_AGG_2_SERVICE,
         4 => &RANGE_PROOF_AGG_4_SERVICE,
         8 => &RANGE_PROOF_AGG_8_SERVICE,
+        16 => &RANGE_PROOF_AGG_16_SERVICE,
         _ => panic!(
-            "Unsupported BP aggregation factor {}. Expected 1/2/4 or 8",
+            "Unsupported BP aggregation factor {}. Expected 1/2/4/8 or 16",
             aggregation_factor
         ),
     }

--- a/crates/engine_types/src/limits.rs
+++ b/crates/engine_types/src/limits.rs
@@ -157,7 +157,14 @@ pub const MAX_PUBLISH_TEMPLATES_PER_TRANSACTION: usize = 1;
 pub struct StealthLimits {
     /// Maximum stealth inputs in a single transfer statement.
     pub max_inputs: usize,
-    /// Maximum stealth outputs in a single transfer statement.
+    /// Maximum stealth outputs in a single transfer statement. Bounded by
+    /// [`crate::crypto::MAX_LAZY_BP_AGG_FACTORS`], the largest aggregated range proof the engine can verify.
+    ///
+    /// A statement's outputs share one aggregated bulletproof, so verification cost per output falls as the
+    /// statement grows while the proof itself grows only logarithmically. Splitting the same outputs across
+    /// statements instead pays [`NativeExecutionPoints::PER_STATEMENT`] and an extra change output each time, so
+    /// this cap shapes a transaction rather than bounding its cost —
+    /// [`StealthLimits::max_total_outputs_per_transaction`] does that.
     pub max_outputs: usize,
     /// Maximum number of conditions in a single `SpendCondition` conjunction (TIP-0006). A revealed leaf is
     /// evaluated in full at spend time, and a builtin predicate (e.g. a covenant balance proof or a hashlock) runs
@@ -206,7 +213,7 @@ pub struct StealthLimits {
 /// rule enforced uniformly during execution, not just a mempool heuristic.
 pub const STEALTH_LIMITS: StealthLimits = StealthLimits {
     max_inputs: 1000,
-    max_outputs: 8,
+    max_outputs: 16,
     max_conditions_per_conjunction: 16,
     max_witness_data_len: 4096,
     max_inclusion_proof_len: 32,

--- a/crates/transaction_validation/src/stealth_limits.rs
+++ b/crates/transaction_validation/src/stealth_limits.rs
@@ -220,10 +220,16 @@ mod tests {
     #[test]
     fn accepts_transaction_at_the_caps() {
         let limits = STEALTH_LIMITS;
-        // Distribute the total input/output caps across transfers so every transfer also respects the per-transfer
-        // limits: 32 transfers of (32 inputs, 8 outputs) = 1024 inputs and 256 outputs (both exactly on the cap),
-        // padded with empty transfers up to the 64-transfer cap.
-        let mut statements = (0..32).map(|_| statement(32, limits.max_outputs)).collect::<Vec<_>>();
+        // Distribute the total input/output caps evenly across transfers so the transaction sits exactly on both
+        // totals while every transfer also respects the per-transfer limits, padded with empty transfers up to the
+        // transfer cap.
+        const N: usize = 32;
+        let inputs_each = limits.max_total_inputs_per_transaction / N;
+        let outputs_each = limits.max_total_outputs_per_transaction / N;
+        assert!(inputs_each <= limits.max_inputs && outputs_each <= limits.max_outputs);
+        assert_eq!(inputs_each * N, limits.max_total_inputs_per_transaction);
+        assert_eq!(outputs_each * N, limits.max_total_outputs_per_transaction);
+        let mut statements = (0..N).map(|_| statement(inputs_each, outputs_each)).collect::<Vec<_>>();
         statements.extend((statements.len()..limits.max_transfers_per_transaction).map(|_| statement(0, 0)));
         let tx = tx_with_stealth_transfers(statements);
         StealthTransactionLimitsValidator::new().validate(&(), &tx).unwrap();

--- a/crates/wallet/crypto/src/bullet_proof.rs
+++ b/crates/wallet/crypto/src/bullet_proof.rs
@@ -68,3 +68,57 @@ pub fn generate_extended_bullet_proof<'a, I: IntoIterator<Item = &'a OutputWitne
     RangeProofBytes::try_from(output_range_proof)
         .map_err(|e| RangeProofError::ProofConstructionError { reason: e.to_string() })
 }
+
+#[cfg(test)]
+mod tests {
+    use tari_crypto::{keys::SecretKey, ristretto::RistrettoPublicKey, tari_utilities::ByteArray};
+    use tari_engine_types::crypto::range_proof::validate_bullet_proof;
+    use tari_template_lib_types::{
+        EncryptedData,
+        crypto::{PedersenCommitmentBytes, RistrettoPublicKeyBytes},
+        stealth::UnspentOutput,
+    };
+
+    use super::*;
+
+    fn witness(amount: u64) -> OutputWitness {
+        OutputWitness {
+            amount,
+            mask: RistrettoSecretKey::random(&mut rand::rng()),
+            sender_public_nonce: RistrettoPublicKey::default(),
+            minimum_value_promise: 0,
+            encrypted_data: EncryptedData::empty(),
+            resource_view_key: None,
+        }
+    }
+
+    fn to_output(witness: &OutputWitness) -> UnspentOutput {
+        UnspentOutput {
+            commitment: PedersenCommitmentBytes::from_bytes(witness.to_commitment().as_bytes()).unwrap(),
+            sender_public_nonce: RistrettoPublicKeyBytes::zero(),
+            encrypted_data: EncryptedData::empty(),
+            minimum_value_promise: witness.minimum_value_promise,
+            viewable_balance_proof: None,
+        }
+    }
+
+    /// Prover and verifier pad independently to `n.next_power_of_two()`, so every count up to the cap must agree on
+    /// the aggregation factor and have a service backing it.
+    #[test]
+    fn proves_and_verifies_at_every_supported_output_count() {
+        for n in 1..=MAX_LAZY_BP_AGG_FACTORS {
+            let witnesses = (0..n).map(|i| witness(1000 + i as u64)).collect::<Vec<_>>();
+            let proof = generate_extended_bullet_proof(&witnesses).unwrap();
+            let outputs = witnesses.iter().map(to_output).collect::<Vec<_>>();
+            validate_bullet_proof(&proof, outputs.iter()).unwrap_or_else(|e| panic!("n={n}: {e}"));
+        }
+    }
+
+    #[test]
+    fn rejects_more_outputs_than_the_cap() {
+        let witnesses = (0..=MAX_LAZY_BP_AGG_FACTORS)
+            .map(|i| witness(1000 + i as u64))
+            .collect::<Vec<_>>();
+        generate_extended_bullet_proof(&witnesses).unwrap_err();
+    }
+}

--- a/crates/wallet/ootle-rs/examples/stealth_transfer.rs
+++ b/crates/wallet/ootle-rs/examples/stealth_transfer.rs
@@ -1,6 +1,8 @@
 //   Copyright 2026 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+use std::num::NonZeroU64;
+
 use ootle_rs::{
     ToAccountAddress,
     TransactionRequest,
@@ -23,6 +25,7 @@ use tari_ootle_common_types::engine_types::transaction_receipt::TransactionRecei
 use tari_ootle_transaction::{Epoch, Transaction};
 
 #[tokio::main]
+#[allow(clippy::too_many_lines)]
 async fn main() {
     // env_logger::builder()
     //     .filter_level(tracing::log::LevelFilter::Debug)
@@ -75,7 +78,10 @@ async fn main() {
     // The revealed amount each transaction reserves to pay its fee. It is deliberately generous rather than fitted to
     // a dry-run estimate: the budget is part of the transfer statement, so spending an estimate would change the
     // transaction it was estimated from. Whatever is not charged is refunded (see the receipt's overcharge line).
-    const FEE_BUDGET: u64 = 20_000;
+    //
+    // It has to cover the second transfer's sixteen outputs, whose aggregated range proof alone prices at roughly
+    // 98,000 µT under the testnet schedule (~6,000 µT per output plus the fixed per-statement cost).
+    const FEE_BUDGET: u64 = 250_000;
     const FIRST_INPUT_AMOUNT: u64 = 6 * TARI;
     const SECOND_INPUT_AMOUNT: u64 = 10 * TARI + FEE_BUDGET - FIRST_INPUT_AMOUNT;
     // // This builder creates a stealth transfer statement (spend proof). This is added to the transaction later.
@@ -123,7 +129,20 @@ async fn main() {
 
     // Then we'll send it to the recipient
     // This builder creates a stealth transfer statement (spend proof). This is added to the transaction later.
-    let (transfer, required_signers) = StealthTransfer::new(tari_token, &provider)
+    //
+    // One statement may carry up to 16 stealth outputs, and all of them share a single aggregated range proof. That
+    // is what makes fanning out inside one statement cheaper than splitting the same outputs across several
+    // transfers, each of which would pay the fixed per-statement cost and need its own change output. Here the
+    // budget goes to two outputs worth spending plus fourteen dust ones.
+    const DUST_OUTPUT_COUNT: u64 = 14;
+    // Dust in the literal sense: each of these holds 1 µT while costing ~6,000 µT of range-proof verification to
+    // create. Fine for showing the fan-out, ruinous as a spending habit.
+    const DUST_AMOUNT: u64 = 1;
+    const RECIPIENT_AMOUNT: u64 = 8 * TARI;
+    // The change absorbs the dust so that ∑inputs == ∑outputs still holds.
+    const CHANGE_AMOUNT: u64 = 2 * TARI - DUST_OUTPUT_COUNT * DUST_AMOUNT;
+
+    let transfer_builder = StealthTransfer::new(tari_token, &provider)
         // Spend both existing stealth inputs that are controlled by the sender address.
         // Together these are worth 10 TARI plus the second transaction's fee budget.
         .spend_stealth_input(sender_address.clone(), inputs_to_spend[0].commitment())
@@ -132,16 +151,25 @@ async fn main() {
         .to_revealed_output(FEE_BUDGET)
         // Spend to a new output (8 TARI) that we'll generate for the recipient address.
         .to_stealth_output(
-            Output::new(recipient, tari_token, const_nonzero_u64!(8 * TARI))
+            Output::new(recipient, tari_token, const_nonzero_u64!(RECIPIENT_AMOUNT))
                 // NOTE: this memo is stored on-chain, and longer memos increase fees. It is encrypted so that only the recipient can read it.
                 .with_memo_message("transfer from ootle-rs!")
         )
-        // Send some change (2 TARI) back to ourselves (NOTE once this example exits, we'll lose the keys for this output!)
-        .to_stealth_output(Output::new(sender_address, tari_token, const_nonzero_u64!(2*TARI)))
-        // Load the inputs from the provider to build the transfer statement. NOTE: this will error if the total input amounts != total output amounts.
-        .prepare()
-        .await
-        .unwrap();
+        // Send the change back to ourselves (NOTE once this example exits, we'll lose the keys for this output!)
+        .to_stealth_output(Output::new(sender_address.clone(), tari_token, const_nonzero_u64!(CHANGE_AMOUNT)));
+
+    // Fan the rest of the statement out into dust, taking the output count up to the per-statement maximum.
+    let transfer_builder = (0..DUST_OUTPUT_COUNT).fold(transfer_builder, |builder, _| {
+        builder.to_stealth_output(Output::new(
+            sender_address.clone(),
+            tari_token,
+            NonZeroU64::new(DUST_AMOUNT).expect("DUST_AMOUNT is non-zero"),
+        ))
+    });
+
+    // Load the inputs from the provider to build the transfer statement. NOTE: this will error if the total input
+    // amounts != total output amounts.
+    let (transfer, required_signers) = transfer_builder.prepare().await.unwrap();
 
     // We'll generate an unsigned transaction directly using the Transaction builder. In future, we may make this
     // easier.


### PR DESCRIPTION
## What

Raises `STEALTH_LIMITS.max_outputs` from 8 to 16, and `MAX_LAZY_BP_AGG_FACTORS` with it, adding the aggregation-16 bulletproof service the larger statement needs. Both had to move together: `validate_bullet_proof` rejects anything above the aggregation cap before it reaches a service, so bumping the limit alone would just have made 9–16-output statements fail.

## Why

A statement's outputs share one aggregated range proof. A payout to more than 8 recipients currently has to split across statements, and each extra statement pays `PER_STATEMENT` (2.1M points) plus a change output (6M) and the inputs to fund it. The aggregate is strictly cheaper than the split.

## Why 16 and not 32

BP+ verification cost per output bottoms out around aggregation factor 4–8, stays flat through 16, and then falls apart. Isolated measurement of `verify_batch` alone (min-of-50, two runs agreeing):

| agg | verify ms | per output | marginal/output | proof bytes | init ms |
|---:|---:|---:|---:|---:|---:|
| 1 | 0.5971 | 0.5971 | – | 577 | 2.4 |
| 2 | 1.0454 | 0.5227 | 0.4484 | 641 | 5.2 |
| 4 | 1.9211 | 0.4803 | 0.4378 | 705 | 10.4 |
| 8 | 3.7552 | 0.4694 | 0.4585 | 769 | 20.9 |
| **16** | **7.5993** | **0.4750** | **0.4805** | **833** | **42.3** |
| 32 | 20.0581 | 0.6268 | 0.7787 | 897 | 86.6 |
| 64 | 46.3866 | 0.7248 | 0.8228 | 961 | 173.7 |

- **8 → 16**: 2.02–2.10× total time for 2× the outputs; per-output marginal **+5% to +12%**. Small, but real and reproducible.
- **16 → 32**: 2.44–2.64× total; per-output marginal **+37% to +62%**. This is the knee, and it is why the cap stops here.

Likely mechanism (inferred from the shape, not directly measured): verification is one `vartime_mixed_multiscalar_mul` against precomputed generator tables of `2 × 64 × agg` bases — 2048 at agg 16, 4096 at agg 32 — which grow linearly with the aggregation factor and stop fitting in L2 right where the knee appears. Not an algorithmic defect in `tari_bulletproofs_plus`.

Proof size is logarithmic throughout: **+64 bytes per doubling**, so per-output bandwidth improves as the statement grows.

Service init (paid once at VN startup via `preload_crypto_services`, which already walks powers of two up to the cap) goes 20.9ms → 42.3ms.

## Blast radius

The per-transaction totals — 64 transfers, 256 outputs, 1024 inputs — are untouched. Those are what bound the verification a single transaction can stack, and what `MAX_NATIVE_POINTS_PER_TRANSACTION` (2.4e9, sized against ~2.23e9) is derived from. This cap only shapes how a transaction distributes that budget, so worst-case block load does not move.

It is a consensus-relevant execution rule, enforced in the engine (`runtime/validation.rs`) and mirrored at mempool ingress (`stealth_limits.rs`) off the same constant. **Every VN needs to be upgraded before any 9+-output statement is emitted.**

## Fee schedule: unchanged, with a caveat

Left as is deliberately — raising `PER_OUTPUT` would have put ~25% on every ordinary stealth transfer for a limit most transactions never approach.

Six calibration runs, comparing the statement-level charge against measured verification cost at 16 outputs:

| | median headroom @ n=16 | @ n=8 |
|---|---|---|
| no view key | ~15% | ~18% |
| view key | ~11% | ~17% |

Covered in 11 of 12 measurements; the one negative reading (−0.9%) came from the run with the worst dispersion of the six.

Two things reviewers should weigh rather than take from me:

- The margin narrows at 16 and does not invert. The +5–12% per-output penalty shown in the table above is the cause, and it is genuine rather than measurement artefact — it reproduces in isolation.
- The n=16 samples in the *fee* calibrator carry 27–45% median-vs-min dispersion on the machine they were taken on, versus 1–15% at n≤8. The per-field bounds it derives at n=16 swing ±20% run to run. **Re-baseline on dedicated hardware before moving any fee constant on the strength of those numbers.**

`OUTPUT_COUNTS` in the calibrator now includes 16 so this stays visible in future runs.

## Verification

- `bullet_proof.rs`: new prove→verify roundtrip across every count `1..=MAX_LAZY_BP_AGG_FACTORS` (catches a raised cap with no backing service) plus a rejection test at `MAX+1`.
- `many_outputs_in_one_transfer`: now derives its shape from `max_outputs` instead of hardcoding 8; passes end-to-end through the engine, 16 UTXOs up from one statement.
- `stealth_limits` validator tests: `accepts_transaction_at_the_caps` now derives the per-transfer shape from the per-transaction totals — 32 transfers × 16 outputs would have blown the 256 cap and made the test assert the wrong thing.
