### PR TITLE
fix(walletd/web_ui): keep the NFT send dialog on its result step

### DIFF
--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/components/SendNft.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/components/SendNft.tsx
@@ -126,7 +126,6 @@ export function TransferNftDialog(props: TransferNftDialogProps) {
     setTransferFormState,
     setValidity,
     setTransferResult,
-    setAutoCloseTimeoutId,
     resetState,
   } = useNftTransferStore();
 
@@ -272,12 +271,6 @@ export function TransferNftDialog(props: TransferNftDialogProps) {
           success: true,
           message: "Your NFT has been successfully transferred!",
         });
-
-        // Auto-close after 10 seconds
-        const timeoutId = setTimeout(() => {
-          handleAutoCloseAfterSuccess();
-        }, 10000);
-        setAutoCloseTimeoutId(timeoutId);
       } else {
         setTransferResult({
           success: false,
@@ -295,18 +288,12 @@ export function TransferNftDialog(props: TransferNftDialogProps) {
   };
 
   const handleClose = () => {
-    resetState(preSelectedNftId, preSelectedResourceAddress);
-    if (transferResult?.success) {
-      props.onSendComplete?.();
-    } else {
-      props.handleClose?.();
-    }
-  };
-
-  const handleAutoCloseAfterSuccess = () => {
+    const wasSuccessful = transferResult?.success;
     resetState(preSelectedNftId, preSelectedResourceAddress);
     props.handleClose?.();
-    props.onSendComplete?.();
+    if (wasSuccessful) {
+      props.onSendComplete?.();
+    }
   };
 
   const handleNftsChange = (event: SelectChangeEvent<string[]>) => {
@@ -362,28 +349,23 @@ export function TransferNftDialog(props: TransferNftDialogProps) {
     }
   }, [loadedNfts]);
 
+  // Seed the form from the props captured when the dialog opened. The NFT props are derived from the account's
+  // NFT list, which the transfer invalidates, so re-seeding on their identity would wipe the result step out
+  // from under the user the moment the refreshed list arrives.
   useEffect(() => {
-    if (props.open && account) {
-      // When dialog opens, always reset to ensure clean state
-      resetState(preSelectedNftId, preSelectedResourceAddress, substateIdToString(account.component_address));
-
-      // If batch-selected NFTs are provided, pre-fill the form
-      if (hasBatchSelection) {
-        setTransferFormState({
-          nfts: preSelectedNfts.map((nft) => nft.nft_id),
-          resourceAddress: preSelectedNfts[0].resource_address,
-        });
-        setValidity({ nfts: true });
-      }
+    if (!props.open || !account) {
+      return;
     }
-  }, [
-    props.open,
-    preSelectedNftId,
-    preSelectedResourceAddress,
-    account?.component_address,
-    hasBatchSelection,
-    preSelectedNfts,
-  ]);
+    resetState(preSelectedNftId, preSelectedResourceAddress, substateIdToString(account.component_address));
+
+    if (hasBatchSelection) {
+      setTransferFormState({
+        nfts: preSelectedNfts.map((nft) => nft.nft_id),
+        resourceAddress: preSelectedNfts[0].resource_address,
+      });
+      setValidity({ nfts: true });
+    }
+  }, [props.open, account?.component_address]);
 
   return (
     <Dialog open={props.open} onClose={handleClose} maxWidth="sm" fullWidth>

--- a/applications/tari_walletd/web_ui/src/services/store/nftTransferStore.ts
+++ b/applications/tari_walletd/web_ui/src/services/store/nftTransferStore.ts
@@ -60,9 +60,6 @@ interface NftTransferState {
   // Result state
   transferResult: TransferResult | null;
 
-  // Auto-close state
-  autoCloseTimeoutId: NodeJS.Timeout | null;
-
   // Actions
   setCurrentStep: (step: DialogStep) => void;
   setDisabled: (disabled: boolean) => void;
@@ -71,7 +68,6 @@ interface NftTransferState {
   setEstimatedFee: (fee: number | null) => void;
   setIsEstimatingFee: (estimating: boolean) => void;
   setTransferResult: (result: TransferResult | null) => void;
-  setAutoCloseTimeoutId: (timeoutId: NodeJS.Timeout | null) => void;
 
   // Complex actions
   updateFormValue: (name: string, value: string, isValid?: boolean) => void;
@@ -115,7 +111,6 @@ export const useNftTransferStore = create<NftTransferState>((set, get) => ({
   estimatedFee: null,
   isEstimatingFee: false,
   transferResult: null,
-  autoCloseTimeoutId: null,
 
   // Simple setters
   setCurrentStep: (step) => set({ currentStep: step }),
@@ -131,7 +126,6 @@ export const useNftTransferStore = create<NftTransferState>((set, get) => ({
   setEstimatedFee: (fee) => set({ estimatedFee: fee }),
   setIsEstimatingFee: (estimating) => set({ isEstimatingFee: estimating }),
   setTransferResult: (result) => set({ transferResult: result }),
-  setAutoCloseTimeoutId: (timeoutId) => set({ autoCloseTimeoutId: timeoutId }),
 
   // Complex actions
   updateFormValue: (name, value, isValid) => {
@@ -151,13 +145,6 @@ export const useNftTransferStore = create<NftTransferState>((set, get) => ({
   },
 
   resetState: (preSelectedNftId, preSelectedResourceAddress, accountAddress) => {
-    const { autoCloseTimeoutId } = get();
-
-    // Clear any active timeout
-    if (autoCloseTimeoutId) {
-      clearTimeout(autoCloseTimeoutId);
-    }
-
     set({
       currentStep: "form",
       disabled: false,
@@ -166,7 +153,6 @@ export const useNftTransferStore = create<NftTransferState>((set, get) => ({
       estimatedFee: null,
       isEstimatingFee: false,
       transferResult: null,
-      autoCloseTimeoutId: null,
     });
   },
 


### PR DESCRIPTION
## Description

Sending an NFT from the wallet web UI leaves the dialog stuck open.

`useNftsTransfer` invalidates the account's NFT list queries `onSettled`. The refreshed list gives the dialog new `preSelectedNftId` / `preSelectedNfts` object identities (and, for the batch dialog, a new `selectedNfts` array once the pruning effect drops the sent NFTs). Those props were dependencies of the effect that seeds the form, so it re-ran right after a successful send and called `resetState()`: the result step was replaced by the form step, and the user was left with an open dialog and no Close button on the path they were on.

The 10s auto-close timer was a workaround for that, and a broken one — `resetState()` clears the timeout, so the very reset that hid the result also cancelled the fallback close.

Changes:

- Seed the form only when the dialog opens for an account, instead of on every prop identity change. The props read there are the ones captured at open time, which is what the seeding wants.
- Remove the auto-close timer and the `autoCloseTimeoutId` store state that existed only to service it.
- `handleClose` now captures success before resetting, always calls `handleClose`, and additionally calls `onSendComplete` on success — the same shape as the send-funds dialog. Previously it called exactly one of the two.

The success screen now stays put until the user closes it, in both the single-NFT and batch dialogs.

## Motivation and Context

Bug report: the NFT send dialog does not close after a successful send.

## How Has This Been Tested?

`tsc --noEmit` over the wallet web UI, prettier clean. Manually reviewed the three call sites (`SendNft`, `NFTList`, `Tokens`) — all three close on either callback, so the `handleClose` change is behaviour-preserving for them.

## What process can a PR reviewer use to test or verify this change?

Send an NFT from the wallet web UI (single from the NFT card, and a batch from the list selection). The dialog should show the success step and stay there until Close is clicked, then close.

## Breaking Changes

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other