### PR TITLE
fix(engine): fund compute from the payment's unspent balance

### DIFF
--- a/applications/tari_walletd/src/handlers/accounts.rs
+++ b/applications/tari_walletd/src/handlers/accounts.rs
@@ -688,7 +688,7 @@ pub(crate) async fn execute_claim_burn(
     if is_dry_run {
         let transaction_id = transaction.calculate_id();
         let result = transaction_service.submit_dry_run_transaction(transaction).await?;
-        let required_fees = result.finalize.fee_receipt.required_fees();
+        let required_fees = result.finalize.required_fees();
         return Ok(ClaimBurnResponse {
             transaction_id,
             required_fees: Some(required_fees),

--- a/applications/tari_walletd/src/handlers/nfts.rs
+++ b/applications/tari_walletd/src/handlers/nfts.rs
@@ -363,7 +363,7 @@ pub async fn handle_transfer(
             transaction_id,
             // Dry-run callers commonly pass a placeholder max_fee that clamps `total_fees_paid`. Report
             // the uncapped estimate so the response is usable for fee selection.
-            fee: finalize.fee_receipt.required_fees(),
+            fee: finalize.required_fees(),
             fee_refunded: finalize
                 .fee_receipt
                 .total_fee_payment()

--- a/applications/tari_walletd/src/handlers/transaction.rs
+++ b/applications/tari_walletd/src/handlers/transaction.rs
@@ -467,7 +467,7 @@ async fn submit_dry_run_inner(
         .await
         .map_err(map_transaction_submission_error)?;
 
-    let required_fees = exec_result.finalize.fee_receipt.required_fees();
+    let required_fees = exec_result.finalize.required_fees();
     Ok(TransactionSubmitDryRunResponse {
         transaction_id: exec_result.finalize.transaction_hash.into_array().into(),
         required_fees,
@@ -571,7 +571,7 @@ pub async fn handle_submit_manifest(
             )
             .into());
         }
-        let required_fees = exec_result.finalize.fee_receipt.required_fees();
+        let required_fees = exec_result.finalize.required_fees();
         return Ok(TransactionSubmitManifestResponse {
             transaction_id: exec_result.finalize.transaction_hash.into_array().into(),
             required_fees: Some(required_fees),
@@ -792,7 +792,7 @@ pub async fn handle_publish_template(
         }
         return Ok(PublishTemplateResponse {
             transaction_id: resp.transaction_id,
-            dry_run_fee: Some(resp.result.finalize.fee_receipt.required_fees()),
+            dry_run_fee: Some(resp.result.finalize.required_fees()),
         });
     }
     let request = TransactionSubmitRequest {

--- a/applications/tari_walletd/src/handlers/validator.rs
+++ b/applications/tari_walletd/src/handlers/validator.rs
@@ -225,7 +225,7 @@ pub async fn handle_claim_validator_fees(
             fee: transaction
                 .finalize
                 .as_ref()
-                .map(|f| f.fee_receipt.required_fees())
+                .map(|f| f.required_fees())
                 .unwrap_or_default(),
             result: transaction
                 .finalize

--- a/crates/engine/src/fees/fee_module.rs
+++ b/crates/engine/src/fees/fee_module.rs
@@ -47,15 +47,12 @@ impl FeeModule {
         Ok((base_bytes, charge))
     }
 
-    /// Charges everything that is a function of the state being persisted, rather than of the work
-    /// done to produce it: storage, the template-publish premium, substate slots, the metering of
-    /// WASM and native execution, and the exhaust burn over the resulting total.
+    /// Charges everything that is a function of the state being persisted: the per-byte storage
+    /// tally, the template-publish premium and the per-substate creation premium.
     ///
-    /// Every charge here is *assigned*, not accumulated, so that running this again against a
-    /// different state replaces the result rather than doubling it. That is what lets a transaction
-    /// be gated on the cost of the state it asked to commit and then billed for the state that is
-    /// actually persisted — see [`RuntimeModule::on_before_persist`].
-    fn charge_finalization_fees<TStore: StateReader>(
+    /// Assigned rather than accumulated, so running it again over a different state replaces the
+    /// result instead of doubling it — see [`RuntimeModule::on_before_persist`].
+    fn charge_state_fees<TStore: StateReader>(
         &self,
         state: &mut ChargeableState<'_, TStore>,
     ) -> Result<(), RuntimeModuleError> {
@@ -120,6 +117,27 @@ impl FeeModule {
             .checked_mul(self.fee_table.per_substate_create_cost())
             .ok_or_else(|| RuntimeModuleError::Overflow("Overflow calculating substate create cost".to_string()))?;
 
+        let fee_state = state.fee_state_mut();
+        fee_state.set_charge(FeeSource::Storage, storage_cost);
+        fee_state.set_charge(FeeSource::TemplatePublish, template_publish_cost);
+        fee_state.set_charge(FeeSource::SubstateCreate, create_cost);
+
+        Ok(())
+    }
+
+    /// Charges everything that is a function of the state being persisted, plus the metering of WASM
+    /// and native execution and the exhaust burn over the resulting total.
+    ///
+    /// Every charge here is *assigned*, not accumulated, so that running this again against a
+    /// different state replaces the result rather than doubling it. That is what lets a transaction
+    /// be gated on the cost of the state it asked to commit and then billed for the state that is
+    /// actually persisted — see [`RuntimeModule::on_before_persist`].
+    fn charge_finalization_fees<TStore: StateReader>(
+        &self,
+        state: &mut ChargeableState<'_, TStore>,
+    ) -> Result<(), RuntimeModuleError> {
+        self.charge_state_fees(state)?;
+
         // WASM execution: charge once against the transaction's accumulated points so the divisor
         // rounds against the total. Per-call rounding would let a transaction split work into
         // sub-divisor chunks and pay zero for any single one (each `points/divisor` is `0`), even
@@ -137,9 +155,6 @@ impl FeeModule {
             .ok_or_else(|| RuntimeModuleError::Overflow("Overflow calculating native execution cost".to_string()))?;
 
         let fee_state = state.fee_state_mut();
-        fee_state.set_charge(FeeSource::Storage, storage_cost);
-        fee_state.set_charge(FeeSource::TemplatePublish, template_publish_cost);
-        fee_state.set_charge(FeeSource::SubstateCreate, create_cost);
         fee_state.set_charge(FeeSource::WasmExecution, wasm_cost);
         fee_state.set_charge(FeeSource::NativeExecution, native_cost);
 
@@ -218,6 +233,12 @@ impl<TStore: StateReader> RuntimeModule<TStore> for FeeModule {
 
     fn on_before_finalize(&self, track: &mut StateTracker<TStore>) -> Result<(), RuntimeModuleError> {
         self.charge_finalization_fees(&mut track.chargeable_state())
+    }
+
+    fn on_fee_checkpoint(&self, state: &mut ChargeableState<'_, TStore>) -> Result<(), RuntimeModuleError> {
+        // Only the state-derived charges. Execution metering is charged once at finalization, over
+        // the whole transaction's accumulated points, so pricing it here would be replaced anyway.
+        self.charge_state_fees(state)
     }
 
     fn on_before_persist(&self, state: &mut ChargeableState<'_, TStore>) -> Result<(), RuntimeModuleError> {

--- a/crates/engine/src/runtime/fee_state.rs
+++ b/crates/engine/src/runtime/fee_state.rs
@@ -115,6 +115,10 @@ impl FeeState {
         self.accumulated_native_points
     }
 
+    pub fn fee_charges(&self) -> &FeeBreakdown {
+        &self.fee_charges
+    }
+
     pub fn take_fee_charges(&mut self) -> FeeBreakdown {
         std::mem::take(&mut self.fee_charges)
     }

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -36,6 +36,7 @@ use tari_engine_types::{
     crypto::OutputBody,
     entity_id_provider::EntityIdProvider,
     events::Event,
+    fees::FeeReceipt,
     hashing::hash_template_code,
     indexed_value::IndexedValue,
     instruction_result::InstructionResult,
@@ -298,6 +299,13 @@ impl<TStore: StateReader + Clone + 'static, TTemplateProvider: TemplateProvider<
             self.invoke_modules_on_before_persist(&mut finalized)?;
         }
         self.tracker.finalize(finalized)
+    }
+
+    fn invoke_modules_on_fee_checkpoint(&mut self) -> Result<(), RuntimeError> {
+        for module in self.modules.iter() {
+            module.on_fee_checkpoint(&mut self.tracker.chargeable_state())?;
+        }
+        Ok(())
     }
 
     fn invoke_modules_on_before_persist(&mut self, finalized: &mut FinalizedState<TStore>) -> Result<(), RuntimeError> {
@@ -3469,7 +3477,18 @@ where
         })
     }
 
+    fn metered_fee_receipt(&self) -> FeeReceipt {
+        FeeReceipt::builder()
+            .with_cost_breakdown(self.tracker.fee_charges())
+            .build()
+    }
+
     fn checkpoint_fee_intent(&mut self) -> Result<(), RuntimeError> {
+        // Price the state the fee intent ended on before testing what was paid against it. This is
+        // the state a transaction that cannot afford its main intent falls back to committing, so a
+        // payment that cannot cover it cannot commit anything at all — better established here,
+        // before the main instructions run, than after they have consumed compute nobody pays for.
+        self.invoke_modules_on_fee_checkpoint()?;
         if !self.tracker.is_fee_state_dry_run() && self.tracker.total_fee_payments() < self.tracker.total_fee_charges()
         {
             return Err(RuntimeError::InsufficientFeesPaid {
@@ -3481,12 +3500,13 @@ where
     }
 
     fn finalize(&mut self) -> Result<FinalizeResult, RuntimeError> {
-        self.invoke_modules_on_runtime_call("finalize")?;
+        // Finalization adds no fee charge of its own. The template never invoked it, and the compute
+        // allowance is sized against the charges standing when it is computed, so anything charged
+        // afterwards puts the total past what that allowance was sized to fit inside.
         self.finalize_with(None)
     }
 
     fn finalize_failure(&mut self, reason: RejectReason) -> Result<FinalizeResult, RuntimeError> {
-        self.invoke_modules_on_runtime_call("finalize_failure")?;
         self.finalize_with(Some(reason))
     }
 

--- a/crates/engine/src/runtime/mod.rs
+++ b/crates/engine/src/runtime/mod.rs
@@ -60,6 +60,7 @@ use tari_engine_types::{
     commit_result::{FinalizeResult, RejectReason},
     component::Component,
     confidential::{ClaimBurnOutputData, MinotariBurnClaimProof},
+    fees::FeeReceipt,
     indexed_value::IndexedValue,
     lock::LockFlag,
     published_template::TemplateBlob,
@@ -270,6 +271,11 @@ pub trait RuntimeInterface {
     /// [`Self::wasm_points_consumed`] when capping a call's payment-funded allowance; excluded
     /// from the WASM-only per-transaction hard cap.
     fn native_points_consumed(&self) -> u64;
+
+    /// The charges metered so far, as a receipt against no payment. A transaction rejected before
+    /// finalization never settles a receipt of its own, so this is the only place the payer can read
+    /// what it would have cost.
+    fn metered_fee_receipt(&self) -> FeeReceipt;
 
     /// The maximum Wasmer metering points the transaction may consume given the fees paid so far,
     /// used by `WasmProcess::invoke` to cap each call's allowance so unpaid compute cannot exceed

--- a/crates/engine/src/runtime/module.rs
+++ b/crates/engine/src/runtime/module.rs
@@ -32,6 +32,14 @@ pub trait RuntimeModule<TStore>: Send + Sync {
         Ok(())
     }
 
+    /// Invoked when the fee intent is checkpointed, against the state it ended on — which is the
+    /// state a transaction that cannot pay for its main intent will fall back to committing.
+    /// Pricing it here is what lets the paid-in-full check that follows, and the compute allowance
+    /// that follows it, both account for what that fallback costs.
+    fn on_fee_checkpoint(&self, _state: &mut ChargeableState<'_, TStore>) -> Result<(), RuntimeModuleError> {
+        Ok(())
+    }
+
     /// Invoked at the start of finalization, against the working state — before it is known
     /// whether the transaction commits or falls back to a fee-intent commit. Charges added here
     /// decide that outcome: they are what the paid-in-full check sees.

--- a/crates/engine/src/runtime/tracker.rs
+++ b/crates/engine/src/runtime/tracker.rs
@@ -25,7 +25,7 @@ use tari_engine_types::{
     commit_result::{FinalizeResult, RejectReason, TransactionResult},
     component::{Component, ComponentBody, ComponentHeader},
     events::Event,
-    fees::{FeeReceipt, FeeSource},
+    fees::{FeeBreakdown, FeeReceipt, FeeSource},
     indexed_value::{IndexedValue, IndexedWellKnownTypes},
     limits,
     lock::LockFlag,
@@ -62,6 +62,16 @@ use crate::{
 };
 
 const LOG_TARGET: &str = "tari::ootle::engine::runtime::state_tracker";
+
+/// The part of a fee payment that charges can actually consume.
+///
+/// The exhaust burn is taken over the charges rather than deducted from the payment, so a payment of
+/// `P` covers charges of at most `P / (1 + rate)`. Rounds down, so the figure never over-states what
+/// is available.
+fn spendable_on_charges(payments: u64, burn_rate_bps: u16) -> u64 {
+    let scaled = u128::from(payments) * 10_000 / (10_000 + u128::from(burn_rate_bps));
+    u64::try_from(scaled).unwrap_or(u64::MAX)
+}
 
 /// The state finalization will persist, detached from the tracker and awaiting fee settlement.
 #[derive(Debug)]
@@ -141,6 +151,17 @@ impl<TStore: StateReader> StateTracker<TStore> {
     /// instructions before it pays, while a transaction that never pays cannot consume more than the
     /// grace. Past the fee checkpoint the credit no longer applies: the transaction has paid what its
     /// fee intent charged, and the compute it may still run is funded by that payment alone.
+    ///
+    /// Compute is funded by what the payment has *left*, not by the whole of it. A transaction that
+    /// cannot pay for the state it commits commits only its fee intent, and that state was priced
+    /// onto the charges when the checkpoint was taken — so the charges standing here already
+    /// include everything the fallback will cost except the compute being authorized. Funding
+    /// compute out of the full payment instead would let a transaction spend the whole of it on
+    /// execution and leave its own fee-intent commit unaffordable, which settles as a rejection
+    /// that collects nothing: the work would be done and never paid for.
+    ///
+    /// The exhaust burn is taken over whatever the charges come to, so the charges themselves can
+    /// only spend the payment net of it.
     pub fn wasm_point_allowance(&self) -> Option<u64> {
         let rate = self.wasm_metering_rate;
         // The credit exists only so a transaction can source its fee before paying. Taking the fee
@@ -151,7 +172,9 @@ impl<TStore: StateReader> StateTracker<TStore> {
             if fee_state.is_dry_run() {
                 return None;
             }
-            let funded = rate.points_funded_by(fee_state.total_payments())?;
+            let unspent = spendable_on_charges(fee_state.total_payments(), fee_state.burn_rate_bps())
+                .saturating_sub(fee_state.total_charges());
+            let funded = rate.points_funded_by(unspent)?;
             if is_fee_intent {
                 Some(funded.saturating_add(limits::FREE_COMPUTE_GRACE_POINTS))
             } else {
@@ -540,6 +563,11 @@ impl<TStore: StateReader> StateTracker<TStore> {
 
     pub fn total_fee_payments(&self) -> u64 {
         self.read_with(|state| state.fee_state().total_payments())
+    }
+
+    /// A copy of the charges metered so far.
+    pub fn fee_charges(&self) -> FeeBreakdown {
+        self.read_with(|state| state.fee_state().fee_charges().clone())
     }
 
     pub fn total_fee_charges(&self) -> u64 {

--- a/crates/engine/src/transaction/processor.rs
+++ b/crates/engine/src/transaction/processor.rs
@@ -246,6 +246,11 @@ where
                 if let Err(err) = runtime.interface_mut().checkpoint_fee_intent() {
                     let mut finalize = FinalizeResult::new_rejected(transaction_hash, err.to_reject_reason(None));
                     finalize.execution_results = execution_results;
+                    // Nothing is taken and nothing is written, but what committing would have cost is
+                    // the number the payer has to raise their fee to.
+                    let metered = runtime.interface().metered_fee_receipt();
+                    finalize.total_fees_required = metered.total_fees_charged();
+                    finalize.fee_receipt = metered;
                     return Ok(ExecuteResult {
                         finalize,
                         execution_time: timer.elapsed(),

--- a/crates/engine/tests/fees.rs
+++ b/crates/engine/tests/fees.rs
@@ -250,6 +250,44 @@ fn a_fee_intent_commit_is_not_charged_for_the_state_it_abandons() {
     );
 }
 
+/// Compute is funded by what the payment has left after the state the transaction falls back to
+/// committing, not by the whole payment.
+///
+/// Funding it from the whole payment let a transaction spend the lot on execution and leave its own
+/// fee-intent commit unaffordable. That settles as a rejection which collects nothing, so the work
+/// was done and never paid for — repeatably, with the same funds each time.
+#[test]
+fn compute_cannot_consume_what_the_fee_intent_commit_needs() {
+    let mut test = TemplateTest::new(CRATE_PATH, vec!["tests/templates/infinity_loop"]);
+    let (account, owner_token, key) = test.create_funded_account();
+    test.enable_fees();
+
+    // A loop that never returns: it runs until the compute allowance stops it, whatever that
+    // allowance is, so the transaction always spends every point it is given.
+    let template = test.get_template_address("InfinityLoopTest");
+    let result = test.execute_expect_commit(
+        test.transaction()
+            .pay_fee_from_component(account, 100_000u64)
+            .call_function(template, "infinity_loop", args![])
+            .build_and_seal(&key),
+        vec![owner_token],
+    );
+
+    // The main intent traps, so only the fee intent commits — and what is left of the payment still
+    // covers it, so the fees are collected.
+    assert!(
+        matches!(result.finalize.result, TransactionResult::AcceptFeeRejectRest(..)),
+        "expected a fee-intent commit, got {:?}",
+        result.finalize.result
+    );
+    let receipt = &result.finalize.fee_receipt;
+    assert!(
+        receipt.total_fees_paid() > 0,
+        "the transaction burned its allowance and paid nothing for it"
+    );
+    assert!(receipt.is_paid_in_full());
+}
+
 /// A fee-intent commit persists real state, so it happens only when the payment covers what that
 /// state costs. When it does not, nothing commits — there is no shallower checkpoint to fall back
 /// to, and committing anyway would be a way to write state for free.
@@ -293,7 +331,7 @@ fn an_unaffordable_fee_intent_commits_nothing() {
     // their fee to, and on a rejection there is nowhere else to read it from.
     let charged = result.finalize.fee_receipt.total_fees_charged();
     assert!(charged > FEE, "expected the metered charges, got {charged}");
-    assert!(result.finalize.fee_receipt.required_fees() > FEE);
+    assert!(result.finalize.required_fees() > FEE);
 
     let balance = test
         .read_only_state_store()
@@ -531,8 +569,9 @@ fn failure_pay_fee_in_main_instructions() {
 
     let reason = test.execute_expect_failure(
         Transaction::builder_localnet(Epoch(1))
-            // Pay in fee intent, enough to pass this step
-            .pay_fee_from_component(account, 100u64)
+            // Pay in the fee intent enough to cover committing it, so the transaction reaches the
+            // main instructions where the violation is.
+            .pay_fee_from_component(account, 2000u64)
             // Call pay_fee in main instructions (outside fee instructions) not permitted
             .call_method(account, "pay_fee", args![100])
             .call_method(account, "balance", args![STEALTH_TARI_RESOURCE_ADDRESS])

--- a/crates/engine_types/src/fees.rs
+++ b/crates/engine_types/src/fees.rs
@@ -151,6 +151,10 @@ impl FeeReceipt {
     /// This is a floor, not a recommendation. Overpayment is returned to the paying vault, so a
     /// caller with a vault to refund to loses nothing by submitting above it — and one paying purely
     /// by stealth reveal, where the overpayment is not refundable, has reason to sit on it.
+    ///
+    /// Reads what this receipt was charged. When only the fee intent committed, that is the fee
+    /// intent's own cost rather than what the transaction needed, so anything telling a caller what
+    /// to resubmit with wants [`crate::commit_result::FinalizeResult::required_fees`] instead.
     pub fn required_fees(&self) -> u64 {
         self.total_fees_charged().saturating_add(FEE_ESTIMATE_ALLOWANCE)
     }

--- a/crates/ootle_sdk_core/src/result.rs
+++ b/crates/ootle_sdk_core/src/result.rs
@@ -208,7 +208,7 @@ fn parse_dry_run_result_value(value: serde_json::Value) -> Result<FinalizedResul
     let wire: WireDryRunResult =
         serde_json::from_value(value).map_err(|e| OotleSdkError::Parse(format!("indexer dry-run result JSON: {e}")))?;
     let mut finalized = finalized_from_execute_result(&wire.result);
-    finalized.estimated_fee = Some(wire.result.finalize.fee_receipt.required_fees());
+    finalized.estimated_fee = Some(wire.result.finalize.required_fees());
     Ok(finalized)
 }
 
@@ -477,7 +477,7 @@ mod tests {
         let exec = execute_result(TransactionResult::Accept(accept_diff()), Some(5));
         // The metered total: Initial(7) + Storage((1<<53)+11) = (1<<53)+18, plus the fee-estimate
         // allowance the engine adds on top.
-        let expected_estimate = exec.finalize.fee_receipt.required_fees();
+        let expected_estimate = exec.finalize.required_fees();
         assert!(expected_estimate > (1u64 << 53) + 18, "the estimate must clear 2^53");
         let json = dry_run_wire_json(exec);
 

--- a/crates/wallet/sdk/src/apis/transaction.rs
+++ b/crates/wallet/sdk/src/apis/transaction.rs
@@ -168,9 +168,7 @@ where
                         warn!(target: LOG_TARGET, "⚠️ Transaction ID mismatch in dry run response. Expected {}, got {}. Updating transaction status to DryRunFailed.", tx_id, query.transaction_id);
                     }
 
-                    let final_fee = execution_result
-                        .as_ref()
-                        .map(|e| e.finalize.fee_receipt.required_fees());
+                    let final_fee = execution_result.as_ref().map(|e| e.finalize.required_fees());
 
                     self.store.with_write_tx(|tx| {
                         tx.transactions_update(


### PR DESCRIPTION
Follow-up to #2417, closing the free-compute consequence its description called out.

## Problem

A transaction that cannot pay for its main intent falls back to committing only its fee intent. Since #2417, a fee intent it cannot afford commits nothing at all — a `Reject` that collects no fees.

Compute was funded by `points_funded_by(total_payments)`: the whole payment, with nothing set aside for that fallback. So a transaction that spent its allowance was **guaranteed** to finish unaffordable — `WasmExecution` alone came to roughly the payment, and the fee intent's own charges on top put the total above it. The work was done and never paid for, repeatably, with the same funds each time.

That made it the ordinary outcome for compute-heavy transactions, not an edge case.

## Fund compute from what is left

```rust
spendable_on_charges(total_payments, burn_rate_bps) - total_charges()
```

The exhaust burn is taken over the charges rather than deducted from the payment, so the charges themselves can only spend the payment net of it.

For `total_charges` to already include what the fallback costs, a new `on_fee_checkpoint` hook prices the checkpoint state *before* `checkpoint_fee_intent` tests what was paid against it. That establishes

```
(C_exec + C_fee_state + W) * (1 + r) <= P
```

so the fee-intent commit is always affordable by the time finalization reaches it. It also closes the gap the #2417 follow-up named: the checkpoint's paid-in-full check no longer sees a zero storage charge.

## Only the fee intent's state is priced this way

The main intent's state is discarded on the fallback path, so reserving it buys no safety. Pricing it as execution proceeds would also gate on peaks that never become charges — substates shrink mid-transaction (`down_utxo`, `down_confidential_output`, falling vault balances), so a transaction whose peak exceeded its final state would be trapped for fees it never owed.

Storage therefore accrues once, at the checkpoint, against the exact state that gets committed on that path.

## Finalization no longer charges a runtime call

The template never invoked `finalize`/`finalize_failure`; they are engine bookkeeping. Charging them landed one microtari *after* the last compute allowance was computed, putting the total past what that allowance was sized to fit inside — the regression test failed by exactly 1 µT until this went.

## Consequences worth reviewing

**Compute-heavy transactions get a smaller allowance.** The payment now has to cover the fee intent's commit as well as the compute, so a given `max_fee` buys slightly less execution than before. That is the point, but it is a real change to what a fee buys.

**A rejection at the checkpoint reports its metered charges** rather than an empty receipt, so the payer can still read what committing would have cost.

**Consumers surfacing a fee to resubmit with now read `FinalizeResult::required_fees`.** `FeeReceipt::required_fees` reports what *that receipt* was charged, which on a fee-intent commit is the fee intent's own cost rather than what the transaction needed. All eight call sites moved.

## Testing

New regression test `compute_cannot_consume_what_the_fee_intent_commit_needs`: an `infinity_loop` call at a 100k fee, which by construction spends every point it is given. Before this change it settled as `Reject` with `total_fees_paid: 0`; now it is `AcceptFeeRejectRest` with `charged == paid == 100_000` exactly.

Two existing tests needed real updates. `failure_pay_fee_in_main_instructions` paid 100 "enough to pass this step", which is no longer true once the checkpoint prices its own commit. `an_unaffordable_fee_intent_commits_nothing` reads the charges off the earlier rejection.

`tari_engine` (`fees`, `compute_fee_budget`, `native_compute_budget`, `metering_budget`, `complex_fee_payment`), `template_builtin`, `engine_types` and `ootle_sdk_core` pass; the workspace typechecks.

## Follow-up

Still outstanding from the #2417 review, in rough priority order: clamp `exhaust_burn_rate_bps` at construction rather than relying on a test; price `emit_log`, which is still flat-rated with `max_logs 256 × 32 KiB` reachable per transaction; tighten `TransactionReceipt::encoded_size_upper_bound`, whose `FeeReceipt::widest()` stand-in makes every transaction pay for up to 256 bytes it does not use; and guard the `new_substates` asymmetry that makes a single-pass storage charge unsound.
