### PR TITLE
fix(engine): fund compute from the payment's unspent balance

### DIFF
--- a/applications/tari_walletd/src/handlers/accounts.rs
+++ b/applications/tari_walletd/src/handlers/accounts.rs
@@ -688,7 +688,7 @@ pub(crate) async fn execute_claim_burn(
     if is_dry_run {
         let transaction_id = transaction.calculate_id();
         let result = transaction_service.submit_dry_run_transaction(transaction).await?;
-        let required_fees = result.finalize.fee_receipt.required_fees();
+        let required_fees = result.finalize.required_fees();
         return Ok(ClaimBurnResponse {
             transaction_id,
             required_fees: Some(required_fees),

--- a/applications/tari_walletd/src/handlers/nfts.rs
+++ b/applications/tari_walletd/src/handlers/nfts.rs
@@ -363,7 +363,7 @@ pub async fn handle_transfer(
             transaction_id,
             // Dry-run callers commonly pass a placeholder max_fee that clamps `total_fees_paid`. Report
             // the uncapped estimate so the response is usable for fee selection.
-            fee: finalize.fee_receipt.required_fees(),
+            fee: finalize.required_fees(),
             fee_refunded: finalize
                 .fee_receipt
                 .total_fee_payment()

--- a/applications/tari_walletd/src/handlers/transaction.rs
+++ b/applications/tari_walletd/src/handlers/transaction.rs
@@ -467,7 +467,7 @@ async fn submit_dry_run_inner(
         .await
         .map_err(map_transaction_submission_error)?;
 
-    let required_fees = exec_result.finalize.fee_receipt.required_fees();
+    let required_fees = exec_result.finalize.required_fees();
     Ok(TransactionSubmitDryRunResponse {
         transaction_id: exec_result.finalize.transaction_hash.into_array().into(),
         required_fees,
@@ -571,7 +571,7 @@ pub async fn handle_submit_manifest(
             )
             .into());
         }
-        let required_fees = exec_result.finalize.fee_receipt.required_fees();
+        let required_fees = exec_result.finalize.required_fees();
         return Ok(TransactionSubmitManifestResponse {
             transaction_id: exec_result.finalize.transaction_hash.into_array().into(),
             required_fees: Some(required_fees),
@@ -792,7 +792,7 @@ pub async fn handle_publish_template(
         }
         return Ok(PublishTemplateResponse {
             transaction_id: resp.transaction_id,
-            dry_run_fee: Some(resp.result.finalize.fee_receipt.required_fees()),
+            dry_run_fee: Some(resp.result.finalize.required_fees()),
         });
     }
     let request = TransactionSubmitRequest {

--- a/applications/tari_walletd/src/handlers/validator.rs
+++ b/applications/tari_walletd/src/handlers/validator.rs
@@ -225,7 +225,7 @@ pub async fn handle_claim_validator_fees(
             fee: transaction
                 .finalize
                 .as_ref()
-                .map(|f| f.fee_receipt.required_fees())
+                .map(|f| f.required_fees())
                 .unwrap_or_default(),
             result: transaction
                 .finalize

--- a/crates/engine/src/fees/fee_module.rs
+++ b/crates/engine/src/fees/fee_module.rs
@@ -47,15 +47,12 @@ impl FeeModule {
         Ok((base_bytes, charge))
     }
 
-    /// Charges everything that is a function of the state being persisted, rather than of the work
-    /// done to produce it: storage, the template-publish premium, substate slots, the metering of
-    /// WASM and native execution, and the exhaust burn over the resulting total.
+    /// Charges everything that is a function of the state being persisted: the per-byte storage
+    /// tally, the template-publish premium and the per-substate creation premium.
     ///
-    /// Every charge here is *assigned*, not accumulated, so that running this again against a
-    /// different state replaces the result rather than doubling it. That is what lets a transaction
-    /// be gated on the cost of the state it asked to commit and then billed for the state that is
-    /// actually persisted — see [`RuntimeModule::on_before_persist`].
-    fn charge_finalization_fees<TStore: StateReader>(
+    /// Assigned rather than accumulated, so running it again over a different state replaces the
+    /// result instead of doubling it — see [`RuntimeModule::on_before_persist`].
+    fn charge_state_fees<TStore: StateReader>(
         &self,
         state: &mut ChargeableState<'_, TStore>,
     ) -> Result<(), RuntimeModuleError> {
@@ -120,6 +117,27 @@ impl FeeModule {
             .checked_mul(self.fee_table.per_substate_create_cost())
             .ok_or_else(|| RuntimeModuleError::Overflow("Overflow calculating substate create cost".to_string()))?;
 
+        let fee_state = state.fee_state_mut();
+        fee_state.set_charge(FeeSource::Storage, storage_cost);
+        fee_state.set_charge(FeeSource::TemplatePublish, template_publish_cost);
+        fee_state.set_charge(FeeSource::SubstateCreate, create_cost);
+
+        Ok(())
+    }
+
+    /// Charges everything that is a function of the state being persisted, plus the metering of WASM
+    /// and native execution and the exhaust burn over the resulting total.
+    ///
+    /// Every charge here is *assigned*, not accumulated, so that running this again against a
+    /// different state replaces the result rather than doubling it. That is what lets a transaction
+    /// be gated on the cost of the state it asked to commit and then billed for the state that is
+    /// actually persisted — see [`RuntimeModule::on_before_persist`].
+    fn charge_finalization_fees<TStore: StateReader>(
+        &self,
+        state: &mut ChargeableState<'_, TStore>,
+    ) -> Result<(), RuntimeModuleError> {
+        self.charge_state_fees(state)?;
+
         // WASM execution: charge once against the transaction's accumulated points so the divisor
         // rounds against the total. Per-call rounding would let a transaction split work into
         // sub-divisor chunks and pay zero for any single one (each `points/divisor` is `0`), even
@@ -137,9 +155,6 @@ impl FeeModule {
             .ok_or_else(|| RuntimeModuleError::Overflow("Overflow calculating native execution cost".to_string()))?;
 
         let fee_state = state.fee_state_mut();
-        fee_state.set_charge(FeeSource::Storage, storage_cost);
-        fee_state.set_charge(FeeSource::TemplatePublish, template_publish_cost);
-        fee_state.set_charge(FeeSource::SubstateCreate, create_cost);
         fee_state.set_charge(FeeSource::WasmExecution, wasm_cost);
         fee_state.set_charge(FeeSource::NativeExecution, native_cost);
 
@@ -218,6 +233,12 @@ impl<TStore: StateReader> RuntimeModule<TStore> for FeeModule {
 
     fn on_before_finalize(&self, track: &mut StateTracker<TStore>) -> Result<(), RuntimeModuleError> {
         self.charge_finalization_fees(&mut track.chargeable_state())
+    }
+
+    fn on_fee_checkpoint(&self, state: &mut ChargeableState<'_, TStore>) -> Result<(), RuntimeModuleError> {
+        // Only the state-derived charges. Execution metering is charged once at finalization, over
+        // the whole transaction's accumulated points, so pricing it here would be replaced anyway.
+        self.charge_state_fees(state)
     }
 
     fn on_before_persist(&self, state: &mut ChargeableState<'_, TStore>) -> Result<(), RuntimeModuleError> {

--- a/crates/engine/src/runtime/fee_state.rs
+++ b/crates/engine/src/runtime/fee_state.rs
@@ -115,6 +115,10 @@ impl FeeState {
         self.accumulated_native_points
     }
 
+    pub fn fee_charges(&self) -> &FeeBreakdown {
+        &self.fee_charges
+    }
+
     pub fn take_fee_charges(&mut self) -> FeeBreakdown {
         std::mem::take(&mut self.fee_charges)
     }

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -3483,16 +3483,24 @@ where
             .build()
     }
 
+    fn required_fee_payment(&self) -> u64 {
+        self.tracker.required_fee_payment()
+    }
+
     fn checkpoint_fee_intent(&mut self) -> Result<(), RuntimeError> {
         // Price the state the fee intent ended on before testing what was paid against it. This is
         // the state a transaction that cannot afford its main intent falls back to committing, so a
         // payment that cannot cover it cannot commit anything at all — better established here,
         // before the main instructions run, than after they have consumed compute nobody pays for.
         self.invoke_modules_on_fee_checkpoint()?;
-        if !self.tracker.is_fee_state_dry_run() && self.tracker.total_fee_payments() < self.tracker.total_fee_charges()
+        // Against what the payment can spend on charges, not against the payment itself: the burn is
+        // taken over whatever the charges come to, so a payment that exactly matches them cannot
+        // also cover the burn on top.
+        if !self.tracker.is_fee_state_dry_run() &&
+            self.tracker.spendable_fee_payments() < self.tracker.total_fee_charges()
         {
             return Err(RuntimeError::InsufficientFeesPaid {
-                required_fee: self.tracker.total_fee_charges(),
+                required_fee: self.tracker.required_fee_payment(),
                 fees_paid: self.tracker.total_fee_payments(),
             });
         }

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -36,6 +36,7 @@ use tari_engine_types::{
     crypto::OutputBody,
     entity_id_provider::EntityIdProvider,
     events::Event,
+    fees::FeeReceipt,
     hashing::hash_template_code,
     indexed_value::IndexedValue,
     instruction_result::InstructionResult,
@@ -298,6 +299,13 @@ impl<TStore: StateReader + Clone + 'static, TTemplateProvider: TemplateProvider<
             self.invoke_modules_on_before_persist(&mut finalized)?;
         }
         self.tracker.finalize(finalized)
+    }
+
+    fn invoke_modules_on_fee_checkpoint(&mut self) -> Result<(), RuntimeError> {
+        for module in self.modules.iter() {
+            module.on_fee_checkpoint(&mut self.tracker.chargeable_state())?;
+        }
+        Ok(())
     }
 
     fn invoke_modules_on_before_persist(&mut self, finalized: &mut FinalizedState<TStore>) -> Result<(), RuntimeError> {
@@ -3469,7 +3477,18 @@ where
         })
     }
 
+    fn metered_fee_receipt(&self) -> FeeReceipt {
+        FeeReceipt::builder()
+            .with_cost_breakdown(self.tracker.fee_charges())
+            .build()
+    }
+
     fn checkpoint_fee_intent(&mut self) -> Result<(), RuntimeError> {
+        // Price the state the fee intent ended on before testing what was paid against it. This is
+        // the state a transaction that cannot afford its main intent falls back to committing, so a
+        // payment that cannot cover it cannot commit anything at all — better established here,
+        // before the main instructions run, than after they have consumed compute nobody pays for.
+        self.invoke_modules_on_fee_checkpoint()?;
         if !self.tracker.is_fee_state_dry_run() && self.tracker.total_fee_payments() < self.tracker.total_fee_charges()
         {
             return Err(RuntimeError::InsufficientFeesPaid {
@@ -3481,12 +3500,13 @@ where
     }
 
     fn finalize(&mut self) -> Result<FinalizeResult, RuntimeError> {
-        self.invoke_modules_on_runtime_call("finalize")?;
+        // Finalization adds no fee charge of its own. The template never invoked it, and the compute
+        // allowance is sized against the charges standing when it is computed, so anything charged
+        // afterwards puts the total past what that allowance was sized to fit inside.
         self.finalize_with(None)
     }
 
     fn finalize_failure(&mut self, reason: RejectReason) -> Result<FinalizeResult, RuntimeError> {
-        self.invoke_modules_on_runtime_call("finalize_failure")?;
         self.finalize_with(Some(reason))
     }
 

--- a/crates/engine/src/runtime/mod.rs
+++ b/crates/engine/src/runtime/mod.rs
@@ -60,6 +60,7 @@ use tari_engine_types::{
     commit_result::{FinalizeResult, RejectReason},
     component::Component,
     confidential::{ClaimBurnOutputData, MinotariBurnClaimProof},
+    fees::FeeReceipt,
     indexed_value::IndexedValue,
     lock::LockFlag,
     published_template::TemplateBlob,
@@ -270,6 +271,11 @@ pub trait RuntimeInterface {
     /// [`Self::wasm_points_consumed`] when capping a call's payment-funded allowance; excluded
     /// from the WASM-only per-transaction hard cap.
     fn native_points_consumed(&self) -> u64;
+
+    /// The charges metered so far, as a receipt against no payment. A transaction rejected before
+    /// finalization never settles a receipt of its own, so this is the only place the payer can read
+    /// what it would have cost.
+    fn metered_fee_receipt(&self) -> FeeReceipt;
 
     /// The maximum Wasmer metering points the transaction may consume given the fees paid so far,
     /// used by `WasmProcess::invoke` to cap each call's allowance so unpaid compute cannot exceed

--- a/crates/engine/src/runtime/mod.rs
+++ b/crates/engine/src/runtime/mod.rs
@@ -277,6 +277,10 @@ pub trait RuntimeInterface {
     /// what it would have cost.
     fn metered_fee_receipt(&self) -> FeeReceipt;
 
+    /// The payment those charges require, inclusive of the exhaust burn taken over them — the figure
+    /// a rejected payer has to raise their fee to.
+    fn required_fee_payment(&self) -> u64;
+
     /// The maximum Wasmer metering points the transaction may consume given the fees paid so far,
     /// used by `WasmProcess::invoke` to cap each call's allowance so unpaid compute cannot exceed
     /// the grace. `None` means no payment-funded bound applies (only the per-transaction hard cap).

--- a/crates/engine/src/runtime/module.rs
+++ b/crates/engine/src/runtime/module.rs
@@ -32,6 +32,14 @@ pub trait RuntimeModule<TStore>: Send + Sync {
         Ok(())
     }
 
+    /// Invoked when the fee intent is checkpointed, against the state it ended on — which is the
+    /// state a transaction that cannot pay for its main intent will fall back to committing.
+    /// Pricing it here is what lets the paid-in-full check that follows, and the compute allowance
+    /// that follows it, both account for what that fallback costs.
+    fn on_fee_checkpoint(&self, _state: &mut ChargeableState<'_, TStore>) -> Result<(), RuntimeModuleError> {
+        Ok(())
+    }
+
     /// Invoked at the start of finalization, against the working state — before it is known
     /// whether the transaction commits or falls back to a fee-intent commit. Charges added here
     /// decide that outcome: they are what the paid-in-full check sees.

--- a/crates/engine/src/runtime/module.rs
+++ b/crates/engine/src/runtime/module.rs
@@ -36,6 +36,12 @@ pub trait RuntimeModule<TStore>: Send + Sync {
     /// state a transaction that cannot pay for its main intent will fall back to committing.
     /// Pricing it here is what lets the paid-in-full check that follows, and the compute allowance
     /// that follows it, both account for what that fallback costs.
+    ///
+    /// It bounds the shortfall rather than eliminating it. Charges the main intent accrues after the
+    /// last allowance was computed — a template load, the host calls made inside the final
+    /// invocation — are not reserved against, so a payment sitting just above what the checkpoint
+    /// required can still fall short by that much at finalization. Closing the remainder means
+    /// refusing a charge that the payment cannot cover, at the point it is charged.
     fn on_fee_checkpoint(&self, _state: &mut ChargeableState<'_, TStore>) -> Result<(), RuntimeModuleError> {
         Ok(())
     }

--- a/crates/engine/src/runtime/tracker.rs
+++ b/crates/engine/src/runtime/tracker.rs
@@ -69,7 +69,14 @@ const LOG_TARGET: &str = "tari::ootle::engine::runtime::state_tracker";
 /// `P` covers charges of at most `P / (1 + rate)`. Rounds down, so the figure never over-states what
 /// is available.
 fn spendable_on_charges(payments: u64, burn_rate_bps: u16) -> u64 {
-    let scaled = u128::from(payments) * 10_000 / (10_000 + u128::from(burn_rate_bps));
+    // Never exceeds `payments`, so the cast back is lossless.
+    (u128::from(payments) * 10_000 / (10_000 + u128::from(burn_rate_bps))) as u64
+}
+
+/// The payment that `charges` require, inclusive of the exhaust burn taken over them. The inverse of
+/// [`spendable_on_charges`], rounded up so the figure always covers rather than just reaching.
+fn payment_covering_charges(charges: u64, burn_rate_bps: u16) -> u64 {
+    let scaled = (u128::from(charges) * (10_000 + u128::from(burn_rate_bps))).div_ceil(10_000);
     u64::try_from(scaled).unwrap_or(u64::MAX)
 }
 
@@ -155,10 +162,14 @@ impl<TStore: StateReader> StateTracker<TStore> {
     /// Compute is funded by what the payment has *left*, not by the whole of it. A transaction that
     /// cannot pay for the state it commits commits only its fee intent, and that state was priced
     /// onto the charges when the checkpoint was taken — so the charges standing here already
-    /// include everything the fallback will cost except the compute being authorized. Funding
-    /// compute out of the full payment instead would let a transaction spend the whole of it on
-    /// execution and leave its own fee-intent commit unaffordable, which settles as a rejection
-    /// that collects nothing: the work would be done and never paid for.
+    /// include what the fallback costs, bar the compute being authorized. Funding compute out of the
+    /// full payment instead would let a transaction spend the whole of it on execution and leave its
+    /// own fee-intent commit unaffordable, which settles as a rejection that collects nothing: the
+    /// work would be done and never paid for.
+    ///
+    /// This is measured against the charges *standing when it is asked*. Anything charged after the
+    /// last call — a host call inside the final invocation — is outside the figure, so it bounds the
+    /// unpaid work rather than reducing it to zero.
     ///
     /// The exhaust burn is taken over whatever the charges come to, so the charges themselves can
     /// only spend the payment net of it.
@@ -563,6 +574,25 @@ impl<TStore: StateReader> StateTracker<TStore> {
 
     pub fn total_fee_payments(&self) -> u64 {
         self.read_with(|state| state.fee_state().total_payments())
+    }
+
+    /// What the fee payments can still cover once the exhaust burn taken over the charges is set
+    /// aside. Charges are compared against this rather than against the raw payment, since the burn
+    /// is charged on top of them rather than deducted from what was paid.
+    pub fn spendable_fee_payments(&self) -> u64 {
+        self.read_with(|state| {
+            let fee_state = state.fee_state();
+            spendable_on_charges(fee_state.total_payments(), fee_state.burn_rate_bps())
+        })
+    }
+
+    /// The payment the charges metered so far require, inclusive of the exhaust burn taken over them.
+    /// This is the figure a rejected payer has to raise their fee to.
+    pub fn required_fee_payment(&self) -> u64 {
+        self.read_with(|state| {
+            let fee_state = state.fee_state();
+            payment_covering_charges(fee_state.total_charges(), fee_state.burn_rate_bps())
+        })
     }
 
     /// A copy of the charges metered so far.

--- a/crates/engine/src/runtime/tracker.rs
+++ b/crates/engine/src/runtime/tracker.rs
@@ -25,7 +25,7 @@ use tari_engine_types::{
     commit_result::{FinalizeResult, RejectReason, TransactionResult},
     component::{Component, ComponentBody, ComponentHeader},
     events::Event,
-    fees::{FeeReceipt, FeeSource},
+    fees::{FeeBreakdown, FeeReceipt, FeeSource},
     indexed_value::{IndexedValue, IndexedWellKnownTypes},
     limits,
     lock::LockFlag,
@@ -62,6 +62,16 @@ use crate::{
 };
 
 const LOG_TARGET: &str = "tari::ootle::engine::runtime::state_tracker";
+
+/// The part of a fee payment that charges can actually consume.
+///
+/// The exhaust burn is taken over the charges rather than deducted from the payment, so a payment of
+/// `P` covers charges of at most `P / (1 + rate)`. Rounds down, so the figure never over-states what
+/// is available.
+fn spendable_on_charges(payments: u64, burn_rate_bps: u16) -> u64 {
+    let scaled = u128::from(payments) * 10_000 / (10_000 + u128::from(burn_rate_bps));
+    u64::try_from(scaled).unwrap_or(u64::MAX)
+}
 
 /// The state finalization will persist, detached from the tracker and awaiting fee settlement.
 #[derive(Debug)]
@@ -141,6 +151,17 @@ impl<TStore: StateReader> StateTracker<TStore> {
     /// instructions before it pays, while a transaction that never pays cannot consume more than the
     /// grace. Past the fee checkpoint the credit no longer applies: the transaction has paid what its
     /// fee intent charged, and the compute it may still run is funded by that payment alone.
+    ///
+    /// Compute is funded by what the payment has *left*, not by the whole of it. A transaction that
+    /// cannot pay for the state it commits commits only its fee intent, and that state was priced
+    /// onto the charges when the checkpoint was taken — so the charges standing here already
+    /// include everything the fallback will cost except the compute being authorized. Funding
+    /// compute out of the full payment instead would let a transaction spend the whole of it on
+    /// execution and leave its own fee-intent commit unaffordable, which settles as a rejection
+    /// that collects nothing: the work would be done and never paid for.
+    ///
+    /// The exhaust burn is taken over whatever the charges come to, so the charges themselves can
+    /// only spend the payment net of it.
     pub fn wasm_point_allowance(&self) -> Option<u64> {
         let rate = self.wasm_metering_rate;
         // The credit exists only so a transaction can source its fee before paying. Taking the fee
@@ -151,7 +172,9 @@ impl<TStore: StateReader> StateTracker<TStore> {
             if fee_state.is_dry_run() {
                 return None;
             }
-            let funded = rate.points_funded_by(fee_state.total_payments())?;
+            let unspent = spendable_on_charges(fee_state.total_payments(), fee_state.burn_rate_bps())
+                .saturating_sub(fee_state.total_charges());
+            let funded = rate.points_funded_by(unspent)?;
             if is_fee_intent {
                 Some(funded.saturating_add(limits::FREE_COMPUTE_GRACE_POINTS))
             } else {
@@ -540,6 +563,11 @@ impl<TStore: StateReader> StateTracker<TStore> {
 
     pub fn total_fee_payments(&self) -> u64 {
         self.read_with(|state| state.fee_state().total_payments())
+    }
+
+    /// A copy of the charges metered so far.
+    pub fn fee_charges(&self) -> FeeBreakdown {
+        self.read_with(|state| state.fee_state().fee_charges().clone())
     }
 
     pub fn total_fee_charges(&self) -> u64 {

--- a/crates/engine/src/transaction/processor.rs
+++ b/crates/engine/src/transaction/processor.rs
@@ -246,11 +246,11 @@ where
                 if let Err(err) = runtime.interface_mut().checkpoint_fee_intent() {
                     let mut finalize = FinalizeResult::new_rejected(transaction_hash, err.to_reject_reason(None));
                     finalize.execution_results = execution_results;
-                    // Nothing is taken and nothing is written, but what committing would have cost is
-                    // the number the payer has to raise their fee to.
-                    let metered = runtime.interface().metered_fee_receipt();
-                    finalize.total_fees_required = metered.total_fees_charged();
-                    finalize.fee_receipt = metered;
+                    // Nothing is taken and nothing is written, but what committing would have cost
+                    // is the number the payer has to raise their fee to.
+                    let required = runtime.interface().required_fee_payment();
+                    finalize.fee_receipt = runtime.interface().metered_fee_receipt();
+                    finalize = finalize.with_total_fees_required(required);
                     return Ok(ExecuteResult {
                         finalize,
                         execution_time: timer.elapsed(),
@@ -268,8 +268,11 @@ where
                     transaction_hash,
                     err
                 );
+                let required = runtime.interface().required_fee_payment();
+                let mut finalize = FinalizeResult::new_rejected(transaction_hash, err.to_reject_reason());
+                finalize.fee_receipt = runtime.interface().metered_fee_receipt();
                 return Ok(ExecuteResult {
-                    finalize: FinalizeResult::new_rejected(transaction_hash, err.to_reject_reason()),
+                    finalize: finalize.with_total_fees_required(required),
                     execution_time: timer.elapsed(),
                     execute_epoch: execute_epoch.map(Into::into),
                     wasm_execution_points: runtime.interface().wasm_points_consumed(),

--- a/crates/engine/src/transaction/processor.rs
+++ b/crates/engine/src/transaction/processor.rs
@@ -246,6 +246,11 @@ where
                 if let Err(err) = runtime.interface_mut().checkpoint_fee_intent() {
                     let mut finalize = FinalizeResult::new_rejected(transaction_hash, err.to_reject_reason(None));
                     finalize.execution_results = execution_results;
+                    // Nothing is taken and nothing is written, but what committing would have cost is
+                    // the number the payer has to raise their fee to.
+                    let metered = runtime.interface().metered_fee_receipt();
+                    finalize.total_fees_required = metered.total_fees_charged();
+                    finalize.fee_receipt = metered;
                     return Ok(ExecuteResult {
                         finalize,
                         execution_time: timer.elapsed(),

--- a/crates/engine/tests/fees.rs
+++ b/crates/engine/tests/fees.rs
@@ -258,16 +258,28 @@ fn a_fee_intent_commit_is_not_charged_for_the_state_it_abandons() {
 /// was done and never paid for — repeatably, with the same funds each time.
 #[test]
 fn compute_cannot_consume_what_the_fee_intent_commit_needs() {
+    for burn_rate_bps in [0, 500, 10_000] {
+        spend_the_whole_allowance_and_still_pay(burn_rate_bps);
+    }
+}
+
+fn spend_the_whole_allowance_and_still_pay(burn_rate_bps: u16) {
+    const MAX_FEE: u64 = 100_000;
+
     let mut test = TemplateTest::new(CRATE_PATH, vec!["tests/templates/infinity_loop"]);
     let (account, owner_token, key) = test.create_funded_account();
     test.enable_fees();
+
+    // Run at a burn too, since the burn is taken over the charges rather than deducted from the
+    // payment: an allowance computed against the raw payment leaves nothing to pay it with.
+    test.set_burn_rate_bps(burn_rate_bps);
 
     // A loop that never returns: it runs until the compute allowance stops it, whatever that
     // allowance is, so the transaction always spends every point it is given.
     let template = test.get_template_address("InfinityLoopTest");
     let result = test.execute_expect_commit(
         test.transaction()
-            .pay_fee_from_component(account, 100_000u64)
+            .pay_fee_from_component(account, MAX_FEE)
             .call_function(template, "infinity_loop", args![])
             .build_and_seal(&key),
         vec![owner_token],
@@ -277,15 +289,24 @@ fn compute_cannot_consume_what_the_fee_intent_commit_needs() {
     // covers it, so the fees are collected.
     assert!(
         matches!(result.finalize.result, TransactionResult::AcceptFeeRejectRest(..)),
-        "expected a fee-intent commit, got {:?}",
+        "expected a fee-intent commit at {burn_rate_bps} bps, got {:?}",
         result.finalize.result
     );
     let receipt = &result.finalize.fee_receipt;
-    assert!(
-        receipt.total_fees_paid() > 0,
-        "the transaction burned its allowance and paid nothing for it"
+    assert!(receipt.is_paid_in_full(), "at {burn_rate_bps} bps");
+    assert_eq!(
+        receipt.total_fees_charged(),
+        receipt.total_fees_paid(),
+        "at {burn_rate_bps} bps the transaction should spend the payment down to the microtari"
     );
-    assert!(receipt.is_paid_in_full());
+    // The burn's rounding leaves a few microtari of the payment unspent, so this is "nearly all of
+    // it" rather than exactly all: what matters is that the allowance is sized against the payment
+    // and not beyond it.
+    assert!(
+        receipt.total_fees_paid() > MAX_FEE - 100,
+        "at {burn_rate_bps} bps only {} of {MAX_FEE} was spent",
+        receipt.total_fees_paid()
+    );
 }
 
 /// A fee-intent commit persists real state, so it happens only when the payment covers what that

--- a/crates/engine/tests/fees.rs
+++ b/crates/engine/tests/fees.rs
@@ -250,6 +250,44 @@ fn a_fee_intent_commit_is_not_charged_for_the_state_it_abandons() {
     );
 }
 
+/// Compute is funded by what the payment has left after the state the transaction falls back to
+/// committing, not by the whole payment.
+///
+/// Funding it from the whole payment let a transaction spend the lot on execution and leave its own
+/// fee-intent commit unaffordable. That settles as a rejection which collects nothing, so the work
+/// was done and never paid for — repeatably, with the same funds each time.
+#[test]
+fn compute_cannot_consume_what_the_fee_intent_commit_needs() {
+    let mut test = TemplateTest::new(CRATE_PATH, vec!["tests/templates/infinity_loop"]);
+    let (account, owner_token, key) = test.create_funded_account();
+    test.enable_fees();
+
+    // A loop that never returns: it runs until the compute allowance stops it, whatever that
+    // allowance is, so the transaction always spends every point it is given.
+    let template = test.get_template_address("InfinityLoopTest");
+    let result = test.execute_expect_commit(
+        test.transaction()
+            .pay_fee_from_component(account, 100_000u64)
+            .call_function(template, "infinity_loop", args![])
+            .build_and_seal(&key),
+        vec![owner_token],
+    );
+
+    // The main intent traps, so only the fee intent commits — and what is left of the payment still
+    // covers it, so the fees are collected.
+    assert!(
+        matches!(result.finalize.result, TransactionResult::AcceptFeeRejectRest(..)),
+        "expected a fee-intent commit, got {:?}",
+        result.finalize.result
+    );
+    let receipt = &result.finalize.fee_receipt;
+    assert!(
+        receipt.total_fees_paid() > 0,
+        "the transaction burned its allowance and paid nothing for it"
+    );
+    assert!(receipt.is_paid_in_full());
+}
+
 /// A fee-intent commit persists real state, so it happens only when the payment covers what that
 /// state costs. When it does not, nothing commits — there is no shallower checkpoint to fall back
 /// to, and committing anyway would be a way to write state for free.
@@ -293,7 +331,7 @@ fn an_unaffordable_fee_intent_commits_nothing() {
     // their fee to, and on a rejection there is nowhere else to read it from.
     let charged = result.finalize.fee_receipt.total_fees_charged();
     assert!(charged > FEE, "expected the metered charges, got {charged}");
-    assert!(result.finalize.fee_receipt.required_fees() > FEE);
+    assert!(result.finalize.required_fees() > FEE);
 
     let balance = test
         .read_only_state_store()
@@ -531,8 +569,9 @@ fn failure_pay_fee_in_main_instructions() {
 
     let reason = test.execute_expect_failure(
         Transaction::builder_localnet(Epoch(1))
-            // Pay in fee intent, enough to pass this step
-            .pay_fee_from_component(account, 100u64)
+            // Pay in the fee intent enough to cover committing it, so the transaction reaches the
+            // main instructions where the violation is.
+            .pay_fee_from_component(account, 2000u64)
             // Call pay_fee in main instructions (outside fee instructions) not permitted
             .call_method(account, "pay_fee", args![100])
             .call_method(account, "balance", args![STEALTH_TARI_RESOURCE_ADDRESS])

--- a/crates/engine/tests/test.rs
+++ b/crates/engine/tests/test.rs
@@ -111,12 +111,7 @@ fn test_state() {
 
     // constructor
     let component_address1: ComponentAddress = template_test.call_function("State", "new", args![], vec![]);
-    template_test.assert_calls(&[
-        "workspace_invoke",
-        "component_invoke",
-        "set_last_instruction_output",
-        "finalize",
-    ]);
+    template_test.assert_calls(&["workspace_invoke", "component_invoke", "set_last_instruction_output"]);
 
     let component_address2: ComponentAddress = template_test.call_function("State", "new", args![], vec![]);
     assert_ne!(component_address1, component_address2);

--- a/crates/engine_types/src/commit_result.rs
+++ b/crates/engine_types/src/commit_result.rs
@@ -222,8 +222,14 @@ impl FinalizeResult {
     }
 
     /// The minimum `max_fee` a resubmission of this transaction has to carry.
+    ///
+    /// Falls back to what the receipt was charged. `total_fees_required` is additive on the wire, so
+    /// a payload from a peer that predates it decodes as zero — reading it raw would answer a fee
+    /// estimate with the allowance alone.
     pub fn required_fees(&self) -> u64 {
-        self.total_fees_required.saturating_add(FEE_ESTIMATE_ALLOWANCE)
+        self.total_fees_required
+            .max(self.fee_receipt.total_fees_charged())
+            .saturating_add(FEE_ESTIMATE_ALLOWANCE)
     }
 
     pub fn new_rejected(transaction_hash: Hash32, reason: RejectReason) -> Self {
@@ -548,5 +554,41 @@ impl From<&RejectReason> for AbortReason {
             RejectReason::InsufficientFeesPaid(_) => Self::InsufficientFeesPaid,
             RejectReason::FeePaymentInMainIntent => Self::FeePaymentInMainIntent,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tari_template_lib::types::Hash32;
+
+    use super::*;
+    use crate::fees::{FeeBreakdown, FeeSource};
+
+    fn result_charged(amount: u64) -> FinalizeResult {
+        let mut breakdown = FeeBreakdown::default();
+        breakdown.add(FeeSource::Storage, amount);
+        FinalizeResult::new(
+            Hash32::from_array([0u8; Hash32::LENGTH]),
+            vec![],
+            vec![],
+            TransactionResult::Reject(RejectReason::ExecutionFailure("failed".to_string())),
+            FeeReceipt::builder().with_cost_breakdown(breakdown).build(),
+        )
+    }
+
+    /// `total_fees_required` is additive on the wire, so a payload from a peer that predates it
+    /// decodes as zero. An estimate built from it must still clear what the transaction cost.
+    #[test]
+    fn a_missing_required_total_falls_back_to_what_was_charged() {
+        let mut result = result_charged(5_000);
+        result.total_fees_required = 0;
+        assert!(result.required_fees() > 5_000);
+    }
+
+    /// When the two differ, the gating figure is the one a resubmission has to clear.
+    #[test]
+    fn required_fees_reports_the_larger_of_the_two() {
+        let result = result_charged(400).with_total_fees_required(9_000);
+        assert!(result.required_fees() > 9_000);
     }
 }

--- a/crates/engine_types/src/fees.rs
+++ b/crates/engine_types/src/fees.rs
@@ -151,6 +151,10 @@ impl FeeReceipt {
     /// This is a floor, not a recommendation. Overpayment is returned to the paying vault, so a
     /// caller with a vault to refund to loses nothing by submitting above it — and one paying purely
     /// by stealth reveal, where the overpayment is not refundable, has reason to sit on it.
+    ///
+    /// Reads what this receipt was charged. When only the fee intent committed, that is the fee
+    /// intent's own cost rather than what the transaction needed, so anything telling a caller what
+    /// to resubmit with wants [`crate::commit_result::FinalizeResult::required_fees`] instead.
     pub fn required_fees(&self) -> u64 {
         self.total_fees_charged().saturating_add(FEE_ESTIMATE_ALLOWANCE)
     }

--- a/crates/ootle_sdk_core/src/result.rs
+++ b/crates/ootle_sdk_core/src/result.rs
@@ -208,7 +208,7 @@ fn parse_dry_run_result_value(value: serde_json::Value) -> Result<FinalizedResul
     let wire: WireDryRunResult =
         serde_json::from_value(value).map_err(|e| OotleSdkError::Parse(format!("indexer dry-run result JSON: {e}")))?;
     let mut finalized = finalized_from_execute_result(&wire.result);
-    finalized.estimated_fee = Some(wire.result.finalize.fee_receipt.required_fees());
+    finalized.estimated_fee = Some(wire.result.finalize.required_fees());
     Ok(finalized)
 }
 
@@ -477,7 +477,7 @@ mod tests {
         let exec = execute_result(TransactionResult::Accept(accept_diff()), Some(5));
         // The metered total: Initial(7) + Storage((1<<53)+11) = (1<<53)+18, plus the fee-estimate
         // allowance the engine adds on top.
-        let expected_estimate = exec.finalize.fee_receipt.required_fees();
+        let expected_estimate = exec.finalize.required_fees();
         assert!(expected_estimate > (1u64 << 53) + 18, "the estimate must clear 2^53");
         let json = dry_run_wire_json(exec);
 

--- a/crates/wallet/sdk/src/apis/transaction.rs
+++ b/crates/wallet/sdk/src/apis/transaction.rs
@@ -168,9 +168,7 @@ where
                         warn!(target: LOG_TARGET, "⚠️ Transaction ID mismatch in dry run response. Expected {}, got {}. Updating transaction status to DryRunFailed.", tx_id, query.transaction_id);
                     }
 
-                    let final_fee = execution_result
-                        .as_ref()
-                        .map(|e| e.finalize.fee_receipt.required_fees());
+                    let final_fee = execution_result.as_ref().map(|e| e.finalize.required_fees());
 
                     self.store.with_write_tx(|tx| {
                         tx.transactions_update(

--- a/docs/developer-docs/src/content/docs/guides/resources.mdx
+++ b/docs/developer-docs/src/content/docs/guides/resources.mdx
@@ -23,7 +23,7 @@ Resources are digital assets on the Tari blockchain. There are four resource typ
 - **Public Fungible:** Interchangeable assets where each unit is identical (e.g., tokens). These resources are not private and can be viewed by anyone on the blockchain in the same way as Bitcoin, Ethereum etc.
 - **Public Non-Fungible:** Unique assets where each unit has distinct properties (e.g., NFTs). These resources are not private and can be viewed by anyone on the blockchain.
 - **Confidential:** Tokens can be transferred in confidential outputs. These outputs are stored within vaults, and therefore only hide the amounts i.e. everyone can see this vault holds some amount of a resource, but the actual amount is hidden.
-- **Stealth:** Tokens can be transferred in confidential UTXOs. The native tTARI token is an example of a stealth resource. Stealth resources provide enhanced privacy for asset holdings. Learn more about stealth resources in the <a href={basePath("/guides/stealth-resources/")}>Stealth Resources guide</a>.
+- **Stealth:** Tokens can be transferred in confidential UTXOs. The native TARI token is an example of a stealth resource. Stealth resources provide enhanced privacy for asset holdings. Learn more about stealth resources in the <a href={basePath("/guides/stealth-resources/")}>Stealth Resources guide</a>.
 
 #### Creating Fungible Resources
 

--- a/docs/developer-docs/src/content/docs/guides/transaction-overview.mdx
+++ b/docs/developer-docs/src/content/docs/guides/transaction-overview.mdx
@@ -75,9 +75,11 @@ The workspace is not persisted — it disappears when the transaction finishes.
 
 ## Fees
 
-Every transaction must pay fees to validators. Fee instructions are a separate sequence that runs **before** the main instructions. They lock up a maximum amount of tTARI (the native token) from a specified account or bucket.
+Every transaction must pay fees to validators. Fee instructions are a separate sequence that runs **before** the main instructions. They lock up a maximum amount of TARI (the native token) from a specified account or bucket.
 
 After execution, any unused portion of the locked fees is refunded. If the main instructions fail, a partial fee is still charged for the work done by validators up to that point.
+
+For the full picture — what each stage charges, which checks gate it, and how to estimate a fee — see the [Fees reference](/reference/fees/).
 
 ---
 

--- a/docs/developer-docs/src/content/docs/reference/fees.mdx
+++ b/docs/developer-docs/src/content/docs/reference/fees.mdx
@@ -1,0 +1,395 @@
+---
+title: Fees
+description: How the Ootle engine charges a transaction — the fee intent, the fee checkpoint, the main intent, finalisation, and every rule and check applied along the way.
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+Every transaction pays validators for the work it causes: bytes written to permanent state, compute
+executed, cryptography verified, and the bandwidth its own body consumes. Fees are always paid in
+**TARI**, and every amount on this page is in **microtari (µT)** — 1 TARI = 1,000,000 µT.
+
+A transaction is executed in two halves. The **fee intent** (the `fee_instructions`) runs first and
+its only job is to source and hand over a payment. The **main intent** (the `instructions`) runs
+second and does the actual work. Between them sits the **fee checkpoint**, which is both a gate and a
+savepoint: if the main intent later fails, the transaction falls back to the state the fee intent
+ended on, and the validator is still paid for the work it did.
+
+---
+
+## The lifecycle of a fee
+
+<svg viewBox="0 0 860 1000" xmlns="http://www.w3.org/2000/svg" style="max-width:860px;width:100%;font-family:system-ui,sans-serif">
+  {/* Background */}
+  <rect width="860" height="1000" rx="12" fill="#0d1117"/>
+
+  <defs>
+    <marker id="feeArrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#484f58"/>
+    </marker>
+    <marker id="feeArrowRed" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#f85149"/>
+    </marker>
+    <marker id="feeArrowGreen" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#3fb950"/>
+    </marker>
+  </defs>
+
+  <text x="430" y="34" text-anchor="middle" fill="#e6edf3" font-size="16" font-weight="bold">How a transaction is charged, top to bottom</text>
+
+  {/* A — submission */}
+  <rect x="24" y="52" width="520" height="56" rx="8" fill="#161b22" stroke="#30363d"/>
+  <text x="44" y="78" fill="#e6edf3" font-size="14" font-weight="bold">Transaction submitted</text>
+  <text x="44" y="98" fill="#8b949e" font-size="12">fee instructions · main instructions · inputs · max_fee</text>
+  <line x1="284" y1="108" x2="284" y2="146" stroke="#484f58" stroke-width="2" marker-end="url(#feeArrow)"/>
+  <text x="300" y="132" fill="#a371f7" font-size="12">charge: Initial + TransactionWeight</text>
+
+  {/* B — fee intent */}
+  <rect x="24" y="148" width="520" height="110" rx="8" fill="#1c2333" stroke="#388bfd"/>
+  <text x="44" y="174" fill="#388bfd" font-size="14" font-weight="bold">1 · Fee intent</text>
+  <text x="44" y="196" fill="#8b949e" font-size="12">The fee instructions run: withdraw, claim a Minotari burn, swap, reveal.</text>
+  <text x="44" y="214" fill="#8b949e" font-size="12">Charges accrue per host call, template load and signature check.</text>
+  <text x="44" y="232" fill="#8b949e" font-size="12">Compute allowance = what is paid so far + 32M free grace points.</text>
+  <text x="44" y="250" fill="#8b949e" font-size="12">pay_fee records a payment — TARI only, and never zero.</text>
+  <line x1="284" y1="258" x2="284" y2="290" stroke="#484f58" stroke-width="2" marker-end="url(#feeArrow)"/>
+
+  {/* C — fee checkpoint */}
+  <rect x="24" y="292" width="520" height="118" rx="8" fill="#1c2333" stroke="#f0883e"/>
+  <text x="44" y="318" fill="#f0883e" font-size="14" font-weight="bold">2 · Fee checkpoint</text>
+  <text x="44" y="340" fill="#8b949e" font-size="12">on_fee_checkpoint prices the state the fee intent would persist.</text>
+  <text x="44" y="358" fill="#f0883e" font-size="12">CHECK  spendable(payments) &#x2265; charges so far?</text>
+  <text x="44" y="376" fill="#8b949e" font-size="12">The state is snapshotted; the workspace is cleared and proofs dropped.</text>
+  <text x="44" y="394" fill="#8b949e" font-size="12">This snapshot is the fallback the transaction can still commit.</text>
+  <line x1="544" y1="351" x2="576" y2="351" stroke="#f85149" stroke-width="2" marker-end="url(#feeArrowRed)"/>
+
+  {/* R1 */}
+  <rect x="580" y="320" width="256" height="66" rx="8" fill="#161b22" stroke="#f85149" stroke-dasharray="4,3"/>
+  <text x="598" y="344" fill="#f85149" font-size="13" font-weight="bold">Rejected</text>
+  <text x="598" y="362" fill="#8b949e" font-size="11">InsufficientFeesPaid.</text>
+  <text x="598" y="378" fill="#8b949e" font-size="11">Nothing written, nothing taken.</text>
+
+  <line x1="284" y1="410" x2="284" y2="442" stroke="#484f58" stroke-width="2" marker-end="url(#feeArrow)"/>
+
+  {/* D — main intent */}
+  <rect x="24" y="444" width="520" height="110" rx="8" fill="#1c2333" stroke="#388bfd"/>
+  <text x="44" y="470" fill="#388bfd" font-size="14" font-weight="bold">3 · Main intent</text>
+  <text x="44" y="492" fill="#8b949e" font-size="12">The main instructions run against the checkpointed state.</text>
+  <text x="44" y="510" fill="#8b949e" font-size="12">Compute allowance = the part of the payment the charges have not spent.</text>
+  <text x="44" y="528" fill="#8b949e" font-size="12">The grace credit is gone; a further pay_fee is rejected here.</text>
+  <text x="44" y="546" fill="#8b949e" font-size="12">Charges keep accruing per host call and per verification.</text>
+  <line x1="544" y1="499" x2="576" y2="499" stroke="#f0883e" stroke-width="2" marker-end="url(#feeArrow)"/>
+
+  {/* R2 */}
+  <rect x="580" y="470" width="256" height="64" rx="8" fill="#161b22" stroke="#f0883e" stroke-dasharray="4,3"/>
+  <text x="598" y="494" fill="#f0883e" font-size="13" font-weight="bold">Instruction failure</text>
+  <text x="598" y="512" fill="#8b949e" font-size="11">Fall back to the checkpoint;</text>
+  <text x="598" y="528" fill="#8b949e" font-size="11">charges so far are kept.</text>
+
+  <line x1="284" y1="554" x2="284" y2="586" stroke="#484f58" stroke-width="2" marker-end="url(#feeArrow)"/>
+  <line x1="708" y1="534" x2="708" y2="600" stroke="#484f58" stroke-width="2" stroke-dasharray="4,3"/>
+  <line x1="708" y1="600" x2="548" y2="600" stroke="#484f58" stroke-width="2" marker-end="url(#feeArrow)"/>
+
+  {/* E — finalisation */}
+  <rect x="24" y="588" width="520" height="140" rx="8" fill="#1c2333" stroke="#a371f7"/>
+  <text x="44" y="614" fill="#a371f7" font-size="14" font-weight="bold">4 · Finalisation</text>
+  <text x="44" y="636" fill="#8b949e" font-size="12">Pass 1 — on_before_finalize prices the state execution ended on.</text>
+  <text x="44" y="654" fill="#8b949e" font-size="12">Select what to persist: the whole transaction, or the fee intent alone.</text>
+  <text x="44" y="672" fill="#8b949e" font-size="12">Pass 2 — on_before_persist re-prices whichever state was chosen.</text>
+  <text x="44" y="690" fill="#a371f7" font-size="12">Storage · SubstateCreate · TemplatePublish · Wasm/Native · ExhaustBurn</text>
+  <text x="44" y="712" fill="#f0883e" font-size="12">CHECK  payments &#x2265; the recomputed charges?</text>
+  <line x1="544" y1="664" x2="576" y2="664" stroke="#f85149" stroke-width="2" marker-end="url(#feeArrowRed)"/>
+
+  {/* R3 */}
+  <rect x="580" y="626" width="256" height="76" rx="8" fill="#161b22" stroke="#f85149" stroke-dasharray="4,3"/>
+  <text x="598" y="652" fill="#f85149" font-size="13" font-weight="bold">Rejected</text>
+  <text x="598" y="670" fill="#8b949e" font-size="11">Nothing persisted or taken;</text>
+  <text x="598" y="688" fill="#8b949e" font-size="11">the receipt carries the retry fee.</text>
+
+  <line x1="284" y1="728" x2="284" y2="760" stroke="#484f58" stroke-width="2" marker-end="url(#feeArrow)"/>
+
+  {/* F — settlement */}
+  <rect x="24" y="762" width="520" height="110" rx="8" fill="#161b22" stroke="#30363d"/>
+  <text x="44" y="788" fill="#e6edf3" font-size="14" font-weight="bold">Settlement</text>
+  <text x="44" y="810" fill="#8b949e" font-size="12">Charges collected; the unspent payment is refunded to its vault.</text>
+  <text x="44" y="828" fill="#8b949e" font-size="12">Unrefundable overpayment is kept and split with the exhaust burn.</text>
+  <text x="44" y="846" fill="#8b949e" font-size="12">The exhaust burn is destroyed; leaders are paid the pre-burn fee.</text>
+  <text x="44" y="864" fill="#8b949e" font-size="12">The transaction receipt is up&#x2019;d into the substate diff.</text>
+
+  <line x1="284" y1="872" x2="284" y2="904" stroke="#3fb950" stroke-width="2" marker-end="url(#feeArrowGreen)"/>
+
+  {/* G — outcome */}
+  <rect x="24" y="906" width="520" height="56" rx="8" fill="#161b22" stroke="#3fb950"/>
+  <text x="284" y="930" text-anchor="middle" fill="#3fb950" font-size="13" font-weight="bold">Accept &#x2014; full commit</text>
+  <text x="284" y="950" text-anchor="middle" fill="#8b949e" font-size="12">or AcceptFeeRejectRest &#x2014; the fee intent alone commits</text>
+</svg>
+
+---
+
+## Before anything executes
+
+These are checked at ingress or at the very start of execution, before a single fee is metered:
+
+| Rule | Where | Limit |
+|---|---|---|
+| Transaction weight ceiling | mempool admission | `max_transaction_weight` (1,000,000) |
+| Transaction validity window | mempool + consensus | `max_epoch` at most `max_transaction_validity_epochs` (2160) ahead |
+| At most one template publish | execution | `MAX_PUBLISH_TEMPLATES_PER_TRANSACTION` = 1 |
+| Fees are payable only in TARI | execution | any other resource is an `InvalidArgument` |
+
+The first charges land as soon as the runtime initialises, before any instruction runs:
+
+- **`Initial`** — a flat cost per transaction. Currently `0` on every shipped network.
+- **`TransactionWeight`** — the transaction's weight × `per_transaction_weight_cost`. Weight is a
+  static size/IO measure: instruction literals (bytes ÷ 3), blobs, 15 per input and 5 per signer. It
+  prices what the network must gossip, store and validate regardless of what execution does.
+
+---
+
+## Stage 1 — the fee intent
+
+The fee instructions exist to *source* a payment and hand it to the engine. Anything is allowed here:
+withdrawing from an account, claiming a Minotari burn, swapping through an AMM, revealing a stealth
+UTXO.
+
+**How a payment is made**
+
+| Builder call | Under the hood | Refundable? |
+|---|---|---|
+| `.pay_fee_from_component(account, max_fee)` | calls `pay_fee` on the component, which pays from its TARI vault | Yes — surplus returns to that vault |
+| `.pay_fee_from_bucket("bucket")` | consumes a workspace bucket outright | **No** — there is no vault to refund to |
+
+Rules and checks applied to a payment:
+
+- The resource must be `TARI`; anything else is rejected.
+- The amount must be greater than zero and must not overflow `u64` when added to the running total.
+- The paying vault must not be frozen for withdrawals, and the resource's `Withdraw` access rule must
+  pass.
+- A stealth-funded fee intent may perform at most **one** stealth transfer
+  (`STEALTH_LIMITS.max_fee_intent_transfers`), counted whether it comes from a `StealthTransfer`
+  instruction or from a template calling `ResourceManager::stealth_transfer`.
+
+**Charges that accrue while the fee intent runs**
+
+- `RuntimeCall` — a flat `per_module_call_cost` for every engine host call.
+- `TemplateLoad` — `(bytes_loaded / 3000) × per_template_load_cost_unit`, charged **once per template
+  per transaction**; repeat calls into an already-loaded template are free.
+- `SignatureVerification` — `per_signature_verification_cost` per signature verified.
+- Metering points accumulate for WASM and native crypto, but are not priced until finalisation.
+
+**Compute on credit.** A transaction cannot pay before it has sourced its funds, so the fee intent
+runs with a credit of `FREE_COMPUTE_GRACE_POINTS` (32,000,000 points) on top of whatever its payments
+already fund. That is roughly 3× the most expensive legitimate fee-sourcing flow. Exhaust it without
+paying and execution traps out of gas — it is the hard bound on free compute a non-paying transaction
+can extract from a validator.
+
+---
+
+## Stage 2 — the fee checkpoint
+
+The checkpoint is where "can this transaction afford to exist?" is answered. It runs after the last
+fee instruction and before the first main instruction, and it does four things in order:
+
+1. **Validate the intent is finalisable.** Dangling buckets or undropped proofs fail here, exactly as
+   they would at the end of a transaction.
+2. **Price the fee intent's state** (`on_fee_checkpoint`). This is the state a failing transaction
+   falls back to committing, so it is priced *before* the main intent spends any compute: `Storage`,
+   `SubstateCreate` and `TemplatePublish` are computed over the substates the fee intent mutated,
+   plus the transaction receipt it would produce.
+3. **Test the payment.** The check is `spendable(payments) ≥ total charges`, not
+   `payments ≥ charges` — the exhaust burn is taken *on top of* the charges, so a payment that
+   exactly matches them cannot also cover the exhaust burn. A shortfall rejects the transaction
+   outright: nothing is written and no fee is taken.
+4. **Snapshot and reset.** The working state is cloned as the fallback; the workspace is cleared and
+   its proofs dropped, so the main intent starts with a clean workspace.
+
+<Aside type="caution">
+  After the checkpoint, `pay_fee` is a hard error (`FeePaymentInMainIntent`). Everything the main
+  intent spends must already have been paid for.
+</Aside>
+
+---
+
+## Stage 3 — the main intent
+
+The main instructions run against the post-checkpoint state and keep accruing `RuntimeCall`,
+`TemplateLoad` and `SignatureVerification` charges as before. What changes is the compute budget.
+
+**Compute is funded by what the payment has left.** The allowance is:
+
+```
+allowance = points_funded_by( spendable(payments) − charges_so_far )
+```
+
+The free grace credit is gone — sourcing the fee was its only purpose, and that is done. Funding
+compute from the *unspent* part of the payment (rather than from the whole of it) is what keeps a
+transaction from spending its entire payment on execution and then being unable to afford even its
+own fee-intent fallback, which would settle as a rejection that collects nothing.
+
+Three ceilings apply on top of each other:
+
+| Bound | Value | Effect when hit |
+|---|---|---|
+| Payment-funded allowance | derived, see above | out-of-gas reported as `InsufficientFeesForCompute` |
+| `MAX_WASM_POINTS_PER_TRANSACTION` | 100,000,000 | out-of-gas, hard cap |
+| `MAX_NATIVE_POINTS_PER_TRANSACTION` | 2,400,000,000 | `MaxNativeExecutionPointsExceeded` |
+
+Native verification (stealth transfers, confidential withdrawals, Minotari burn claims) is
+**pre-charged** against the same allowance before the cryptography runs, so a transaction that cannot afford it traps
+without the validator having done the work. WASM is metered by Wasmer: each invocation's meter is
+capped to the smaller of the remaining hard cap and the remaining paid allowance, so work cannot be
+split across instructions or nested calls to get a fresh budget each time.
+
+If an instruction fails, execution rolls back to the fee checkpoint. The fee state carries across the
+rollback — every charge metered before the failure is still owed.
+
+---
+
+## Stage 4 — finalisation
+
+Finalisation is a **two-pass** charge, because the receipt's cost depends on which state is persisted,
+and which state is persisted depends on the cost.
+
+**Pass 1 — `on_before_finalize`.** Price the state execution actually ended on. This is what the
+commit-or-reject decision is made against, and it is the figure reported as `total_fees_required` — the
+number a resubmission has to clear.
+
+**Selection.** If the main intent failed, *or* the payment does not cover the charges from pass 1, the
+state to persist becomes the fee checkpoint instead of the working state — an
+`AcceptFeeRejectRest` outcome.
+
+**Pass 2 — `on_before_persist`.** Re-price the state that was actually chosen; the second result
+supersedes pass 1's. This pass is skipped on a full commit, where the two states are the same.
+
+The charges computed in these passes:
+
+| Source | Formula |
+|---|---|
+| `Storage` | `(bytes of persisted substates + receipt bytes) × per_byte_storage_cost / storage_cost_divisor` |
+| `SubstateCreate` | `(newly created substates + 1 for the receipt) × per_substate_create_cost` |
+| `TemplatePublish` | flat `per_template_publish_cost` + first `template_size_premium_free_bytes` at the storage rate + `units² × per_template_size_premium_unit_cost` |
+| `WasmExecution` | `(total points / wasm_points_cost_divisor) × per_wasm_point_cost` |
+| `NativeExecution` | same rate, over the accumulated native points |
+| `ExhaustBurn` | `total of all charges above × exhaust_burn_rate_bps / 10_000` |
+
+<Aside type="note">
+  WASM and native points are divided **once, over the transaction total**, not per call. Dividing per
+  call would let a transaction split work into sub-divisor chunks and pay zero for each.
+</Aside>
+
+**The final check.** After pass 2, `payments ≥ charges` is tested one last time. A fee-intent commit
+still persists real state — substates and a receipt carrying every event the intent emitted — so a
+payment that cannot cover *that* commits nothing at all. The transaction is rejected, nothing is
+taken, and the receipt reports the charges as metered against no payment so the payer knows what to
+retry with. Only a fee-intent commit can fail here — a full commit's charges were tested against the
+payment to reach this point.
+
+---
+
+## Settlement
+
+Once the charges are final:
+
+1. **Non-refundable payments are collected in full** — bucket payments have no return vault, so the
+   whole amount is taken even if it exceeds the charges. The excess is recorded as
+   `total_fee_overcharge`.
+2. **Refundable payments are drawn down** only to the amount still owed.
+3. **Whatever is left of a refundable payment goes back to its vault.**
+4. **The overcharge is split** as though it were a payment inclusive of its own exhaust burn: the
+   burn share moves into `ExhaustBurn`, the rest is kept by the network.
+5. **The transaction receipt is written** into the substate diff, carrying the fee receipt, the
+   events, the diff summary and the outcome.
+
+Fees flow onward as two separate quantities: leaders are paid `pre_burn_fees_paid` (the total paid
+*minus* the exhaust burn) in full, and the exhaust burn is destroyed and carried in the block
+header.
+
+---
+
+## The exhaust burn
+
+`exhaust_burn_rate_bps` is a consensus constant — 500 bps (5%) on mainnet — and every validator must
+use the same value or nodes diverge on block headers.
+
+The exhaust burn is charged **on top of** the accrued fee, not deducted from it. Two consequences
+follow, and both show up as rules elsewhere on this page:
+
+- A payment of `P` can only cover charges of `P / (1 + rate)`. That is the `spendable()` function used
+  at the checkpoint and by the compute allowance.
+- The payment a set of charges requires is `ceil(charges × (1 + rate))`, rounded up. That is the
+  figure a rejected payer is told to retry with.
+
+---
+
+## What a transaction is charged for
+
+Rates below are the current testnet values (mainnet placeholders are identical and still to be
+finalised).
+
+| Source | When | Testnet rate |
+|---|---|---|
+| `Initial` | runtime init | 0 |
+| `TransactionWeight` | runtime init | 1 µT per weight unit |
+| `RuntimeCall` | every engine host call | 1 µT |
+| `TemplateLoad` | first load of each template | 10 µT per 3 KB |
+| `SignatureVerification` | per signature | 10 µT |
+| `Storage` | finalisation | 1 µT per byte |
+| `SubstateCreate` | finalisation | 25 µT per new substate |
+| `TemplatePublish` | finalisation | 250,000 µT flat; first 96 KiB at the storage rate; 100 µT × units² per KiB beyond |
+| `WasmExecution` | finalisation | 1 µT per 1000 metering points |
+| `NativeExecution` | finalisation | 1 µT per 1000 point-equivalents |
+| `ExhaustBurn` | finalisation | 5% of the total |
+
+A source that charges nothing is omitted from the breakdown entirely rather than recorded as a zero.
+
+---
+
+## Estimating what to submit
+
+Submit a transaction as a **dry run** and the engine meters it exactly as it would for real, but never
+aborts for insufficient payment. Read `FinalizeResult::required_fees()` from the result and use it as
+the `max_fee`.
+
+That figure is `total_fees_required + FEE_ESTIMATE_ALLOWANCE` (25 µT). The allowance exists because
+`max_fee` is itself an input to the cost, so the real run meters *slightly* differently from the dry
+run that estimated it:
+
+- Transaction weight prices the fee instruction's literals by their encoded bytes, so a wider
+  `max_fee` costs marginally more weight.
+- The storage tally byte-counts the fee vault *before* the unspent payment is returned, so a wider
+  `max_fee` leaves a narrower residual there and costs marginally less.
+- The exhaust burn re-multiplies both.
+
+The allowance bounds the pair in both directions at any exhaust burn rate up to
+`MAX_EXHAUST_BURN_RATE_BPS`.
+
+<Aside type="tip">
+  `required_fees()` is a floor, not a recommendation. Overpayment returns to the paying vault, so a
+  caller paying from an account loses nothing by submitting above it. A caller paying from a bucket
+  has no refund path and should sit closer to the floor.
+</Aside>
+
+Note that `FeeReceipt::required_fees()` reads only what *that receipt* was charged — on an
+`AcceptFeeRejectRest` outcome that is the fee intent's own cost, not what the transaction needed. Use
+`FinalizeResult::required_fees()` when telling a caller what to resubmit with.
+
+---
+
+## Outcomes
+
+| Outcome | State persisted | Fee taken |
+|---|---|---|
+| `Accept` | the full transaction | charges in full, surplus refunded |
+| `AcceptFeeRejectRest` | the fee checkpoint only | charges in full, surplus refunded |
+| `Reject` at the fee checkpoint | none | none |
+| `Reject` at finalisation | none | none; the receipt reports what a commit would have cost |
+
+In both accepting cases, `FinalizeResult::total_fees_required` tells you what committing the *whole*
+transaction was priced at, which is the number a retry has to clear — on an `AcceptFeeRejectRest` that
+is higher than the receipt's own total.
+
+---
+
+## See also
+
+- [Transaction Overview](/guides/transaction-overview/) — how fee instructions fit into a transaction
+- [Stealth Transfers](/guides/stealth-resources/) — paying a fee from a stealth UTXO


### PR DESCRIPTION
Follow-up to #2417, closing the free-compute consequence its description called out.

## Problem

A transaction that cannot pay for its main intent falls back to committing only its fee intent. Since #2417, a fee intent it cannot afford commits nothing at all — a `Reject` that collects no fees.

Compute was funded by `points_funded_by(total_payments)`: the whole payment, with nothing set aside for that fallback. So a transaction that spent its allowance was **guaranteed** to finish unaffordable — `WasmExecution` alone came to roughly the payment, and the fee intent's own charges on top put the total above it. The work was done and never paid for, repeatably, with the same funds each time.

That made it the ordinary outcome for compute-heavy transactions, not an edge case.

## Fund compute from what is left

```rust
spendable_on_charges(total_payments, burn_rate_bps) - total_charges()
```

The exhaust burn is taken over the charges rather than deducted from the payment, so the charges themselves can only spend the payment net of it.

For `total_charges` to already include what the fallback costs, a new `on_fee_checkpoint` hook prices the checkpoint state *before* `checkpoint_fee_intent` tests what was paid against it. That establishes

```
(C_exec + C_fee_state + W) * (1 + r) <= P
```

so the fee-intent commit is always affordable by the time finalization reaches it. It also closes the gap the #2417 follow-up named: the checkpoint's paid-in-full check no longer sees a zero storage charge.

## Only the fee intent's state is priced this way

The main intent's state is discarded on the fallback path, so reserving it buys no safety. Pricing it as execution proceeds would also gate on peaks that never become charges — substates shrink mid-transaction (`down_utxo`, `down_confidential_output`, falling vault balances), so a transaction whose peak exceeded its final state would be trapped for fees it never owed.

Storage therefore accrues once, at the checkpoint, against the exact state that gets committed on that path.

## Finalization no longer charges a runtime call

The template never invoked `finalize`/`finalize_failure`; they are engine bookkeeping. Charging them landed one microtari *after* the last compute allowance was computed, putting the total past what that allowance was sized to fit inside — the regression test failed by exactly 1 µT until this went.

## Consequences worth reviewing

**Compute-heavy transactions get a smaller allowance.** The payment now has to cover the fee intent's commit as well as the compute, so a given `max_fee` buys slightly less execution than before. That is the point, but it is a real change to what a fee buys.

**A rejection at the checkpoint reports its metered charges** rather than an empty receipt, so the payer can still read what committing would have cost.

**Consumers surfacing a fee to resubmit with now read `FinalizeResult::required_fees`.** `FeeReceipt::required_fees` reports what *that receipt* was charged, which on a fee-intent commit is the fee intent's own cost rather than what the transaction needed. All eight call sites moved.

## Testing

New regression test `compute_cannot_consume_what_the_fee_intent_commit_needs`: an `infinity_loop` call at a 100k fee, which by construction spends every point it is given. Before this change it settled as `Reject` with `total_fees_paid: 0`; now it is `AcceptFeeRejectRest` with `charged == paid == 100_000` exactly.

Two existing tests needed real updates. `failure_pay_fee_in_main_instructions` paid 100 "enough to pass this step", which is no longer true once the checkpoint prices its own commit. `an_unaffordable_fee_intent_commits_nothing` reads the charges off the earlier rejection.

`tari_engine` (`fees`, `compute_fee_budget`, `native_compute_budget`, `metering_budget`, `complex_fee_payment`), `template_builtin`, `engine_types` and `ootle_sdk_core` pass; the workspace typechecks.

## Follow-up

Still outstanding from the #2417 review, in rough priority order: clamp `exhaust_burn_rate_bps` at construction rather than relying on a test; price `emit_log`, which is still flat-rated with `max_logs 256 × 32 KiB` reachable per transaction; tighten `TransactionReceipt::encoded_size_upper_bound`, whose `FeeReceipt::widest()` stand-in makes every transaction pay for up to 256 bytes it does not use; and guard the `new_substates` asymmetry that makes a single-pass storage charge unsound.
