### PR TITLE
feat(engine)!: price logs by the byte, drop EmitLog, bound the burn rate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,8 +40,8 @@ invariants, the reason for a non-obvious approach, tricky edge cases. They must 
 
 - DSL parsed by `tari_transaction_manifest::parse_manifest()`
 - Parser is in `crates/transaction_manifest/src/parser.rs`, generator in `generator.rs`
-- Macros: `var!`/`arg!`/`global!`, `new_component_addr!`, `new_resource_addr!`, `create_account!`, `drop_all_proofs!`,
-  log macros
+- Macros: `var!`/`arg!`/`global!`, `new_component_addr!`, `new_resource_addr!`, `create_account!`,
+  `drop_all_proofs!`
 - `create_account!(owner_pk)` generates `Instruction::CreateAccount` - idempotent account creation
 - Variables passed to manifests are parsed via `ManifestValue::FromStr` which handles: substate IDs (`component_<hex>`,
   `resource_<hex>`, etc.), NFT IDs, Rust literals, and raw hex bytes (for public keys)

--- a/applications/tari_indexer/src/dry_run/processor.rs
+++ b/applications/tari_indexer/src/dry_run/processor.rs
@@ -104,7 +104,7 @@ impl DryRunTransactionProcessor {
 
         // Estimate the burn at the rate in effect for the current epoch.
         let current_epoch = self.epoch_manager.current_epoch().await?;
-        let burn_rate_bps = self.consensus_constants.exhaust_burn_rate(current_epoch);
+        let burn_rate_bps = self.consensus_constants.exhaust_burn_rate(current_epoch).as_bps();
 
         let mut state_store = new_memory_store();
         state_store.set_many(found_substates)?;

--- a/applications/tari_indexer/src/network_state_sync/worker.rs
+++ b/applications/tari_indexer/src/network_state_sync/worker.rs
@@ -196,7 +196,7 @@ impl NetworkWideStateSync {
         match ReadOnlyStore::new(self.store.clone()).get_tari_economics().await {
             Ok(economics) => {
                 let current_epoch = self.epoch_manager.get_current_epoch();
-                let target_burn_rate_bps = self.consensus_constants.exhaust_burn_rate(current_epoch);
+                let target_burn_rate_bps = self.consensus_constants.exhaust_burn_rate(current_epoch).as_bps();
                 self.metrics.update(&economics, target_burn_rate_bps);
             },
             Err(err) => {

--- a/applications/tari_indexer/src/rest_api/handlers/network.rs
+++ b/applications/tari_indexer/src/rest_api/handlers/network.rs
@@ -54,7 +54,9 @@ pub async fn get_economics(Extension(context): Extension<HandlerContext>) -> Han
         .await
         .map_err(ErrorResponse::anyhow)?;
 
-    let target_burn_rate_bps = ConsensusConstants::from(context.network()).exhaust_burn_rate(current_epoch);
+    let target_burn_rate_bps = ConsensusConstants::from(context.network())
+        .exhaust_burn_rate(current_epoch)
+        .as_bps();
     // Supply nets the receipt-sourced burn against claimed (both advance on the state-sync frontier), matching
     // `get_xtr_total_supply`; `total_exhaust_burned` (header) is reported alongside as a cross-check.
     let total_supply = econ

--- a/applications/tari_ootle_app_utilities/src/fee_tables.rs
+++ b/applications/tari_ootle_app_utilities/src/fee_tables.rs
@@ -37,6 +37,10 @@
 //! - **`per_byte_storage_cost`**: Cost per byte of data written to persistent storage (substates). Note: The actual
 //!   cost is reduced by a factor of 4 (cost × 0.25) to make storage more affordable.
 //!
+//! - **`log_bytes_cost_divisor`**: Divides the per-byte storage rate when charging for a log message
+//!   (`per_byte_storage_cost × message_bytes / log_bytes_cost_divisor`). A log is retained in every validator's
+//!   execution record but is not consensus state and is prunable, so it is priced below a persisted byte.
+//!
 //! ## Template Publishing Fees
 //!
 //! A published template's binary is priced by its own model instead of the flat per-byte storage rate, since it is
@@ -93,6 +97,12 @@ const TESTNET_FEE_TABLE: FeeTable = FeeTable {
     template_load_bytes_cost_divisor: 3000,
     // 1 µT per 1000 Wasmer points. Lower values make metering more aggressive.
     wasm_points_cost_divisor: 1000,
+    // A log byte costs a 64th of a persisted byte. A log is retained in each validator's record of
+    // the execution rather than in consensus state, so it is priced well under permanent storage:
+    // a max-size entry (32 KiB) is ~512 µT and a transaction that fills `max_logs` with them is
+    // ~0.13 tTARI, against ~8.4 tTARI for the same bytes in a substate. An ordinary diagnostic line
+    // costs about as much as the host call that emits it.
+    log_bytes_cost_divisor: 64,
     // First 96 KiB of a template binary are priced at the per-byte storage rate; beyond that the
     // quadratic publish premium applies. A published template carries ~25 KiB of fixed
     // `template_lib` machinery before any author code, and a minimal component template optimised
@@ -133,6 +143,7 @@ const MAINNET_FEE_TABLE: FeeTable = FeeTable {
     storage_cost_divisor: 1,
     template_load_bytes_cost_divisor: 3000,
     wasm_points_cost_divisor: 1000,
+    log_bytes_cost_divisor: 64,
     template_size_premium_free_bytes: 96 * 1024,
     template_size_premium_unit_bytes: 1024,
     per_template_size_premium_unit_cost: 100,

--- a/applications/tari_ootle_app_utilities/src/fee_tables.rs
+++ b/applications/tari_ootle_app_utilities/src/fee_tables.rs
@@ -34,8 +34,9 @@
 //!
 //! ## Storage Fees
 //!
-//! - **`per_byte_storage_cost`**: Cost per byte of data written to persistent storage (substates). Note: The actual
-//!   cost is reduced by a factor of 4 (cost × 0.25) to make storage more affordable.
+//! - **`per_byte_storage_cost`**: Cost per byte of data written to persistent storage (substates), divided by
+//!   `storage_cost_divisor`. Both shipped tables set that divisor to 1: storage is the only indefinite-liability
+//!   category, so the full byte cost stands until a rent or endowment model lands.
 //!
 //! - **`log_bytes_cost_divisor`**: Divides the per-byte storage rate when charging for a log message
 //!   (`per_byte_storage_cost × message_bytes / log_bytes_cost_divisor`). A log is retained in every validator's

--- a/applications/tari_validator_node/src/consensus/block_transaction_executor.rs
+++ b/applications/tari_validator_node/src/consensus/block_transaction_executor.rs
@@ -88,7 +88,7 @@ where
 
         // Resolve the exhaust burn rate for the epoch this transaction executes in, so the payer is charged the
         // rate in effect at execution time.
-        let burn_rate_bps = self.consensus_constants.exhaust_burn_rate(execute_epoch);
+        let burn_rate_bps = self.consensus_constants.exhaust_burn_rate(execute_epoch).as_bps();
 
         // Execute the transaction and get the result
         let exec_output = self

--- a/applications/tari_walletd/web_ui/src/routes/Transactions/Instructions.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/Transactions/Instructions.tsx
@@ -117,10 +117,6 @@ function summarize(instruction: Instruction): string {
   if ("PutLastInstructionOutputOnWorkspace" in instruction) {
     return `PutLastInstructionOutputOnWorkspace($${instruction.PutLastInstructionOutputOnWorkspace.key})`;
   }
-  if ("EmitLog" in instruction) {
-    const { level, message } = instruction.EmitLog;
-    return `EmitLog(${level}, ${JSON.stringify(message)})`;
-  }
   if ("ClaimBurn" in instruction) {
     return `ClaimBurn(${instruction.ClaimBurn.claim.commitment})`;
   }

--- a/bindings/src/types/Instruction.ts
+++ b/bindings/src/types/Instruction.ts
@@ -7,7 +7,6 @@ import type { ComponentAccessRules } from "./ComponentAccessRules";
 import type { ComponentReference } from "./ComponentReference";
 import type { Hash32 } from "./Hash32";
 import type { InstructionArg } from "./InstructionArg";
-import type { LogLevel } from "./LogLevel";
 import type { MigrateFunction } from "./MigrateFunction";
 import type { MinotariBurnClaimProof } from "./MinotariBurnClaimProof";
 import type { OwnerRule } from "./OwnerRule";
@@ -29,7 +28,6 @@ export type Instruction =
   | { CallFunction: { address: Hash32; function: string; args: Array<InstructionArg> } }
   | { CallMethod: { call: ComponentReference; method: string; args: Array<InstructionArg> } }
   | { PutLastInstructionOutputOnWorkspace: { key: number } }
-  | { EmitLog: { level: LogLevel; message: string } }
   | { ClaimBurn: { claim: MinotariBurnClaimProof; output_data: ClaimBurnOutputData } }
   | { ClaimValidatorFees: { address: ValidatorFeePoolAddress; max_amount: Amount | null } }
   | "DropAllProofsInWorkspace"

--- a/crates/consensus/src/consensus_constants.rs
+++ b/crates/consensus/src/consensus_constants.rs
@@ -22,6 +22,7 @@
 
 use std::{env, time::Duration};
 
+use tari_engine_types::fees::ExhaustBurnRate;
 use tari_ootle_common_types::{Epoch, NumPreshards};
 use tari_ootle_transaction::Network;
 
@@ -93,11 +94,11 @@ pub struct ConsensusConstants {
     /// honest proposals are never rejected.
     /// CONSENSUS RULE: must be uniform network-wide, otherwise nodes diverge on block validity.
     pub max_block_validation_execution_points: u64,
-    /// The exhaust burn rate in basis points, charged to the fee payer on top of the execution fee and burned. 0
-    /// means no fees are burned. CONSENSUS RULE: must be uniform network-wide, otherwise nodes diverge on the burn
-    /// totals in block headers. Use `exhaust_burn_rate` to resolve the rate for a given epoch rather than reading
-    /// this field directly.
-    pub exhaust_burn_rate_bps: u16,
+    /// The exhaust burn rate, charged to the fee payer on top of the execution fee and burned.
+    /// `ExhaustBurnRate::ZERO` means no fees are burned. CONSENSUS RULE: must be uniform network-wide, otherwise
+    /// nodes diverge on the burn totals in block headers. Use `exhaust_burn_rate` to resolve the rate for a given
+    /// epoch rather than reading this field directly.
+    pub exhaust_burn_rate: ExhaustBurnRate,
     /// The furthest ahead of the current epoch a transaction's `max_epoch` may be set. Every
     /// transaction declares a mandatory `max_epoch`, so this caps how long any transaction can
     /// remain sequenceable: a wallet can declare a transaction permanently dead once this many
@@ -152,7 +153,7 @@ impl ConsensusConstants {
             // (`MAX_WASM_POINTS_PER_TRANSACTION` + `MAX_NATIVE_POINTS_PER_TRANSACTION`) + margin, so honest
             // proposals are never rejected.
             max_block_validation_execution_points: 7_100_000_000,
-            exhaust_burn_rate_bps: 500, // 5%
+            exhaust_burn_rate: ExhaustBurnRate::new(500), // 5%
             max_transaction_validity_epochs: 2160,
             epoch_end_spread_blocks: 10,
         }
@@ -193,7 +194,7 @@ impl ConsensusConstants {
             // (`MAX_WASM_POINTS_PER_TRANSACTION` + `MAX_NATIVE_POINTS_PER_TRANSACTION`) + margin, so honest
             // proposals are never rejected.
             max_block_validation_execution_points: 7_100_000_000,
-            exhaust_burn_rate_bps: 500, // 5%
+            exhaust_burn_rate: ExhaustBurnRate::new(500), // 5%
             max_transaction_validity_epochs: 2160,
             epoch_end_spread_blocks: 1,
         }
@@ -234,7 +235,7 @@ impl ConsensusConstants {
             // (`MAX_WASM_POINTS_PER_TRANSACTION` + `MAX_NATIVE_POINTS_PER_TRANSACTION`) + margin, so honest
             // proposals are never rejected.
             max_block_validation_execution_points: 7_100_000_000,
-            exhaust_burn_rate_bps: 500, // 5%
+            exhaust_burn_rate: ExhaustBurnRate::new(500), // 5%
             max_transaction_validity_epochs: 2160,
             epoch_end_spread_blocks: 5,
         }
@@ -275,19 +276,28 @@ impl ConsensusConstants {
             // (`MAX_WASM_POINTS_PER_TRANSACTION` + `MAX_NATIVE_POINTS_PER_TRANSACTION`) + margin, so honest
             // proposals are never rejected.
             max_block_validation_execution_points: 7_100_000_000,
-            exhaust_burn_rate_bps: 500, // 5%
+            exhaust_burn_rate: ExhaustBurnRate::new(500), // 5%
             max_transaction_validity_epochs: 2160,
             epoch_end_spread_blocks: 5,
         }
     }
 
-    /// Resolves the exhaust burn rate (in basis points) in effect at the given epoch. The rate is currently a
+    /// Resolves the exhaust burn rate in effect at the given epoch. The rate is currently a
     /// network-wide constant; the epoch parameter is the seam through which a future epoch-varying rate is
     /// introduced without touching call sites.
-    pub fn exhaust_burn_rate(&self, _epoch: Epoch) -> u16 {
-        self.exhaust_burn_rate_bps
+    pub fn exhaust_burn_rate(&self, _epoch: Epoch) -> ExhaustBurnRate {
+        self.exhaust_burn_rate
     }
 }
+
+/// Const-evaluates every shipped network, so a rate above `MAX_EXHAUST_BURN_RATE_BPS` fails the
+/// build rather than reaching a network.
+const _: () = {
+    ConsensusConstants::mainnet();
+    ConsensusConstants::devnet(1);
+    ConsensusConstants::esmeralda();
+    ConsensusConstants::testnet();
+};
 
 impl From<Network> for ConsensusConstants {
     fn from(network: Network) -> Self {
@@ -308,29 +318,6 @@ impl From<Network> for ConsensusConstants {
 
 #[cfg(test)]
 mod tests {
-    use tari_engine_types::fees::MAX_EXHAUST_BURN_RATE_BPS;
-
-    /// `FeeReceipt::required_fees` is derived against `MAX_EXHAUST_BURN_RATE_BPS`. A network that
-    /// burns faster than that makes every dry-run estimate too low to submit with.
-    #[test]
-    fn every_shipped_network_stays_within_the_burn_rate_ceiling() {
-        for network in [
-            Network::MainNet,
-            Network::StageNet,
-            Network::NextNet,
-            Network::Igor,
-            Network::Esmeralda,
-            Network::LocalNet,
-        ] {
-            let constants = super::ConsensusConstants::from(network);
-            assert!(
-                constants.exhaust_burn_rate_bps <= MAX_EXHAUST_BURN_RATE_BPS,
-                "{network} burns at {} bps, above the {MAX_EXHAUST_BURN_RATE_BPS} bps the fee estimate assumes",
-                constants.exhaust_burn_rate_bps
-            );
-        }
-    }
-
     use tari_engine_types::limits::{
         ENGINE_LIMITS,
         MAX_NATIVE_POINTS_PER_TRANSACTION,

--- a/crates/consensus/src/consensus_constants.rs
+++ b/crates/consensus/src/consensus_constants.rs
@@ -118,45 +118,137 @@ pub struct ConsensusConstants {
 }
 
 impl ConsensusConstants {
+    /// Committee size used when `TARI_DEVNET_COMMITTEE_SIZE` is unset, and the size [`Self::DEVNET`]
+    /// is const-evaluated at.
+    pub const DEFAULT_DEVNET_COMMITTEE_SIZE: u32 = 7;
+    /// Const-evaluates [`Self::devnet`], so every shipped network's constants are checked at compile
+    /// time whether they are a const item or a const function of one argument.
+    pub const DEVNET: Self = Self::devnet(Self::DEFAULT_DEVNET_COMMITTEE_SIZE);
+    pub const ESMERALDA: Self = Self {
+        base_layer_confirmations: 100,
+        committee_size_per_shard_group: 40,
+        num_preshards: NumPreshards::current(),
+        pacemaker_block_time: Duration::from_secs(10),
+        missed_proposal_suspend_threshold: 5,
+        missed_proposal_evict_threshold: 10,
+        missed_proposal_recovery_threshold: 5,
+        // Calibrated against 2-core hardware (Esmeralda class), where ~500 LocalOnly stress
+        // transactions (~62 weight each, ~31k weight) executed in ~11.5s — i.e. ~2.7k weight/s.
+        // A 10000 budget (~160 of those commands) therefore projects to ~3.7s of propose-time
+        // execution, comfortably within the 10s block time and under the 5s execution circuit
+        // breaker, while heavier transactions naturally consume more of the budget. The breaker in
+        // on_propose is the backstop for outliers the static weight under-estimates. NOTE:
+        // propose-time execution is sequential, so more cores does not raise this proportionally —
+        // calibrate to single-core throughput.
+        max_block_weight: 10_000,
+        max_commands_in_block: 1000,
+        // 1.5x the proposal budget: honest blocks (<= max_block_weight) are never rejected, while a
+        // full validation-weight block projects to ~5.5s of execution on 2-core hardware — well
+        // within the 10s block time. Rejects the ~31k-weight/500-command overload that broke things.
+        max_block_validation_weight: 15_000,
+        // Admits the heaviest legitimate transaction — a 1.5 MiB template publish is ~524k weight
+        // (binary bytes / 3) — with ~2x headroom, while bounding any single transaction's
+        // size/execution cost at ingress. A mempool admission bound, not a consensus rule.
+        max_transaction_weight: 1_000_000,
+        // ~45 max-compute transactions (100M points each, ~33ms on ~3GHz x86) — ~1.5s of serial WASM
+        // execution with ~3x headroom for slower validator hardware. Provisional pending re-measurement
+        // of the metering costs on x86-class hardware.
+        max_block_execution_points: 4_500_000_000,
+        // Proposal budget + the largest single-transaction overshoot the per-transaction ceilings allow
+        // (`MAX_WASM_POINTS_PER_TRANSACTION` + `MAX_NATIVE_POINTS_PER_TRANSACTION`) + margin, so honest
+        // proposals are never rejected.
+        max_block_validation_execution_points: 7_100_000_000,
+        exhaust_burn_rate: ExhaustBurnRate::new(500), // 5%
+        max_transaction_validity_epochs: 2160,
+        epoch_end_spread_blocks: 5,
+    };
+    pub const MAINNET: Self = Self {
+        base_layer_confirmations: 1000,
+        committee_size_per_shard_group: 40,
+        num_preshards: NumPreshards::current(),
+        pacemaker_block_time: Duration::from_secs(10),
+        missed_proposal_suspend_threshold: 5,
+        missed_proposal_evict_threshold: 10,
+        missed_proposal_recovery_threshold: 5,
+        // Calibrated against 2-core hardware (Esmeralda class), where ~500 LocalOnly stress
+        // transactions (~62 weight each, ~31k weight) executed in ~11.5s — i.e. ~2.7k weight/s.
+        // A 10000 budget (~160 of those commands) therefore projects to ~3.7s of propose-time
+        // execution, comfortably within the 10s block time and under the 5s execution circuit
+        // breaker, while heavier transactions naturally consume more of the budget. The breaker in
+        // on_propose is the backstop for outliers the static weight under-estimates. NOTE:
+        // propose-time execution is sequential, so more cores does not raise this proportionally —
+        // calibrate to single-core throughput.
+        max_block_weight: 10_000,
+        max_commands_in_block: 1000,
+        // 1.5x the proposal budget: honest blocks (<= max_block_weight) are never rejected, while a
+        // full validation-weight block projects to ~5.5s of execution on 2-core hardware — well
+        // within the 10s block time. Rejects the ~31k-weight/500-command overload that broke things.
+        max_block_validation_weight: 15_000,
+        // Admits the heaviest legitimate transaction — a 1.5 MiB template publish is ~524k weight
+        // (binary bytes / 3) — with ~2x headroom, while bounding any single transaction's
+        // size/execution cost at ingress. A mempool admission bound, not a consensus rule.
+        max_transaction_weight: 1_000_000,
+        // ~45 max-compute transactions (100M points each, ~33ms on ~3GHz x86) — ~1.5s of serial WASM
+        // execution with ~3x headroom for slower validator hardware. Provisional pending re-measurement
+        // of the metering costs on x86-class hardware.
+        max_block_execution_points: 4_500_000_000,
+        // Proposal budget + the largest single-transaction overshoot the per-transaction ceilings allow
+        // (`MAX_WASM_POINTS_PER_TRANSACTION` + `MAX_NATIVE_POINTS_PER_TRANSACTION`) + margin, so honest
+        // proposals are never rejected.
+        max_block_validation_execution_points: 7_100_000_000,
+        exhaust_burn_rate: ExhaustBurnRate::new(500), // 5%
+        max_transaction_validity_epochs: 2160,
+        epoch_end_spread_blocks: 10,
+    };
+    pub const TESTNET: Self = Self {
+        base_layer_confirmations: 100,
+        committee_size_per_shard_group: 40,
+        num_preshards: NumPreshards::current(),
+        pacemaker_block_time: Duration::from_secs(10),
+        missed_proposal_suspend_threshold: 5,
+        missed_proposal_evict_threshold: 10,
+        missed_proposal_recovery_threshold: 5,
+        // Calibrated against 2-core hardware (Esmeralda class), where ~500 LocalOnly stress
+        // transactions (~62 weight each, ~31k weight) executed in ~11.5s — i.e. ~2.7k weight/s.
+        // A 10000 budget (~160 of those commands) therefore projects to ~3.7s of propose-time
+        // execution, comfortably within the 10s block time and under the 5s execution circuit
+        // breaker, while heavier transactions naturally consume more of the budget. The breaker in
+        // on_propose is the backstop for outliers the static weight under-estimates. NOTE:
+        // propose-time execution is sequential, so more cores does not raise this proportionally —
+        // calibrate to single-core throughput.
+        max_block_weight: 10_000,
+        max_commands_in_block: 1000,
+        // 1.5x the proposal budget: honest blocks (<= max_block_weight) are never rejected, while a
+        // full validation-weight block projects to ~5.5s of execution on 2-core hardware — well
+        // within the 10s block time. Rejects the ~31k-weight/500-command overload that broke things.
+        max_block_validation_weight: 15_000,
+        // Admits the heaviest legitimate transaction — a 1.5 MiB template publish is ~524k weight
+        // (binary bytes / 3) — with ~2x headroom, while bounding any single transaction's
+        // size/execution cost at ingress. A mempool admission bound, not a consensus rule.
+        max_transaction_weight: 1_000_000,
+        // ~45 max-compute transactions (100M points each, ~33ms on ~3GHz x86) — ~1.5s of serial WASM
+        // execution with ~3x headroom for slower validator hardware. Provisional pending re-measurement
+        // of the metering costs on x86-class hardware.
+        max_block_execution_points: 4_500_000_000,
+        // Proposal budget + the largest single-transaction overshoot the per-transaction ceilings allow
+        // (`MAX_WASM_POINTS_PER_TRANSACTION` + `MAX_NATIVE_POINTS_PER_TRANSACTION`) + margin, so honest
+        // proposals are never rejected.
+        max_block_validation_execution_points: 7_100_000_000,
+        exhaust_burn_rate: ExhaustBurnRate::new(500), // 5%
+        max_transaction_validity_epochs: 2160,
+        epoch_end_spread_blocks: 5,
+    };
+
     pub const fn mainnet() -> Self {
-        Self {
-            base_layer_confirmations: 1000,
-            committee_size_per_shard_group: 40,
-            num_preshards: NumPreshards::current(),
-            pacemaker_block_time: Duration::from_secs(10),
-            missed_proposal_suspend_threshold: 5,
-            missed_proposal_evict_threshold: 10,
-            missed_proposal_recovery_threshold: 5,
-            // Calibrated against 2-core hardware (Esmeralda class), where ~500 LocalOnly stress
-            // transactions (~62 weight each, ~31k weight) executed in ~11.5s — i.e. ~2.7k weight/s.
-            // A 10000 budget (~160 of those commands) therefore projects to ~3.7s of propose-time
-            // execution, comfortably within the 10s block time and under the 5s execution circuit
-            // breaker, while heavier transactions naturally consume more of the budget. The breaker in
-            // on_propose is the backstop for outliers the static weight under-estimates. NOTE:
-            // propose-time execution is sequential, so more cores does not raise this proportionally —
-            // calibrate to single-core throughput.
-            max_block_weight: 10_000,
-            max_commands_in_block: 1000,
-            // 1.5x the proposal budget: honest blocks (<= max_block_weight) are never rejected, while a
-            // full validation-weight block projects to ~5.5s of execution on 2-core hardware — well
-            // within the 10s block time. Rejects the ~31k-weight/500-command overload that broke things.
-            max_block_validation_weight: 15_000,
-            // Admits the heaviest legitimate transaction — a 1.5 MiB template publish is ~524k weight
-            // (binary bytes / 3) — with ~2x headroom, while bounding any single transaction's
-            // size/execution cost at ingress. A mempool admission bound, not a consensus rule.
-            max_transaction_weight: 1_000_000,
-            // ~45 max-compute transactions (100M points each, ~33ms on ~3GHz x86) — ~1.5s of serial WASM
-            // execution with ~3x headroom for slower validator hardware. Provisional pending re-measurement
-            // of the metering costs on x86-class hardware.
-            max_block_execution_points: 4_500_000_000,
-            // Proposal budget + the largest single-transaction overshoot the per-transaction ceilings allow
-            // (`MAX_WASM_POINTS_PER_TRANSACTION` + `MAX_NATIVE_POINTS_PER_TRANSACTION`) + margin, so honest
-            // proposals are never rejected.
-            max_block_validation_execution_points: 7_100_000_000,
-            exhaust_burn_rate: ExhaustBurnRate::new(500), // 5%
-            max_transaction_validity_epochs: 2160,
-            epoch_end_spread_blocks: 10,
-        }
+        Self::MAINNET
+    }
+
+    pub const fn esmeralda() -> Self {
+        Self::ESMERALDA
+    }
+
+    pub const fn testnet() -> Self {
+        Self::TESTNET
     }
 
     pub const fn devnet(committee_size: u32) -> Self {
@@ -200,88 +292,6 @@ impl ConsensusConstants {
         }
     }
 
-    pub const fn esmeralda() -> Self {
-        Self {
-            base_layer_confirmations: 100,
-            committee_size_per_shard_group: 40,
-            num_preshards: NumPreshards::current(),
-            pacemaker_block_time: Duration::from_secs(10),
-            missed_proposal_suspend_threshold: 5,
-            missed_proposal_evict_threshold: 10,
-            missed_proposal_recovery_threshold: 5,
-            // Calibrated against 2-core hardware (Esmeralda class), where ~500 LocalOnly stress
-            // transactions (~62 weight each, ~31k weight) executed in ~11.5s — i.e. ~2.7k weight/s.
-            // A 10000 budget (~160 of those commands) therefore projects to ~3.7s of propose-time
-            // execution, comfortably within the 10s block time and under the 5s execution circuit
-            // breaker, while heavier transactions naturally consume more of the budget. The breaker in
-            // on_propose is the backstop for outliers the static weight under-estimates. NOTE:
-            // propose-time execution is sequential, so more cores does not raise this proportionally —
-            // calibrate to single-core throughput.
-            max_block_weight: 10_000,
-            max_commands_in_block: 1000,
-            // 1.5x the proposal budget: honest blocks (<= max_block_weight) are never rejected, while a
-            // full validation-weight block projects to ~5.5s of execution on 2-core hardware — well
-            // within the 10s block time. Rejects the ~31k-weight/500-command overload that broke things.
-            max_block_validation_weight: 15_000,
-            // Admits the heaviest legitimate transaction — a 1.5 MiB template publish is ~524k weight
-            // (binary bytes / 3) — with ~2x headroom, while bounding any single transaction's
-            // size/execution cost at ingress. A mempool admission bound, not a consensus rule.
-            max_transaction_weight: 1_000_000,
-            // ~45 max-compute transactions (100M points each, ~33ms on ~3GHz x86) — ~1.5s of serial WASM
-            // execution with ~3x headroom for slower validator hardware. Provisional pending re-measurement
-            // of the metering costs on x86-class hardware.
-            max_block_execution_points: 4_500_000_000,
-            // Proposal budget + the largest single-transaction overshoot the per-transaction ceilings allow
-            // (`MAX_WASM_POINTS_PER_TRANSACTION` + `MAX_NATIVE_POINTS_PER_TRANSACTION`) + margin, so honest
-            // proposals are never rejected.
-            max_block_validation_execution_points: 7_100_000_000,
-            exhaust_burn_rate: ExhaustBurnRate::new(500), // 5%
-            max_transaction_validity_epochs: 2160,
-            epoch_end_spread_blocks: 5,
-        }
-    }
-
-    pub const fn testnet() -> Self {
-        Self {
-            base_layer_confirmations: 100,
-            committee_size_per_shard_group: 40,
-            num_preshards: NumPreshards::current(),
-            pacemaker_block_time: Duration::from_secs(10),
-            missed_proposal_suspend_threshold: 5,
-            missed_proposal_evict_threshold: 10,
-            missed_proposal_recovery_threshold: 5,
-            // Calibrated against 2-core hardware (Esmeralda class), where ~500 LocalOnly stress
-            // transactions (~62 weight each, ~31k weight) executed in ~11.5s — i.e. ~2.7k weight/s.
-            // A 10000 budget (~160 of those commands) therefore projects to ~3.7s of propose-time
-            // execution, comfortably within the 10s block time and under the 5s execution circuit
-            // breaker, while heavier transactions naturally consume more of the budget. The breaker in
-            // on_propose is the backstop for outliers the static weight under-estimates. NOTE:
-            // propose-time execution is sequential, so more cores does not raise this proportionally —
-            // calibrate to single-core throughput.
-            max_block_weight: 10_000,
-            max_commands_in_block: 1000,
-            // 1.5x the proposal budget: honest blocks (<= max_block_weight) are never rejected, while a
-            // full validation-weight block projects to ~5.5s of execution on 2-core hardware — well
-            // within the 10s block time. Rejects the ~31k-weight/500-command overload that broke things.
-            max_block_validation_weight: 15_000,
-            // Admits the heaviest legitimate transaction — a 1.5 MiB template publish is ~524k weight
-            // (binary bytes / 3) — with ~2x headroom, while bounding any single transaction's
-            // size/execution cost at ingress. A mempool admission bound, not a consensus rule.
-            max_transaction_weight: 1_000_000,
-            // ~45 max-compute transactions (100M points each, ~33ms on ~3GHz x86) — ~1.5s of serial WASM
-            // execution with ~3x headroom for slower validator hardware. Provisional pending re-measurement
-            // of the metering costs on x86-class hardware.
-            max_block_execution_points: 4_500_000_000,
-            // Proposal budget + the largest single-transaction overshoot the per-transaction ceilings allow
-            // (`MAX_WASM_POINTS_PER_TRANSACTION` + `MAX_NATIVE_POINTS_PER_TRANSACTION`) + margin, so honest
-            // proposals are never rejected.
-            max_block_validation_execution_points: 7_100_000_000,
-            exhaust_burn_rate: ExhaustBurnRate::new(500), // 5%
-            max_transaction_validity_epochs: 2160,
-            epoch_end_spread_blocks: 5,
-        }
-    }
-
     /// Resolves the exhaust burn rate in effect at the given epoch. The rate is currently a
     /// network-wide constant; the epoch parameter is the seam through which a future epoch-varying rate is
     /// introduced without touching call sites.
@@ -289,15 +299,6 @@ impl ConsensusConstants {
         self.exhaust_burn_rate
     }
 }
-
-/// Const-evaluates every shipped network, so a rate above `MAX_EXHAUST_BURN_RATE_BPS` fails the
-/// build rather than reaching a network.
-const _: () = {
-    ConsensusConstants::mainnet();
-    ConsensusConstants::devnet(1);
-    ConsensusConstants::esmeralda();
-    ConsensusConstants::testnet();
-};
 
 impl From<Network> for ConsensusConstants {
     fn from(network: Network) -> Self {
@@ -308,7 +309,7 @@ impl From<Network> for ConsensusConstants {
                 env::var("TARI_DEVNET_COMMITTEE_SIZE")
                     .ok()
                     .and_then(|s| s.parse().ok())
-                    .unwrap_or(7),
+                    .unwrap_or(Self::DEFAULT_DEVNET_COMMITTEE_SIZE),
             ),
             Network::Esmeralda => Self::esmeralda(),
             Network::StageNet | Network::NextNet | Network::Igor => Self::testnet(),

--- a/crates/consensus_tests/src/support/harness.rs
+++ b/crates/consensus_tests/src/support/harness.rs
@@ -18,7 +18,7 @@ use tari_consensus::{
 };
 use tari_consensus_types::{BlockId, Decision};
 use tari_crypto::ristretto::RistrettoPublicKey;
-use tari_engine_types::substate::SubstateId;
+use tari_engine_types::{fees::ExhaustBurnRate, substate::SubstateId};
 use tari_epoch_manager::EpochManagerReader;
 use tari_ootle_common_types::{
     Epoch,
@@ -683,7 +683,7 @@ impl TestBuilder {
                     // lower these explicitly and opt out via `allow_wasm_budget_deferrals`.
                     max_block_execution_points: 4_500_000_000,
                     max_block_validation_execution_points: 5_000_000_000,
-                    exhaust_burn_rate_bps: 500,
+                    exhaust_burn_rate: ExhaustBurnRate::new(500),
                     epoch_end_spread_blocks: 0,
                 },
                 state_tree_cleanup_interval: Duration::from_secs(1000),

--- a/crates/engine/src/fees/fee_module.rs
+++ b/crates/engine/src/fees/fee_module.rs
@@ -257,6 +257,19 @@ impl<TStore: StateReader> RuntimeModule<TStore> for FeeModule {
                     self.fee_table.per_signature_verification_cost(),
                 );
             },
+            RuntimeEvent::LogEmitted { size_bytes } => {
+                // Charged under the same source as the host call that emitted the log: the flat
+                // per-call cost prices the call, this prices what it carried. Division per call
+                // forgoes less than a divisor's worth of bytes per log, bounded by
+                // `ENGINE_LIMITS.max_logs`.
+                let cost = self
+                    .fee_table
+                    .per_byte_storage_cost()
+                    .checked_mul(*size_bytes as u64)
+                    .ok_or_else(|| RuntimeModuleError::Overflow("Overflow calculating log cost".to_string()))? /
+                    self.fee_table.log_bytes_cost_divisor();
+                track.add_fee_charge(FeeSource::RuntimeCall, cost);
+            },
         }
 
         Ok(())

--- a/crates/engine/src/fees/fee_table.rs
+++ b/crates/engine/src/fees/fee_table.rs
@@ -53,6 +53,12 @@ pub struct FeeTable {
     /// (`per_template_load_cost_unit × (bytes_loaded / template_load_bytes_cost_divisor)`). Lower
     /// values increase the load fee. Must be non-zero; a zero divisor is treated as `1`.
     pub template_load_bytes_cost_divisor: u64,
+    /// Divisor applied to a log message's bytes when charging for it
+    /// (`per_byte_storage_cost × message_bytes / log_bytes_cost_divisor`). A log is retained in
+    /// each validator's record of the execution rather than in consensus state, and is prunable, so
+    /// it is priced well below a persisted byte. Must be non-zero; a zero divisor is treated as
+    /// `1`.
+    pub log_bytes_cost_divisor: u64,
     /// Divisor applied to consumed Wasmer points when computing WASM execution units
     /// (`per_wasm_point_cost × (points_consumed / wasm_points_cost_divisor)`). Lower values make
     /// metering more aggressive. Must be non-zero; a zero divisor is treated as `1`.
@@ -88,6 +94,7 @@ impl FeeTable {
             per_wasm_point_cost: 0,
             storage_cost_divisor: 1,
             template_load_bytes_cost_divisor: 1,
+            log_bytes_cost_divisor: 1,
             wasm_points_cost_divisor: 1,
             template_size_premium_free_bytes: 0,
             template_size_premium_unit_bytes: 1,
@@ -156,6 +163,10 @@ impl FeeTable {
 
     pub fn wasm_points_cost_divisor(&self) -> u64 {
         non_zero(self.wasm_points_cost_divisor)
+    }
+
+    pub fn log_bytes_cost_divisor(&self) -> u64 {
+        non_zero(self.log_bytes_cost_divisor)
     }
 
     pub fn template_size_premium_free_bytes(&self) -> u64 {

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -1090,6 +1090,9 @@ where
 
     fn emit_log(&mut self, level: LogLevel, message: String) -> Result<(), RuntimeError> {
         self.invoke_modules_on_runtime_call("emit_log")?;
+        self.invoke_modules_on_runtime_event(RuntimeEvent::LogEmitted {
+            size_bytes: message.len(),
+        })?;
 
         let log_level = match level {
             LogLevel::Error => log::Level::Error,

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -1090,9 +1090,6 @@ where
 
     fn emit_log(&mut self, level: LogLevel, message: String) -> Result<(), RuntimeError> {
         self.invoke_modules_on_runtime_call("emit_log")?;
-        self.invoke_modules_on_runtime_event(RuntimeEvent::LogEmitted {
-            size_bytes: message.len(),
-        })?;
 
         let log_level = match level {
             LogLevel::Error => log::Level::Error,
@@ -1103,7 +1100,11 @@ where
 
         // eprintln!("{}: {}", log_level, message);
         log::log!(target: "tari::ootle::engine::runtime", log_level, "{}", message);
+        let size_bytes = message.len();
+        // Charged after the entry is accepted, so the bytes billed for are the bytes retained: the
+        // size and count limits `add_log` enforces are what decides that.
         self.tracker.add_log(LogEntry::new(level, message))?;
+        self.invoke_modules_on_runtime_event(RuntimeEvent::LogEmitted { size_bytes })?;
         Ok(())
     }
 

--- a/crates/engine/src/runtime/module.rs
+++ b/crates/engine/src/runtime/module.rs
@@ -84,6 +84,12 @@ pub trait RuntimeModule<TStore>: Send + Sync {
 #[derive(Debug, Clone)]
 pub enum RuntimeEvent {
     SignatureVerified,
+    /// A log entry was emitted, carrying `size_bytes` of message. The payload is held in memory for
+    /// the length of execution and retained in every validator's record of the execution, so its
+    /// size is charged for on top of the flat cost of the host call that emitted it.
+    LogEmitted {
+        size_bytes: usize,
+    },
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/engine/src/transaction/processor.rs
+++ b/crates/engine/src/transaction/processor.rs
@@ -387,10 +387,6 @@ where
                 Self::drop_all_proofs_in_workspace(runtime)?;
                 Ok(InstructionResult::empty())
             },
-            Instruction::EmitLog { level, message } => {
-                runtime.interface_mut().emit_log(level, message.into_string())?;
-                Ok(InstructionResult::empty())
-            },
             Instruction::ClaimBurn { claim, output_data } => {
                 runtime.interface_mut().claim_burn(*claim, output_data)?;
                 Ok(InstructionResult::empty())

--- a/crates/engine/tests/fees.rs
+++ b/crates/engine/tests/fees.rs
@@ -2,9 +2,11 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use tari_crypto::ristretto::RistrettoSecretKey;
+use tari_engine::fees::FeeTable;
 use tari_engine_types::{
     commit_result::{RejectReason, TransactionResult},
     fees::{FeeReceipt, FeeSource},
+    limits::ENGINE_LIMITS,
 };
 use tari_ootle_transaction::{Epoch, Transaction, args};
 use tari_template_lib::types::{
@@ -54,6 +56,45 @@ fn deducts_fees_from_payments_and_refunds_the_rest() {
     assert_eq!(new_balance, orig_balance - payment.total_fees_charged());
     assert_eq!(payment.total_refunded(), 1000 - payment.total_fees_charged());
     assert!(payment.is_paid_in_full());
+}
+
+/// A log's message is charged for by the byte, so filling the per-transaction log budget costs in
+/// proportion to what it carries rather than a flat per-call fee.
+#[test]
+fn a_log_is_charged_for_the_bytes_it_carries() {
+    fn runtime_call_charge(message_len: usize) -> (u64, FeeTable) {
+        let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/limits"]);
+        let (account, owner_token, private_key) = test.create_funded_account();
+        test.enable_fees();
+
+        let result = test.execute_expect_success(
+            Transaction::builder_localnet(Epoch(1))
+                .pay_fee_from_component(account, 100_000u64)
+                .call_function(
+                    test.get_template_address("PushItToTheLimit"),
+                    "emit_log_of_size",
+                    args![message_len as u32],
+                )
+                .build_and_seal(&private_key),
+            vec![owner_token],
+        );
+        (
+            result.finalize.fee_receipt.fee_breakdown().get(FeeSource::RuntimeCall),
+            test.fee_table().clone(),
+        )
+    }
+
+    let bytes = ENGINE_LIMITS.max_log_size_bytes;
+    let (with_log, table) = runtime_call_charge(bytes);
+    let (without_log, _) = runtime_call_charge(0);
+
+    // Both runs make the same host calls, so the difference is what the message carried.
+    let charged = with_log - without_log;
+    assert_eq!(
+        charged,
+        table.per_byte_storage_cost() * bytes as u64 / table.log_bytes_cost_divisor()
+    );
+    assert!(charged > 0, "a max-size log message was charged nothing");
 }
 
 #[test]

--- a/crates/engine/tests/fees.rs
+++ b/crates/engine/tests/fees.rs
@@ -95,6 +95,12 @@ fn a_log_is_charged_for_the_bytes_it_carries() {
         table.per_byte_storage_cost() * bytes as u64 / table.log_bytes_cost_divisor()
     );
     assert!(charged > 0, "a max-size log message was charged nothing");
+
+    // The division is per call, so a message shorter than the divisor rounds to nothing. What that
+    // forgoes over a transaction is bounded by `max_logs × log_bytes_cost_divisor` bytes.
+    let short = table.log_bytes_cost_divisor() as usize - 1;
+    let (with_short_log, _) = runtime_call_charge(short);
+    assert_eq!(with_short_log, without_log);
 }
 
 #[test]

--- a/crates/engine/tests/templates/limits/src/lib.rs
+++ b/crates/engine/tests/templates/limits/src/lib.rs
@@ -23,5 +23,9 @@ mod template {
         pub fn request_random_bytes(len: u32) -> Vec<u8> {
             rand::random_bytes(len)
         }
+
+        pub fn emit_log_of_size(len: u32) {
+            debug!("{}", "a".repeat(len as usize));
+        }
     }
 }

--- a/crates/engine_types/src/fees.rs
+++ b/crates/engine_types/src/fees.rs
@@ -1,8 +1,6 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::fmt;
-
 use indexmap::{IndexMap, map::Entry};
 use serde::{Deserialize, Serialize};
 

--- a/crates/engine_types/src/fees.rs
+++ b/crates/engine_types/src/fees.rs
@@ -20,15 +20,12 @@ pub const MAX_EXHAUST_BURN_RATE_BPS: u16 = 10_000;
 /// [`FEE_ESTIMATE_ALLOWANCE`] is derived against, so a network burning above it under-states what
 /// a dry run reports as required. A rate reaches consensus only through this type, so no such
 /// network can be configured.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ExhaustBurnRate(u16);
 
 impl ExhaustBurnRate {
-    /// No fees are burned.
-    pub const ZERO: Self = Self(0);
-
-    /// Panics if `bps` is above [`MAX_EXHAUST_BURN_RATE_BPS`]. In a const context — where the
-    /// shipped network constants are evaluated — that panic is a compile error.
+    /// Panics if `bps` is above [`MAX_EXHAUST_BURN_RATE_BPS`]. The network constants are const
+    /// items, so for them that panic is a compile error.
     pub const fn new(bps: u16) -> Self {
         assert!(
             bps <= MAX_EXHAUST_BURN_RATE_BPS,
@@ -37,40 +34,10 @@ impl ExhaustBurnRate {
         Self(bps)
     }
 
-    /// Validates a rate that is only known at runtime, such as one read from configuration.
-    pub const fn try_new(bps: u16) -> Result<Self, ExhaustBurnRateOutOfRange> {
-        if bps > MAX_EXHAUST_BURN_RATE_BPS {
-            return Err(ExhaustBurnRateOutOfRange(bps));
-        }
-        Ok(Self(bps))
-    }
-
     pub const fn as_bps(self) -> u16 {
         self.0
     }
-
-    pub const fn is_zero(self) -> bool {
-        self.0 == 0
-    }
 }
-
-impl TryFrom<u16> for ExhaustBurnRate {
-    type Error = ExhaustBurnRateOutOfRange;
-
-    fn try_from(bps: u16) -> Result<Self, Self::Error> {
-        Self::try_new(bps)
-    }
-}
-
-impl fmt::Display for ExhaustBurnRate {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} bps", self.0)
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-#[error("exhaust burn rate of {0} bps is above the maximum of {MAX_EXHAUST_BURN_RATE_BPS} bps")]
-pub struct ExhaustBurnRateOutOfRange(u16);
 
 /// The allowance a dry-run estimate carries on top of what it metered, so that a real run of the
 /// same transaction at a different `max_fee` can never cost more than the estimate.
@@ -298,6 +265,9 @@ impl Default for FeeReceipt {
 pub enum FeeSource {
     #[n(0)]
     Initial = 0,
+    /// Engine host calls: a flat per-call cost, plus the per-byte cost of a log's message. Two
+    /// unlike prices share this source because a source of its own would widen
+    /// [`FeeReceipt::widest`] and so the receipt size bound on every transaction.
     #[n(1)]
     RuntimeCall = 1,
     #[n(2)]
@@ -436,20 +406,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn a_burn_rate_cannot_be_built_above_the_ceiling() {
+    fn a_burn_rate_holds_every_value_up_to_the_ceiling() {
+        assert_eq!(ExhaustBurnRate::new(0).as_bps(), 0);
         assert_eq!(
             ExhaustBurnRate::new(MAX_EXHAUST_BURN_RATE_BPS).as_bps(),
             MAX_EXHAUST_BURN_RATE_BPS
         );
-        assert!(ExhaustBurnRate::try_new(MAX_EXHAUST_BURN_RATE_BPS).is_ok());
-        assert!(ExhaustBurnRate::try_new(MAX_EXHAUST_BURN_RATE_BPS + 1).is_err());
-        assert!(ExhaustBurnRate::try_from(u16::MAX).is_err());
-        assert!(ExhaustBurnRate::ZERO.is_zero());
     }
 
     #[test]
     #[should_panic(expected = "exhaust burn rate is above MAX_EXHAUST_BURN_RATE_BPS")]
-    fn a_burn_rate_above_the_ceiling_panics_when_it_is_not_caught_at_compile_time() {
+    fn a_burn_rate_above_the_ceiling_panics_where_const_evaluation_cannot_catch_it() {
         ExhaustBurnRate::new(MAX_EXHAUST_BURN_RATE_BPS + 1);
     }
 

--- a/crates/engine_types/src/fees.rs
+++ b/crates/engine_types/src/fees.rs
@@ -1,6 +1,8 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+use std::fmt;
+
 use indexmap::{IndexMap, map::Entry};
 use serde::{Deserialize, Serialize};
 
@@ -9,9 +11,66 @@ use serde::{Deserialize, Serialize};
 /// The burn is taken over the running fee total, so it re-multiplies every term that can make a
 /// real run cost more than the dry run that estimated it. A network configured above this rate
 /// under-states `FeeReceipt::required_fees`, and every submission built from a dry run is then
-/// rejected as underpaid — `every_shipped_network_stays_within_the_burn_rate_ceiling` holds the
-/// shipped networks to it.
+/// rejected as underpaid — [`ExhaustBurnRate`] holds every configured rate to it.
 pub const MAX_EXHAUST_BURN_RATE_BPS: u16 = 10_000;
+
+/// An exhaust burn rate in basis points, at or below [`MAX_EXHAUST_BURN_RATE_BPS`].
+///
+/// The ceiling is a fee-estimation invariant rather than a policy preference: it is the rate
+/// [`FEE_ESTIMATE_ALLOWANCE`] is derived against, so a network burning above it under-states what
+/// a dry run reports as required. A rate reaches consensus only through this type, so no such
+/// network can be configured.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct ExhaustBurnRate(u16);
+
+impl ExhaustBurnRate {
+    /// No fees are burned.
+    pub const ZERO: Self = Self(0);
+
+    /// Panics if `bps` is above [`MAX_EXHAUST_BURN_RATE_BPS`]. In a const context — where the
+    /// shipped network constants are evaluated — that panic is a compile error.
+    pub const fn new(bps: u16) -> Self {
+        assert!(
+            bps <= MAX_EXHAUST_BURN_RATE_BPS,
+            "exhaust burn rate is above MAX_EXHAUST_BURN_RATE_BPS"
+        );
+        Self(bps)
+    }
+
+    /// Validates a rate that is only known at runtime, such as one read from configuration.
+    pub const fn try_new(bps: u16) -> Result<Self, ExhaustBurnRateOutOfRange> {
+        if bps > MAX_EXHAUST_BURN_RATE_BPS {
+            return Err(ExhaustBurnRateOutOfRange(bps));
+        }
+        Ok(Self(bps))
+    }
+
+    pub const fn as_bps(self) -> u16 {
+        self.0
+    }
+
+    pub const fn is_zero(self) -> bool {
+        self.0 == 0
+    }
+}
+
+impl TryFrom<u16> for ExhaustBurnRate {
+    type Error = ExhaustBurnRateOutOfRange;
+
+    fn try_from(bps: u16) -> Result<Self, Self::Error> {
+        Self::try_new(bps)
+    }
+}
+
+impl fmt::Display for ExhaustBurnRate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} bps", self.0)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("exhaust burn rate of {0} bps is above the maximum of {MAX_EXHAUST_BURN_RATE_BPS} bps")]
+pub struct ExhaustBurnRateOutOfRange(u16);
 
 /// The allowance a dry-run estimate carries on top of what it metered, so that a real run of the
 /// same transaction at a different `max_fee` can never cost more than the estimate.
@@ -375,6 +434,24 @@ pub struct FeeCostBreakdown {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_burn_rate_cannot_be_built_above_the_ceiling() {
+        assert_eq!(
+            ExhaustBurnRate::new(MAX_EXHAUST_BURN_RATE_BPS).as_bps(),
+            MAX_EXHAUST_BURN_RATE_BPS
+        );
+        assert!(ExhaustBurnRate::try_new(MAX_EXHAUST_BURN_RATE_BPS).is_ok());
+        assert!(ExhaustBurnRate::try_new(MAX_EXHAUST_BURN_RATE_BPS + 1).is_err());
+        assert!(ExhaustBurnRate::try_from(u16::MAX).is_err());
+        assert!(ExhaustBurnRate::ZERO.is_zero());
+    }
+
+    #[test]
+    #[should_panic(expected = "exhaust burn rate is above MAX_EXHAUST_BURN_RATE_BPS")]
+    fn a_burn_rate_above_the_ceiling_panics_when_it_is_not_caught_at_compile_time() {
+        ExhaustBurnRate::new(MAX_EXHAUST_BURN_RATE_BPS + 1);
+    }
 
     #[test]
     fn fee_source_all_is_exhaustive() {

--- a/crates/template_test_tooling/src/template_test.rs
+++ b/crates/template_test_tooling/src/template_test.rs
@@ -250,6 +250,7 @@ impl TemplateTest {
                 storage_cost_divisor: 1,
                 template_load_bytes_cost_divisor: 3000,
                 wasm_points_cost_divisor: 1000,
+                log_bytes_cost_divisor: 64,
                 template_size_premium_free_bytes: 96 * 1024,
                 template_size_premium_unit_bytes: 1024,
                 per_template_size_premium_unit_cost: 100,

--- a/crates/transaction/src/builder/mod.rs
+++ b/crates/transaction/src/builder/mod.rs
@@ -960,7 +960,6 @@ impl<D> TransactionBuilder<D> {
             } |
             Instruction::CreateAccount { .. } |
             Instruction::PutLastInstructionOutputOnWorkspace { .. } |
-            Instruction::EmitLog { .. } |
             Instruction::ClaimBurn { .. } |
             Instruction::DropAllProofsInWorkspace |
             Instruction::TakeFromBucket { .. } |

--- a/crates/transaction/src/v1/instruction.rs
+++ b/crates/transaction/src/v1/instruction.rs
@@ -3,17 +3,12 @@
 
 use std::fmt::{Display, Formatter};
 
-use tari_engine_types::{
-    confidential::{ClaimBurnOutputData, MinotariBurnClaimProof},
-    limits,
-};
+use tari_engine_types::confidential::{ClaimBurnOutputData, MinotariBurnClaimProof};
 use tari_ootle_common_types::displayable::Displayable;
 use tari_ootle_template_metadata::MetadataHash;
 use tari_template_lib_types::{
     Amount,
     FunctionName,
-    LogLevel,
-    MaxString,
     OwnerRule,
     TemplateAddress,
     ValidatorFeePoolAddress,
@@ -70,14 +65,6 @@ pub enum Instruction {
     PutLastInstructionOutputOnWorkspace {
         #[n(0)]
         key: WorkspaceId,
-    },
-    #[n(4)]
-    EmitLog {
-        #[n(0)]
-        level: LogLevel,
-        #[n(1)]
-        #[cfg_attr(feature = "ts", ts(type = "string"))]
-        message: MaxString<{ limits::ENGINE_LIMITS.max_log_size_bytes }>,
     },
     #[n(5)]
     ClaimBurn {
@@ -204,7 +191,6 @@ impl Instruction {
             // No blob references in these variants
             Self::CreateAccount { .. } |
             Self::PutLastInstructionOutputOnWorkspace { .. } |
-            Self::EmitLog { .. } |
             Self::ClaimBurn { .. } |
             Self::ClaimValidatorFees { .. } |
             Self::DropAllProofsInWorkspace |
@@ -250,7 +236,6 @@ impl Instruction {
             // No blob references in these variants
             Self::CreateAccount { .. } |
             Self::PutLastInstructionOutputOnWorkspace { .. } |
-            Self::EmitLog { .. } |
             Self::ClaimBurn { .. } |
             Self::ClaimValidatorFees { .. } |
             Self::DropAllProofsInWorkspace |
@@ -350,7 +335,6 @@ impl Instruction {
                 }
             },
             // No workspace IDs in these variants
-            Self::EmitLog { .. } |
             Self::ClaimBurn { .. } |
             Self::ClaimValidatorFees { .. } |
             Self::DropAllProofsInWorkspace |
@@ -412,9 +396,6 @@ impl Display for Instruction {
             ),
             Self::PutLastInstructionOutputOnWorkspace { key } => {
                 write!(f, "PutLastInstructionOutputOnWorkspace {{ key: {key} }}")
-            },
-            Self::EmitLog { level, message } => {
-                write!(f, "EmitLog {{ level: {level}, message: {message} }}")
             },
             Self::ClaimBurn { claim, .. } => {
                 write!(f, "ClaimBurn {{ {claim} }}",)

--- a/crates/transaction/src/v1/transaction.rs
+++ b/crates/transaction/src/v1/transaction.rs
@@ -330,7 +330,6 @@ impl Display for TransactionV1 {
 }
 
 fn calc_instruction_weight(instruction: &Instruction) -> u64 {
-    const BINARY_WEIGHT_DIVISOR: u64 = 3;
     // TODO: formalize costing numbers
     const CLAIM_FIXED_COST: u64 = 1100;
     match instruction {
@@ -345,7 +344,6 @@ fn calc_instruction_weight(instruction: &Instruction) -> u64 {
         Instruction::CallFunction { args, .. } => calc_args_weight(args),
         Instruction::CallMethod { args, .. } => calc_args_weight(args),
         Instruction::PutLastInstructionOutputOnWorkspace { .. } => 0, // Call already costs
-        Instruction::EmitLog { message, .. } => message.len() as u64 / BINARY_WEIGHT_DIVISOR,
         Instruction::ClaimBurn { .. } => CLAIM_FIXED_COST,
         Instruction::ClaimValidatorFees { .. } => 1,
         Instruction::DropAllProofsInWorkspace => 1,

--- a/crates/transaction_manifest/src/generator.rs
+++ b/crates/transaction_manifest/src/generator.rs
@@ -236,12 +236,6 @@ impl ManifestInstructionGenerator {
                     .insert(assign.variable_name.to_string(), assign.blob_name.to_string());
                 Ok(vec![])
             },
-            ManifestIntent::Log(log) => Ok(vec![Instruction::EmitLog {
-                level: log.level,
-                message: log.message.try_into().map_err(|e| ManifestError::InvalidInstruction {
-                    reason: format!("Log message is too long: {}", e),
-                })?,
-            }]),
             ManifestIntent::DropAllProofs => Ok(vec![Instruction::DropAllProofsInWorkspace]),
             ManifestIntent::PutIntoBucket(p) => {
                 let resolve = |name: &Ident| {

--- a/crates/transaction_manifest/src/parser.rs
+++ b/crates/transaction_manifest/src/parser.rs
@@ -36,7 +36,6 @@ use tari_ootle_transaction::AllocatableAddressType;
 use tari_template_builtin::ACCOUNT_TEMPLATE_ADDRESS;
 use tari_template_lib_types::{
     Amount,
-    LogLevel,
     Metadata,
     NonFungibleId,
     TemplateAddress,
@@ -54,7 +53,6 @@ pub enum ManifestIntent {
     AssignBlob(AssignBlobStmt),
     AllocateAddress(AllocateAddressStmt),
     CreateAccount(CreateAccountIntent),
-    Log(LogIntent),
     DropAllProofs,
     PublishTemplate(PublishTemplateIntent),
     PutIntoBucket(PutIntoBucketIntent),
@@ -126,12 +124,6 @@ pub struct CreateAccountIntent {
     pub owner_rule: Option<Ident>,
     pub access_rules: Option<Ident>,
     pub bucket: Option<Ident>,
-}
-
-#[derive(Debug, Clone)]
-pub struct LogIntent {
-    pub level: LogLevel,
-    pub message: String,
 }
 
 #[derive(Debug, Clone)]
@@ -486,23 +478,6 @@ fn assignment_from_macro(var_name: Ident, mac: &Ident, tokens: TokenStream) -> R
 
 fn macro_call(mac: &Ident, tokens: TokenStream) -> Result<ManifestIntent, syn::Error> {
     match mac.to_string().as_str() {
-        "info" => Ok(ManifestIntent::Log(LogIntent {
-            level: LogLevel::Info,
-            // TODO: Support format args - of course, this requires runtime support so is quite a heavy lift.
-            message: parse2::<LitStr>(tokens)?.value(),
-        })),
-        "debug" => Ok(ManifestIntent::Log(LogIntent {
-            level: LogLevel::Debug,
-            message: parse2::<LitStr>(tokens)?.value(),
-        })),
-        "warn" => Ok(ManifestIntent::Log(LogIntent {
-            level: LogLevel::Warn,
-            message: parse2::<LitStr>(tokens)?.value(),
-        })),
-        "error" => Ok(ManifestIntent::Log(LogIntent {
-            level: LogLevel::Error,
-            message: parse2::<LitStr>(tokens)?.value(),
-        })),
         "drop_all_proofs" => Ok(ManifestIntent::DropAllProofs),
         "put_into_bucket" => {
             let args = syn::parse::Parser::parse2(

--- a/docs/developer-docs/src/content/docs/reference/fees.mdx
+++ b/docs/developer-docs/src/content/docs/reference/fees.mdx
@@ -170,7 +170,10 @@ Rules and checks applied to a payment:
 
 **Charges that accrue while the fee intent runs**
 
-- `RuntimeCall` — a flat `per_module_call_cost` for every engine host call.
+- `RuntimeCall` — a flat `per_module_call_cost` for every engine host call, plus
+  `per_byte_storage_cost × message_bytes / log_bytes_cost_divisor` for a log's message. A log is
+  retained in each validator's record of the execution rather than in consensus state, so its
+  bytes are priced well below persisted ones.
 - `TemplateLoad` — `(bytes_loaded / 3000) × per_template_load_cost_unit`, charged **once per template
   per transaction**; repeat calls into an already-loaded template are free.
 - `SignatureVerification` — `per_signature_verification_cost` per signature verified.
@@ -331,7 +334,7 @@ finalised).
 |---|---|---|
 | `Initial` | runtime init | 0 |
 | `TransactionWeight` | runtime init | 1 µT per weight unit |
-| `RuntimeCall` | every engine host call | 1 µT |
+| `RuntimeCall` | every engine host call | 1 µT, plus 1 µT per 64 bytes of a log message |
 | `TemplateLoad` | first load of each template | 10 µT per 3 KB |
 | `SignatureVerification` | per signature | 10 µT |
 | `Storage` | finalisation | 1 µT per byte |

--- a/docs/developer-docs/src/content/docs/reference/fees.mdx
+++ b/docs/developer-docs/src/content/docs/reference/fees.mdx
@@ -269,7 +269,7 @@ The charges computed in these passes:
 | `TemplatePublish` | flat `per_template_publish_cost` + first `template_size_premium_free_bytes` at the storage rate + `units² × per_template_size_premium_unit_cost` |
 | `WasmExecution` | `(total points / wasm_points_cost_divisor) × per_wasm_point_cost` |
 | `NativeExecution` | same rate, over the accumulated native points |
-| `ExhaustBurn` | `total of all charges above × exhaust_burn_rate_bps / 10_000` |
+| `ExhaustBurn` | `total of all charges above × exhaust_burn_rate / 10_000` |
 
 <Aside type="note">
   WASM and native points are divided **once, over the transaction total**, not per call. Dividing per
@@ -307,8 +307,10 @@ header.
 
 ## The exhaust burn
 
-`exhaust_burn_rate_bps` is a consensus constant — 500 bps (5%) on mainnet — and every validator must
-use the same value or nodes diverge on block headers.
+`exhaust_burn_rate` is a consensus constant — 500 bps (5%) on mainnet — and every validator must
+use the same value or nodes diverge on block headers. It is an `ExhaustBurnRate`, which cannot hold a
+rate above `MAX_EXHAUST_BURN_RATE_BPS` (10 000 bps): that is the rate the dry-run allowance is
+derived against, so a network burning faster would under-state what every estimate reports.
 
 The exhaust burn is charged **on top of** the accrued fee, not deducted from it. Two consequences
 follow, and both show up as rules elsewhere on this page:

--- a/docs/skills/claude-code/tari-manifest/SKILL.md
+++ b/docs/skills/claude-code/tari-manifest/SKILL.md
@@ -113,12 +113,6 @@ account.deposit(item);
 let addr = new_component_addr!();
 let addr = new_resource_addr!();
 
-// Logging
-info!("message");
-debug!("message");
-warn!("message");
-error!("message");
-
 // Proof management
 drop_all_proofs!();
 ```

--- a/docs/skills/claude-code/tari-manifest/references/manifest-syntax.md
+++ b/docs/skills/claude-code/tari-manifest/references/manifest-syntax.md
@@ -78,17 +78,6 @@ let addr = new_resource_addr!();
 let addr = allocate_component_address!();  // Alias
 ```
 
-### Logging
-
-```rust
-info!("Informational message");
-debug!("Debug message");
-warn!("Warning message");
-error!("Error message");
-```
-
-Note: only string literals are supported (no format args).
-
 ### Proof Management
 
 ```rust


### PR DESCRIPTION
Follow-ups from #2438, in three independent commits.

## Charge a log for the bytes it carries

`emit_log` was charged a flat `per_module_call_cost` whatever it carried. With
`max_logs: 256` and `max_log_size_bytes: 32 KiB`, that puts **8 MiB within reach of a transaction
paying 256 µT**. #2416 removed logs from the persisted `TransactionReceipt`, so the permanent cost
is gone, but the transient one is not: the payload is held in memory for the length of execution
and retained in every validator's `transaction_executions` record via `FinalizeResult.logs`.

`emit_log` now raises `RuntimeEvent::LogEmitted { size_bytes }`, and `FeeModule` charges
`per_byte_storage_cost × bytes / log_bytes_cost_divisor` for it.

- **Charged as the log is emitted**, not at finalisation, so the bytes shrink the compute allowance
  #2438 introduced rather than being billed after the work is already done.
- **Under `FeeSource::RuntimeCall`**, the same source as the host call that emitted it — a new
  `FeeSource` would widen `FeeReceipt::widest()` and move the receipt size bound, and therefore the
  fee, on every transaction on the network.
- **Divisor 64 on the shipped tables.** A log lives in a per-node, prunable execution record rather
  than in consensus state, so it is priced well under a persisted byte: a max-size entry is ~512 µT
  and a transaction that fills `max_logs` with them ~0.13 tTARI, against ~8.4 tTARI for the same
  bytes in a substate. An ordinary diagnostic line costs about what the host call does, so no
  shipped fee assertion moved.

## Drop the `EmitLog` instruction and the manifest log macros

A transaction-carried log gives the sender nothing a template's own `debug!` does not: the message
is a literal fixed at signing time, so it says only what the sender already knew, and with the
change above it is paid for twice — as transaction weight for the bytes on the wire, and again for
the bytes it puts in the execution record.

Removes `Instruction::EmitLog`, its weight term and execution arm, and the
`info!`/`debug!`/`warn!`/`error!` manifest macros that generated it, along with the TS binding, the
web-UI branch and the doc references. **Logging from a template is untouched.**

## Hold the exhaust burn rate to the fee estimate's ceiling

`FEE_ESTIMATE_ALLOWANCE` is derived against `MAX_EXHAUST_BURN_RATE_BPS`, so a network configured
above that rate under-states `FeeReceipt::required_fees` and every submission built from a dry run
is rejected as underpaid. The rate was a bare `u16` on `ConsensusConstants`, guarded only by a test
over the values we ship.

`ExhaustBurnRate` cannot hold a rate above the ceiling: `new` panics — a compile error in the const
context the network constants are built in — and `try_new` validates a rate known only at runtime.
A `const _` block const-evaluates every shipped network, so an out-of-range rate fails the build
rather than a test. Verified by temporarily setting a network to 20 000 bps: `error[E0080]:
evaluation panicked: exhaust burn rate is above MAX_EXHAUST_BURN_RATE_BPS`.

## Breaking changes

- A log's bytes are now charged for, and `FeeTable` gains `log_bytes_cost_divisor`.
- `Instruction::EmitLog` is gone, and a manifest using the log macros no longer parses.
- `ConsensusConstants::exhaust_burn_rate_bps: u16` is now `exhaust_burn_rate: ExhaustBurnRate`, and
  `exhaust_burn_rate()` returns that type.

## Test plan

- [x] `cargo check --workspace --tests`
- [x] `tari_engine --test {fees, compute_fee_budget, native_compute_budget, metering_budget, complex_fee_payment, limits}`
- [x] `tari_template_builtin --test liquidity_pool`
- [x] `tari_transaction_manifest`, `tari_ootle_transaction`, `ootle_sdk_core` (golden vectors included)
- [x] `tari_indexer`, `tari_validator_node`, `consensus_tests` compile against the new constant type

## Still open from #2438's follow-up list

Items 7 (tighten the receipt size bound) and 8 (a test for the `new_substates` asymmetry) are not
in this PR.
