### PR TITLE
fix(walletd): settle the stealth transfer fee estimate before reporting it

### DIFF
--- a/applications/tari_walletd/src/handlers/accounts.rs
+++ b/applications/tari_walletd/src/handlers/accounts.rs
@@ -1283,7 +1283,7 @@ pub async fn handle_stealth_transfer(
         })
         .collect::<anyhow::Result<_>>()?;
 
-    let params = StealthTransferParams {
+    let mut params = StealthTransferParams {
         max_epoch: context.transaction_max_epoch().await?,
         fee_params: req.fee_params,
         input_selection: req.input_selection,
@@ -1302,63 +1302,116 @@ pub async fn handle_stealth_transfer(
     // Spawn here is to prevent the async block from being aborted if the caller aborts the request early as this can
     // cause funds to remain locked indefinitely.
     task::spawn(async move {
-        let (lock, transfer) = sdk.stealth_transfer_api().transfer(owner_account, params).await?;
+        // A dry run's estimate is only worth anything if it describes the transaction that will be
+        // submitted, and the fee is an input to that: input selection targets `amount + max_fee`, so
+        // the fee decides which UTXOs are spent and whether any change is left over. A change output
+        // is another stealth output, and another output is another `PER_OUTPUT` of verification —
+        // enough that an estimate taken at the caller's guessed fee prices a shape the real
+        // submission will not have. Rebuild at each figure reported until building at it needs no
+        // more than it, then answer with the run that named it, which is a figure the caller can
+        // submit at.
+        let mut verified_estimate: Option<StealthTransferResponse> = None;
+        let mut rounds = 0usize;
 
-        let transaction = transfer.transaction;
-        let main_pk = transfer.main_signer.public_key().to_byte_type();
+        loop {
+            let (lock, transfer) = sdk
+                .stealth_transfer_api()
+                .transfer(owner_account.clone(), params.clone())
+                .await?;
 
-        // Signer api which sign transaction types that require the seal signer public key
-        let main_signer = sdk.signer_api().with_context(&main_pk);
-        // Add additional signature if needed
-        let transaction = match transfer.additional_signer.as_ref() {
-            Some(s) => main_signer.sign(s.key_id, transaction)?,
-            None => transaction.finish(),
-        };
+            let transaction = transfer.transaction;
+            let main_pk = transfer.main_signer.public_key().to_byte_type();
 
-        // Add required UTXO spend key signatures
-        let transaction = transfer
-            .utxo_spend_keys
-            .iter()
-            .try_fold(transaction, |tx, key| main_signer.sign_with_stealth_key(key, tx))?;
-
-        // Sign and seal the final transaction
-        let transaction = sdk.signer_api().sign(transfer.main_signer.key_id, transaction)?;
-
-        if req.dry_run {
-            // Release the lock immediately as dry run does not submit the transaction
-            // TODO: maybe transfer() should not lock the outputs if it's a dry run
-            lock.release();
-            let result = transaction_service.submit_dry_run_transaction(transaction).await;
-            return match result {
-                Ok(res) => Ok(StealthTransferResponse {
-                    transaction_id: res.finalize.transaction_hash.into(),
-                }),
-                Err(e) => Err(anyhow::anyhow!("Dry run transaction failed: {}", e)),
+            // Signer api which sign transaction types that require the seal signer public key
+            let main_signer = sdk.signer_api().with_context(&main_pk);
+            // Add additional signature if needed
+            let transaction = match transfer.additional_signer.as_ref() {
+                Some(s) => main_signer.sign(s.key_id, transaction)?,
+                None => transaction.finish(),
             };
+
+            // Add required UTXO spend key signatures
+            let transaction = transfer
+                .utxo_spend_keys
+                .iter()
+                .try_fold(transaction, |tx, key| main_signer.sign_with_stealth_key(key, tx))?;
+
+            // Sign and seal the final transaction
+            let transaction = sdk.signer_api().sign(transfer.main_signer.key_id, transaction)?;
+
+            if req.dry_run {
+                // Release the lock immediately as dry run does not submit the transaction
+                // TODO: maybe transfer() should not lock the outputs if it's a dry run
+                lock.release();
+                let result = transaction_service
+                    .submit_dry_run_transaction(transaction)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("Dry run transaction failed: {}", e))?;
+
+                let required_fees = result.finalize.required_fees();
+                // What this round's shape actually costs, without the estimate allowance that
+                // `required_fees` carries on top. That allowance is the caller's margin against the
+                // metering drift a wider `max_fee` causes; testing against it here would treat a fee
+                // that pays in full as insufficient and spend another round chasing it.
+                let charged = result.finalize.total_fees_required;
+                let response = StealthTransferResponse {
+                    transaction_id: result.finalize.transaction_hash.into(),
+                };
+                rounds += 1;
+
+                // `verified_estimate` reported the fee this round was built at, so this round is what
+                // establishes that a transaction built at that fee pays for itself.
+                if charged <= params.max_fee &&
+                    let Some(verified) = verified_estimate
+                {
+                    return Ok(verified);
+                }
+                if rounds >= MAX_FEE_ESTIMATE_ROUNDS {
+                    // Out of rounds: answer with the highest figure reached rather than one nothing
+                    // has been built at, since an estimate below the cost cannot be submitted at all.
+                    warn!(
+                        target: LOG_TARGET,
+                        "Stealth transfer fee estimate did not settle in {MAX_FEE_ESTIMATE_ROUNDS} rounds (a max fee \
+                         of {} was charged {charged})",
+                        params.max_fee
+                    );
+                    return Ok(response);
+                }
+
+                params.max_fee = required_fees;
+                verified_estimate = Some(response);
+                continue;
+            }
+
+            let tx_id = transaction_service
+                .submit_transaction_with_opts(
+                    transaction,
+                    Some(TransactionContext::with_accounts(linked_accounts)),
+                    Some(lock.id()),
+                )
+                .await
+                .context("Transaction failed to submit")?;
+
+            // Transaction submitted, we're home free, make sure to allow the lock to persist past this call.
+            // The wallet will monitor the transaction and release the lock when it's finalized.
+            lock.keep_locked();
+
+            notifier.notify(TransactionSubmittedEvent {
+                transaction_id: tx_id,
+                context: None,
+            });
+
+            return Ok(StealthTransferResponse { transaction_id: tx_id });
         }
-
-        let tx_id = transaction_service
-            .submit_transaction_with_opts(
-                transaction,
-                Some(TransactionContext::with_accounts(linked_accounts)),
-                Some(lock.id()),
-            )
-            .await
-            .context("Transaction failed to submit")?;
-
-        // Transaction submitted, we're home free, make sure to allow the lock to persist past this call.
-        // The wallet will monitor the transaction and release the lock when it's finalized.
-        lock.keep_locked();
-
-        notifier.notify(TransactionSubmittedEvent {
-            transaction_id: tx_id,
-            context: None,
-        });
-
-        Ok(StealthTransferResponse { transaction_id: tx_id })
     })
     .await?
 }
+
+/// How many times a dry run may rebuild at the fee it last reported before answering with whatever
+/// it reached. Two rounds settle the common case — the caller's guessed fee, then the shape that
+/// fee produces — and the third confirms it; the rest is headroom for a selection that keeps
+/// growing.
+const MAX_FEE_ESTIMATE_ROUNDS: usize = 4;
 
 #[allow(clippy::too_many_lines)]
 pub async fn handle_create_stealth_transfer_statement(

--- a/crates/template_test_tooling/src/template_test.rs
+++ b/crates/template_test_tooling/src/template_test.rs
@@ -302,8 +302,6 @@ impl TemplateTest {
         template_addr
     }
 
-    /// Enables fee charging for subsequent transaction executions.
-    /// By default, fees are disabled in tests.
     /// Executes subsequent transactions as a dry run: fees are metered but not settled, as the
     /// indexer's fee estimation does.
     pub fn set_dry_run(&mut self, dry_run: bool) -> &mut Self {
@@ -311,6 +309,8 @@ impl TemplateTest {
         self
     }
 
+    /// Enables fee charging for subsequent transaction executions.
+    /// By default, fees are disabled in tests.
     pub fn enable_fees(&mut self) -> &mut Self {
         self.enable_fees = true;
         self

--- a/crates/wallet/sdk/src/apis/stealth_transfer/params.rs
+++ b/crates/wallet/sdk/src/apis/stealth_transfer/params.rs
@@ -16,7 +16,7 @@ use crate::apis::{
     stealth_transfer::{StealthOutputToCreate, StealthTransferApiError},
 };
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct StealthTransferParams {
     /// Parameters related to fee payment
     pub fee_params: TransferFeeParams,

--- a/docs/developer-docs/src/content/docs/reference/fees.mdx
+++ b/docs/developer-docs/src/content/docs/reference/fees.mdx
@@ -362,11 +362,6 @@ Submit a transaction as a **dry run** and the engine meters it exactly as it wou
 aborts for insufficient payment. Read `FinalizeResult::required_fees()` from the result and use it as
 the `max_fee`.
 
-The one bound a dry run *does* enforce is the fee intent's compute credit. It is a flat figure rather
-than one derived from a payment, so it is the same for an estimate as for a real run — a fee intent
-above it fails estimation with `FeeIntentComputeExceeded` instead of first surfacing at submission,
-where the only remedy is to restructure the transaction.
-
 That figure is `total_fees_required + FEE_ESTIMATE_ALLOWANCE` (25 µT). The allowance exists because
 `max_fee` is itself an input to the cost, so the real run meters *slightly* differently from the dry
 run that estimated it:
@@ -379,6 +374,18 @@ run that estimated it:
 
 The allowance bounds the pair in both directions at any exhaust burn rate up to
 `MAX_EXHAUST_BURN_RATE_BPS`.
+
+An estimate describes the transaction it was metered on, which matters wherever the fee feeds back
+into the transaction's shape. Stealth input selection targets `amount + max_fee`, so the fee decides
+which UTXOs are spent and whether any change is left over — and a change output is another stealth
+output to verify. A figure taken at a guessed fee therefore prices a shape the real submission need
+not have, so it has to be re-derived at the fee it reports until it settles. The wallet daemon does
+that internally for its dry runs.
+
+The one bound a dry run *does* enforce is the fee intent's compute credit. It is a flat figure rather
+than one derived from a payment, so it is the same for an estimate as for a real run — a fee intent
+above it fails estimation with `FeeIntentComputeExceeded` instead of first surfacing at submission,
+where the only remedy is to restructure the transaction.
 
 <Aside type="tip">
   `required_fees()` is a floor, not a recommendation. Overpayment returns to the paying vault, so a


### PR DESCRIPTION
## The bug

A dry run prices whatever shape the caller's guessed fee produces — and that fee is an input to the
shape. Stealth input selection targets `amount + max_fee`, so the fee decides which UTXOs are spent
and whether any change is left over, and a change output is another stealth output to verify at
`PER_OUTPUT` = 6,000,000 points. The estimate could therefore describe a materially cheaper
transaction than the one built from it.

Reproduced on a local swarm, on the transaction that prompted this:

| | inputs selected | stealth outputs | `NativeExecution` | required |
|---|---|---|---|---|
| dry run at the frontend's `max_fee=1` | worth 8,000,001 | 1 (change = 0) | 8,184 | **9,354** |
| dry run at 9,354 | worth 8,986,059 | 2 (change 976,705) | 14,184 | 15,951 |
| the submission built from the estimate | worth 8,986,059 | 2 | 14,184 | **15,951** |

At `max_fee=1` the selected inputs covered the transfer exactly, so there was no change and the
statement carried a single output. At the real fee they no longer cover it, a larger pair is chosen,
change appears, and the transaction is rejected as underpaid — collecting nothing, since a fee intent
that fails leaves no checkpoint to fall back to.

The whole 6,597 shortfall is one stealth output: 6,000 for the output, 300 of exhaust burn on it, and
~297 of storage and substate creation.

## The fix

The dry-run path in `handle_stealth_transfer` rebuilds at each figure it reports until a build at
that figure pays for itself, then answers with the run that named it. The caller therefore reads a
fee that some build has been held to, rather than one derived from a shape that is about to change.

The settling test is against **what the shape was charged**, not against `required_fees`. The estimate
allowance `required_fees` carries on top is the caller's margin for the metering drift a wider
`max_fee` causes; testing against it treats a fee that already pays in full as insufficient and spends
another round chasing the padding. On the swarm that difference alone took the loop from 4 rounds to
2. The reported figure still includes the allowance.

Bounded at 5 rounds, with a warning and the highest figure reached if it does not settle — an estimate
below the cost cannot be submitted at all, so the higher figure is the safer answer.

`StealthTransferParams` gains `Clone` so a round can rebuild. Each round's lock is released as before,
which also discards that round's unconfirmed change outputs.

## Verified on a swarm

Wallet daemon rebuilt and restarted on this branch, same account and destination as the failing
transaction:

| transfer | estimate | rounds | submission |
|---|---|---|---|
| 8,000,000 | 15,978 | 4 (before the `charged` refinement) | **Accepted**, paid 15,978 |
| 500,000 | 15,909 | 2 | **Accepted**, paid 15,909 |

Both settle with an overcharge equal to the estimate allowance (25 and 23 µT), which is expected and
is not refundable on a stealth-revealed fee — the reason this iterates rather than padding the
estimate.

## Also, from review on #2441

- `enable_fees` gets its doc comment back; inserting `set_dry_run` above it had taken it.
- The dry-run credit paragraph in `reference/fees.mdx` moves below the `FEE_ESTIMATE_ALLOWANCE`
  bullets, so "That figure" refers to `required_fees()` again.
- Adds a paragraph there on why an estimate only describes the shape it was metered on, which is the
  bug class this PR fixes.

## Test plan

- [x] `cargo check` clean on `tari_ootle_walletd` and `tari_ootle_wallet_sdk`, including tests
- [x] Docs site builds
- [x] End-to-end on a local swarm: estimate → submit → committed, twice (table above)
