### PR TITLE
fix(walletd): price the settle decision against a figure that survives the wire

### DIFF
--- a/applications/tari_walletd/src/handlers/accounts.rs
+++ b/applications/tari_walletd/src/handlers/accounts.rs
@@ -1315,16 +1315,23 @@ pub async fn handle_stealth_transfer(
 
         loop {
             let max_fee_this_round = params.max_fee;
-            let (lock, transfer) = sdk
+            let build = sdk
                 .stealth_transfer_api()
                 .transfer(owner_account.clone(), params.clone())
-                .await
-                .with_context(|| {
+                .await;
+            // Only an estimate names a round, and only an estimate raises the fee between builds:
+            // a later round widens the selection target to `amount + max_fee`, so it can exhaust an
+            // account that funded the earlier one, and the failure needs to say which fee did it.
+            let (lock, transfer) = if req.dry_run {
+                build.with_context(|| {
                     format!(
-                        "building the transfer at a max fee of {max_fee_this_round} (round {})",
+                        "building the transfer at a max fee of {max_fee_this_round} (fee estimate round {})",
                         rounds + 1
                     )
-                })?;
+                })?
+            } else {
+                build?
+            };
 
             let transaction = transfer.transaction;
             let main_pk = transfer.main_signer.public_key().to_byte_type();
@@ -1353,7 +1360,13 @@ pub async fn handle_stealth_transfer(
                 let result = transaction_service
                     .submit_dry_run_transaction(transaction)
                     .await
-                    .map_err(|e| anyhow::anyhow!("Dry run transaction failed: {}", e))?;
+                    .map_err(|e| {
+                        anyhow::anyhow!(
+                            "Dry run transaction failed at a max fee of {max_fee_this_round} (fee estimate round {}): \
+                             {e}",
+                            rounds + 1
+                        )
+                    })?;
 
                 let required_fees = result.finalize.required_fees();
                 // What this round's shape actually costs, without the estimate allowance that
@@ -1944,8 +1957,11 @@ mod fee_estimate_step_tests {
 
     /// The caller's guessed fee has nothing behind it, so a round that covers itself with no
     /// candidate still has to be built at the figure it reports before that figure can be answered
-    /// with. This is what stops a legacy payload — whose cost decodes as zero — settling on the
-    /// guess.
+    /// with.
+    ///
+    /// This delays a cost of zero by one round rather than rejecting it: a second round does hold a
+    /// candidate, and `0 <= built_at`, so it would settle. What keeps a zero out of here is
+    /// `FinalizeResult::charged_fees`, which falls back to what the receipt was charged.
     #[test]
     fn does_not_settle_on_the_callers_guess() {
         assert_eq!(next_fee_estimate_step(1, 0, 9_354, false, 1), FeeEstimateStep::Retry {

--- a/applications/tari_walletd/src/handlers/accounts.rs
+++ b/applications/tari_walletd/src/handlers/accounts.rs
@@ -3,7 +3,7 @@
 
 use std::{collections::HashSet, iter, path::Path, time::Duration};
 
-use anyhow::{Context, anyhow};
+use anyhow::anyhow;
 use axum_extra::headers::authorization::Bearer;
 use indexmap::{IndexMap, IndexSet};
 use log::*;
@@ -1322,10 +1322,12 @@ pub async fn handle_stealth_transfer(
             // Only an estimate names a round, and only an estimate raises the fee between builds:
             // a later round widens the selection target to `amount + max_fee`, so it can exhaust an
             // account that funded the earlier one, and the failure needs to say which fee did it.
+            // The cause is interpolated rather than added as context: `anyhow::Error` renders only
+            // its outermost layer under `{}`, which is what the caller and the log see.
             let (lock, transfer) = if req.dry_run {
-                build.with_context(|| {
-                    format!(
-                        "building the transfer at a max fee of {max_fee_this_round} (fee estimate round {})",
+                build.map_err(|e| {
+                    anyhow!(
+                        "building the transfer at a max fee of {max_fee_this_round} (fee estimate round {}): {e}",
                         rounds + 1
                     )
                 })?
@@ -1407,7 +1409,7 @@ pub async fn handle_stealth_transfer(
                     Some(lock.id()),
                 )
                 .await
-                .context("Transaction failed to submit")?;
+                .map_err(|e| anyhow!("Transaction failed to submit: {e}"))?;
 
             // Transaction submitted, we're home free, make sure to allow the lock to persist past this call.
             // The wallet will monitor the transaction and release the lock when it's finalized.
@@ -1999,7 +2001,9 @@ mod fee_estimate_step_tests {
     /// a build at what that shape reported.
     #[test]
     fn the_cap_leaves_room_for_the_common_case() {
-        assert!(MAX_FEE_ESTIMATE_ROUNDS >= 3);
+        const {
+            assert!(MAX_FEE_ESTIMATE_ROUNDS >= 3);
+        }
     }
 }
 

--- a/applications/tari_walletd/src/handlers/accounts.rs
+++ b/applications/tari_walletd/src/handlers/accounts.rs
@@ -1310,14 +1310,21 @@ pub async fn handle_stealth_transfer(
         // submission will not have. Rebuild at each figure reported until building at it needs no
         // more than it, then answer with the run that named it, which is a figure the caller can
         // submit at.
-        let mut verified_estimate: Option<StealthTransferResponse> = None;
+        let mut candidate: Option<StealthTransferResponse> = None;
         let mut rounds = 0usize;
 
         loop {
+            let max_fee_this_round = params.max_fee;
             let (lock, transfer) = sdk
                 .stealth_transfer_api()
                 .transfer(owner_account.clone(), params.clone())
-                .await?;
+                .await
+                .with_context(|| {
+                    format!(
+                        "building the transfer at a max fee of {max_fee_this_round} (round {})",
+                        rounds + 1
+                    )
+                })?;
 
             let transaction = transfer.transaction;
             let main_pk = transfer.main_signer.public_key().to_byte_type();
@@ -1353,34 +1360,31 @@ pub async fn handle_stealth_transfer(
                 // `required_fees` carries on top. That allowance is the caller's margin against the
                 // metering drift a wider `max_fee` causes; testing against it here would treat a fee
                 // that pays in full as insufficient and spend another round chasing it.
-                let charged = result.finalize.total_fees_required;
+                let charged = result.finalize.charged_fees();
                 let response = StealthTransferResponse {
                     transaction_id: result.finalize.transaction_hash.into(),
                 };
                 rounds += 1;
 
-                // `verified_estimate` reported the fee this round was built at, so this round is what
-                // establishes that a transaction built at that fee pays for itself.
-                if charged <= params.max_fee &&
-                    let Some(verified) = verified_estimate
-                {
-                    return Ok(verified);
+                match next_fee_estimate_step(params.max_fee, charged, required_fees, candidate.is_some(), rounds) {
+                    FeeEstimateStep::Settle => {
+                        return Ok(candidate.expect("BUG: Settle is only reached with a candidate"));
+                    },
+                    FeeEstimateStep::GiveUp => {
+                        warn!(
+                            target: LOG_TARGET,
+                            "Stealth transfer fee estimate did not settle in {MAX_FEE_ESTIMATE_ROUNDS} rounds (built \
+                             at {} but cost {charged})",
+                            params.max_fee
+                        );
+                        return Ok(response);
+                    },
+                    FeeEstimateStep::Retry { max_fee } => {
+                        params.max_fee = max_fee;
+                        candidate = Some(response);
+                        continue;
+                    },
                 }
-                if rounds >= MAX_FEE_ESTIMATE_ROUNDS {
-                    // Out of rounds: answer with the highest figure reached rather than one nothing
-                    // has been built at, since an estimate below the cost cannot be submitted at all.
-                    warn!(
-                        target: LOG_TARGET,
-                        "Stealth transfer fee estimate did not settle in {MAX_FEE_ESTIMATE_ROUNDS} rounds (a max fee \
-                         of {} was charged {charged})",
-                        params.max_fee
-                    );
-                    return Ok(response);
-                }
-
-                params.max_fee = required_fees;
-                verified_estimate = Some(response);
-                continue;
             }
 
             let tx_id = transaction_service
@@ -1407,11 +1411,46 @@ pub async fn handle_stealth_transfer(
     .await?
 }
 
-/// How many times a dry run may rebuild at the fee it last reported before answering with whatever
-/// it reached. Two rounds settle the common case — the caller's guessed fee, then the shape that
-/// fee produces — and the third confirms it; the rest is headroom for a selection that keeps
-/// growing.
-const MAX_FEE_ESTIMATE_ROUNDS: usize = 4;
+/// How many times a dry run may build before answering with whatever figure it reached. Three
+/// settle the common case — the caller's guessed fee, the shape that fee produces, and a build at
+/// the figure that shape reported, which confirms it — and the rest is headroom for a selection
+/// that keeps growing as the fee rises.
+const MAX_FEE_ESTIMATE_ROUNDS: usize = 5;
+
+/// What a dry-run estimation round decides to do next.
+#[derive(Debug, PartialEq, Eq)]
+enum FeeEstimateStep {
+    /// The fee this round was built at covers the shape it produced, so the candidate that named
+    /// that fee is an answer the caller can submit at. Only reached with a candidate in hand.
+    Settle,
+    /// Build again at this fee.
+    Retry { max_fee: u64 },
+    /// Out of rounds; answer with what this round reached.
+    GiveUp,
+}
+
+/// Decides what an estimation round leads to, given what the round was `built_at`, what the shape it
+/// produced was `charged`, the `required` figure it reports, whether an earlier round named
+/// `built_at`, and how many rounds have run.
+///
+/// A round settles only against a candidate: a figure is worth reporting once a build at it has been
+/// shown to cover itself, and the round that shows that is the one after the round that named it.
+/// Without a candidate the fee under test is the caller's guess, which nothing has verified.
+fn next_fee_estimate_step(
+    built_at: u64,
+    charged: u64,
+    required: u64,
+    has_candidate: bool,
+    rounds_taken: usize,
+) -> FeeEstimateStep {
+    if has_candidate && charged <= built_at {
+        return FeeEstimateStep::Settle;
+    }
+    if rounds_taken >= MAX_FEE_ESTIMATE_ROUNDS {
+        return FeeEstimateStep::GiveUp;
+    }
+    FeeEstimateStep::Retry { max_fee: required }
+}
 
 #[allow(clippy::too_many_lines)]
 pub async fn handle_create_stealth_transfer_statement(
@@ -1883,6 +1922,68 @@ mod balance_change_handler_tests {
         drop(transaction_service);
         utxo_worker.abort();
         drop(utxo_worker.await);
+    }
+}
+
+#[cfg(test)]
+mod fee_estimate_step_tests {
+    use super::*;
+
+    /// The round after the one that named a fee is what shows a build at that fee covers itself.
+    #[test]
+    fn settles_once_a_named_fee_covers_the_shape_it_produces() {
+        assert_eq!(
+            next_fee_estimate_step(9_000, 9_000, 9_025, true, 2),
+            FeeEstimateStep::Settle
+        );
+        assert_eq!(
+            next_fee_estimate_step(9_000, 8_000, 8_025, true, 2),
+            FeeEstimateStep::Settle
+        );
+    }
+
+    /// The caller's guessed fee has nothing behind it, so a round that covers itself with no
+    /// candidate still has to be built at the figure it reports before that figure can be answered
+    /// with. This is what stops a legacy payload — whose cost decodes as zero — settling on the
+    /// guess.
+    #[test]
+    fn does_not_settle_on_the_callers_guess() {
+        assert_eq!(next_fee_estimate_step(1, 0, 9_354, false, 1), FeeEstimateStep::Retry {
+            max_fee: 9_354
+        });
+    }
+
+    /// A shape that costs more than the fee it was built at is not submittable, so the figure it
+    /// reports becomes the next fee to try.
+    #[test]
+    fn retries_at_the_reported_figure_when_the_shape_costs_more() {
+        assert_eq!(
+            next_fee_estimate_step(9_354, 15_951, 15_976, true, 2),
+            FeeEstimateStep::Retry { max_fee: 15_976 }
+        );
+    }
+
+    /// The cap is a bound on rounds, not a settle condition: the estimate returned is whatever the
+    /// last round reached, which is the highest, since a round only continues while the shape costs
+    /// more than it was built at.
+    #[test]
+    fn gives_up_at_the_round_cap() {
+        assert_eq!(
+            next_fee_estimate_step(15_976, 15_978, 16_003, true, MAX_FEE_ESTIMATE_ROUNDS),
+            FeeEstimateStep::GiveUp
+        );
+        // The cap does not pre-empt a settle that has already been established.
+        assert_eq!(
+            next_fee_estimate_step(15_976, 15_976, 16_001, true, MAX_FEE_ESTIMATE_ROUNDS),
+            FeeEstimateStep::Settle
+        );
+    }
+
+    /// Three builds settle the case this exists for: the caller's guess, the shape it produces, and
+    /// a build at what that shape reported.
+    #[test]
+    fn the_cap_leaves_room_for_the_common_case() {
+        assert!(MAX_FEE_ESTIMATE_ROUNDS >= 3);
     }
 }
 

--- a/applications/tari_walletd/src/server.rs
+++ b/applications/tari_walletd/src/server.rs
@@ -345,7 +345,9 @@ pub fn resolve_handler_error(answer_id: axum_jrpc::Id, e: &HandlerError) -> Json
 }
 
 fn resolve_any_error(answer_id: axum_jrpc::Id, e: &anyhow::Error) -> JsonRpcResponse {
-    warn!(target: LOG_TARGET, "🌐 JSON-RPC error: {}", e);
+    // `{:#}` renders the whole context chain. `{}` prints only the outermost, so every handler that
+    // adds context with `.context(…)` would report the context and drop the cause under it.
+    warn!(target: LOG_TARGET, "🌐 JSON-RPC error: {:#}", e);
     if let Some(handler_err) = e.downcast_ref::<HandlerError>() {
         return resolve_handler_error(answer_id, handler_err);
     }
@@ -371,7 +373,9 @@ fn resolve_any_error(answer_id: axum_jrpc::Id, e: &anyhow::Error) -> JsonRpcResp
             answer_id,
             JsonRpcError::new(
                 JsonRpcErrorReason::ApplicationError(ApplicationErrorCode::GeneralError as i32),
-                e.to_string(),
+                // The whole chain, for the same reason as the log above: a caller needs the cause,
+                // not just the context the handler wrapped it in.
+                format!("{e:#}"),
                 json!({}),
             ),
         )

--- a/applications/tari_walletd/src/server.rs
+++ b/applications/tari_walletd/src/server.rs
@@ -345,9 +345,7 @@ pub fn resolve_handler_error(answer_id: axum_jrpc::Id, e: &HandlerError) -> Json
 }
 
 fn resolve_any_error(answer_id: axum_jrpc::Id, e: &anyhow::Error) -> JsonRpcResponse {
-    // `{:#}` renders the whole context chain. `{}` prints only the outermost, so every handler that
-    // adds context with `.context(…)` would report the context and drop the cause under it.
-    warn!(target: LOG_TARGET, "🌐 JSON-RPC error: {:#}", e);
+    warn!(target: LOG_TARGET, "🌐 JSON-RPC error: {}", e);
     if let Some(handler_err) = e.downcast_ref::<HandlerError>() {
         return resolve_handler_error(answer_id, handler_err);
     }
@@ -373,9 +371,7 @@ fn resolve_any_error(answer_id: axum_jrpc::Id, e: &anyhow::Error) -> JsonRpcResp
             answer_id,
             JsonRpcError::new(
                 JsonRpcErrorReason::ApplicationError(ApplicationErrorCode::GeneralError as i32),
-                // The whole chain, for the same reason as the log above: a caller needs the cause,
-                // not just the context the handler wrapped it in.
-                format!("{e:#}"),
+                e.to_string(),
                 json!({}),
             ),
         )

--- a/crates/engine_types/src/commit_result.rs
+++ b/crates/engine_types/src/commit_result.rs
@@ -221,15 +221,19 @@ impl FinalizeResult {
         self
     }
 
-    /// The minimum `max_fee` a resubmission of this transaction has to carry.
+    /// What committing this transaction costs, with no estimate allowance on top.
     ///
     /// Falls back to what the receipt was charged. `total_fees_required` is additive on the wire, so
-    /// a payload from a peer that predates it decodes as zero — reading it raw would answer a fee
-    /// estimate with the allowance alone.
+    /// a payload from a peer that predates it decodes as zero — reading it raw would price a
+    /// transaction at nothing.
+    pub fn charged_fees(&self) -> u64 {
+        self.total_fees_required.max(self.fee_receipt.total_fees_charged())
+    }
+
+    /// The minimum `max_fee` a resubmission of this transaction has to carry: [`Self::charged_fees`]
+    /// plus the allowance covering the metering drift a different `max_fee` causes.
     pub fn required_fees(&self) -> u64 {
-        self.total_fees_required
-            .max(self.fee_receipt.total_fees_charged())
-            .saturating_add(FEE_ESTIMATE_ALLOWANCE)
+        self.charged_fees().saturating_add(FEE_ESTIMATE_ALLOWANCE)
     }
 
     pub fn new_rejected(transaction_hash: Hash32, reason: RejectReason) -> Self {
@@ -583,6 +587,9 @@ mod tests {
         let mut result = result_charged(5_000);
         result.total_fees_required = 0;
         assert!(result.required_fees() > 5_000);
+        // The same fallback, for a caller that wants the cost without the allowance on top: reading
+        // the raw field would price this transaction at nothing.
+        assert_eq!(result.charged_fees(), 5_000);
     }
 
     /// When the two differ, the gating figure is the one a resubmission has to clear.

--- a/docs/developer-docs/src/content/docs/reference/fees.mdx
+++ b/docs/developer-docs/src/content/docs/reference/fees.mdx
@@ -379,8 +379,9 @@ An estimate describes the transaction it was metered on, which matters wherever 
 into the transaction's shape. Stealth input selection targets `amount + max_fee`, so the fee decides
 which UTXOs are spent and whether any change is left over — and a change output is another stealth
 output to verify. A figure taken at a guessed fee therefore prices a shape the real submission need
-not have, so it has to be re-derived at the fee it reports until it settles. The wallet daemon does
-that internally for its dry runs.
+not have, so it has to be re-derived at the fee it reports until it settles. The wallet daemon's
+`accounts.stealth_transfer` does that internally for its dry runs; `accounts.confidential_transfer`
+answers from a single round and carries the same caveat.
 
 The one bound a dry run *does* enforce is the fee intent's compute credit. It is a flat figure rather
 than one derived from a payment, so it is the same for an estimate as for a real run — a fee intent


### PR DESCRIPTION
Follow-ups from review on #2443, which landed after it merged.

## Blocking: the settle test read a field that decodes as zero

The loop tested `FinalizeResult::total_fees_required` raw. That field is additive on the wire and
decodes as `0` from a peer that predates it — which is exactly why `required_fees()` applies a
`.max(fee_receipt.total_fees_charged())` fallback and says so, pinned by
`a_missing_required_total_falls_back_to_what_was_charged`.

Against such an indexer the shape's cost read as zero, so `charged <= max_fee` held unconditionally
and round 2 answered with round 1's estimate: the figure taken at the caller's guessed fee, priced on
the shape that fee produced. That is the bug #2443 exists to prevent, restored silently — no warning,
no round cap hit, and `required_fees()` still falling back correctly, so the returned figure looked
plausible while describing the wrong shape.

`FinalizeResult::charged_fees()` now names "what this cost, with no allowance on top" and applies the
same fallback; `required_fees()` is defined in terms of it. There was previously no way to ask that
question without reaching for the raw field, so the next caller would have made the same mistake.

## The settle decision is now testable

`next_fee_estimate_step(built_at, charged, required, has_candidate, rounds_taken)` returns
`Settle | Retry { max_fee } | GiveUp`. The loop keeps the I/O; the conditions it turns on are a pure
function with five unit tests, including the case above — a round that covers itself with **no**
candidate must still retry, because the fee under test is the caller's guess and nothing has verified
it.

## Also

- `MAX_FEE_ESTIMATE_ROUNDS` is 5. #2443's description said 5 while the constant said 4; the intended
  value is 5, which leaves headroom past the three builds the common case needs. Its doc no longer
  says "rebuild" when the counter counts builds.
- A build failure carries the fee and round that provoked it. A later round widens the selection
  target to `amount + max_fee`, so it can exhaust an account that funded the earlier one, and that
  surfaced as a bare `InsufficientFunds` with nothing tying it to the round that raised the fee.
- `verified_estimate` is now `candidate` — it is not verified when assigned; the round after it is
  what verifies it.
- The fee reference no longer implies the daemon iterates generally: `accounts.stealth_transfer`
  does, `accounts.confidential_transfer` still answers from a single round and has the same
  feedback.

## Test plan

- [x] `cargo test -p tari_ootle_walletd --lib fee_estimate_step` — 5 passing
- [x] `cargo test -p tari_engine_types --lib commit_result` — including the extended fallback test
- [x] `cargo check --workspace --tests`
- [x] Docs site builds
