### PR TITLE
ci: run the compile-bound jobs on the self-hosted high-cpu runners

### DIFF
--- a/.github/workflows/build_binaries.json
+++ b/.github/workflows/build_binaries.json
@@ -2,7 +2,7 @@
   {
     "name": "linux-x86_64",
     "runs-on": "ubuntu-22.04",
-    "rust": "stable",
+    "rust": "1.97.1",
     "target": "x86_64-unknown-linux-gnu",
     "cross": false,
     "features": ""
@@ -10,7 +10,7 @@
   {
     "name": "linux-arm64",
     "runs-on": "ubuntu-22.04-arm",
-    "rust": "stable",
+    "rust": "1.97.1",
     "target": "aarch64-unknown-linux-gnu",
     "cross": false,
     "build_enabled": true,
@@ -19,7 +19,7 @@
   {
     "name": "linux-riscv64",
     "runs-on": "ubuntu-latest",
-    "rust": "stable",
+    "rust": "1.97.1",
     "target": "riscv64gc-unknown-linux-gnu",
     "cross": true,
     "build_enabled": true,
@@ -28,7 +28,7 @@
   {
     "name": "macos-x86_64",
     "runs-on": "macos-15-intel",
-    "rust": "stable",
+    "rust": "1.97.1",
     "target": "x86_64-apple-darwin",
     "cross": false,
     "features": ""
@@ -36,7 +36,7 @@
   {
     "name": "macos-arm64",
     "runs-on": "macos-14",
-    "rust": "stable",
+    "rust": "1.97.1",
     "target": "aarch64-apple-darwin",
     "cross": false,
     "features": "",
@@ -46,7 +46,7 @@
   {
     "name": "windows-x64",
     "runs-on": "windows-2022",
-    "rust": "stable",
+    "rust": "1.97.1",
     "target": "x86_64-pc-windows-msvc",
     "cross": false,
     "features": ""
@@ -54,7 +54,7 @@
   {
     "name": "windows-arm64",
     "runs-on": "windows-latest",
-    "rust": "stable",
+    "rust": "1.97.1",
     "target": "aarch64-pc-windows-msvc",
     "cross": false,
     "features": "",

--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -37,7 +37,7 @@ env:
   TS_BUILD: "release"
   TARI_TARGET_NETWORK: igor
   TARI_NETWORK: igor
-  toolchain: 1.77
+  toolchain: 1.97.1
   matrix-json-file: ".github/workflows/build_binaries.json"
   CARGO_HTTP_MULTIPLEXING: false
   CARGO_UNSTABLE_SPARSE_REGISTRY: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,10 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     env:
-      RUSTFLAGS: -C link-arg=-fuse-ld=mold
+      # Host-scoped, not RUSTFLAGS: template_builtin's build.rs shells out to
+      # `cargo build --target wasm32-unknown-unknown`, and rust-lld rejects
+      # `-fuse-ld`.
+      CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=mold
 
     steps:
       - name: checkout
@@ -192,7 +195,10 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     env:
-      RUSTFLAGS: -C link-arg=-fuse-ld=mold
+      # Host-scoped, not RUSTFLAGS: template_builtin's build.rs shells out to
+      # `cargo build --target wasm32-unknown-unknown`, and rust-lld rejects
+      # `-fuse-ld`.
+      CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=mold
 
     steps:
       - name: checkout
@@ -269,7 +275,10 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     env:
-      RUSTFLAGS: -C link-arg=-fuse-ld=mold
+      # Host-scoped, not RUSTFLAGS: template_builtin's build.rs shells out to
+      # `cargo build --target wasm32-unknown-unknown`, and rust-lld rejects
+      # `-fuse-ld`.
+      CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=mold
     strategy:
       matrix:
         partition: ["1/3", "2/3", "3/3"]
@@ -361,7 +370,10 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     env:
-      RUSTFLAGS: -C link-arg=-fuse-ld=mold
+      # Host-scoped, not RUSTFLAGS: template_builtin's build.rs shells out to
+      # `cargo build --target wasm32-unknown-unknown`, and rust-lld rejects
+      # `-fuse-ld`.
+      CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=mold
 
     steps:
       - name: checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ concurrency:
 
 env:
   nightly_toolchain: nightly-2025-12-05
-  stable_toolchain: stable
+  rust_toolchain: 1.97.1
   CARGO_HTTP_MULTIPLEXING: false
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
@@ -162,9 +162,9 @@ jobs:
         uses: actions/checkout@v7.0.1
 
       - name: toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772  # master (no version tag)
         with:
-          toolchain: ${{ env.stable_toolchain }}
+          toolchain: ${{ env.rust_toolchain }}
           components: clippy
 
       - uses: ./.github/actions/rust-cache
@@ -199,9 +199,9 @@ jobs:
         uses: actions/checkout@v7.0.1
 
       - name: toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772  # master (no version tag)
         with:
-          toolchain: ${{ env.stable_toolchain }}
+          toolchain: ${{ env.rust_toolchain }}
           components: clippy, rustfmt
 
       - uses: ./.github/actions/rust-cache
@@ -279,9 +279,9 @@ jobs:
         uses: actions/checkout@v7.0.1
 
       - name: toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772  # master (no version tag)
         with:
-          toolchain: ${{ env.stable_toolchain }}
+          toolchain: ${{ env.rust_toolchain }}
 
       - uses: ./.github/actions/rust-cache
         with:
@@ -368,9 +368,9 @@ jobs:
         uses: actions/checkout@v7.0.1
 
       - name: toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772  # master (no version tag)
         with:
-          toolchain: ${{ env.stable_toolchain }}
+          toolchain: ${{ env.rust_toolchain }}
 
       - uses: ./.github/actions/rust-cache
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
 
   clippy:
     name: clippy
-    runs-on: [ ubuntu-latest ]
+    runs-on: [ self-hosted, ubuntu-high-cpu ]
 
     steps:
       - name: checkout
@@ -181,7 +181,7 @@ jobs:
   machete:
     # Checks for unused dependencies.
     name: machete
-    runs-on: [ ubuntu-latest ]
+    runs-on: [ self-hosted, ubuntu-high-cpu ]
 
     steps:
       - name: checkout
@@ -311,7 +311,7 @@ jobs:
     # `cancel-in-progress` must leave this check cancelled rather than failed.
     if: ${{ !cancelled() }}
     needs: [ test-shards ]
-    runs-on: [ ubuntu-latest ]
+    runs-on: [ self-hosted, ubuntu-high-cpu ]
     steps:
       - name: check shard results
         run: |
@@ -348,7 +348,7 @@ jobs:
 
   integration-test:
     name: integration test
-    runs-on: [ ubuntu-latest ]
+    runs-on: [ self-hosted, ubuntu-high-cpu ]
 
     steps:
       - name: checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,7 +256,7 @@ jobs:
 
   test-shards:
     name: test (${{ matrix.partition }})
-    runs-on: [ ubuntu-latest ]
+    runs-on: [ self-hosted, ubuntu-high-cpu ]
     strategy:
       matrix:
         partition: ["1/3", "2/3", "3/3"]
@@ -311,7 +311,7 @@ jobs:
     # `cancel-in-progress` must leave this check cancelled rather than failed.
     if: ${{ !cancelled() }}
     needs: [ test-shards ]
-    runs-on: [ self-hosted, ubuntu-high-cpu ]
+    runs-on: [ ubuntu-latest ]
     steps:
       - name: check shard results
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ name: CI
       - synchronize
   merge_group:
 
+permissions:
+  contents: read
+  packages: read
+
 concurrency:
   # https://docs.github.com/en/actions/examples/using-concurrency-expressions-and-a-test-matrix
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
@@ -145,6 +149,11 @@ jobs:
   clippy:
     name: clippy
     runs-on: [ self-hosted, ubuntu-high-cpu ]
+    container:
+      image: ghcr.io/tari-project/ootle-ci:development
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - name: checkout
@@ -157,11 +166,6 @@ jobs:
           components: clippy
 
       - uses: ./.github/actions/rust-cache
-
-      - name: ubuntu dependencies
-        run: |
-          sudo apt-get update
-          sudo bash scripts/install_ubuntu_dependencies.sh
 
       - uses: rui314/setup-mold@v1
 
@@ -182,6 +186,11 @@ jobs:
     # Checks for unused dependencies.
     name: machete
     runs-on: [ self-hosted, ubuntu-high-cpu ]
+    container:
+      image: ghcr.io/tari-project/ootle-ci:development
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - name: checkout
@@ -194,11 +203,6 @@ jobs:
           components: clippy, rustfmt
 
       - uses: ./.github/actions/rust-cache
-
-      - name: ubuntu dependencies
-        run: |
-          sudo apt-get update
-          sudo bash scripts/install_ubuntu_dependencies.sh
 
       - name: cargo machete
         run: |
@@ -257,6 +261,11 @@ jobs:
   test-shards:
     name: test (${{ matrix.partition }})
     runs-on: [ self-hosted, ubuntu-high-cpu ]
+    container:
+      image: ghcr.io/tari-project/ootle-ci:development
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       matrix:
         partition: ["1/3", "2/3", "3/3"]
@@ -273,11 +282,6 @@ jobs:
       - uses: ./.github/actions/rust-cache
         with:
           save-if: ${{ matrix.partition == '1/3' }}
-
-      - name: ubuntu dependencies
-        run: |
-          sudo apt-get update
-          sudo bash scripts/install_ubuntu_dependencies.sh
 
       - uses: rui314/setup-mold@v1
 
@@ -349,6 +353,11 @@ jobs:
   integration-test:
     name: integration test
     runs-on: [ self-hosted, ubuntu-high-cpu ]
+    container:
+      image: ghcr.io/tari-project/ootle-ci:development
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - name: checkout
@@ -360,11 +369,6 @@ jobs:
           toolchain: ${{ env.stable_toolchain }}
 
       - uses: ./.github/actions/rust-cache
-
-      - name: ubuntu dependencies
-        run: |
-          sudo apt-get update
-          sudo bash scripts/install_ubuntu_dependencies.sh
 
       - uses: rui314/setup-mold@v1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,8 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      RUSTFLAGS: -C link-arg=-fuse-ld=mold
 
     steps:
       - name: checkout
@@ -166,8 +168,6 @@ jobs:
           components: clippy
 
       - uses: ./.github/actions/rust-cache
-
-      - uses: rui314/setup-mold@v1
 
       - name: wasm target install
         run: rustup target add wasm32-unknown-unknown
@@ -191,6 +191,8 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      RUSTFLAGS: -C link-arg=-fuse-ld=mold
 
     steps:
       - name: checkout
@@ -266,6 +268,8 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      RUSTFLAGS: -C link-arg=-fuse-ld=mold
     strategy:
       matrix:
         partition: ["1/3", "2/3", "3/3"]
@@ -282,8 +286,6 @@ jobs:
       - uses: ./.github/actions/rust-cache
         with:
           save-if: ${{ matrix.partition == '1/3' }}
-
-      - uses: rui314/setup-mold@v1
 
       - name: wasm target install
         run: rustup target add wasm32-unknown-unknown
@@ -358,6 +360,8 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      RUSTFLAGS: -C link-arg=-fuse-ld=mold
 
     steps:
       - name: checkout
@@ -369,8 +373,6 @@ jobs:
           toolchain: ${{ env.stable_toolchain }}
 
       - uses: ./.github/actions/rust-cache
-
-      - uses: rui314/setup-mold@v1
 
       - name: wasm target install
         run: rustup target add wasm32-unknown-unknown

--- a/.github/workflows/ci_base_image.yml
+++ b/.github/workflows/ci_base_image.yml
@@ -1,0 +1,92 @@
+---
+name: Build CI base image
+
+# The `chef` stage of the application Dockerfile already carries everything CI needs to compile the
+# workspace: the Rust toolchain with the wasm32 target, the system libraries the native crates link
+# against, and node/pnpm for the web UIs. Publishing that stage lets the CI jobs run inside it
+# instead of installing the same packages on every runner, every run.
+
+'on':
+  push:
+    branches:
+      - development
+    paths:
+      - 'docker/ootle.Dockerfile'
+      - '.github/workflows/ci_base_image.yml'
+  pull_request:
+    paths:
+      - 'docker/ootle.Dockerfile'
+      - '.github/workflows/ci_base_image.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/development' }}
+
+env:
+  IMAGE_NAME: ootle-ci
+
+jobs:
+  build:
+    name: Build and push CI base image (linux/amd64)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
+          labels: |
+            org.opencontainers.image.vendor=Tari Labs
+            org.opencontainers.image.title=${{ env.IMAGE_NAME }}
+            org.opencontainers.image.description=Build environment for Tari Ootle CI jobs
+            org.opencontainers.image.url=https://github.com/${{ github.repository }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: ./docker/ootle.Dockerfile
+          target: chef
+          platforms: linux/amd64
+          push: true
+          provenance: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Summary
+        run: |
+          echo "## CI base image" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Digest:** \`${{ steps.build.outputs.digest }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Tags:**" >> "$GITHUB_STEP_SUMMARY"
+          echo '${{ steps.meta.outputs.tags }}' | while read -r tag; do
+            echo "- \`${tag}\`" >> "$GITHUB_STEP_SUMMARY"
+          done

--- a/.github/workflows/ci_base_image.yml
+++ b/.github/workflows/ci_base_image.yml
@@ -71,7 +71,7 @@ jobs:
         with:
           context: .
           file: ./docker/ootle.Dockerfile
-          target: chef
+          target: ci
           platforms: linux/amd64
           push: true
           provenance: false

--- a/.github/workflows/ci_base_image.yml
+++ b/.github/workflows/ci_base_image.yml
@@ -73,7 +73,9 @@ jobs:
           file: ./docker/ootle.Dockerfile
           target: ci
           platforms: linux/amd64
-          push: true
+          # A pull_request build validates the Dockerfile only. Pushing needs a
+          # token with `packages: write`, which fork PRs are never issued.
+          push: ${{ github.event_name != 'pull_request' }}
           provenance: false
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -81,6 +83,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Summary
+        if: ${{ github.event_name != 'pull_request' }}
         run: |
           echo "## CI base image" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,7 +22,7 @@ jobs:
           sudo bash scripts/install_ubuntu_dependencies.sh
 
       - name: toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772  # master (no version tag)
         with:
           toolchain: nightly
           components: llvm-tools-preview

--- a/.github/workflows/ffi_libs.yml
+++ b/.github/workflows/ffi_libs.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772  # master (no version tag)
         with:
-          toolchain: ${{ matrix.platform == 'windows-x64' && 'stable-x86_64-pc-windows-gnu' || 'stable' }}
+          toolchain: ${{ matrix.platform == 'windows-x64' && '1.97.1-x86_64-pc-windows-gnu' || '1.97.1' }}
           targets: ${{ matrix.target }}
 
       - name: Build + stage native libs

--- a/crates/template_builtin/build.rs
+++ b/crates/template_builtin/build.rs
@@ -75,8 +75,14 @@ fn main() -> anyhow::Result<()> {
 fn compile_template<P: AsRef<Path>>(package_dir: P) -> io::Result<()> {
     let args = ["build", "--target", "wasm32-unknown-unknown", "--release"];
 
+    // The template compiles to wasm32, whose linker is rust-lld. Cargo hands this build script
+    // the host rustflags in CARGO_ENCODED_RUSTFLAGS, and that variable applies to every target,
+    // so anything host-specific in it (a `-fuse-ld`, a `-C target-cpu`) would reach the wasm link
+    // and be rejected.
     let output = Command::new("cargo")
         .current_dir(package_dir.as_ref())
+        .env_remove("CARGO_ENCODED_RUSTFLAGS")
+        .env_remove("RUSTFLAGS")
         .args(args)
         .output()?;
 

--- a/docker/ootle.Dockerfile
+++ b/docker/ootle.Dockerfile
@@ -43,6 +43,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 #   - protobuf-compiler (for prost-build)
 #   - git (for cargo to fetch git deps)
 #   - curl, ca-certificates, gnupg (bootstrap for NodeSource)
+#   - mold, the linker the CI jobs select via `-fuse-ld=mold`
 #   - sudo, so that CI actions which install to system paths work when a job
 #     runs inside this image (see .github/workflows/ci_base_image.yml)
 #
@@ -75,6 +76,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       libssl-dev \
       libudev-dev \
       make \
+      mold \
       openssl \
       pkg-config \
       protobuf-compiler \

--- a/docker/ootle.Dockerfile
+++ b/docker/ootle.Dockerfile
@@ -43,6 +43,8 @@ ENV DEBIAN_FRONTEND=noninteractive \
 #   - protobuf-compiler (for prost-build)
 #   - git (for cargo to fetch git deps)
 #   - curl, ca-certificates, gnupg (bootstrap for NodeSource)
+#   - sudo, so that CI actions which install to system paths work when a job
+#     runs inside this image (see .github/workflows/ci_base_image.yml)
 #
 # If you add a binary that needs more system deps, add them here. The repo's
 # scripts/install_ubuntu_dependencies.sh is the source of truth for dev setup;
@@ -75,7 +77,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       make \
       openssl \
       pkg-config \
-      protobuf-compiler && \
+      protobuf-compiler \
+      sudo && \
     curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - && \
     apt-get install -y --no-install-recommends nodejs && \
     corepack enable && \

--- a/docker/ootle.Dockerfile
+++ b/docker/ootle.Dockerfile
@@ -5,7 +5,9 @@
 # See docs/docker-build-pipeline.md for an architecture overview.
 #
 # Stages:
-#   chef    - base toolchain: rust + system deps + node + pnpm + cargo-chef
+#   sysdeps - rust toolchain + the system libraries every build links against
+#   ci      - sysdeps, published as the image the CI jobs run inside
+#   chef    - sysdeps + node + pnpm + cargo-chef
 #   planner - emits cargo-chef recipe (dependency graph snapshot)
 #   builder - cooks Rust deps, installs JS deps, builds binaries
 #   runtime - minimal Debian 13 with tini and the compiled binaries
@@ -16,20 +18,17 @@
 # Run:
 #   docker run --rm ootle:local tari_validator_node --help
 
-ARG RUST_VERSION=1.95
+ARG RUST_VERSION=1.97.1
 ARG DEBIAN_VERSION=trixie
 ARG NODE_MAJOR=24
 ARG PNPM_VERSION=9
 
 
 # ---------------------------------------------------------------------------
-# chef: shared base for planner and builder
+# sysdeps: rust toolchain and the system libraries every build links against
 # ---------------------------------------------------------------------------
 # Note: Docker Hub uses `<rust>-slim-<distro>` tag ordering (slim before distro).
-FROM rust:${RUST_VERSION}-slim-${DEBIAN_VERSION} AS chef
-
-ARG NODE_MAJOR
-ARG PNPM_VERSION
+FROM rust:${RUST_VERSION}-slim-${DEBIAN_VERSION} AS sysdeps
 
 ENV DEBIAN_FRONTEND=noninteractive \
     CARGO_HTTP_MULTIPLEXING=false
@@ -42,7 +41,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 #   - libudev, libhidapi, libdbus (for ledger HW wallet support in wallet_cli)
 #   - protobuf-compiler (for prost-build)
 #   - git (for cargo to fetch git deps)
-#   - curl, ca-certificates, gnupg (bootstrap for NodeSource)
+#   - curl, ca-certificates, gnupg (bootstrap for NodeSource in the chef stage)
 #   - mold, the linker the CI jobs select via `-fuse-ld=mold`
 #   - sudo, so that CI actions which install to system paths work when a job
 #     runs inside this image (see .github/workflows/ci_base_image.yml)
@@ -80,22 +79,43 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       openssl \
       pkg-config \
       protobuf-compiler \
-      sudo && \
+      sudo
+
+# RUST_VERSION must match the channel pinned in the repo's rust-toolchain.toml.
+# When they agree, rustup resolves the workspace's toolchain to the one already
+# in the base image and installs nothing further.
+#
+# Wasm32 target is required: tari_template_builtin compiles its WASM
+# templates via build.rs (`cargo build --target wasm32-unknown-unknown`).
+RUN rustup target add wasm32-unknown-unknown
+
+
+# ---------------------------------------------------------------------------
+# ci: the image the CI jobs run inside
+# ---------------------------------------------------------------------------
+# Deliberately stops at sysdeps. The CI jobs compile and test the Rust
+# workspace; node, pnpm and cargo-chef are build-pipeline tools they never
+# invoke, and every megabyte here is pulled again on every job because the
+# runners are ephemeral.
+FROM sysdeps AS ci
+
+WORKDIR /base
+
+
+# ---------------------------------------------------------------------------
+# chef: sysdeps plus the JS toolchain and cargo-chef, for the binary build
+# ---------------------------------------------------------------------------
+FROM sysdeps AS chef
+
+ARG NODE_MAJOR
+ARG PNPM_VERSION
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - && \
     apt-get install -y --no-install-recommends nodejs && \
     corepack enable && \
     corepack prepare "pnpm@${PNPM_VERSION}" --activate
-
-# The repo's rust-toolchain.toml pins channel = "stable", which rustup
-# treats as a distinct toolchain from the pre-installed `1.95.0` shipped
-# in the rust:* base image. Switch the default to `stable` first so any
-# `rustup target add` (and subsequent cargo invocations) target the
-# toolchain that the workspace will actually use.
-#
-# Wasm32 target is required: tari_template_builtin compiles its WASM
-# templates via build.rs (`cargo build --target wasm32-unknown-unknown`).
-RUN rustup default stable && \
-    rustup target add wasm32-unknown-unknown
 
 # cargo-chef for Rust dependency prewarming.
 RUN cargo install cargo-chef --locked

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -12,4 +12,4 @@
 # other places to check:
 # - the CI files in .github folder
 [toolchain]
-channel = "stable"
+channel = "1.97.1"


### PR DESCRIPTION
Description
---

Moves the four compile-bound CI jobs — `clippy`, `machete`, `test (n/3)` and `integration test` — from `ubuntu-latest` onto the org's self-hosted runners via `[ self-hosted, ubuntu-high-cpu ]`. Every other job (fmt, prettier, web ui build, docs build, file licenses, ledger app, and the two required-check aggregators) stays on `ubuntu-latest`.

Motivation and Context
---

These jobs used to run on `[ self-hosted, ubuntu-high-cpu ]`. They were switched to `ubuntu-latest` in #1291, an unrelated wallet-daemon auth PR, with no stated reason — it looks incidental rather than deliberate. `tari-project/tari` still runs its heavy job on that same label today, so the runner group and label are live.

Only the jobs whose wall time is dominated by `cargo` are moved; the node/npm and no-op aggregator jobs gain nothing from a bigger machine and are left alone.

How Has This Been Tested?
---

Not yet — this PR *is* the test. The open question is whether these jobs run cleanly on a self-hosted runner, since the hosted images paper over a few assumptions:

- `clippy` and `machete` both run `sudo apt-get update && sudo bash scripts/install_ubuntu_dependencies.sh`, which needs passwordless sudo and mutates the runner host on every run.
- `rui314/setup-mold@v1`, `cargo install cargo-lints` and `cargo install cargo-machete` assume a writable cargo home that isn't shared between concurrent jobs.
- `PROTOC: protoc` assumes protoc is already on PATH.
- Self-hosted runners don't get a clean workspace between runs the way a hosted image does.

If any of those bite, that is very likely the reason the label was dropped in the first place, and the fix belongs in this PR before it merges.

What process can a PR reviewer use to test or verify this change?
---

Watch the run on this PR. The four moved jobs should pick up a self-hosted runner rather than sitting queued, and should finish faster than the `ubuntu-latest` baseline on `development`. If they queue indefinitely, the org runner group isn't exposed to this repo (or to fork PRs) and this needs a settings change rather than a workflow change.

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify