### PR TITLE
docs: add 0.39.0 release notes to the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,80 @@
 All notable changes to this project will be documented in this file.
 See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [0.39.0](https://github.com/tari-project/tari-ootle/compare/v0.38.0...v0.39.0) (2026-08-20)
+
+### ⚠️ Upgrade notes
+
+- `breaking` — **Testnet reset required.** Transaction ids, `TransactionReceipt`, `max_epoch`, the CBOR 128-bit
+  encoding and the fee tables all changed — existing transactions are not compatible.
+- `breaking` — **Templates must be rebuilt and republished against the latest `tari_template_lib`.** `Amount`'s
+  wire format is now minicbor's native integer encoding (compact up to `u64::MAX`, bignum above)
+  instead of a two-element digit array. It's smaller, but not backwards compatible — a template built
+  on the old lib can't decode an `Amount` from the engine, or produce one it can read.
+- `feat!` — **Manifests: the `info!`/`debug!`/`warn!`/`error!` macros are gone** (`Instruction::EmitLog` was
+  removed). Logging *inside* a template is unchanged.
+- `fix!` — **JS clients no longer patch `BigInt.prototype.toJSON`.** All bigints now serialize as strings,
+  consistently — previously small values went out as numbers.
+
+### Wallet 
+
+- `feat!` — **`max_epoch` is now mandatory** on every transaction. `Transaction::builder(network, max_epoch)`
+  takes it at construction; the network caps the window at 2160 epochs (~30 days). This change ensures 
+	transactions have bounded validity.
+- `feat!` — **Stealth transfers can pay up to 16 recipients in one statement** (was 8), which is cheaper than
+  splitting across statements.
+- `fix` — **Stealth fee estimates now settle before they're reported.** The estimate is priced from the
+  transfer's actual shape locally, instead of dry-running at a guessed fee — no more estimates that
+  describe a cheaper transaction than the one that gets built, and no extra network round trips.
+- `fix` — **`final_fee` reports what was actually paid** (`total_fees_paid`), not the dry-run minimum. Partly
+  paid transactions no longer look like they were overcharged.
+- `fix` — **NFT transfers**: the wallet waits for local NFT records to update before answering, so a sent NFT
+  disappears from your NFT list immediately; the web UI send dialog now stays on its result step
+  instead of snapping back to the form.
+- `feat` — **Web UI**: indexer liveness pill in the app bar (colour + tooltip with URL/epoch/error).
+- `fix` — **Web UI**: the login screen no longer issues authenticated RPCs.
+- `feat` — **ootle-wasm**: new `buildScriptPathWitness`, `buildStealthInputsStatementFromInputs` and
+  `createTransferStatement` bindings — `PayTo::Conditions` outputs (hashlock/timelock/covenant MAST
+  trees) can now be spent from the browser.
+
+### Indexer
+
+- `feat` — **Blob references are validated at ingress**, so malformed blob lists are rejected before signature
+  verification instead of being forwarded to committees.
+- `fix!` — `tari_indexer_client` / `@tari-project/indexer-client` pick up the bigint-as-string encoding.
+
+### Consensus
+
+- `feat!` — **Transactions have a bounded lifetime.** `max_transaction_validity_epochs = 2160` on every network;
+  a transaction can no longer stay sequenceable forever.
+- `feat!` — **Transaction ids exclude the seal signature's witness data**, so re-sealing an identical body can't
+  produce N distinct valid transactions (no approve-once-execute-many).
+- `feat!` — **`TransactionReceipt` gains a 32-byte intent commitment** — you can prove a transaction
+  produced a given receipt without revealing the signers' or sealer's public keys.
+- `fix!` — The exhaust burn rate is now bounded at build time, so a network can't be configured above
+  the rate the fee estimate assumes.
+- `chore!` — 128-bit CBOR integers use minicbor's native encoding (wire-breaking for values inside the
+  CBOR integer range).
+
+### Execution Engine
+
+- `feat!` — **Publish fees retuned.** Free allowance 30 KiB → 96 KiB plus a flat 250,000 µT per publish. A large
+  template (~260 KiB) drops from ~5 tTARI to ~2.7 tTARI; oversized templates stay expensive.
+- `fix!` — **Receipts no longer carry `logs`**; use events for anything you need to index.
+- `fix!` — **Receipts are now paid for.** The receipt substate is now charged as storage.
+- `fix!` — **A log is charged for the bytes it carries**, not a flat per-call fee. Ordinary diagnostics
+  cost about what they did; filling `max_logs` with 32 KiB entries no longer does.
+- `fix!` — **Finalization fees are charged against the state actually persisted.** A transaction that commits
+  only its fee intent is no longer priced against state that gets thrown away.
+- `fix!` — **Compute is funded from the payment's unspent balance**, and the fee intent's compute is capped at a
+  flat credit — free compute from repeated fee-intent aborts is closed.
+- `fix!` — **Confidential accounting**: `total_supply` now tracks confidential commitments (previously
+  only the revealed amount, so burnt value was reported forever), and the ElGamal value proof is sound
+  (it was forgeable for any claimed value).
+- `fix!` — **Engine calls are refused outside a template invocation** — from `tari_alloc`, `tari_free` or the
+  response allocation. Nothing legitimate does this; it was a route to unmetered effects and, via
+  `tari_alloc`, a node crash.
+
 ## [0.3.0](https://github.com/tari-project/tari-ootle/compare/v0.2.0...v0.3.0) (2023-12-19)
 
 ### ⚠ BREAKING CHANGES


### PR DESCRIPTION
## Description

Adds a curated `0.39.0` entry to `CHANGELOG.md` covering everything since `v0.38.0`, grouped by audience — upgrade notes, wallet, indexer, consensus, execution engine — with each entry tagged by change type (`feat!`, `fix`, `chore!`, `breaking`).

Called out up front:

- **Testnet reset required** — transaction ids, `TransactionReceipt`, `max_epoch`, the CBOR 128-bit encoding and the fee tables all changed.
- **Templates must be rebuilt and republished** against the latest `tari_template_lib` — `Amount`'s wire format is now minicbor's native integer encoding instead of a two-element digit array.

## Motivation and Context

The changelog was last written for `0.3.0`. Release notes shouldn't have to be reconstructed from `git log` at tag time, and the two upgrade steps above are not discoverable from commit subjects.

## How Has This Been Tested?

Docs only — read through against `git log v0.38.0..HEAD`.

## What process can a PR reviewer use to test or verify this change?

Compare the entry against `git log v0.38.0..development --oneline --no-merges` and check nothing user-visible is missing or mischaracterised.