### PR TITLE
fix(scripts): correct the publish order for ootle_serde

### DIFF
--- a/.github/workflows/ffi_libs.yml
+++ b/.github/workflows/ffi_libs.yml
@@ -74,8 +74,7 @@ jobs:
           echo "TARI_VERSION=${VER}" >> "$GITHUB_OUTPUT"
 
       # Windows: install the GNU host toolchain (bundles its own mingw linker) so the .a is the
-      # GNU-ABI lib cgo links against — not the MSVC .lib. Setting it as the toolchain (rather than
-      # a later `rustup default`) avoids the action's RUSTUP_TOOLCHAIN override winning.
+      # GNU-ABI lib cgo links against — not the MSVC .lib.
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772  # master (no version tag)
         with:
@@ -83,6 +82,13 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Build + stage native libs
+        env:
+          # The action installs the toolchain above and makes it the rustup DEFAULT, but
+          # rust-toolchain.toml outranks the default — so on Windows the build would silently run on
+          # the MSVC host toolchain, which carries no std for x86_64-pc-windows-gnu ("can't find
+          # crate for `core`"). RUSTUP_TOOLCHAIN outranks rust-toolchain.toml, so pin it here. Keep
+          # it in step with the `toolchain:` input above.
+          RUSTUP_TOOLCHAIN: ${{ matrix.platform == 'windows-x64' && '1.97.1-x86_64-pc-windows-gnu' || '1.97.1' }}
         run: |
           scripts/build_ffi_lib.sh \
             --platform "${{ matrix.platform }}" \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7859,7 +7859,6 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tari_bor",
- "tari_template_lib",
 ]
 
 [[package]]

--- a/crates/ootle_serde/Cargo.toml
+++ b/crates/ootle_serde/Cargo.toml
@@ -18,7 +18,6 @@ hex = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_urlencoded = "0.7"
-tari_template_lib = { workspace = true }
 tari_bor = { workspace = true, features = ["std", "serde"] }
 
 [features]

--- a/crates/ootle_serde/src/base64.rs
+++ b/crates/ootle_serde/src/base64.rs
@@ -43,23 +43,23 @@ where
 #[cfg(test)]
 mod tests {
     use serde::Serialize;
-    use tari_template_lib::types::Hash32;
 
     use super::*;
+    use crate::test_fixtures::Bytes32;
 
     #[derive(Deserialize, Serialize, PartialEq, Debug)]
     struct SampleData {
         #[serde(with = "super")]
         data: Vec<u8>,
         #[serde(with = "super")]
-        hash: Hash32,
+        hash: Bytes32,
     }
 
     #[test]
     fn it_encodes_and_decodes_from_base64() {
         let original = SampleData {
             data: vec![1, 2, 3, 4, 5],
-            hash: Hash32::from_array([123u8; 32]),
+            hash: Bytes32::new([123u8; 32]),
         };
 
         // Serialize to JSON (human-readable)

--- a/crates/ootle_serde/src/hex.rs
+++ b/crates/ootle_serde/src/hex.rs
@@ -112,9 +112,9 @@ pub mod option {
 #[cfg(test)]
 mod tests {
     use serde::Serialize;
-    use tari_template_lib::types::Hash32;
 
     use super::*;
+    use crate::test_fixtures::Bytes32;
 
     #[derive(Serialize, Deserialize)]
     struct TestCase {
@@ -123,7 +123,7 @@ mod tests {
         #[serde(with = "super")]
         vec: Vec<u8>,
         #[serde(with = "super")]
-        hash: Hash32,
+        hash: Bytes32,
     }
 
     // Test it
@@ -132,7 +132,7 @@ mod tests {
         let data = TestCase {
             fixed: [1; 32],
             vec: vec![5; 100],
-            hash: Hash32::from_array([2; 32]),
+            hash: Bytes32::new([2; 32]),
         };
         let serialized = serde_json::to_vec(&data).unwrap();
         let deserialized: TestCase = serde_json::from_slice(&serialized).unwrap();

--- a/crates/ootle_serde/src/lib.rs
+++ b/crates/ootle_serde/src/lib.rs
@@ -16,3 +16,6 @@ pub mod map;
 pub mod str_number;
 pub mod string;
 pub mod visitor;
+
+#[cfg(test)]
+mod test_fixtures;

--- a/crates/ootle_serde/src/test_fixtures.rs
+++ b/crates/ootle_serde/src/test_fixtures.rs
@@ -1,0 +1,50 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use alloc::vec::Vec;
+use core::fmt::{self, Display};
+
+/// A fixed-size byte wrapper standing in for the newtype hash/address types downstream crates pass
+/// to these adapters. It exercises the `TryFrom<&[u8]> + AsRef<[u8]>` path, which is distinct from
+/// the `[u8; N]` and `Vec<u8>` paths.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Bytes32([u8; 32]);
+
+impl Bytes32 {
+    pub const fn new(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+}
+
+impl AsRef<[u8]> for Bytes32 {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl TryFrom<&[u8]> for Bytes32 {
+    type Error = WrongLength;
+
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        <[u8; 32]>::try_from(bytes)
+            .map(Self)
+            .map_err(|_| WrongLength(bytes.len()))
+    }
+}
+
+impl TryFrom<Vec<u8>> for Bytes32 {
+    type Error = WrongLength;
+
+    fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
+        Self::try_from(bytes.as_slice())
+    }
+}
+
+#[derive(Debug)]
+pub struct WrongLength(usize);
+
+impl Display for WrongLength {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "expected 32 bytes, got {}", self.0)
+    }
+}

--- a/scripts/publish_crates.py
+++ b/scripts/publish_crates.py
@@ -32,15 +32,13 @@ import urllib.error
 # (crate_name, crate_directory, tier)
 CRATES = [
     ("tari_bor", "crates/tari_bor", 1),
+    ("ootle_serde", "crates/ootle_serde", 1),
     ("ootle-network", "crates/ootle_network", 1),
     ("tari_template_abi", "crates/template_abi", 2),
     ("tari_template_lib_types", "crates/template_lib_types", 2),
     ("ootle_byte_type", "crates/ootle_byte_type", 1),
     ("tari_template_macros", "crates/template_macros", 2),
     ("tari_template_lib", "crates/template_lib", 2),
-    # ootle_serde has a dev-dependency on tari_template_lib, so it must be
-    # published after tari_template_lib even though it's a stable/foundational crate.
-    ("ootle_serde", "crates/ootle_serde", 1),
     ("tari_ootle_template_metadata", "crates/template_metadata", 2),
     ("tari_ootle_template_build", "crates/template_build", 2),
     ("tari_engine_types", "crates/engine_types", 3),
@@ -94,6 +92,36 @@ def get_local_version(crate_name: str, crate_dir: str) -> str:
         if pkg["name"] == crate_name:
             return pkg["version"]
     raise RuntimeError(f"Package {crate_name} not found in cargo metadata")
+
+
+def check_order() -> list:
+    """Return (dependent, dependency) pairs whose normal dep is published too late.
+
+    CRATES is hand-maintained, so a newly added dependency edge can silently
+    invalidate the order. Only normal (and build) deps constrain it. Dev-dep
+    cycles are tolerated, but only when the dev-dependency is declared path-only
+    (no version), as tari_engine does for tari_template_test_tooling — cargo
+    resolves versioned dev-deps against the index when packaging, so a versioned
+    one in a cycle fails the publish.
+    """
+    result = subprocess.run(
+        ["cargo", "metadata", "--no-deps", "--format-version", "1"],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"cargo metadata failed: {result.stderr}")
+
+    position = {name: i for i, (name, _, _) in enumerate(CRATES)}
+    violations = []
+    for pkg in json.loads(result.stdout)["packages"]:
+        if pkg["name"] not in position:
+            continue
+        for dep in pkg["dependencies"]:
+            if dep["name"] not in position or (dep.get("kind") or "normal") == "dev":
+                continue
+            if position[dep["name"]] > position[pkg["name"]]:
+                violations.append((pkg["name"], dep["name"]))
+    return sorted(violations)
 
 
 def crate_index_path(name: str) -> str:
@@ -165,6 +193,14 @@ def main():
         help="Print the publish order and exit.",
     )
     args = parser.parse_args()
+
+    violations = check_order()
+    if violations:
+        print(f"{RED}Error: publish order in CRATES is stale — "
+              f"these crates are listed before a dependency:{NC}")
+        for dependent, dep in violations:
+            print(f"  {dependent} needs {dep} published first")
+        sys.exit(1)
 
     # --list mode
     if args.list:


### PR DESCRIPTION
## Motivation

`tari_template_lib_types` gained a dependency on `ootle_serde`, but `publish_crates.py` still listed `ootle_serde` at position 8 — after `tari_template_lib`. A release run therefore tried to publish `tari_template_lib_types` before a crate it depends on.

## What changed

**Publish order.** `ootle_serde` moves to just after `tari_bor`.

**Order check.** `check_order()` cross-references the hand-maintained `CRATES` list against `cargo metadata` and aborts before anything is uploaded if a crate is listed ahead of a normal/build dependency. `CRATES` is maintained by hand, so this class of staleness was invisible until a publish was already half-done. Dev edges are ignored — they're allowed to cycle.

**Dropped a dev-dependency cycle.** Moving `ootle_serde` ahead of `tari_template_lib_types` closed a cycle with its versioned dev-dependency on `tari_template_lib`. Cargo resolves dev-deps against the index while packaging, so the publish aborted:

```
error: failed to prepare local package for uploading
Caused by:
  failed to select a version for the requirement `tari_template_lib = "^0.31"`
  candidate versions found which didn't match: 0.29.0, 0.28.0, 0.27.1, ...
```

The repo's existing idiom for this is a path-only dev-dep (see `crates/engine/Cargo.toml` for `tari_template_test_tooling`). Here the dependency existed only to borrow `Hash32` in two unit tests as a stand-in for a `TryFrom<&[u8]> + AsRef<[u8]>` newtype, so it's removed outright in favour of a local `Bytes32` fixture — a tier-1 crate has no business reaching up into a tier-2 template crate, even for tests.

## Testing

- `cargo test -p ootle_serde --all-features` — 23 passed
- `cargo publish -p ootle_serde --dry-run --no-verify` — packages cleanly (previously failed)
- `./scripts/publish_crates.py --list` — clean; a deliberately broken order reports all 8 violations

`crate_versioning.py` needs no change: it builds its graph from `cargo metadata`, so it already sees the new edge.