### PR TITLE
docs: add a reference page on reducing template size

### DIFF
--- a/docs/developer-docs/src/content/docs/guides/publishing-templates.mdx
+++ b/docs/developer-docs/src/content/docs/guides/publishing-templates.mdx
@@ -32,6 +32,14 @@ cargo build --target wasm32-unknown-unknown --release
   file you will publish to the Tari Ootle network.
 </Aside>
 
+The size of that binary is capped at 1.5 MiB, and it is priced twice: once in the publish fee, which
+rises quadratically above a 96 KiB allowance, and again in the `TemplateLoad` fee that every caller
+of your template pays. A few lines in your `Cargo.toml` typically cut it by a third — see
+<a href={basePath("/reference/reducing-template-size/")}>Reducing Template Size</a>.
+
+The wallet daemon runs `wasm-opt` over the binary for you before it estimates the fee or publishes,
+so you do not need to optimize it yourself.
+
 ### Publishing Your Template
 
 To publish your template, you need to create a transaction that includes the `PublishTemplate` instruction.
@@ -72,5 +80,6 @@ Now that your template is published, it's ready to be used in transactions!
 
 ### Next Steps
 
+- Learn how to <a href={basePath("/reference/reducing-template-size/")}>reduce your template's size</a> to publish it more cheaply.
 - Learn some basics about <a href={basePath("/guides/transaction-overview/")}>Ootle transactions</a>.
 - Learn how to programmatically <a href={basePath("/guides/play-the-guessing-game/")}>interact with the guessing game template</a>.

--- a/docs/developer-docs/src/content/docs/guides/randomness.mdx
+++ b/docs/developer-docs/src/content/docs/guides/randomness.mdx
@@ -3,10 +3,13 @@ title: Randomness in Templates
 description: How pseudorandom values are produced in Tari Ootle, what guarantees they carry, and when you must not rely on them.
 ---
 
+import { Aside } from "@astrojs/starlight/components";
+
 ### Covered in this guide
 
 In this guide, you will:
 - Learn which randomness APIs templates can call.
+- Understand why `rand`, `getrandom` and other OS-backed RNGs cannot be used.
 - Understand how those values are derived and why they are deterministic across shards.
 - See exactly which adversarial properties the current randomness does and does not provide.
 - Learn which contract patterns are safe to build on it and which are not.
@@ -31,6 +34,28 @@ use tari_template_lib::consensus::Consensus;
 
 let epoch_hash: Hash = Consensus::current_epoch_hash();
 ```
+
+### Why you cannot use `rand` or `getrandom`
+
+**Randomness doesn't work on a blockchain.** Validators have to agree on state transitions
+deterministically, so no local source of entropy works: whatever each validator drew on its own,
+they would no longer agree, and the transaction could not commit. This is not particular to Ootle —
+no smart-contract platform exposes a true RNG to contract code, and the workarounds are the same
+everywhere: derive from data consensus already agrees on (what `random_bytes` and the epoch hash do
+here), run a commit-reveal among participants, or defer to an external VRF or oracle.
+
+**There is also no entropy to draw on.** Templates compile to `wasm32-unknown-unknown`, a target
+with no operating system behind it, and the engine gives a template exactly three host functions:
+`tari_engine`, `tari_debug` and `on_panic`. `getrandom` — which every RNG in the Rust ecosystem
+calls for its seed — has no backend available to it, and a template importing anything the engine
+does not provide is rejected when it is published.
+
+<Aside type="caution">
+  `getrandom` can technically be pointed at a custom backend, and you could implement that backend
+  on top of `random_bytes`. Doing so does not give you secure randomness: every `rand` consumer in
+  your dependency tree silently inherits the grinding weaknesses described under
+  [Adversarial properties](#adversarial-properties), while looking like a CSPRNG at the call site.
+</Aside>
 
 ### How randomness is derived
 

--- a/docs/developer-docs/src/content/docs/guides/template-overview.mdx
+++ b/docs/developer-docs/src/content/docs/guides/template-overview.mdx
@@ -227,3 +227,4 @@ You can still declare `struct`/`enum` types inside a stateless module to use as 
 ### Next Steps
 
 - Now that you know a little about templates, let's build a simple <a href={basePath("/guides/build-a-guessing-game")}>Guessing Game</a>.
+- Keep an eye on how big your template compiles to — see <a href={basePath("/reference/reducing-template-size/")}>Reducing Template Size</a>.

--- a/docs/developer-docs/src/content/docs/reference/reducing-template-size.mdx
+++ b/docs/developer-docs/src/content/docs/reference/reducing-template-size.mdx
@@ -1,0 +1,357 @@
+---
+title: Reducing Template Size
+description: How to make a published template's WASM binary smaller — the release profile, wasm-opt, no_std, and the code-level habits that cost the most bytes.
+---
+
+import { Aside } from "@astrojs/starlight/components";
+import { basePath } from '../../../helpers/path';
+
+A template's compiled WASM is stored permanently on the network and shipped to every validator in the
+committee. Size is therefore priced twice: once when you publish, and again — for your users — on
+every transaction that calls the template.
+
+Everything on this page was measured against the same ~85 line `state` template using the current
+testnet fee table. Your numbers will differ, but the ratios hold.
+
+---
+
+## Why size matters
+
+**There is a hard cap.** `ENGINE_LIMITS.max_template_binary_size_bytes` is **1.5 MiB**. A larger
+binary is rejected at publish time, and a transaction may publish at most one template.
+
+**Publishing is priced quadratically above 96 KiB.** The publish charge is a flat
+250,000 µT, plus the first 96 KiB at the per-byte storage rate, plus `100 µT × units²` for every
+whole KiB beyond that allowance:
+
+| Binary size | Publish charge (testnet) | `TemplateLoad` charged to each caller |
+|---|---|---|
+| 72 KiB | ~0.32 tTARI | 240 µT |
+| 96 KiB | ~0.35 tTARI | 320 µT |
+| 128 KiB | ~0.45 tTARI | 430 µT |
+| 256 KiB | ~2.9 tTARI | 870 µT |
+| 512 KiB | ~17.7 tTARI | 1,740 µT |
+| 1.5 MiB | ~208 tTARI | 5,240 µT |
+
+The 96 KiB allowance is deliberately set just above the floor for a minimal component template, so
+the premium prices *your* code rather than the fixed `tari_template_lib` machinery. A template that
+stays under it pays the same as ordinary storage.
+
+**Your users pay for size on every call.** `TemplateLoad` is charged at 10 µT per 3 KB the first
+time each template is loaded in a transaction — a cost carried by whoever calls your template, not
+by you. Halving your binary halves that line item forever.
+
+<Aside type="note">
+  See <a href={basePath("/reference/fees/")}>Fees</a> for the full fee model, including the storage
+  and execution charges that component state and logic incur separately from binary size.
+</Aside>
+
+---
+
+## Start with the release profile
+
+The single highest-leverage change is the `[profile.release]` section of your template's
+`Cargo.toml`. The default `cargo build --release` profile is tuned for native speed, not for WASM
+size.
+
+```toml
+[profile.release]
+opt-level = 's'     # Optimize for size ('z' is more aggressive — measure both)
+lto = true          # Link-time optimization: drops unreachable library code
+codegen-units = 1   # One unit lets LTO see the whole crate graph
+panic = 'abort'     # Unwinding tables are dead weight on wasm32
+strip = true        # Drop the `name`, `producers` and `target_features` sections
+```
+
+Measured on the `state` template (sizes after the same `wasm-opt` pass the walletd applies):
+
+| Build | Raw `.wasm` | After `wasm-opt` |
+|---|---|---|
+| Default `--release` | 138 KiB | 95 KiB |
+| Profile above | 88 KiB | 78 KiB |
+| Profile above + `no_std` | 75 KiB | 67 KiB |
+| Profile above + [immediate-abort panics](#dropping-panic-messages-entirely) | 68 KiB | 60 KiB |
+| All three together | 63 KiB | 55 KiB |
+
+A few things worth knowing about those knobs:
+
+- **`lto` and `codegen-units = 1` do the heavy lifting.** They are also what makes `opt-level` pay
+off: on its own, `opt-level = 's'` or `'z'` actually produced a *larger* binary than the default
+`opt-level = 3`. Only in combination with LTO did the size profile win.
+- **`'s'` is not always beaten by `'z'`.** In the measurement above `'s'` came out ~1.5 KiB smaller
+than `'z'` after `wasm-opt`. Try both; it costs one rebuild.
+- **`panic = 'abort'` is near-free either way.** `wasm32-unknown-unknown` has no unwinder, so this
+changed the binary by under 100 bytes. Keep it for correctness of intent, not for the savings.
+- **`strip = true` is about more than bytes.** The engine rejects a published template carrying any
+custom section other than `tari_tdef`, and the toolchain emits `name`, `producers` and
+`target_features` by default. `strip = true` removes exactly those three and leaves `tari_tdef`
+intact.
+
+<Aside type="tip">
+  Keep the `[profile.dev.package.*]` entries from the
+  <a href={basePath("/guides/build-a-guessing-game/#speeding-up-template-tests")}> guessing game guide</a> as
+  well — they speed up template *tests* and have no effect on the published release binary.
+</Aside>
+
+---
+
+## `wasm-opt` — the walletd already runs it
+
+[Binaryen](https://github.com/WebAssembly/binaryen)'s `wasm-opt` rewrites an existing binary to be
+smaller. **You do not need to run it before publishing:** the wallet daemon optimizes every binary
+it receives, on both the fee-estimate path and the publish path, before the transaction is built.
+That applies to the wallet web UI, `tari publish`, and any direct JSON-RPC call.
+
+The walletd's pass is equivalent to:
+
+```bash
+wasm-opt -Os \
+  --enable-bulk-memory --enable-reference-types \
+  --strip-debug --strip-producers --strip-target-features \
+  template.wasm -o template.optimized.wasm
+```
+
+On an unoptimized default-profile build that pass alone recovered ~31% (138 KiB → 95 KiB). On a
+binary already built with the size profile it still recovered ~12%.
+
+Running it yourself is still useful when you want to know the *published* size before you publish —
+to check it against the 96 KiB allowance in CI, for example. Install it with
+`cargo install wasm-opt` or from the [Binaryen releases](https://github.com/WebAssembly/binaryen/releases).
+
+<Aside type="caution">
+  Do not add extra `wasm-opt` passes that rewrite custom sections or enable SIMD. The engine rejects
+  binaries carrying custom sections other than `tari_tdef`, and the walletd's pass explicitly
+  disables SIMD and relaxed-SIMD.
+</Aside>
+
+---
+
+## Going `no_std`
+
+`tari_template_lib` supports `no_std`. Dropping `std` removed a further ~11 KiB (~14%) from the
+optimized `state` binary, most of it Rust's standard-library startup, panic-unwinding and allocator
+machinery.
+
+```toml
+[dependencies]
+tari_template_lib = { version = "*", default-features = false, features = ["macro", "alloc"] }
+
+# A small allocator. `talc` is what the engine's own no_std test template uses.
+talc = { version = "5.0.3", default-features = false }
+```
+
+```rust
+#![no_std]
+
+extern crate alloc;
+
+#[cfg(target_arch = "wasm32")]
+#[global_allocator]
+static TALC: talc::wasm::WasmDynamicTalc = talc::wasm::new_wasm_dynamic_allocator();
+
+use tari_template_lib::prelude::*;
+
+#[template]
+mod counter {
+    use alloc::{format, string::String};
+
+    use super::*;
+    // ...
+}
+```
+
+What changes in practice:
+
+- **You must supply a global allocator.** Templates allocate — every `String`, `Vec` and CBOR
+decode does. `talc` is the recommended choice. Avoid `wee_alloc`, which is
+[unmaintained and leaks](https://github.com/rustwasm/wee_alloc/issues/106).
+- **`std` and `alloc` are mutually exclusive.** Enabling both (or neither) on `wasm32` is a compile
+error from `tari_template_lib`, so you will find out immediately.
+- **Imports move to `alloc`.** `use alloc::{string::String, vec::Vec, format, collections::BTreeMap}`
+inside your template module.
+- **Panic messages still work.** `tari_template_lib` installs a `#[panic_handler]` for `no_std`
+WASM that forwards the message, line and column to the engine, so a failed template still
+produces a readable reject reason.
+
+`no_std` is the right call for a template you expect to publish once and have called often. For a
+template you are still iterating on, the release profile plus `wasm-opt` gets you most of the way
+with none of the friction.
+
+---
+
+## Dropping panic messages entirely
+
+Most of what remains in a small binary is panic and formatting machinery: the code that builds a
+message, and the message text itself. Rust's `immediate-abort` panic strategy replaces every panic
+site with a bare trap, and the optimizer then deletes the messages and the formatting code that fed
+them. On the measured template it removed a further **23%** (78 KiB → 60 KiB), shrinking the data
+section from ~8.8 KiB to ~2.8 KiB.
+
+It needs a nightly toolchain with the `rust-src` component, because the standard library has to be
+rebuilt with the strategy:
+
+```bash
+rustup toolchain install nightly
+rustup component add rust-src --toolchain nightly
+
+RUSTFLAGS="-Zunstable-options -Cpanic=immediate-abort" \
+  cargo +nightly build --target wasm32-unknown-unknown --release \
+  -Z build-std=std,panic_abort
+```
+
+For a `no_std` template, build `core` instead: `-Z build-std=core,alloc,panic_abort`.
+
+<Aside type="caution">
+  **You lose every panic message.** Normally a failed template produces
+  `Panic! <your message>` in the reject reason, with the source line and column logged by the
+  validator — `tari_template_lib` forwards them through the engine's `on_panic` host call. Under
+  `immediate-abort` that call never happens, and the failure surfaces as a bare WASM trap with no
+  message, no line and no column. Every `expect`, `assert!` and arithmetic-overflow message becomes
+  indistinguishable from every other.
+</Aside>
+
+Because of that, prefer the `RUSTFLAGS` form above over baking it into `[profile.release]`: it is
+opt-in per build, so your `cargo test` runs and your debugging builds keep their messages and only
+the binary you publish is stripped of them. Confirm the template behaves identically before and
+after — semantics do not change (a trap still aborts execution and rejects the transaction), but
+your ability to diagnose a failure in production does.
+
+<Aside type="note">
+  This is unstable and the interface has changed: on older nightlies the equivalent is
+  `-Z build-std-features=panic_immediate_abort`, and it can also be enabled as
+  `panic = "immediate-abort"` in `[profile.release]` together with
+  `cargo-features = ["panic-immediate-abort"]` at the top of `Cargo.toml`.
+</Aside>
+
+---
+
+## Code-level habits that cost the most
+
+### Strings and formatting
+
+Every string literal lands verbatim in the binary's data section, and every `format!`, `debug!`,
+`panic!` or `assert!` message drags in `core::fmt` code for the types it formats. In a minimal
+template the data section is already ~9 KiB, most of it CBOR and `core` error text you have no
+control over — what you write is added on top of that.
+
+- A single `debug!("Changing value from {:?} to {}", self, value)` cost **1.7 KiB** in the measured
+build. Formatting is not free; treat log lines as a debugging tool you remove before publishing,
+or gate them.
+- Prefer short, fixed messages: `expect("no vault")` over
+`unwrap_or_else(|| panic!("no vault for resource {resource} in component {addr}"))`.
+- Reuse one message rather than writing five near-identical ones — each distinct literal is
+separate bytes.
+- Prefer `&'static str` over `String` for constants, and return `&str` where you can.
+- Logs are also charged a runtime fee per 64 bytes, so short messages save twice.
+
+### `Debug` and `Display`
+
+A derived `Debug` impl is only dead weight if something actually formats it — with LTO enabled,
+removing `#[derive(Debug)]` *after* removing the last `{:?}` use changed the binary by **zero
+bytes**. The rule is therefore about the call site, not the derive:
+
+- Remove the formatting, and the derive costs nothing.
+- Never derive `Debug` on a type just to `{:?}` it in a log line you plan to keep.
+- Hand-writing `Display` to emit a fixed `&'static str` is smaller than deriving `Debug` on a large
+enum you format.
+
+### Dependencies
+
+A single carelessly chosen crate can dwarf everything else on this page.
+
+- Audit with `cargo tree --target wasm32-unknown-unknown`. Anything you do not recognise is a
+candidate for removal.
+- Avoid the usual heavyweights: `serde_json`, `regex`, `chrono`, `num-bigint`. Most have no meaning
+on-chain anyway — a clock, for instance, is `Consensus::current_epoch()`.
+- An RNG crate such as `rand` is not an option at all: it cannot work inside a template, and adding
+one only costs you bytes. Use `tari_template_lib::rand` and read
+<a href={basePath("/guides/randomness/")}>Randomness in Templates</a> first.
+- Depend on crates that are `no_std`-capable and default-features-off wherever possible.
+- Do not enable `tari_template_lib` features you are not using — `extra-maps` pulls in `indexmap`
+and `xxhash-rust`, and `precision`, `extra-arith`, `serde`, `borsh` and `ts` all add code. The
+last three exist for host-side tooling, not for templates.
+- `dev-dependencies` (such as `tari_template_test_tooling`) and `#[cfg(test)]` code are never
+compiled into the `cdylib`, so tests cost you nothing on-chain.
+
+### Generics and duplication
+
+Monomorphisation duplicates a function's body for every type it is instantiated with. When a
+generic function is large, keep the generic part thin:
+
+```rust
+pub fn transfer<A: Into<Amount>>(&mut self, amount: A) {
+  self.transfer_inner(amount.into()); // one instantiation of the big body
+}
+
+  fn transfer_inner(&mut self, amount: Amount) { /* ... */}
+  ```
+
+  The same applies to macro-generated code and to copy-pasted method bodies — factor the shared part
+  into one non-generic function.
+
+  ### Collections
+
+  Prefer `Vec` and `BTreeMap` over `HashMap` in component state: the standard hasher brings machinery
+  you are paying for in bytes, and ordered collections give you a deterministic encoding for free.
+  Reach for `extra-maps`' `IndexMap` only when you genuinely need insertion order plus lookup.
+
+  ### Share code across templates instead of duplicating it
+
+  Templates can call other templates. If several of your templates share a body of logic, publishing
+  it once and calling it with `TemplateManager::get(address).call(...)` beats compiling it into each
+  binary — you pay the publish premium once instead of N times.
+
+  ---
+
+  ## Measuring what is actually big
+
+  Guessing is a waste of time; both of these take seconds.
+
+  **Per-function sizes**, from Binaryen:
+
+  ```bash
+  wasm-opt --func-metrics target/wasm32-unknown-unknown/release/my_template.wasm -o /dev/null
+  ```
+
+  **A ranked breakdown**, from [twiggy](https://github.com/rustwasm/twiggy):
+
+  ```bash
+  cargo install twiggy
+  twiggy top -n 20 target/wasm32-unknown-unknown/release/my_template.wasm
+  ```
+
+  <Aside type="note">
+    Both tools report readable function names only if the `name` section is present — build with
+    `strip = "debuginfo"` (or no `strip` at all) while profiling, then switch back to `strip = true`
+    for the build you publish.
+  </Aside>
+
+  ---
+
+  ## Conclusion
+
+  Applied together, these steps took the measured template from the 95 KiB (just using `cargo build --release`)
+  down to 55 KiB — a 42% smaller binary running the same logic.
+
+  ---
+
+  ## Checklist
+
+  1. Add the `[profile.release]` block above; try `opt-level = 's'` and `'z'` and keep the winner.
+  2. Build with `cargo build --target wasm32-unknown-unknown --release`.
+  3. Check the published size with `wasm-opt -Os ...` — the walletd will apply the same pass.
+  4. If you are over the 96 KiB allowance, run `twiggy top` before changing any code.
+  5. Remove or shorten log and panic formatting; drop dependencies you do not need.
+  6. If it still matters, switch to `no_std` + `alloc` with a `talc` global allocator.
+  7. As a last resort, build the published binary with `immediate-abort` panics — and accept that a
+  production failure will no longer tell you what went wrong.
+
+  ---
+
+  ## See also
+
+  - <a href={basePath("/reference/fees/")}>Fees</a> — the full fee model, including the publish premium and
+  `TemplateLoad`
+  - <a href={basePath("/guides/publishing-templates/")}>Publishing Templates</a> — compiling and publishing a template
+  - <a href={basePath("/guides/template-overview/")}>Templates Overview</a> — the `#[template]` macro and component
+  state


### PR DESCRIPTION
## Description

Adds a developer-docs reference page, **Reducing Template Size**, and links it from the *Publishing Templates* and *Templates Overview* guides. There was no existing coverage of the topic anywhere in the docs.

Every number on the page is measured, not estimated. Each variant is the engine's `state` test template built under the profile in question and then passed through the exact `wasm-opt` invocation `wasm_optimizer.rs` applies before publishing:

| Build | Raw `.wasm` | Published (after wasm-opt) |
|---|---|---|
| default `--release` | 138 KiB | 95 KiB |
| size profile | 88 KiB | 78 KiB |
| size profile + `no_std` | 75 KiB | 67 KiB |
| size profile + immediate-abort panics | 68 KiB | 60 KiB |
| all three | 63 KiB | 55 KiB |

The page covers:

- **Why size matters** — the 1.5 MiB cap, the quadratic publish premium above the 96 KiB allowance (with a fee table computed from the current testnet values), and the `TemplateLoad` charge that every *caller* pays on every transaction.
- **The release profile** — the `Cargo.toml` block, plus what each knob is actually worth.
- **`wasm-opt`** — noting that the wallet daemon runs it for you on both the fee-estimate and publish paths, so authors do not need to.
- **`no_std`** — the manifest, the `talc` global allocator, and what changes in practice.
- **immediate-abort panics** — the biggest remaining win, with the diagnostic cost stated plainly.
- **Code-level habits** — strings and formatting, `Debug`/`Display`, dependencies, monomorphisation, collections, and sharing code across templates.
- **Measuring** — `wasm-opt --func-metrics` and `twiggy`.

A few findings worth flagging, since they contradict the usual folklore:

- `opt-level = 's'`/`'z'` **on their own made the binary larger** than the default `opt-level = 3`. The win only materialises alongside `lto` + `codegen-units = 1`. And `'s'` beat `'z'` post-`wasm-opt`, so the page tells authors to measure both rather than reflexively reaching for `'z'`.
- `panic = 'abort'` is worth <100 bytes on `wasm32-unknown-unknown` — there is no unwinder to remove.
- `strip = true` removes `name`, `producers` and `target_features` while leaving `tari_tdef` intact (verified by dumping custom sections), which matters because the engine rejects any other custom section at registration.
- A single `debug!("... {:?} ...")` cost 1.7 KiB. Removing the then-unused `#[derive(Debug)]` afterwards cost **zero** — LTO had already dropped it. The tip is therefore about call sites, not derives.
- On current nightly, `-Z build-std-features=panic_immediate_abort` hard-errors and directs you to `-Cpanic=immediate-abort`. The page documents the working form and mentions the older/profile variants in a note.

## Randomness guide

Also adds a short section on why `rand`/`getrandom` cannot be used, since reaching for an RNG crate is a natural thing to try and it is a dependency that can never work. Determinism leads; the absence of an entropy source follows. Includes a caution that pointing `getrandom` at a custom backend over `random_bytes` compiles but silently gives every `rand` consumer the grinding weaknesses the guide already documents.

## Test plan

- `npm run build` in `docs/developer-docs` passes; the new page renders and appears in the auto-generated Reference sidebar.
- Fee figures cross-checked against `fee_tables.rs` and `fee_module.rs::template_publish_metrics`.
