### PR TITLE
perf(template): drop the EngineOp Debug table and the last prose panics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12563,7 +12563,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "borsh",
  "minicbor",

--- a/crates/template_abi/src/abi/mod.rs
+++ b/crates/template_abi/src/abi/mod.rs
@@ -66,13 +66,13 @@ where
     let input_ptr = encoded_input.as_mut_ptr();
     let result_ptr = unsafe { tari_engine(op.as_i32(), input_ptr, len) };
     if result_ptr.is_null() {
-        panic!("ENGCALL_NULL op {:?}", op);
+        panic!("ENGCALL_NULL op {}", op.as_i32());
     }
     // SAFETY: The pointer returned by `tari_engine` is valid and points to a length-prefixed block of memory allocated
     // by `tari_alloc`.
     let owned = unsafe { OwnedData::owned_from_ptr(result_ptr) };
     // Decode the output data, skipping the length prefix
-    decode_exact(owned.data()).unwrap_or_else(|e| panic!("DECODEFAIL op {:?} input len: {}: {}", op, len, e))
+    decode_exact(owned.data()).unwrap_or_else(|e| panic!("DECODEFAIL op {} input len: {}: {}", op.as_i32(), len, e))
 }
 
 /// Takes ownership of a length-prefixed block of memory allocated by `tari_alloc` and provides access to the data.

--- a/crates/template_abi/src/abi/mod.rs
+++ b/crates/template_abi/src/abi/mod.rs
@@ -66,7 +66,9 @@ where
     let input_ptr = encoded_input.as_mut_ptr();
     let result_ptr = unsafe { tari_engine(op.as_i32(), input_ptr, len) };
     if result_ptr.is_null() {
-        panic!("ENGCALL_NULL op {}", op.as_i32());
+        // Terse by design: the engine identifies the refused call on its own side, and a formatted
+        // panic pulls `core::fmt::Arguments` into every published template.
+        panic!("ENGCALL_NULL");
     }
     // SAFETY: The pointer returned by `tari_engine` is valid and points to a length-prefixed block of memory allocated
     // by `tari_alloc`.

--- a/crates/template_lib/Cargo.toml
+++ b/crates/template_lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_template_lib"
 description = "Tari template library provides abstrations that interface with the Tari validator engine"
-version = "0.31.0"
+version = "0.31.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_lib/src/engine.rs
+++ b/crates/template_lib/src/engine.rs
@@ -28,6 +28,7 @@ use tari_template_lib_types::{ComponentAddress, LogLevel, OwnerRule, access_rule
 use crate::{
     args::{ComponentAction, ComponentInvokeArg, ComponentRef, CreateComponentArg, EmitLogArg, InvokeResult},
     component::ComponentManager,
+    error_variants::ERR_ENGINE_DECODE_FAIL,
     models::ComponentAddressAllocation,
 };
 
@@ -64,7 +65,7 @@ impl TariEngine {
             }],
         });
 
-        result.decode().expect("failed to decode component address")
+        result.decode().expect(ERR_ENGINE_DECODE_FAIL)
     }
 
     pub fn emit_log<T: Into<String>>(&self, level: LogLevel, msg: T) {

--- a/crates/template_lib/src/models/vault.rs
+++ b/crates/template_lib/src/models/vault.rs
@@ -48,6 +48,7 @@ use crate::{
         VaultInvokeArg,
         VaultWithdrawArg,
     },
+    error_variants::ERR_ENGINE_DECODE_FAIL,
     models::{Bucket, NonFungible, Proof, ProofAuth},
     resource::ResourceManager,
     types::Amount,
@@ -165,7 +166,7 @@ impl Vault {
             args: invoke_args![VaultWithdrawArg::Fungible { amount: amount.into() }],
         });
 
-        resp.decode().expect("failed to decode Bucket")
+        resp.decode().expect(ERR_ENGINE_DECODE_FAIL)
     }
 
     /// Withdraw a single non-fungible token from the vault into a new bucket.
@@ -185,7 +186,7 @@ impl Vault {
             }],
         });
 
-        resp.decode().expect("failed to decode Bucket")
+        resp.decode().expect(ERR_ENGINE_DECODE_FAIL)
     }
 
     /// Withdraws confidential resources from the vault into a new bucket.
@@ -207,7 +208,7 @@ impl Vault {
             args: invoke_args![VaultWithdrawArg::Confidential { proof: Box::new(proof) }],
         });
 
-        resp.decode().expect("failed to decode Bucket")
+        resp.decode().expect(ERR_ENGINE_DECODE_FAIL)
     }
 
     /// Withdraws all fungible, non-fungible and revealed confidential amounts from the vault into a new bucket.
@@ -229,7 +230,7 @@ impl Vault {
             args: invoke_args![],
         });
 
-        resp.decode().expect("failed to decode Amount")
+        resp.decode().expect(ERR_ENGINE_DECODE_FAIL)
     }
 
     /// Returns how many tokens are locked (unspendable) in this vault.
@@ -240,7 +241,7 @@ impl Vault {
             args: invoke_args![],
         });
 
-        resp.decode().expect("failed to decode Amount")
+        resp.decode().expect(ERR_ENGINE_DECODE_FAIL)
     }
 
     /// Returns how many confidential outputs this vault holds.
@@ -252,7 +253,7 @@ impl Vault {
             args: invoke_args![],
         });
 
-        resp.decode().expect("failed to decode commitment count")
+        resp.decode().expect(ERR_ENGINE_DECODE_FAIL)
     }
 
     /// Returns the IDs of all the non-fungibles contained in this vault.

--- a/crates/template_lib/src/template/manager.rs
+++ b/crates/template_lib/src/template/manager.rs
@@ -23,7 +23,10 @@ use minicbor::Decode;
 use tari_template_abi::{EngineOp, call_engine, rust::prelude::*};
 use tari_template_lib_types::{TemplateAddress, bytes::Bytes};
 
-use crate::args::{CallAction, CallFunctionArg, CallInvokeArg, InvokeResult};
+use crate::{
+    args::{CallAction, CallFunctionArg, CallInvokeArg, InvokeResult},
+    error_variants::ERR_ENGINE_DECODE_FAIL,
+};
 
 /// Utility to allow template code to call functions from other templates (i.e., composability)
 #[derive(Debug)]
@@ -53,9 +56,7 @@ impl TemplateManager {
             args: invoke_args![arg],
         });
 
-        result
-            .decode()
-            .expect("failed to decode template function call result from engine")
+        result.decode().expect(ERR_ENGINE_DECODE_FAIL)
     }
 
     /// Calls a function in the template. The invoked function must return a unit type or a panic will occur.


### PR DESCRIPTION
## Description

Two small cuts to the fixed `template_lib` overhead every published template carries. Follow-up to #2454, same motivation: bytes in a template are replicated to every validator and priced at publish.

### 1. `{:?}` on `EngineOp`

`call_engine` formatted the op with `{:?}` on both of its panic paths, which pulls the derived `Debug` for `EngineOp` into every template. It shows up in a built binary as one concatenated 253-byte table:

```
EmitLogComponentInvokeResourceInvokeVaultInvokeBucketInvokeNonFungibleInvokeGenerateUniqueId…
```

plus the match that indexes it. Both panics now print `op.as_i32()`. These fire only when a template and an engine disagree about the ABI, where a number is as actionable as a name — and the engine can map it back, exactly as it now renders argument types for dispatcher panics.

### 2. The last eight prose panics

The `expect("failed to decode Bucket")`-style messages in `vault.rs`, `engine.rs` and `template/manager.rs` predate `error_variants.rs`, whose own doc comment says it exists "to reduce WASM binary size by avoiding … long error messages". They describe precisely what `ERR_ENGINE_DECODE_FAIL` already describes — an engine response that did not decode — so they now use it, and the crate is internally consistent again.

Nothing is lost that the engine does not already receive: `on_panic` is given the panic's line and column, so the specific call site is still identified.

### 3. A bare code when an engine call returns null

Formatting the op into `ENGCALL_NULL` costs a second `core::fmt::Arguments` construction in every template — 203 bytes of the 263 the whole null branch occupies. It is now a bare code, matching `CALLINFO_NULL` in the dispatcher.

The branch itself stays. Deleting it buys only 60 bytes more, and a null would then fall through to `decode_exact(&[])` failing — panicking `DECODEFAIL`, i.e. reporting a response that did not decode when the engine actually refused the call. (It is safe either way: `owned_from_ptr` null-checks independently at `abi/mod.rs:92`.)

### Sizes

Published (`wasm-opt`'d) binaries:

| Template | Before | After | Δ |
|---|---|---|---|
| `account` | 268,671 | 268,020 | **−651** |
| `state` | 79,120 | 78,696 | −424 |
| `hello_world` | 71,567 | 71,352 | −215 |

`state` gains without touching a vault, because any template that calls the engine at all carried the variant-name table.

## Versioning

`tari_template_lib` 0.31.0 → **0.31.1**: 0.31.0 is live on crates.io and this changes it, so without the bump `publish_crates.py` would skip it and no template author would get the change.

`tari_template_abi` stays at 0.19.1 — that version is bumped in the repo but not yet published, so this rides along with it.

The workspace pin for `tari_template_lib` deliberately stays `^0.31`: nothing *requires* 0.31.1, since this adds no API. (Contrast #2454, where the pin was tightened because `tari_template_macros` and `tari_engine` genuinely needed `diagnostics`.)

## Follow-up for the engine side

Three sites return null without recording an error — `process.rs:230` (invalid opcode), `:241` (call size limit) and `:361` (for a non-`RuntimeError`). On those the template's panic is the only thing that reaches the reject reason, so the op is no longer in it. The engine logs the op at all three, so a validator operator still sees it, but recording an error there rather than returning null would put it back in the reject reason — worth doing on its own, and a prerequisite for ever making the entrypoint trap instead of returning null.

## Test plan

- `cargo test -p tari_template_lib`, `errors::` (3), `fungible_mint_and_burn`, `test_engine_errors` all pass.
- `cargo clippy` clean on both crates; `cargo fmt` applied.
- Verified no test, UI or client asserts any of the removed strings.

Unrelated pre-existing failure, not touched here: the doctest at `crates/template_lib/src/lib.rs:43` fails on a clean `development` (`Component` / `Vault` not in scope in the example).

