### PR TITLE
fix(engine): fail the transaction when an engine call is refused

### DIFF
--- a/crates/engine/src/wasm/environment.rs
+++ b/crates/engine/src/wasm/environment.rs
@@ -35,10 +35,7 @@ use wasmer::{
     WasmPtr,
 };
 
-use crate::{
-    runtime::RuntimeError,
-    wasm::{WasmExecutionError, mem_writer::MemWriter},
-};
+use crate::wasm::{WasmExecutionError, mem_writer::MemWriter};
 
 pub(crate) type WasmAllocFn = TypedFunction<u32, WasmPtr<u8>>;
 pub(crate) type WasmFreeFn = TypedFunction<WasmPtr<u8>, ()>;
@@ -52,7 +49,7 @@ pub struct WasmEnv<T> {
     mem_alloc: Option<WasmAllocFn>,
     mem_free: Option<WasmFreeFn>,
     last_panic: Option<String>,
-    last_engine_error: Option<RuntimeError>,
+    last_engine_error: Option<WasmExecutionError>,
     invocation_meter: Option<InvocationMeter>,
     in_template_invocation: bool,
     refused_engine_call: Option<EngineOp>,
@@ -194,11 +191,17 @@ impl<T> WasmEnv<T> {
         self.last_panic.take()
     }
 
-    pub(super) fn set_last_engine_error(&mut self, error: RuntimeError) {
-        self.last_engine_error = Some(error);
+    /// Records why an engine call could not be answered. `tari_engine_entrypoint` can only reply to
+    /// the WASM with a null pointer, which carries no reason and which a template is free to
+    /// ignore, so the reason is left here for `WasmProcess::invoke` to fail the call with.
+    ///
+    /// Every path that answers null must record one, or the failure reaches the transaction as
+    /// whatever the template panicked with on the null instead.
+    pub(super) fn set_last_engine_error<E: Into<WasmExecutionError>>(&mut self, error: E) {
+        self.last_engine_error = Some(error.into());
     }
 
-    pub(super) fn take_last_engine_error(&mut self) -> Option<RuntimeError> {
+    pub(super) fn take_last_engine_error(&mut self) -> Option<WasmExecutionError> {
         self.last_engine_error.take()
     }
 

--- a/crates/engine/src/wasm/error.rs
+++ b/crates/engine/src/wasm/error.rs
@@ -52,6 +52,13 @@ pub enum WasmExecutionError {
     MissingAbiFunction { function: &'static str },
     #[error("Engine call size limit of {limit} bytes exceeded")]
     CallSizeLimitExceeded { limit: usize },
+    /// The argument buffer a template passed to an engine call. Distinct from
+    /// [`Self::CallSizeLimitExceeded`], which bounds the arguments passed the other way, into a
+    /// template function.
+    #[error("Engine call argument size limit of {limit} bytes exceeded: {size} bytes")]
+    EngineCallArgSizeExceeded { limit: usize, size: usize },
+    #[error("Invalid engine op {op}")]
+    InvalidEngineOp { op: i32 },
     #[error("Runtime error: {0}")]
     RuntimeError(#[from] RuntimeError),
     #[error("Failed to decode argument for engine call: {0:?}")]

--- a/crates/engine/src/wasm/process.rs
+++ b/crates/engine/src/wasm/process.rs
@@ -227,10 +227,15 @@ impl WasmProcess {
             Some(op) => op,
             None => {
                 log::error!(target: LOG_TARGET, "Invalid opcode: {}", op);
+                env.data_mut()
+                    .set_last_engine_error(WasmExecutionError::InvalidEngineOp { op });
                 return WasmPtr::null();
             },
         };
 
+        // Defence in depth: `max_internal_call_size` sits above what a template can build inside
+        // `WASM_LIMITS.max_memory_pages`, since the argument and its encoded copy must both fit, so
+        // a template reaching this limit runs out of linear memory first.
         if arg_len as usize > limits::ENGINE_LIMITS.max_internal_call_size {
             log::error!(
                 target: LOG_TARGET,
@@ -238,6 +243,11 @@ impl WasmProcess {
                 limits::ENGINE_LIMITS.max_internal_call_size,
                 arg_len
             );
+            env.data_mut()
+                .set_last_engine_error(WasmExecutionError::EngineCallArgSizeExceeded {
+                    limit: limits::ENGINE_LIMITS.max_internal_call_size,
+                    size: arg_len as usize,
+                });
             return WasmPtr::null();
         }
 
@@ -359,9 +369,7 @@ impl WasmProcess {
             }
 
             log::error!(target: LOG_TARGET, "{}", err);
-            if let WasmExecutionError::RuntimeError(e) = err {
-                env.data_mut().set_last_engine_error(e);
-            }
+            env.data_mut().set_last_engine_error(err);
             WasmPtr::null()
         })
     }
@@ -518,7 +526,7 @@ impl Invokable<Store> for WasmProcess {
         // template is free to ignore that and return normally, so the trap path alone is not enough
         // to catch it.
         if let Some(err) = self.env_mut(store).take_last_engine_error() {
-            return Err(WasmExecutionError::RuntimeError(err));
+            return Err(err);
         }
         // Every site that closes the window drains its own refusal before returning, so this
         // catches only a site that is later added without one.

--- a/crates/engine/src/wasm/process.rs
+++ b/crates/engine/src/wasm/process.rs
@@ -50,7 +50,7 @@ use tari_template_lib::{
         SpendContextInvokeArg,
         VaultInvokeArg,
     },
-    types::{LogLevel, engine_args::SignatureInvokeArg},
+    types::engine_args::SignatureInvokeArg,
 };
 use wasmer::{AsStoreMut, AsStoreRef, Function, FunctionEnv, FunctionEnvMut, Instance, Store, WasmPtr, imports};
 use wasmer_middlewares::metering::{MeteringPoints, get_remaining_points, set_remaining_points};
@@ -359,15 +359,8 @@ impl WasmProcess {
         };
 
         result.unwrap_or_else(|err| {
-            if let Err(err) = env
-                .data_mut()
-                .state_mut()
-                .interface_mut()
-                .emit_log(LogLevel::Error, format!("Execution error: {}", err))
-            {
-                log::error!(target: LOG_TARGET, "Error emitting log: {}", err);
-            }
-
+            // The recorded error is what reaches the transaction, as its reject reason. This line is
+            // the validator's own record of it.
             log::error!(target: LOG_TARGET, "{}", err);
             env.data_mut().set_last_engine_error(err);
             WasmPtr::null()

--- a/crates/engine/tests/templates/errors/Cargo.toml
+++ b/crates/engine/tests/templates/errors/Cargo.toml
@@ -8,6 +8,9 @@ edition = "2024"
 
 [dependencies]
 tari_template_lib = { path = "../../../../template_lib" }
+# Used to reach the raw `tari_engine` import, so a test can make an engine call the way a broken or
+# hostile template would: with an op the engine cannot map, or arguments it cannot decode.
+tari_template_abi = { path = "../../../../template_abi", default-features = false }
 
 
 [lib]

--- a/crates/engine/tests/templates/errors/src/lib.rs
+++ b/crates/engine/tests/templates/errors/src/lib.rs
@@ -41,5 +41,28 @@ mod template {
             // Cannot create a vault for a resource that doesnt exist
             let vault = Vault::new_empty(resource_addr);
         }
+
+        /// Calls the engine with an op no `EngineOp` maps to, and carries on as if it had worked.
+        /// The entrypoint can only answer with a null pointer, and this ignores it: the refusal has
+        /// to fail the transaction on the engine's side alone.
+        pub fn ignore_refused_engine_call() {
+            let arg = [0u8; 1];
+            unsafe {
+                tari_template_abi::tari_engine(i32::MAX, arg.as_ptr(), arg.len());
+            }
+        }
+
+        /// As above, but with a valid op and an argument the engine cannot decode.
+        pub fn ignore_undecodable_engine_call() {
+            // 0xff is a CBOR break byte, which is not a value.
+            let arg = [0xffu8; 8];
+            unsafe {
+                tari_template_abi::tari_engine(
+                    tari_template_abi::EngineOp::EmitLog.as_i32(),
+                    arg.as_ptr(),
+                    arg.len(),
+                );
+            }
+        }
     }
 }

--- a/crates/engine/tests/test.rs
+++ b/crates/engine/tests/test.rs
@@ -469,6 +469,42 @@ mod errors {
         }
     }
 
+    /// A refusal must fail the transaction even when the template ignores the null pointer it is
+    /// answered with, which is only true if the engine records why it refused.
+    #[test]
+    fn a_refused_engine_call_fails_the_transaction() {
+        let mut test = TemplateTest::new(CRATE_PATH, vec!["tests/templates/errors"]);
+
+        let reason = test.execute_expect_failure(
+            test.transaction()
+                .call_function(
+                    test.get_template_address("Errors"),
+                    "ignore_refused_engine_call",
+                    args![],
+                )
+                .build_and_seal(test.secret_key()),
+            vec![],
+        );
+        assert_reject_reason(reason, format!("Invalid engine op {}", i32::MAX));
+    }
+
+    #[test]
+    fn an_undecodable_engine_call_fails_the_transaction() {
+        let mut test = TemplateTest::new(CRATE_PATH, vec!["tests/templates/errors"]);
+
+        let reason = test.execute_expect_failure(
+            test.transaction()
+                .call_function(
+                    test.get_template_address("Errors"),
+                    "ignore_undecodable_engine_call",
+                    args![],
+                )
+                .build_and_seal(test.secret_key()),
+            vec![],
+        );
+        assert_reject_reason(reason, "Failed to decode argument for engine call");
+    }
+
     #[test]
     fn invalid_tuple_arg() {
         let mut test = TemplateTest::new(CRATE_PATH, vec!["tests/templates/tuples"]);


### PR DESCRIPTION
## Description

This started as the diagnostics follow-up noted in #2455, and turned out to be a correctness bug.

`tari_engine_entrypoint` can only answer the WASM with a null pointer. A null carries no reason, and a template is free to ignore it, so `WasmProcess::invoke` fails the call from an error the entrypoint records on the side — the invariant stated at `process.rs:516`:

> a refusal must fail the transaction even when the template ignores the null pointer it is handed

Only two of the five null-return paths actually recorded one:

| Site | Before |
|---|---|
| `process.rs:230` invalid opcode | logged, **not recorded** |
| `process.rs:241` argument size limit | logged, **not recorded** |
| `process.rs:361` handler failure | recorded only `WasmExecutionError::RuntimeError`, dropping `EngineArgDecodeFailed`, `MemoryAccessError` and every other variant |

So a template that made such a call and ignored the null returned normally, `invoke` found nothing recorded, and **the transaction committed** — with the engine call's effect never applied.

The two new tests demonstrate it. Without this change they fail with:

```
Transaction succeeded but it was expected to fail
```

### Impact

A template gains nothing it could not get by simply not making the call — the refused call did no work, so no state change can be forged this way. What it breaks is the stated invariant, and the realistic way to hit it is version skew: a template built against a newer `template_abi`, calling an op an older engine cannot map, silently continues and commits instead of failing cleanly. That is a wrong result rather than a clear error, and templates are immutable once published.

## Changes

- `last_engine_error` carries a `WasmExecutionError` instead of a `RuntimeError`, so every failure shape fits; `set_last_engine_error` takes `impl Into<WasmExecutionError>`.
- Every path that answers null now records why, with the requirement written on the setter.
- Adds `WasmExecutionError::InvalidEngineOp { op }` and `EngineCallArgSizeExceeded { limit, size }`. The latter is deliberately separate from `CallSizeLimitExceeded`: that one bounds the arguments passed the other way, *into* a template function, and conflating two different limits under one message makes both harder to read.

## Test plan

Two tests in `errors::` call the raw `tari_engine` import the way a broken or hostile template would — an unmappable op, and an argument the engine cannot decode — and ignore the null it is answered with. Verified both fail without the fix (one with "Transaction succeeded but it was expected to fail") and pass with it.

Also passing: the rest of `errors::` (3), `--test limits` (2), `--test fees` (25). `cargo clippy` clean on `tari_engine` (the two `resource.rs` warnings are pre-existing in `tari_engine_types`); `cargo fmt` applied.

### Why there is no test for the argument size limit

`max_internal_call_size` is 1 MiB, against `WASM_LIMITS.max_memory_pages` = 32 pages = 2 MiB of linear memory. The argument and its encoded copy must both be resident, so a template runs out of memory and traps before it can present an oversized argument — my first attempt at the test failed with `Wasm RuntimeError: unreachable` from the allocator, not the limit. The guard is still worth recording an error for as defence in depth (the memory limit may rise, or a cheaper construction path may appear), and I have noted why it is unreachable at the guard itself.

## Also: the engine's own error log is no longer billed to the caller

A failed engine call emitted `Execution error: {err}` through the metered `emit_log` — a `RuntimeCall` charge plus a byte rate, and one of the 256 `max_logs` slots. The payer covers that whenever the fee intent succeeded: `AcceptFeeRejectRest` runs `finalize_fees_and_refunds`, so the main intent's charges stand even though its state is discarded. Only a full `Reject` escapes it, and then only because nothing is charged at all.

It was never the caller's log to pay for — the engine emits it, not the template. With every null path now recording its error (above), the same text reaches the caller as the reject reason, and the `log::error!` on the next line already keeps it in the validator's own record. The charge bought a third copy, and did it by mutating state on an error path through a fallible call whose failure had to be caught and swallowed.

Only a couple of µT per failed call, but it is the payer's µT for the engine's diagnostic.

## Not included

Trapping from the entrypoint instead of returning null — which would delete this whole side channel — stays out. This PR is its prerequisite: every null path now carries a reason to trap with.
