### PR TITLE
ci: run machete on a hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,40 +186,23 @@ jobs:
         run: du -sh target/ 2>/dev/null || true
 
   machete:
-    # Checks for unused dependencies.
+    # Checks for unused dependencies. Machete reads the manifests and scans the sources for each
+    # dependency's name — it compiles nothing, so it needs neither a build container, a toolchain,
+    # a target dir nor the cache the compiling jobs share.
     name: machete
-    runs-on: [ self-hosted, ubuntu-high-cpu ]
-    container:
-      image: ghcr.io/tari-project/ootle-ci:development
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    env:
-      # Host-scoped, not RUSTFLAGS: template_builtin's build.rs shells out to
-      # `cargo build --target wasm32-unknown-unknown`, and rust-lld rejects
-      # `-fuse-ld`.
-      CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=mold
+    runs-on: [ ubuntu-latest ]
 
     steps:
       - name: checkout
         uses: actions/checkout@v7.0.1
 
-      - name: toolchain
-        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772  # master (no version tag)
+      - name: Install cargo-machete
+        uses: taiki-e/install-action@v2.85.13
         with:
-          toolchain: ${{ env.rust_toolchain }}
-          components: clippy, rustfmt
-
-      - uses: ./.github/actions/rust-cache
+          tool: cargo-machete
 
       - name: cargo machete
-        run: |
-          cargo install cargo-machete
-          cargo machete
-
-      - name: target dir size
-        if: always()
-        run: du -sh target/ 2>/dev/null || true
+        run: cargo machete
 
   licenses:
     name: file licenses


### PR DESCRIPTION
## Description

`cargo machete` reads the manifests and scans each crate's sources for its dependencies' names. It compiles nothing — so the build container, toolchain install, shared cargo cache, mold link flags and target-dir size report wrapped around it were all serving a step that takes **0.6s** wall clock on this workspace:

```
$ time cargo machete
Analyzing dependencies of crates in this directory...
cargo-machete didn't find any unused dependencies in this directory. Good job!
( cargo machete; )  0.585 total
```

Meanwhile it held a `[self-hosted, ubuntu-high-cpu]` runner that `clippy`, `test-shards` and `integration-test` are queueing for.

## Changes

- `runs-on: [ ubuntu-latest ]`, dropping the container, the `dtolnay/rust-toolchain` step, `./.github/actions/rust-cache`, the `CARGO_TARGET_*_RUSTFLAGS` mold setting and the target-dir report. None of them apply to a job that never invokes rustc.
- Installs the binary via `taiki-e/install-action@v2.85.13`, matching how the `test` job installs `cargo-nextest`, instead of `cargo install cargo-machete` compiling it from source on every run.

Net: 8 lines replacing 25, one fewer self-hosted slot held per CI run.

## Test plan

- `cargo machete` passes on `development` and on the branches currently in flight (#2455, #2456), including the `tari_template_abi` dependency #2456 adds to a test template, which is referenced by fully-qualified path rather than a `use`.
- Job parsed back out of the YAML to confirm it carries no `container` or `env` key and the three expected steps.
- No other job `needs:` machete, so the runner-label change cannot reorder anything.
