### PR TITLE
fix(state-store): scope block diff queries to the queried branch

### DIFF
--- a/crates/state_store_rocksdb/src/reader.rs
+++ b/crates/state_store_rocksdb/src/reader.rs
@@ -1096,7 +1096,13 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx, R: RocksR
         let mut max_change = None::<BlockDiffKey>;
         for result in iter {
             let key = result?;
-            if max_change.as_ref().is_none_or(|c| c.version < key.version) && applicable_blocks.contains(block_id) {
+            if !applicable_blocks.contains(&key.block_id) {
+                continue;
+            }
+            if max_change
+                .as_ref()
+                .is_none_or(|c| block_diff_change_order(c) < block_diff_change_order(&key))
+            {
                 max_change = Some(key);
             }
         }
@@ -1130,18 +1136,27 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx, R: RocksR
         let query = self.db().cf(block_diff::BySubstateIdQuery)?;
         let iter = query.query_prefix_range_key_iterator(Ordering::default(), versioned.substate_id());
 
+        let mut last_change = None::<BlockDiffKey>;
         for result in iter {
             let key = result?;
-            if versioned.version() == key.version && applicable_blocks.contains(block_id) {
-                let change = cf.get(&key, OPERATION)?;
-                return Ok(change);
+            if versioned.version() != key.version || !applicable_blocks.contains(&key.block_id) {
+                continue;
+            }
+            if last_change
+                .as_ref()
+                .is_none_or(|c| block_diff_change_order(c) < block_diff_change_order(&key))
+            {
+                last_change = Some(key);
             }
         }
 
-        Err(StorageError::NotFound {
+        let key = last_change.ok_or_else(|| StorageError::NotFound {
             item: "SubstateChange",
             key: format!("{versioned} in {block_id}"),
-        })
+        })?;
+
+        let change = cf.get(&key, OPERATION)?;
+        Ok(change)
     }
 
     fn proposal_certificates_get(&self, epoch: Epoch, qc_id: &PcId) -> Result<ProposalCertificate, StorageError> {
@@ -2081,4 +2096,10 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx, R: RocksR
 
         Ok(count)
     }
+}
+
+/// Orders two changes for the same substate within a branch. A substate version is only ever DOWNed after it is UPed,
+/// so a DOWN supersedes the UP of the same version.
+fn block_diff_change_order(key: &BlockDiffKey) -> (u32, bool) {
+    (key.version, !key.is_up)
 }

--- a/crates/state_store_rocksdb/src/reader.rs
+++ b/crates/state_store_rocksdb/src/reader.rs
@@ -349,6 +349,44 @@ impl<'a, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'a, R: RocksRea
         Ok(blocks)
     }
 
+    /// Returns the key of the last change to `substate_id` on the branch ending at `end_block`, or `None` if the
+    /// branch contains no change for it. If `version` is given, only changes to that version are considered.
+    ///
+    /// Changes recorded by blocks that are not in the branch (forked-out siblings, other subtrees) are never
+    /// considered. A substate version is only ever DOWNed after it is UPed, so a DOWN supersedes the UP of the same
+    /// version.
+    fn block_diffs_select_last_change(
+        &self,
+        end_block: &BlockId,
+        substate_id: &SubstateId,
+        version: Option<u32>,
+    ) -> Result<Option<BlockDiffKey>, RocksDbStorageError> {
+        let applicable_blocks = self.get_pending_chain_until(end_block)?;
+
+        let query = self.db().cf(block_diff::BySubstateIdQuery)?;
+        let iter = query.query_prefix_range_key_iterator(Ordering::default(), substate_id);
+
+        let mut last_change = None::<BlockDiffKey>;
+        for result in iter {
+            let key = result?;
+            if version.is_some_and(|v| v != key.version) || !applicable_blocks.contains(&key.block_id) {
+                continue;
+            }
+            // A DOWN is the last change a version can have, so with the version fixed there is nothing left to find.
+            if version.is_some() && !key.is_up {
+                return Ok(Some(key));
+            }
+            if last_change
+                .as_ref()
+                .is_none_or(|c| block_diff_change_order(c) < block_diff_change_order(&key))
+            {
+                last_change = Some(key);
+            }
+        }
+
+        Ok(last_change)
+    }
+
     pub fn get_commit_block(&self) -> Result<CommitBlock, RocksDbStorageError> {
         let cf = self.db().cf(CommitBlockCf)?;
         let value = cf.get_by_default_key("get_commit_block")?;
@@ -1087,32 +1125,14 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx, R: RocksR
             });
         }
 
-        let applicable_blocks = self.get_pending_chain_until(block_id)?;
+        let key = self
+            .block_diffs_select_last_change(block_id, substate_id, None)?
+            .ok_or_else(|| StorageError::NotFound {
+                item: "SubstateChange",
+                key: format!("{substate_id} in {block_id}"),
+            })?;
 
-        let cf = self.db().cf(BlockDiffCf)?;
-        let query = self.db().cf(block_diff::BySubstateIdQuery)?;
-        let iter = query.query_prefix_range_key_iterator(Ordering::default(), substate_id);
-
-        let mut max_change = None::<BlockDiffKey>;
-        for result in iter {
-            let key = result?;
-            if !applicable_blocks.contains(&key.block_id) {
-                continue;
-            }
-            if max_change
-                .as_ref()
-                .is_none_or(|c| block_diff_change_order(c) < block_diff_change_order(&key))
-            {
-                max_change = Some(key);
-            }
-        }
-
-        let key = max_change.ok_or_else(|| StorageError::NotFound {
-            item: "SubstateChange",
-            key: format!("{substate_id} in {block_id}"),
-        })?;
-
-        let change = cf.get(&key, OPERATION)?;
+        let change = self.db().cf(BlockDiffCf)?.get(&key, OPERATION)?;
         Ok(change)
     }
 
@@ -1130,32 +1150,14 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx, R: RocksR
 
         let versioned = substate_id.into();
 
-        let applicable_blocks = self.get_pending_chain_until(block_id)?;
+        let key = self
+            .block_diffs_select_last_change(block_id, versioned.substate_id(), Some(versioned.version()))?
+            .ok_or_else(|| StorageError::NotFound {
+                item: "SubstateChange",
+                key: format!("{versioned} in {block_id}"),
+            })?;
 
-        let cf = self.db().cf(BlockDiffCf)?;
-        let query = self.db().cf(block_diff::BySubstateIdQuery)?;
-        let iter = query.query_prefix_range_key_iterator(Ordering::default(), versioned.substate_id());
-
-        let mut last_change = None::<BlockDiffKey>;
-        for result in iter {
-            let key = result?;
-            if versioned.version() != key.version || !applicable_blocks.contains(&key.block_id) {
-                continue;
-            }
-            if last_change
-                .as_ref()
-                .is_none_or(|c| block_diff_change_order(c) < block_diff_change_order(&key))
-            {
-                last_change = Some(key);
-            }
-        }
-
-        let key = last_change.ok_or_else(|| StorageError::NotFound {
-            item: "SubstateChange",
-            key: format!("{versioned} in {block_id}"),
-        })?;
-
-        let change = cf.get(&key, OPERATION)?;
+        let change = self.db().cf(BlockDiffCf)?.get(&key, OPERATION)?;
         Ok(change)
     }
 

--- a/crates/state_store_rocksdb/tests/block_diffs.rs
+++ b/crates/state_store_rocksdb/tests/block_diffs.rs
@@ -2,7 +2,7 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use tari_engine_types::substate::{Substate, hash_substate};
-use tari_ootle_common_types::VersionedSubstateId;
+use tari_ootle_common_types::{VersionedSubstateId, optional::Optional};
 use tari_ootle_storage::{
     StateStore,
     StateStoreReadTransaction,
@@ -15,6 +15,7 @@ use helpers::{
     build_substate_record,
     build_substate_value,
     commit_chain,
+    create_block_with_qc,
     create_chain,
     create_random_substate_id,
     create_rocksdb,
@@ -94,6 +95,96 @@ fn block_diffs_operations(db: impl StateStore) {
     tx.block_diffs_remove(&block_id9).unwrap();
     let res = tx.block_diffs_get(&block_id9).unwrap();
     assert_eq!(res.changes().len(), 0);
+
+    tx.rollback().unwrap();
+}
+
+#[test]
+fn block_diffs_are_scoped_to_the_queried_branch() {
+    let (db, _tmp) = create_rocksdb();
+    let mut tx = db.create_write_tx().unwrap();
+
+    let chain = create_chain(10);
+    commit_chain(&mut tx, &chain);
+
+    // chain[8] is the last block shared by both branches: chain[9] extends it and `fork` is a sibling of chain[9].
+    let fork_point = chain[8].as_leaf();
+    let fork = create_block_with_qc(&fork_point);
+    fork.insert(&mut tx).unwrap();
+    tx.proposal_certificates_save(fork.justify()).unwrap();
+
+    let substate_id = create_random_substate_id();
+    let versioned_substate_id = VersionedSubstateId::new(substate_id.clone(), 0);
+    let value = build_substate_value(None);
+    tx.block_diffs_insert(fork.id(), &[
+        SubstateChange::Down {
+            id: versioned_substate_id.clone(),
+            shard: fork.shard_group().start(),
+        },
+        SubstateChange::Up {
+            id: substate_id.clone(),
+            shard: fork.shard_group().start(),
+            substate: Box::new(Substate::new(1, value)),
+        },
+    ])
+    .unwrap();
+
+    // The changes only exist on the forked-out branch, so they must not be visible from chain[9].
+    assert!(
+        tx.block_diffs_get_last_change_for_substate(chain[9].id(), &substate_id)
+            .optional()
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        tx.block_diffs_get_change_for_versioned_substate(chain[9].id(), &versioned_substate_id)
+            .optional()
+            .unwrap()
+            .is_none()
+    );
+
+    // ...and they are visible from the branch that contains them.
+    let change = tx
+        .block_diffs_get_last_change_for_substate(fork.id(), &substate_id)
+        .unwrap();
+    assert_eq!(change.versioned_substate_id().version(), 1);
+    assert!(change.is_up());
+
+    tx.rollback().unwrap();
+}
+
+#[test]
+fn block_diffs_last_change_prefers_the_down_of_a_version() {
+    let (db, _tmp) = create_rocksdb();
+    let mut tx = db.create_write_tx().unwrap();
+
+    let chain = create_chain(10);
+    commit_chain(&mut tx, &chain);
+
+    let substate_id = create_random_substate_id();
+    let versioned_substate_id = VersionedSubstateId::new(substate_id.clone(), 0);
+    let value = build_substate_value(None);
+    tx.block_diffs_insert(chain[8].id(), &[SubstateChange::Up {
+        id: substate_id.clone(),
+        shard: chain[8].shard_group().start(),
+        substate: Box::new(Substate::new(0, value)),
+    }])
+    .unwrap();
+    tx.block_diffs_insert(chain[9].id(), &[SubstateChange::Down {
+        id: versioned_substate_id.clone(),
+        shard: chain[9].shard_group().start(),
+    }])
+    .unwrap();
+
+    let change = tx
+        .block_diffs_get_last_change_for_substate(chain[9].id(), &substate_id)
+        .unwrap();
+    assert!(!change.is_up(), "Expected the DOWN of version 0 but got {change}");
+
+    let change = tx
+        .block_diffs_get_change_for_versioned_substate(chain[9].id(), &versioned_substate_id)
+        .unwrap();
+    assert!(!change.is_up(), "Expected the DOWN of version 0 but got {change}");
 
     tx.rollback().unwrap();
 }

--- a/crates/state_store_rocksdb/tests/block_diffs.rs
+++ b/crates/state_store_rocksdb/tests/block_diffs.rs
@@ -150,6 +150,12 @@ fn block_diffs_are_scoped_to_the_queried_branch() {
     assert_eq!(change.versioned_substate_id().version(), 1);
     assert!(change.is_up());
 
+    let change = tx
+        .block_diffs_get_change_for_versioned_substate(fork.id(), &versioned_substate_id)
+        .unwrap();
+    assert_eq!(change.versioned_substate_id().version(), 0);
+    assert!(!change.is_up());
+
     tx.rollback().unwrap();
 }
 

--- a/crates/storage/src/consensus_models/block_diff.rs
+++ b/crates/storage/src/consensus_models/block_diff.rs
@@ -74,6 +74,9 @@ impl BlockDiff {
         tx.block_diffs_remove(&self.block_id)
     }
 
+    /// Returns the last change to `substate_id` recorded by the branch ending at `block_id`, or `NotFound` if the
+    /// branch contains no change for it. Changes recorded by blocks outside that branch are never returned, and a
+    /// DOWN supersedes the UP of the same version.
     pub fn get_last_change_for_substate<TTx: StateStoreReadTransaction>(
         tx: &TTx,
         block_id: &BlockId,
@@ -82,6 +85,9 @@ impl BlockDiff {
         tx.block_diffs_get_last_change_for_substate(block_id, substate_id)
     }
 
+    /// Returns the last change to the given substate version recorded by the branch ending at `block_id`, or
+    /// `NotFound` if the branch contains no change for it. Selection follows the same rules as
+    /// [`Self::get_last_change_for_substate`], restricted to the requested version.
     pub fn get_for_versioned_substate<'a, TTx: StateStoreReadTransaction, T: Into<VersionedSubstateIdRef<'a>>>(
         tx: &TTx,
         block_id: &BlockId,

--- a/crates/storage/src/state_store/mod.rs
+++ b/crates/storage/src/state_store/mod.rs
@@ -204,11 +204,20 @@ pub trait StateStoreReadTransaction: Sized {
 
     fn block_diffs_get(&self, block_id: &BlockId) -> Result<BlockDiff, StorageError>;
 
+    /// Returns the last change to `substate_id` recorded by the branch ending at `block_id`, or `NotFound` if the
+    /// branch contains no change for it.
+    ///
+    /// Implementations must only consider changes recorded by blocks in that branch: a change from a forked-out
+    /// sibling or any other subtree must never be returned. A substate version is only ever DOWNed after it is UPed,
+    /// so where a branch both UPs and DOWNs the same version, the DOWN is the last change.
     fn block_diffs_get_last_change_for_substate(
         &self,
         block_id: &BlockId,
         substate_id: &SubstateId,
     ) -> Result<SubstateChange, StorageError>;
+    /// Returns the last change to the given substate version recorded by the branch ending at `block_id`, or
+    /// `NotFound` if the branch contains no change for it. Selection follows the same rules as
+    /// [`Self::block_diffs_get_last_change_for_substate`], restricted to the requested version.
     fn block_diffs_get_change_for_versioned_substate<'a, T: Into<VersionedSubstateIdRef<'a>>>(
         &self,
         block_id: &BlockId,


### PR DESCRIPTION
## Description

`block_diffs_get_last_change_for_substate` and `block_diffs_get_change_for_versioned_substate` filtered candidate diff entries with `applicable_blocks.contains(block_id)` — the query's own argument, which is trivially a member of its own pending chain — instead of `key.block_id`, the block that recorded the entry. The branch filter was a no-op: the `(SubstateId, BlockId, Version, Seq)` index scan accepted diffs from every stored block, including forked-out siblings.

`PendingSubstateStore::{get, get_latest_version, get_latest_change_from_store}` are built on these queries, so pending substate state from an abandoned branch leaked into the evaluation of blocks on the surviving branch.

Both queries now match on the entry's own block id. They also order two changes of the same substate by `(version, is_down)` rather than by `version` alone, so a DOWN supersedes the UP of the same version instead of the winner depending on block id iteration order.

## Motivation and Context

This is the root cause of the flaky `consensus_tests::catch_up_rewind::catch_up_rewind_below_leaf_recovers` ([failing job](https://github.com/tari-project/tari-ootle/actions/runs/32454421433/job/96689191530)). In that run:

- h2 block `c2eece80` (justify h1) carried all 5 test transactions as `LocalOnly Commit`; its block diff, downing the inputs, was persisted on vote.
- It got no QC. A TC formed and h3 `a2b9792d` was built on a **dummy** h2 block, so `c2eece80` was forked out and the transactions were correctly re-proposed.
- Replicas evaluating h3 nonetheless hit `Lock failure: Substate component_00d248…:0 is DOWN` — the down from the forked-out block — and voted no (`Decision disagreement. Local: Abort(LockInputsOutputsFailed), Remote: Commit`).
- h4 resolved the same leaked DOWN into `RejectReason::SubstateNotFound` and proposed all 5 as `Abort(OneOrMoreInputsNotFound)`, which was certified at h5 and committed.

The test's `has_committed_substates` check could then never pass, and it panicked at the height budget with the misleading "catch-up view-rewind deadlock" message even though the target had re-joined consensus (HighPC 73 vs network height 71). The tight 2s `pacemaker_block_time` makes that early fork likely on a loaded CI runner.

Beyond the test, any timeout fork on a live network could spuriously and permanently abort transactions on the surviving branch.

Introduced in 45b633b9ae (#1340).

## How Has This Been Tested?

Two new tests in `crates/state_store_rocksdb/tests/block_diffs.rs`:

- `block_diffs_are_scoped_to_the_queried_branch` — writes a diff into a sibling of `chain[9]` and asserts both queries do not see it from `chain[9]`, but do from the fork. Fails on `development`, passes here.
- `block_diffs_last_change_prefers_the_down_of_a_version` — an UP of v0 in one branch block and a DOWN of v0 in its child; both queries must return the DOWN.

Full `cargo test -p tari_state_store_rocksdb` suite passes locally.

## What process can a PR reviewer use to test or verify this change?

Revert the two `applicable_blocks.contains(&key.block_id)` lines to `contains(block_id)` and run `cargo test -p tari_state_store_rocksdb --test block_diffs`; the branch-scoping test fails.

## Breaking Changes

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other