### PR TITLE
fix(consensus): scope proposal vote aggregation to the voted block

### DIFF
--- a/crates/consensus/src/hotstuff/vote_collector/collector.rs
+++ b/crates/consensus/src/hotstuff/vote_collector/collector.rs
@@ -41,10 +41,11 @@ impl<V: Vote + Display> VoteCollector<V> {
         access_mut.clear_votes_before(current_epoch, current_height);
         let epoch = vote.epoch();
         let height = vote.height();
+        let agg_key = vote.aggregation_key();
         let vote_display = vote.to_string();
         access_mut.save_vote(vote)?;
 
-        let threshold_decision = access_mut.calculate_threshold_decision(epoch, height, committee);
+        let threshold_decision = access_mut.calculate_threshold_decision(epoch, height, &agg_key, committee);
 
         let quorum_threshold = committee.quorum_threshold();
         let Some(quorum_decision) = threshold_decision.decision else {
@@ -82,7 +83,7 @@ impl<V: Vote + Display> VoteCollector<V> {
             quorum_threshold
         );
 
-        let votes = access_mut.take_votes_with_decision(epoch, height, quorum_decision);
+        let votes = access_mut.take_votes_with_decision(epoch, height, &agg_key, quorum_decision);
 
         Ok(votes.map(|v| (v, quorum_decision)))
     }
@@ -163,12 +164,18 @@ impl<V: Vote + Display> VoteStoreInner<V> {
         &mut self,
         epoch: Epoch,
         height: NodeHeight,
+        agg_key: &V::AggregationKey,
         decision: QuorumDecision,
     ) -> Option<Vec<V>> {
         let epoch_height = (epoch, height);
-        // Take all votes, discarding any other votes for this epoch/height that do not match the decision
+        // Once a block is decided at this height, votes for any losing fork at the same height can be dropped too.
         let votes = self.store.remove(&epoch_height)?;
-        Some(votes.into_values().filter(|vote| vote.decision() == decision).collect())
+        Some(
+            votes
+                .into_values()
+                .filter(|vote| vote.decision() == decision && vote.aggregation_key() == *agg_key)
+                .collect(),
+        )
     }
 
     fn votes_for_key_iter(&self, epoch: Epoch, height: NodeHeight) -> Option<impl Iterator<Item = &V>> {
@@ -181,6 +188,7 @@ impl<V: Vote + Display> VoteStoreInner<V> {
         &self,
         epoch: Epoch,
         height: NodeHeight,
+        agg_key: &V::AggregationKey,
         committee: &Committee<TAddr>,
     ) -> ThresholdDecision {
         let Some(votes_iter) = self.votes_for_key_iter(epoch, height) else {
@@ -199,7 +207,7 @@ impl<V: Vote + Display> VoteStoreInner<V> {
         };
         let mut count_accept = VotePower::zero();
         let mut count_reject = VotePower::zero();
-        for vote in votes_iter {
+        for vote in votes_iter.filter(|vote| vote.aggregation_key() == *agg_key) {
             let power = committee.get_power_by_public_key(vote.public_key()).unwrap_or_default();
             match vote.decision() {
                 QuorumDecision::Accept => count_accept += power,
@@ -259,6 +267,7 @@ pub struct VoteEquivocationDetected<V: Vote> {
 mod tests {
     use tari_common_types::types::FixedHash;
     use tari_consensus_types::{SignedMessage, ToSignatureMessage};
+    use tari_ootle_common_types::committee::CommitteeMember;
     use tari_template_lib_types::crypto::{RistrettoPublicKeyBytes, Scalar32Bytes, SchnorrSignatureBytes};
 
     use super::*;
@@ -266,10 +275,12 @@ mod tests {
     const ZERO_SIG: SchnorrSignatureBytes = SchnorrSignatureBytes::zero();
     const ZERO_PUBKEY: RistrettoPublicKeyBytes = RistrettoPublicKeyBytes::zero();
 
-    #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+    #[derive(Debug, Clone, PartialEq, Eq)]
     struct TestVote {
         epoch: Epoch,
         height: NodeHeight,
+        block_id: FixedHash,
+        decision: QuorumDecision,
         sig: SchnorrSignatureBytes,
         public_key: RistrettoPublicKeyBytes,
     }
@@ -297,6 +308,8 @@ mod tests {
     }
 
     impl Vote for TestVote {
+        type AggregationKey = FixedHash;
+
         fn epoch(&self) -> Epoch {
             self.epoch
         }
@@ -306,8 +319,29 @@ mod tests {
         }
 
         fn decision(&self) -> QuorumDecision {
-            QuorumDecision::Accept
+            self.decision
         }
+
+        fn aggregation_key(&self) -> FixedHash {
+            self.block_id
+        }
+    }
+
+    fn pubkey(byte: u8) -> RistrettoPublicKeyBytes {
+        RistrettoPublicKeyBytes::from_bytes(&[byte; 32]).unwrap()
+    }
+
+    fn committee(public_keys: &[RistrettoPublicKeyBytes]) -> Committee<RistrettoPublicKeyBytes> {
+        Committee::new(
+            public_keys
+                .iter()
+                .map(|pk| CommitteeMember {
+                    address: *pk,
+                    public_key: *pk,
+                    vote_power: VotePower::of(1),
+                })
+                .collect(),
+        )
     }
 
     #[test]
@@ -316,6 +350,8 @@ mod tests {
         let vote = TestVote {
             epoch: Epoch(1),
             height: NodeHeight(1),
+            block_id: FixedHash::zero(),
+            decision: QuorumDecision::Accept,
             sig: ZERO_SIG,
             public_key: ZERO_PUBKEY,
         };
@@ -330,6 +366,8 @@ mod tests {
         let vote = TestVote {
             epoch: Epoch(1),
             height: NodeHeight(1),
+            block_id: FixedHash::zero(),
+            decision: QuorumDecision::Accept,
             sig: ZERO_SIG,
             public_key: ZERO_PUBKEY,
         };
@@ -343,11 +381,59 @@ mod tests {
         let vote = TestVote {
             epoch: Epoch(1),
             height: NodeHeight(1),
+            block_id: FixedHash::zero(),
+            decision: QuorumDecision::Accept,
             public_key: ZERO_PUBKEY,
             sig: SchnorrSignatureBytes::new([1u8; 32].into(), Scalar32Bytes::zero()),
         };
 
         // Try to save the a different vote from the same public key and epoch/height - should error
         store.save_vote(vote).unwrap_err();
+    }
+
+    #[test]
+    fn a_foreign_block_vote_does_not_count_towards_a_block_quorum() {
+        let mut store = VoteStoreInner::<TestVote>::new();
+        let epoch = Epoch(1);
+        let height = NodeHeight(1);
+
+        let block_a = FixedHash::new([0xAu8; 32]);
+        let block_phantom = FixedHash::new([0xBu8; 32]);
+
+        let honest1 = pubkey(1);
+        let honest2 = pubkey(2);
+        let byzantine = pubkey(3);
+        let absent = pubkey(4);
+
+        // n = 4, quorum_threshold = 3
+        let committee = committee(&[honest1, honest2, byzantine, absent]);
+        assert_eq!(committee.quorum_threshold(), VotePower::of(3));
+
+        let mk = |pk, block_id| TestVote {
+            epoch,
+            height,
+            block_id,
+            decision: QuorumDecision::Accept,
+            sig: ZERO_SIG,
+            public_key: pk,
+        };
+
+        // Two honest Accept votes for block A plus one Byzantine Accept vote for a phantom block, all at the same
+        // (epoch, height).
+        store.save_vote(mk(honest1, block_a)).unwrap();
+        store.save_vote(mk(honest2, block_a)).unwrap();
+        store.save_vote(mk(byzantine, block_phantom)).unwrap();
+
+        // Block A only has 2 of the required 3 power and does not reach a quorum.
+        let decision_a = store.calculate_threshold_decision(epoch, height, &block_a, &committee);
+        assert_eq!(decision_a.decision, None);
+        assert_eq!(decision_a.total_power, VotePower::of(2));
+
+        // The Byzantine phantom-block vote never folds into block A's votes.
+        let votes_a = store
+            .take_votes_with_decision(epoch, height, &block_a, QuorumDecision::Accept)
+            .unwrap();
+        assert_eq!(votes_a.len(), 2);
+        assert!(votes_a.iter().all(|v| v.block_id == block_a));
     }
 }

--- a/crates/consensus_types/src/certificates/proposal_vote.rs
+++ b/crates/consensus_types/src/certificates/proposal_vote.rs
@@ -32,6 +32,8 @@ pub struct ProposalVote {
 }
 
 impl Vote for ProposalVote {
+    type AggregationKey = BlockId;
+
     fn epoch(&self) -> Epoch {
         self.epoch
     }
@@ -42,6 +44,10 @@ impl Vote for ProposalVote {
 
     fn decision(&self) -> QuorumDecision {
         self.decision
+    }
+
+    fn aggregation_key(&self) -> BlockId {
+        self.block_id
     }
 }
 

--- a/crates/consensus_types/src/certificates/timeout_vote.rs
+++ b/crates/consensus_types/src/certificates/timeout_vote.rs
@@ -26,6 +26,8 @@ impl TimeoutVote {
 }
 
 impl Vote for TimeoutVote {
+    type AggregationKey = ();
+
     fn epoch(&self) -> Epoch {
         self.epoch
     }
@@ -37,6 +39,8 @@ impl Vote for TimeoutVote {
     fn decision(&self) -> QuorumDecision {
         QuorumDecision::Accept
     }
+
+    fn aggregation_key(&self) {}
 }
 
 impl ToSignatureMessage for TimeoutVote {

--- a/crates/consensus_types/src/traits.rs
+++ b/crates/consensus_types/src/traits.rs
@@ -16,7 +16,12 @@ pub trait SignedMessage: ToSignatureMessage {
 }
 
 pub trait Vote: SignedMessage {
+    /// Identifies which votes aggregate together within an (epoch, height) bucket.
+    /// Proposal votes aggregate per voted block; timeout votes aggregate per (epoch, height).
+    type AggregationKey: PartialEq;
+
     fn epoch(&self) -> Epoch;
     fn height(&self) -> NodeHeight;
     fn decision(&self) -> QuorumDecision;
+    fn aggregation_key(&self) -> Self::AggregationKey;
 }

--- a/crates/state_store_rocksdb/src/reader.rs
+++ b/crates/state_store_rocksdb/src/reader.rs
@@ -1639,21 +1639,29 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx, R: RocksR
             }
         }
 
-        // In the committed chain?
+        // In the committed chain? This index is ordered by (substate_id, transaction_id, block_id, height), not by
+        // height, so scan every committed lock for the substate and keep the one from the highest block (the latest).
         let commit_block = self.get_commit_block()?;
         let query = self.db().cf(substate_locks::BySubstateIdQuery)?;
-        let mut iter = query.query_prefix_range_key_iterator(Ordering::default(), substate_id);
-        let key = iter
-            .find_map(|r| match r {
-                Ok(key) if key.block_height <= commit_block.height => Some(Ok(key)),
-                Ok(_) => None,
-                Err(err) => Some(Err(err)),
-            })
-            .transpose()?
-            .ok_or_else(|| StorageError::NotFound {
-                item: "SubstateLock",
-                key: format!("for substate {substate_id} in block {leaf_block}"),
-            })?;
+        let iter = query.query_prefix_range_key_iterator(Ordering::default(), substate_id);
+        let mut latest: Option<substate_locks::SubstateLockKey> = None;
+        for result in iter {
+            let key = result?;
+            if key.block_height > commit_block.height {
+                continue;
+            }
+            let is_later = match &latest {
+                Some(prev) => prev.block_height < key.block_height,
+                None => true,
+            };
+            if is_later {
+                latest = Some(key);
+            }
+        }
+        let key = latest.ok_or_else(|| StorageError::NotFound {
+            item: "SubstateLock",
+            key: format!("for substate {substate_id} in block {leaf_block}"),
+        })?;
 
         let lock = cf.get(&key, OPERATION)?;
         Ok(lock)


### PR DESCRIPTION
Two independent fixes found while reviewing the consensus crate and the RocksDB state store. The first is a liveness bug in consensus; the second is a correctness bug on a storage read path.

## 1. Proposal vote aggregation is not scoped to the voted block

The generic `VoteCollector`/`VoteStoreInner` aggregates votes in a `BTreeMap<(Epoch, NodeHeight), HashMap<pubkey, V>>` keyed only by `(epoch, height)`. `calculate_threshold_decision` and `take_votes_with_decision` sum/return over **every** vote in the `(epoch, height)` bucket, without filtering by which block the vote is for.

This is correct for `TimeoutVote`, whose signature genuinely binds `(epoch, height)`. It is **wrong** for `ProposalVote`: its signature binds `(block_id, decision)`, and its `block_height` field is unsigned and attacker-controlled.

### Consequence (liveness halt)

A single Byzantine committee member submits a validly-signed Accept `ProposalVote` at the current height for an arbitrary `block_id` it invents. It lands in the same `(epoch, height)` bucket as the honest votes for the real block A. When A reaches quorum, the minted `ProposalCertificate` folds in the Byzantine signature (made over a different `block_id`).

QC verification (`check_quorum_certificate_signatures` in `validations/common.rs`) recomputes the signature message from the QC's own block and returns `QcInvalidSignature` on the first bad signature, so every honest peer rejects the block carrying that QC as its justify. Block A can never re-certify — its honest votes were already consumed by `take_votes_with_decision` — and the attack repeats every height, halting the chain well below the Byzantine fault threshold.

Safety was never at risk: signatures bind the `block_id`, so no invalid block can be certified. Only liveness is affected.

### Fix

Add a per-vote aggregation key to the `Vote` trait:

- `ProposalVote::AggregationKey = BlockId` (the voted block)
- `TimeoutVote::AggregationKey = ()` (all timeout votes in a bucket aggregate together — behaviour unchanged)

`calculate_threshold_decision` and `take_votes_with_decision` now take the aggregation key and filter by it, so quorum is evaluated per voted block. A Byzantine phantom-block vote only ever forms a (never-reached) quorum for its own phantom block and is never folded into a legitimate block's certificate. The outer `(epoch, height)` bucket and pubkey-keyed inner map are unchanged, so pruning via `clear_votes_before` and per-`(epoch, height, pubkey)` equivocation detection are preserved.

Adds a regression test: with n=4 (quorum=3), two honest Accept votes for block A plus one Byzantine Accept vote for a different `block_id` at the same `(epoch, height)` do not reach quorum for A, and taking A's votes never returns the Byzantine vote.

## 2. Committed substate lock lookup returned an arbitrary lock

The committed-chain fallback in `substate_locks_get_latest_for_substate` returned the first key whose block height was at or below the commit block. The `BySubstateIdQuery` index is ordered by `(substate_id, transaction_id, block_id, height)`, so that first match is arbitrary with respect to recency and could return a superseded lock — which then feeds `try_lock`'s conflict decisions.

It now scans the committed locks for the substate and keeps the one from the highest block. This path runs only when both the head-index fast path and the pending-chain lookup miss, and the number of live locks per substate is bounded by lock removal on finalize and per block, so the extra scan is negligible.

A follow-up PR will address the related `SubstateIdIndex` key prefix, which needs a data migration.

## Testing

`cargo test -p tari_consensus --lib vote_collector` — 3 passed. `cargo check` clean for `tari_consensus`, `tari_consensus_types` and `tari_state_store_rocksdb`.
