### PR TITLE
fix(state-store): give the substate lock substate-id index its table prefix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12813,6 +12813,7 @@ dependencies = [
  "tari_transaction_components",
  "tari_validator_node_client",
  "tari_validator_node_rpc",
+ "tempfile",
  "thiserror 2.0.18",
  "time",
  "tokio",

--- a/applications/tari_validator_node/Cargo.toml
+++ b/applications/tari_validator_node/Cargo.toml
@@ -84,6 +84,9 @@ console-subscriber = { version = "0.4.1", optional = true }
 [build-dependencies]
 tari_common = { workspace = true, features = ["build"] }
 
+[dev-dependencies]
+tempfile = { workspace = true }
+
 [package.metadata.cargo-machete]
 ignored = [
     # We want to bundle this lib

--- a/applications/tari_validator_node/src/migrations/common.rs
+++ b/applications/tari_validator_node/src/migrations/common.rs
@@ -1,0 +1,45 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! Helpers shared by more than one migration.
+
+use tari_ootle_storage::{Ordering, StorageError};
+use tari_state_store_rocksdb::{
+    cf_api::CfContext,
+    traits::{Cf, RocksReader, RocksWriter},
+};
+
+/// Rewrites every row below `upper_bound` in the column family shared by `legacy_cf` and `current_cf`, moving it from
+/// the legacy unprefixed key encoding to the prefixed one. Returns the number of rows rewritten.
+///
+/// Tables sharing a column family are namespaced by a leading `KeyPrefix` byte. A table that declared a prefix but
+/// never encoded it wrote its keys into the low keyspace of that family instead, below every prefix in use.
+///
+/// `upper_bound` must be the lowest table prefix in use in that column family, so that everything below it is a legacy
+/// row. Each scan is confined to a single leading byte, which keeps it consistent with the family's one byte prefix
+/// extractor, and a rewritten key leads with a byte at or above the bound, so it lands outside every scanned range and
+/// is never revisited. That makes the rewrite idempotent and safe to interrupt.
+pub fn rewrite_unprefixed_rows<DB, TLegacy, TCurrent>(
+    legacy_cf: &CfContext<'_, DB, TLegacy>,
+    current_cf: &CfContext<'_, DB, TCurrent>,
+    upper_bound: u8,
+    operation: &'static str,
+) -> Result<usize, StorageError>
+where
+    DB: RocksReader + RocksWriter,
+    TLegacy: Cf,
+    TCurrent: Cf<Key = TLegacy::Key, Value = TLegacy::Value>,
+{
+    let mut num_rewritten = 0usize;
+    for leading_byte in 0..upper_bound {
+        for result in legacy_cf.prefix_range_iterator_raw_key(Ordering::Ascending, vec![leading_byte]) {
+            let (key, value) = result?;
+            // The same key encodes without the prefix through the legacy table and with it through the current one.
+            legacy_cf.delete(&key, operation)?;
+            current_cf.put(&key, &value, operation)?;
+            num_rewritten += 1;
+        }
+    }
+
+    Ok(num_rewritten)
+}

--- a/applications/tari_validator_node/src/migrations/mod.rs
+++ b/applications/tari_validator_node/src/migrations/mod.rs
@@ -9,36 +9,34 @@
 //! stored version and [`CURRENT_VERSION`]. A fresh database skips migrations entirely - it is stamped
 //! directly with `CURRENT_VERSION` once the genesis state is laid down.
 //!
-//! There are currently no migrations: the previous ones were folded into the genesis state on a
-//! testnet reset (see [`CURRENT_VERSION`]).
-//!
 //! # Adding a migration
 //!
-//! To take the schema from version 0 to 1:
+//! To take the schema from version `N` to `N + 1`:
 //!
-//! 1. Add `v1.rs` with `pub fn migrate(...) -> ...` performing the upgrade, and declare it here with `mod v1;`.
-//! 2. Bump [`CURRENT_VERSION`] to `1`.
-//! 3. Apply it to already-bootstrapped databases by stepping the stored version up to `CURRENT_VERSION`, persisting the
-//!    new version as you go - replace the `Some(version)` arm in [`migrate`] with:
+//! 1. Add `v{N+1}.rs` with `pub fn migrate(...) -> ...` performing the upgrade, and declare it here with `mod v{N+1};`.
+//! 2. Bump [`CURRENT_VERSION`] to `N + 1`.
+//! 3. Add the arm that applies it to the step loop in [`migrate`], keyed by the version it upgrades *from*:
 //!
 //! ```ignore
-//! Some(mut version) => {
-//!     while version < CURRENT_VERSION {
-//!         match version {
-//!             0 => v1::migrate(tx, network, consensus_constants.num_preshards)?,
-//!             other => unreachable!("no migration defined for database version {other}"),
-//!         }
-//!         version += 1;
-//!         tx.db().cf(DatabaseMigrationVersion)?.put(&ByteColumn, &version, OPERATION)?;
-//!     }
-//! },
+//! match version {
+//!     0 => v1::migrate(tx)?,
+//!     1 => v2::migrate(tx, network)?,
+//!     other => unreachable!("no migration defined for database version {other}"),
+//! }
 //! ```
+//!
+//! A migration must be able to run against a database at any earlier supported version, so it may not assume the
+//! current schema of anything it does not itself write.
 //!
 //! IMPORTANT: a migration that creates or mutates substates must write them to the per-shard state
 //! tree (JMT), not only the substate store - otherwise they have no inclusion proof and verified
 //! reads of them fail. Mirror [`crate::genesis_state::create_genesis_state`], which commits each
 //! substate to both the store and the state tree. (Note that, unlike genesis, adding state-tree
 //! entries to a live chain shifts its state root, so such a migration is itself consensus-affecting.)
+
+mod v1;
+
+use std::time::Instant;
 
 use log::*;
 use tari_consensus::consensus_constants::ConsensusConstants;
@@ -57,10 +55,9 @@ const LOG_TARGET: &str = "tari::validator::migrations";
 /// The on-disk state schema version stamped onto a freshly bootstrapped database.
 ///
 /// Bump this and apply the upgrade in [`migrate`] whenever the persisted state must change for
-/// already-running nodes. It was reset to 0 with the genesis-in-state-tree testnet reset: the former
-/// v1 (token symbol) and v2 (faucet claim resource) migrations are now part of the genesis state, so
-/// they no longer need to run.
-const CURRENT_VERSION: u64 = 0;
+/// already-running nodes. It was reset to 0 with the genesis-in-state-tree testnet reset, and is at 1
+/// for the substate lock index prefix ([`v1`]).
+const CURRENT_VERSION: u64 = 1;
 
 pub fn migrate<TAddr: NodeAddressable + 'static>(
     tx: &mut RocksDbStateStoreWriteTransaction<'_, TAddr>,
@@ -77,13 +74,34 @@ pub fn migrate<TAddr: NodeAddressable + 'static>(
     };
 
     match maybe_version {
-        // An already-bootstrapped database. No migrations are currently defined; when one is needed,
-        // step `version` up to `CURRENT_VERSION` here, applying each upgrade and persisting the new
-        // version as it goes.
-        Some(version) => {
+        // An already-bootstrapped database: step it up to `CURRENT_VERSION`, applying each upgrade and
+        // persisting the new version as it goes.
+        Some(version) if version >= CURRENT_VERSION => {
             debug!(
                 target: LOG_TARGET,
                 "Database already bootstrapped at migration version {version} (current {CURRENT_VERSION})"
+            );
+        },
+        Some(mut version) => {
+            info!(
+                target: LOG_TARGET,
+                "🔀 Migrating database from version {version} to {CURRENT_VERSION}"
+            );
+            let timer = Instant::now();
+            while version < CURRENT_VERSION {
+                match version {
+                    0 => v1::migrate(tx)?,
+                    other => unreachable!("no migration defined for database version {other}"),
+                }
+                version += 1;
+                tx.db()
+                    .cf(DatabaseMigrationVersion)?
+                    .put(&ByteColumn, &version, OPERATION)?;
+            }
+            info!(
+                target: LOG_TARGET,
+                "🔀 Database migrated to version {CURRENT_VERSION} in {:.2?}",
+                timer.elapsed()
             );
         },
         // A fresh database: lay down the genesis state and stamp the current version.

--- a/applications/tari_validator_node/src/migrations/mod.rs
+++ b/applications/tari_validator_node/src/migrations/mod.rs
@@ -14,7 +14,7 @@
 //! To take the schema from version `N` to `N + 1`:
 //!
 //! 1. Add `v{N+1}.rs` with `pub fn migrate(...) -> ...` performing the upgrade, and declare it here with `mod v{N+1};`.
-//! 2. Bump [`CURRENT_VERSION`] to `N + 1`.
+//! 2. Bump `CURRENT_SCHEMA_VERSION` (in the state store, beside `DatabaseMigrationVersion`) to `N + 1`.
 //! 3. Add the arm that applies it to the step loop in [`migrate`], keyed by the version it upgrades *from*:
 //!
 //! ```ignore
@@ -34,7 +34,9 @@
 //! substate to both the store and the state tree. (Note that, unlike genesis, adding state-tree
 //! entries to a live chain shifts its state root, so such a migration is itself consensus-affecting.)
 
+mod common;
 mod v1;
+mod v2;
 
 use std::time::Instant;
 
@@ -44,7 +46,9 @@ use tari_ootle_common_types::{NodeAddressable, optional::Optional};
 use tari_ootle_transaction::Network;
 use tari_state_store_rocksdb::{
     codecs::ByteColumn,
-    column_families::bookkeeping::DatabaseMigrationVersion,
+    // The version constant lives in the state store because it describes the on-disk schema, and tools that write to
+    // a database directly must check it before doing so. Bump it there and apply the upgrade in `migrate`.
+    column_families::bookkeeping::{CURRENT_SCHEMA_VERSION as CURRENT_VERSION, DatabaseMigrationVersion},
     writer::RocksDbStateStoreWriteTransaction,
 };
 
@@ -52,12 +56,16 @@ use crate::genesis_state::create_genesis_state;
 
 const LOG_TARGET: &str = "tari::validator::migrations";
 
-/// The on-disk state schema version stamped onto a freshly bootstrapped database.
-///
-/// Bump this and apply the upgrade in [`migrate`] whenever the persisted state must change for
-/// already-running nodes. It was reset to 0 with the genesis-in-state-tree testnet reset, and is at 1
-/// for the substate lock index prefix ([`v1`]).
-const CURRENT_VERSION: u64 = 1;
+#[cfg(test)]
+mod test_helpers {
+    use tari_ootle_p2p::PeerAddress;
+    use tari_state_store_rocksdb::{DatabaseOptions, RocksDbStateStore};
+
+    /// Opens a store with the production options, so migrations run against the same prefix extractor as a real node.
+    pub fn open_store(tmp: &tempfile::TempDir) -> RocksDbStateStore<PeerAddress> {
+        RocksDbStateStore::open(tmp.path(), DatabaseOptions::default()).unwrap()
+    }
+}
 
 pub fn migrate<TAddr: NodeAddressable + 'static>(
     tx: &mut RocksDbStateStoreWriteTransaction<'_, TAddr>,
@@ -91,6 +99,7 @@ pub fn migrate<TAddr: NodeAddressable + 'static>(
             while version < CURRENT_VERSION {
                 match version {
                     0 => v1::migrate(tx)?,
+                    1 => v2::migrate(tx)?,
                     other => unreachable!("no migration defined for database version {other}"),
                 }
                 version += 1;

--- a/applications/tari_validator_node/src/migrations/mod.rs
+++ b/applications/tari_validator_node/src/migrations/mod.rs
@@ -56,17 +56,6 @@ use crate::genesis_state::create_genesis_state;
 
 const LOG_TARGET: &str = "tari::validator::migrations";
 
-#[cfg(test)]
-mod test_helpers {
-    use tari_ootle_p2p::PeerAddress;
-    use tari_state_store_rocksdb::{DatabaseOptions, RocksDbStateStore};
-
-    /// Opens a store with the production options, so migrations run against the same prefix extractor as a real node.
-    pub fn open_store(tmp: &tempfile::TempDir) -> RocksDbStateStore<PeerAddress> {
-        RocksDbStateStore::open(tmp.path(), DatabaseOptions::default()).unwrap()
-    }
-}
-
 pub fn migrate<TAddr: NodeAddressable + 'static>(
     tx: &mut RocksDbStateStoreWriteTransaction<'_, TAddr>,
     network: Network,
@@ -124,4 +113,15 @@ pub fn migrate<TAddr: NodeAddressable + 'static>(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod test_helpers {
+    use tari_ootle_p2p::PeerAddress;
+    use tari_state_store_rocksdb::{DatabaseOptions, RocksDbStateStore};
+
+    /// Opens a store with the production options, so migrations run against the same prefix extractor as a real node.
+    pub fn open_store(tmp: &tempfile::TempDir) -> RocksDbStateStore<PeerAddress> {
+        RocksDbStateStore::open(tmp.path(), DatabaseOptions::default()).unwrap()
+    }
 }

--- a/applications/tari_validator_node/src/migrations/v1.rs
+++ b/applications/tari_validator_node/src/migrations/v1.rs
@@ -88,7 +88,7 @@ mod tests {
             })
             .unwrap();
 
-        store.with_write_tx(|tx| migrate(tx)).unwrap();
+        store.with_write_tx(migrate).unwrap();
 
         store
             .with_write_tx(|tx| {
@@ -125,7 +125,7 @@ mod tests {
             })
             .unwrap();
 
-        store.with_write_tx(|tx| migrate(tx)).unwrap();
+        store.with_write_tx(migrate).unwrap();
 
         store
             .with_write_tx(|tx| {
@@ -163,9 +163,9 @@ mod tests {
             })
             .unwrap();
 
-        store.with_write_tx(|tx| migrate(tx)).unwrap();
+        store.with_write_tx(migrate).unwrap();
         // A second run has nothing left below the bound to rewrite, so the entry keeps its single prefix.
-        store.with_write_tx(|tx| migrate(tx)).unwrap();
+        store.with_write_tx(migrate).unwrap();
 
         store
             .with_write_tx(|tx| {

--- a/applications/tari_validator_node/src/migrations/v1.rs
+++ b/applications/tari_validator_node/src/migrations/v1.rs
@@ -1,0 +1,195 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! Gives the substate lock substate-id index its table prefix.
+//!
+//! The index shares a column family with the substate tables, where each table is namespaced by a leading
+//! [`KeyPrefix`] byte. This index was written without one, so its keys sat in the low keyspace of that family,
+//! namespaced only by the leading borsh `SubstateId` discriminant. This migration rewrites each of those keys with
+//! the prefix the index now encodes.
+
+use std::time::Instant;
+
+use log::*;
+use tari_ootle_common_types::NodeAddressable;
+use tari_ootle_storage::Ordering;
+use tari_state_store_rocksdb::{
+    codecs::KeyPrefix,
+    column_families::substate_locks::{LegacyUnprefixedSubstateIdIndex, SubstateIdIndex},
+    writer::RocksDbStateStoreWriteTransaction,
+};
+
+const LOG_TARGET: &str = "tari::validator::migrations::v1";
+
+/// The exclusive upper bound of the legacy unprefixed keyspace.
+///
+/// Every prefixed table in the column family uses a [`KeyPrefix`] byte at or above this bound, and a legacy key begins
+/// with a borsh `SubstateId` discriminant, which is far below it. So every key under this bound is a legacy row, and
+/// the rewritten keys (which lead with a byte well above it) are never rescanned.
+const LEGACY_UNPREFIXED_UPPER_BOUND: u8 = KeyPrefix::ForeignSubstatePledges.as_u8();
+
+pub fn migrate<TAddr: NodeAddressable + 'static>(
+    tx: &mut RocksDbStateStoreWriteTransaction<'_, TAddr>,
+) -> anyhow::Result<()> {
+    const OPERATION: &str = "migrations::v1";
+    let timer = Instant::now();
+
+    let legacy_cf = tx.db().cf(LegacyUnprefixedSubstateIdIndex)?;
+    let new_cf = tx.db().cf(SubstateIdIndex)?;
+
+    // Each scan is confined to a single leading byte. The column family is opened with a one byte prefix extractor, so
+    // scanning one prefix at a time keeps every scan consistent with it. A rewritten key leads with a byte above the
+    // bound, so it lands outside every scanned range and is never revisited.
+    let mut num_migrated = 0usize;
+    for leading_byte in 0..LEGACY_UNPREFIXED_UPPER_BOUND {
+        for result in legacy_cf.prefix_range_iterator_raw_key(Ordering::Ascending, vec![leading_byte]) {
+            let (key, lock_type) = result?;
+            // The same key encodes without the prefix through the legacy index and with it through the current one.
+            legacy_cf.delete(&key, OPERATION)?;
+            new_cf.put(&key, &lock_type, OPERATION)?;
+            num_migrated += 1;
+        }
+    }
+
+    if num_migrated == 0 {
+        debug!(target: LOG_TARGET, "No unprefixed substate lock index entries to migrate");
+        return Ok(());
+    }
+
+    info!(
+        target: LOG_TARGET,
+        "🔀 Prefixed {num_migrated} substate lock index entries in {:.2?}",
+        timer.elapsed()
+    );
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use tari_common_types::types::FixedHash;
+    use tari_consensus_types::BlockId;
+    use tari_ootle_common_types::{NodeHeight, SubstateLockType};
+    use tari_ootle_p2p::PeerAddress;
+    use tari_ootle_storage::StateStore;
+    use tari_ootle_transaction::TransactionId;
+    use tari_state_store_rocksdb::{DatabaseOptions, RocksDbStateStore, column_families::substate_locks};
+    use tari_template_lib::types::{ComponentAddress, ObjectKey};
+
+    use super::*;
+
+    fn lock_key(seed: u8) -> substate_locks::SubstateLockKey {
+        substate_locks::SubstateLockKey {
+            block_id: BlockId::new(FixedHash::from([seed; FixedHash::byte_size()])),
+            block_height: NodeHeight(u64::from(seed)),
+            substate_id: ComponentAddress::from_array([seed; ObjectKey::LENGTH]).into(),
+            transaction_id: TransactionId::new([seed; 32]),
+        }
+    }
+
+    /// Deleting each entry as the scan yields it must not cause any to be skipped.
+    #[test]
+    fn it_migrates_every_entry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = RocksDbStateStore::<PeerAddress>::open(tmp.path(), DatabaseOptions::default()).unwrap();
+
+        let keys = (0u8..=255).map(lock_key).collect::<Vec<_>>();
+        store
+            .with_write_tx(|tx| {
+                let legacy_cf = tx.db().cf(LegacyUnprefixedSubstateIdIndex)?;
+                for key in &keys {
+                    legacy_cf.put(key, &SubstateLockType::Write, "test")?;
+                }
+                Ok::<_, anyhow::Error>(())
+            })
+            .unwrap();
+
+        store.with_write_tx(migrate).unwrap();
+
+        store
+            .with_write_tx(|tx| {
+                let legacy_cf = tx.db().cf(LegacyUnprefixedSubstateIdIndex)?;
+                let new_cf = tx.db().cf(SubstateIdIndex)?;
+                for key in &keys {
+                    assert_eq!(new_cf.get(key, "test")?, SubstateLockType::Write, "missing {key}");
+                    assert!(!legacy_cf.exists(key, "test")?, "legacy entry {key} was not removed");
+                }
+                Ok::<_, anyhow::Error>(())
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn it_prefixes_legacy_entries_and_leaves_the_rest_alone() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = RocksDbStateStore::<PeerAddress>::open(tmp.path(), DatabaseOptions::default()).unwrap();
+
+        let legacy_keys = (1u8..=3).map(lock_key).collect::<Vec<_>>();
+        // An entry already carrying the prefix, which the migration must neither rescan nor prefix again.
+        let already_prefixed = lock_key(4);
+
+        store
+            .with_write_tx(|tx| {
+                let legacy_cf = tx.db().cf(LegacyUnprefixedSubstateIdIndex)?;
+                for key in &legacy_keys {
+                    legacy_cf.put(key, &SubstateLockType::Write, "test")?;
+                }
+                tx.db()
+                    .cf(SubstateIdIndex)?
+                    .put(&already_prefixed, &SubstateLockType::Read, "test")?;
+                Ok::<_, anyhow::Error>(())
+            })
+            .unwrap();
+
+        store.with_write_tx(migrate).unwrap();
+
+        store
+            .with_write_tx(|tx| {
+                let legacy_cf = tx.db().cf(LegacyUnprefixedSubstateIdIndex)?;
+                let new_cf = tx.db().cf(SubstateIdIndex)?;
+
+                for key in &legacy_keys {
+                    assert!(!legacy_cf.exists(key, "test")?, "legacy entry {key} was not removed");
+                    assert_eq!(new_cf.get(key, "test")?, SubstateLockType::Write);
+                }
+
+                // Untouched, and still readable exactly once under the prefix.
+                assert_eq!(new_cf.get(&already_prefixed, "test")?, SubstateLockType::Read);
+                assert!(!legacy_cf.exists(&already_prefixed, "test")?);
+
+                Ok::<_, anyhow::Error>(())
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn it_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = RocksDbStateStore::<PeerAddress>::open(tmp.path(), DatabaseOptions::default()).unwrap();
+
+        let key = lock_key(7);
+        store
+            .with_write_tx(|tx| {
+                tx.db()
+                    .cf(LegacyUnprefixedSubstateIdIndex)?
+                    .put(&key, &SubstateLockType::Output, "test")?;
+                Ok::<_, anyhow::Error>(())
+            })
+            .unwrap();
+
+        store.with_write_tx(migrate).unwrap();
+        // A second run has nothing left below the bound to rewrite, so the entry keeps its single prefix.
+        store.with_write_tx(migrate).unwrap();
+
+        store
+            .with_write_tx(|tx| {
+                assert_eq!(
+                    tx.db().cf(SubstateIdIndex)?.get(&key, "test")?,
+                    SubstateLockType::Output
+                );
+                assert!(!tx.db().cf(LegacyUnprefixedSubstateIdIndex)?.exists(&key, "test")?);
+                Ok::<_, anyhow::Error>(())
+            })
+            .unwrap();
+    }
+}

--- a/applications/tari_validator_node/src/migrations/v1.rs
+++ b/applications/tari_validator_node/src/migrations/v1.rs
@@ -12,21 +12,15 @@ use std::time::Instant;
 
 use log::*;
 use tari_ootle_common_types::NodeAddressable;
-use tari_ootle_storage::Ordering;
 use tari_state_store_rocksdb::{
     codecs::KeyPrefix,
-    column_families::substate_locks::{LegacyUnprefixedSubstateIdIndex, SubstateIdIndex},
+    column_families::substate_locks,
     writer::RocksDbStateStoreWriteTransaction,
 };
 
-const LOG_TARGET: &str = "tari::validator::migrations::v1";
+use super::common::rewrite_unprefixed_rows;
 
-/// The exclusive upper bound of the legacy unprefixed keyspace.
-///
-/// Every prefixed table in the column family uses a [`KeyPrefix`] byte at or above this bound, and a legacy key begins
-/// with a borsh `SubstateId` discriminant, which is far below it. So every key under this bound is a legacy row, and
-/// the rewritten keys (which lead with a byte well above it) are never rescanned.
-const LEGACY_UNPREFIXED_UPPER_BOUND: u8 = KeyPrefix::ForeignSubstatePledges.as_u8();
+const LOG_TARGET: &str = "tari::validator::migrations::v1";
 
 pub fn migrate<TAddr: NodeAddressable + 'static>(
     tx: &mut RocksDbStateStoreWriteTransaction<'_, TAddr>,
@@ -34,22 +28,13 @@ pub fn migrate<TAddr: NodeAddressable + 'static>(
     const OPERATION: &str = "migrations::v1";
     let timer = Instant::now();
 
-    let legacy_cf = tx.db().cf(LegacyUnprefixedSubstateIdIndex)?;
-    let new_cf = tx.db().cf(SubstateIdIndex)?;
-
-    // Each scan is confined to a single leading byte. The column family is opened with a one byte prefix extractor, so
-    // scanning one prefix at a time keeps every scan consistent with it. A rewritten key leads with a byte above the
-    // bound, so it lands outside every scanned range and is never revisited.
-    let mut num_migrated = 0usize;
-    for leading_byte in 0..LEGACY_UNPREFIXED_UPPER_BOUND {
-        for result in legacy_cf.prefix_range_iterator_raw_key(Ordering::Ascending, vec![leading_byte]) {
-            let (key, lock_type) = result?;
-            // The same key encodes without the prefix through the legacy index and with it through the current one.
-            legacy_cf.delete(&key, OPERATION)?;
-            new_cf.put(&key, &lock_type, OPERATION)?;
-            num_migrated += 1;
-        }
-    }
+    // Every other table in the substates family is prefixed at or above `ForeignSubstatePledges`.
+    let num_migrated = rewrite_unprefixed_rows(
+        &tx.db().cf(substate_locks::LegacyUnprefixedSubstateIdIndex)?,
+        &tx.db().cf(substate_locks::SubstateIdIndex)?,
+        KeyPrefix::ForeignSubstatePledges.as_u8(),
+        OPERATION,
+    )?;
 
     if num_migrated == 0 {
         debug!(target: LOG_TARGET, "No unprefixed substate lock index entries to migrate");
@@ -70,13 +55,12 @@ mod tests {
     use tari_common_types::types::FixedHash;
     use tari_consensus_types::BlockId;
     use tari_ootle_common_types::{NodeHeight, SubstateLockType};
-    use tari_ootle_p2p::PeerAddress;
     use tari_ootle_storage::StateStore;
     use tari_ootle_transaction::TransactionId;
-    use tari_state_store_rocksdb::{DatabaseOptions, RocksDbStateStore, column_families::substate_locks};
     use tari_template_lib::types::{ComponentAddress, ObjectKey};
 
     use super::*;
+    use crate::migrations::test_helpers::open_store;
 
     fn lock_key(seed: u8) -> substate_locks::SubstateLockKey {
         substate_locks::SubstateLockKey {
@@ -91,12 +75,12 @@ mod tests {
     #[test]
     fn it_migrates_every_entry() {
         let tmp = tempfile::tempdir().unwrap();
-        let store = RocksDbStateStore::<PeerAddress>::open(tmp.path(), DatabaseOptions::default()).unwrap();
+        let store = open_store(&tmp);
 
         let keys = (0u8..=255).map(lock_key).collect::<Vec<_>>();
         store
             .with_write_tx(|tx| {
-                let legacy_cf = tx.db().cf(LegacyUnprefixedSubstateIdIndex)?;
+                let legacy_cf = tx.db().cf(substate_locks::LegacyUnprefixedSubstateIdIndex)?;
                 for key in &keys {
                     legacy_cf.put(key, &SubstateLockType::Write, "test")?;
                 }
@@ -104,12 +88,12 @@ mod tests {
             })
             .unwrap();
 
-        store.with_write_tx(migrate).unwrap();
+        store.with_write_tx(|tx| migrate(tx)).unwrap();
 
         store
             .with_write_tx(|tx| {
-                let legacy_cf = tx.db().cf(LegacyUnprefixedSubstateIdIndex)?;
-                let new_cf = tx.db().cf(SubstateIdIndex)?;
+                let legacy_cf = tx.db().cf(substate_locks::LegacyUnprefixedSubstateIdIndex)?;
+                let new_cf = tx.db().cf(substate_locks::SubstateIdIndex)?;
                 for key in &keys {
                     assert_eq!(new_cf.get(key, "test")?, SubstateLockType::Write, "missing {key}");
                     assert!(!legacy_cf.exists(key, "test")?, "legacy entry {key} was not removed");
@@ -122,7 +106,7 @@ mod tests {
     #[test]
     fn it_prefixes_legacy_entries_and_leaves_the_rest_alone() {
         let tmp = tempfile::tempdir().unwrap();
-        let store = RocksDbStateStore::<PeerAddress>::open(tmp.path(), DatabaseOptions::default()).unwrap();
+        let store = open_store(&tmp);
 
         let legacy_keys = (1u8..=3).map(lock_key).collect::<Vec<_>>();
         // An entry already carrying the prefix, which the migration must neither rescan nor prefix again.
@@ -130,23 +114,23 @@ mod tests {
 
         store
             .with_write_tx(|tx| {
-                let legacy_cf = tx.db().cf(LegacyUnprefixedSubstateIdIndex)?;
+                let legacy_cf = tx.db().cf(substate_locks::LegacyUnprefixedSubstateIdIndex)?;
                 for key in &legacy_keys {
                     legacy_cf.put(key, &SubstateLockType::Write, "test")?;
                 }
                 tx.db()
-                    .cf(SubstateIdIndex)?
+                    .cf(substate_locks::SubstateIdIndex)?
                     .put(&already_prefixed, &SubstateLockType::Read, "test")?;
                 Ok::<_, anyhow::Error>(())
             })
             .unwrap();
 
-        store.with_write_tx(migrate).unwrap();
+        store.with_write_tx(|tx| migrate(tx)).unwrap();
 
         store
             .with_write_tx(|tx| {
-                let legacy_cf = tx.db().cf(LegacyUnprefixedSubstateIdIndex)?;
-                let new_cf = tx.db().cf(SubstateIdIndex)?;
+                let legacy_cf = tx.db().cf(substate_locks::LegacyUnprefixedSubstateIdIndex)?;
+                let new_cf = tx.db().cf(substate_locks::SubstateIdIndex)?;
 
                 for key in &legacy_keys {
                     assert!(!legacy_cf.exists(key, "test")?, "legacy entry {key} was not removed");
@@ -165,29 +149,35 @@ mod tests {
     #[test]
     fn it_is_idempotent() {
         let tmp = tempfile::tempdir().unwrap();
-        let store = RocksDbStateStore::<PeerAddress>::open(tmp.path(), DatabaseOptions::default()).unwrap();
+        let store = open_store(&tmp);
 
         let key = lock_key(7);
         store
             .with_write_tx(|tx| {
-                tx.db()
-                    .cf(LegacyUnprefixedSubstateIdIndex)?
-                    .put(&key, &SubstateLockType::Output, "test")?;
+                tx.db().cf(substate_locks::LegacyUnprefixedSubstateIdIndex)?.put(
+                    &key,
+                    &SubstateLockType::Output,
+                    "test",
+                )?;
                 Ok::<_, anyhow::Error>(())
             })
             .unwrap();
 
-        store.with_write_tx(migrate).unwrap();
+        store.with_write_tx(|tx| migrate(tx)).unwrap();
         // A second run has nothing left below the bound to rewrite, so the entry keeps its single prefix.
-        store.with_write_tx(migrate).unwrap();
+        store.with_write_tx(|tx| migrate(tx)).unwrap();
 
         store
             .with_write_tx(|tx| {
                 assert_eq!(
-                    tx.db().cf(SubstateIdIndex)?.get(&key, "test")?,
+                    tx.db().cf(substate_locks::SubstateIdIndex)?.get(&key, "test")?,
                     SubstateLockType::Output
                 );
-                assert!(!tx.db().cf(LegacyUnprefixedSubstateIdIndex)?.exists(&key, "test")?);
+                assert!(
+                    !tx.db()
+                        .cf(substate_locks::LegacyUnprefixedSubstateIdIndex)?
+                        .exists(&key, "test")?
+                );
                 Ok::<_, anyhow::Error>(())
             })
             .unwrap();

--- a/applications/tari_validator_node/src/migrations/v2.rs
+++ b/applications/tari_validator_node/src/migrations/v2.rs
@@ -1,0 +1,100 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! Gives the transaction pool state update debug history its table prefix.
+//!
+//! The table shares the diagnostics column family with the no-vote diagnostics, where each table is namespaced by a
+//! leading [`KeyPrefix`] byte. It declared a prefix but never encoded it, so its keys sat in the low keyspace of that
+//! family, led by a big-endian `Epoch`. This migration rewrites each of those keys with the prefix the table now
+//! encodes.
+//!
+//! Nothing collided in practice - an `Epoch` only reaches the no-vote prefix byte at absurd epoch numbers - so this
+//! removes latent fragility rather than fixing observed corruption. The table is only written when `debugging_data` is
+//! enabled, so on most databases there is nothing to rewrite.
+
+use std::time::Instant;
+
+use log::*;
+use tari_ootle_common_types::NodeAddressable;
+use tari_state_store_rocksdb::{
+    codecs::KeyPrefix,
+    column_families::transaction_pool_state_update,
+    writer::RocksDbStateStoreWriteTransaction,
+};
+
+use super::common::rewrite_unprefixed_rows;
+
+const LOG_TARGET: &str = "tari::validator::migrations::v2";
+
+pub fn migrate<TAddr: NodeAddressable + 'static>(
+    tx: &mut RocksDbStateStoreWriteTransaction<'_, TAddr>,
+) -> anyhow::Result<()> {
+    const OPERATION: &str = "migrations::v2";
+    let timer = Instant::now();
+
+    // The only other table in the diagnostics family is prefixed `DiagnosticsNoVotes`.
+    let num_migrated = rewrite_unprefixed_rows(
+        &tx.db()
+            .cf(transaction_pool_state_update::LegacyUnprefixedDebugHistoryCf)?,
+        &tx.db()
+            .cf(transaction_pool_state_update::TransactionPoolStateUpdateDebugHistoryCf)?,
+        KeyPrefix::DiagnosticsNoVotes.as_u8(),
+        OPERATION,
+    )?;
+
+    if num_migrated == 0 {
+        debug!(target: LOG_TARGET, "No unprefixed debug history entries to migrate");
+        return Ok(());
+    }
+
+    info!(
+        target: LOG_TARGET,
+        "🔀 Prefixed {num_migrated} debug history entries in {:.2?}",
+        timer.elapsed()
+    );
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use tari_common_types::types::FixedHash;
+    use tari_consensus_types::BlockId;
+    use tari_ootle_storage::StateStore;
+    use tari_state_store_rocksdb::column_families::diagnostic_no_vote::{DiagnosticsNoVoteCf, DiagnosticsNoVoteData};
+
+    use super::*;
+    use crate::migrations::test_helpers::open_store;
+
+    /// The debug history shares the diagnostics column family with the no-vote table, whose rows lead with a byte
+    /// above the scan bound and so must survive untouched.
+    #[test]
+    fn it_leaves_no_vote_diagnostics_alone() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = open_store(&tmp);
+
+        let block_id = BlockId::new(FixedHash::from([2u8; FixedHash::byte_size()]));
+        store
+            .with_write_tx(|tx| {
+                tx.db().cf(DiagnosticsNoVoteCf)?.put(
+                    &block_id,
+                    &DiagnosticsNoVoteData {
+                        reason: "because".into(),
+                    },
+                    "test",
+                )?;
+                Ok::<_, anyhow::Error>(())
+            })
+            .unwrap();
+
+        store.with_write_tx(|tx| migrate(tx)).unwrap();
+
+        store
+            .with_write_tx(|tx| {
+                let data = tx.db().cf(DiagnosticsNoVoteCf)?.get(&block_id, "test")?;
+                assert_eq!(&*data.reason, "because");
+                Ok::<_, anyhow::Error>(())
+            })
+            .unwrap();
+    }
+}

--- a/applications/tari_validator_node/src/migrations/v2.rs
+++ b/applications/tari_validator_node/src/migrations/v2.rs
@@ -87,7 +87,7 @@ mod tests {
             })
             .unwrap();
 
-        store.with_write_tx(|tx| migrate(tx)).unwrap();
+        store.with_write_tx(migrate).unwrap();
 
         store
             .with_write_tx(|tx| {

--- a/crates/state_store_rocksdb/src/column_families/bookkeeping.rs
+++ b/crates/state_store_rocksdb/src/column_families/bookkeeping.rs
@@ -70,6 +70,14 @@ impl BookKeepingKey {
     }
 }
 
+/// The database schema version that this build expects a database to be at.
+///
+/// The migration steps that bring a database up to this version live in the validator node, but the constant lives
+/// here because it describes the on-disk schema rather than any one binary. Tools that write to a database directly
+/// must check the stored [`DatabaseMigrationVersion`] against it first: writing through the current key encodings to a
+/// database still at an older version silently misses the rows that a pending migration has yet to rewrite.
+pub const CURRENT_SCHEMA_VERSION: u64 = 2;
+
 pub struct DatabaseMigrationVersion;
 
 impl Cf for DatabaseMigrationVersion {

--- a/crates/state_store_rocksdb/src/column_families/substate_locks.rs
+++ b/crates/state_store_rocksdb/src/column_families/substate_locks.rs
@@ -142,7 +142,7 @@ pub struct SubstateIdIndex;
 impl Cf for SubstateIdIndex {
     type Key = SubstateLockKey;
     type KeyCodec = SubstateLockKeyCodec<(SubstateId, TransactionId, BlockId, NodeHeight)>;
-    type Prefix = ();
+    type Prefix = SubstateIdIndexPrefix;
     type Value = SubstateLockType;
     type ValueCodec = DefaultCodec<Self::Value>;
 
@@ -157,4 +157,23 @@ impl QueryCf for BySubstateIdQuery {
     type Cf = SubstateIdIndex;
     type Key = SubstateId;
     type KeyCodec = SubstateIdCodec;
+}
+
+/// The [`SubstateIdIndex`] key shape from before the index carried its table prefix.
+///
+/// These keys are namespaced only by the leading borsh `SubstateId` discriminant, so they sort below every prefixed
+/// table sharing the column family. Exists so the migration that rewrites them can address them; remove it once no
+/// supported database can still be at a version that predates that migration.
+pub struct LegacyUnprefixedSubstateIdIndex;
+
+impl Cf for LegacyUnprefixedSubstateIdIndex {
+    type Key = SubstateLockKey;
+    type KeyCodec = SubstateLockKeyCodec<(SubstateId, TransactionId, BlockId, NodeHeight)>;
+    type Prefix = ();
+    type Value = SubstateLockType;
+    type ValueCodec = DefaultCodec<Self::Value>;
+
+    fn name() -> &'static str {
+        cf_names::SUBSTATES
+    }
 }

--- a/crates/state_store_rocksdb/src/column_families/transaction_pool_state_update.rs
+++ b/crates/state_store_rocksdb/src/column_families/transaction_pool_state_update.rs
@@ -122,6 +122,25 @@ pub struct TransactionPoolStateUpdateDebugHistoryCf;
 impl Cf for TransactionPoolStateUpdateDebugHistoryCf {
     type Key = (Epoch, NodeHeight, TransactionId);
     type KeyCodec = (EpochCodec, NumberCodec<NodeHeight>, BytesCodec);
+    type Prefix = TransactionPoolStateUpdateDebugHistoryPrefix;
+    type Value = TransactionPoolStateUpdateData;
+    type ValueCodec = DefaultCodec<TransactionPoolStateUpdateData>;
+
+    fn name() -> &'static str {
+        cf_names::DIAGNOSTICS
+    }
+}
+
+/// The [`TransactionPoolStateUpdateDebugHistoryCf`] key shape from before the table carried its prefix.
+///
+/// These keys lead with a big-endian [`Epoch`], so they sort below every prefixed table sharing the column family.
+/// Exists so the migration that rewrites them can address them; remove it once no supported database can still be at a
+/// version that predates that migration.
+pub struct LegacyUnprefixedDebugHistoryCf;
+
+impl Cf for LegacyUnprefixedDebugHistoryCf {
+    type Key = (Epoch, NodeHeight, TransactionId);
+    type KeyCodec = (EpochCodec, NumberCodec<NodeHeight>, BytesCodec);
     type Prefix = ();
     type Value = TransactionPoolStateUpdateData;
     type ValueCodec = DefaultCodec<TransactionPoolStateUpdateData>;

--- a/utilities/validator_rollback/src/apply.rs
+++ b/utilities/validator_rollback/src/apply.rs
@@ -9,14 +9,19 @@ use std::{
 
 use anyhow::{Context, anyhow, bail};
 use clap::Args as ClapArgs;
-use tari_ootle_common_types::{Epoch, ShardGroup, shard::Shard};
+use tari_ootle_common_types::{Epoch, ShardGroup, optional::Optional, shard::Shard};
 use tari_ootle_p2p::PeerAddress;
 use tari_ootle_storage::{
     StateStore,
     StateStoreReadTransaction,
     consensus_models::{EpochCheckpoint, RollbackHistoryEntry},
 };
-use tari_state_store_rocksdb::{DatabaseOptions, RocksDbStateStore};
+use tari_state_store_rocksdb::{
+    DatabaseOptions,
+    RocksDbStateStore,
+    codecs::ByteColumn,
+    column_families::bookkeeping::{CURRENT_SCHEMA_VERSION, DatabaseMigrationVersion},
+};
 
 use crate::{
     audit::AuditWriter,
@@ -106,6 +111,39 @@ pub struct ApplyOutcome {
 
 /// Run the rollback flow with explicit options. Returns a summary of what the audit
 /// footer recorded so callers can assert on impact.
+/// Refuses to operate on a database whose schema version is not the one this build encodes.
+///
+/// The rollback primitives write through the current key encodings. Against an older database those encodings do not
+/// match what is on disk, so a cascade silently misses the rows a pending migration has yet to rewrite - leaving
+/// orphans that the migration then promotes into live entries referring to rolled-back blocks. Against a newer
+/// database the encodings are simply unknown to this build.
+fn check_schema_version(store: &RocksDbStateStore<PeerAddress>) -> anyhow::Result<()> {
+    let version = store.with_read_tx(|tx| -> anyhow::Result<_> {
+        let version = tx
+            .db()
+            .cf(DatabaseMigrationVersion)?
+            .get(&ByteColumn, "check_schema_version")
+            .optional()?;
+        Ok(version)
+    })?;
+
+    match version {
+        Some(version) if version == CURRENT_SCHEMA_VERSION => Ok(()),
+        Some(version) if version < CURRENT_SCHEMA_VERSION => bail!(
+            "State db is at schema version {version} but this tool writes version {CURRENT_SCHEMA_VERSION}. Start the \
+             validator once to migrate the database, stop it again, then re-run the rollback."
+        ),
+        Some(version) => bail!(
+            "State db is at schema version {version}, which is newer than the {CURRENT_SCHEMA_VERSION} this tool \
+             understands. Use a rollback tool built from the same release as the validator."
+        ),
+        None => bail!(
+            "State db has no schema version recorded, so it has never been bootstrapped by a validator. There is \
+             nothing to roll back."
+        ),
+    }
+}
+
 pub fn run_with_options(opts: ApplyOptions) -> anyhow::Result<ApplyOutcome> {
     let target_epoch = Epoch(opts.target_epoch);
     let now_unix = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
@@ -119,6 +157,8 @@ pub fn run_with_options(opts: ApplyOptions) -> anyhow::Result<ApplyOutcome> {
     // after we snapshot would produce a stale audit.
     let store: RocksDbStateStore<PeerAddress> = RocksDbStateStore::open(&opts.state_db, DatabaseOptions::default())
         .with_context(|| format!("opening state db at {:?}", opts.state_db))?;
+
+    check_schema_version(&store)?;
 
     // Resolve the checkpoint for target_epoch.
     let (checkpoint, shard_group) = locate_checkpoint(&store, target_epoch, opts.shard_group)?;

--- a/utilities/validator_rollback/src/apply.rs
+++ b/utilities/validator_rollback/src/apply.rs
@@ -109,8 +109,6 @@ pub struct ApplyOutcome {
     pub dry_run: bool,
 }
 
-/// Run the rollback flow with explicit options. Returns a summary of what the audit
-/// footer recorded so callers can assert on impact.
 /// Refuses to operate on a database whose schema version is not the one this build encodes.
 ///
 /// The rollback primitives write through the current key encodings. Against an older database those encodings do not
@@ -144,6 +142,8 @@ fn check_schema_version(store: &RocksDbStateStore<PeerAddress>) -> anyhow::Resul
     }
 }
 
+/// Run the rollback flow with explicit options. Returns a summary of what the audit
+/// footer recorded so callers can assert on impact.
 pub fn run_with_options(opts: ApplyOptions) -> anyhow::Result<ApplyOutcome> {
     let target_epoch = Epoch(opts.target_epoch);
     let now_unix = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();


### PR DESCRIPTION
Follow-up to #2459, which noted this as latent fragility and deferred it because fixing it properly needs a data migration.

## Problem

`SubstateIdIndex` shares the substates column family with the substate and lock tables, where each table is namespaced by a leading `KeyPrefix` byte. It declared `type Prefix = ()`, so its keys were written unprefixed and sat in the low keyspace of that family, namespaced only by the leading borsh `SubstateId` discriminant. A `SubstateIdIndexPrefix` was declared for it but never used.

Nothing collides today — `SubstateId` discriminants are 0..=9 and the other tables in the family use 21 and 32..=38 — so this is latent fragility rather than a live bug. But a new `SubstateId` variant reaching the prefix range would start overlapping another table, and the failure would be silent key overlap in the lock index.

## Fix

The index now encodes its prefix. Because the key encoding changes, existing entries need rewriting, hence migration `v1`.

The migration scans the column family one leading byte at a time, below the lowest table prefix, and rewrites each key it finds through the current index. Scanning a single leading byte per pass keeps each scan consistent with the family's one byte prefix extractor. Rewritten keys lead with a byte above the scanned range, so they land outside every scan and are never revisited — which makes the migration idempotent and safe to interrupt.

This is the first migration since the version marker was reset to 0, so it also wires up the version step loop that `migrations/mod.rs` already documented, and the module docs are updated for adding the next one. A fresh database is stamped at `CURRENT_VERSION` with the genesis state and skips the migration, which is correct — it has no legacy rows.

Migration timing is logged, both per run and overall.

## Testing

Three tests in `migrations/v1.rs`, run against a real store opened with the production options (so the prefix extractor is in play):

- `it_migrates_every_entry` — 256 entries spanning every legacy leading byte all survive the rewrite, confirming that deleting each entry as the scan yields it skips none.
- `it_prefixes_legacy_entries_and_leaves_the_rest_alone` — legacy entries are rewritten and an already-prefixed entry is neither rescanned nor prefixed twice.
- `it_is_idempotent` — a second run is a no-op.

`cargo test -p tari_validator_node --lib migrations` — 3 passed. `cargo test -p tari_state_store_rocksdb` — 11 passed.
