### PR TITLE
chore: bump workspace version to 0.39.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1733,7 +1733,7 @@ dependencies = [
 
 [[package]]
 name = "consensus_tests"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "fern",
  "futures 0.3.31",
@@ -2744,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "db-inspector"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -5128,7 +5128,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "integration_tests"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "config",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-messaging"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "async-trait",
  "futures-bounded 0.2.4",
@@ -6074,7 +6074,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-substream"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "libp2p",
  "prometheus-client",
@@ -7743,7 +7743,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -7754,7 +7754,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm-core"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -7814,7 +7814,7 @@ dependencies = [
 
 [[package]]
 name = "ootle_sdk_core"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "blake2 0.10.6",
  "hex",
@@ -7840,7 +7840,7 @@ dependencies = [
 
 [[package]]
 name = "ootle_sdk_ffi_c"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "cbindgen",
  "hex",
@@ -8835,7 +8835,7 @@ dependencies = [
 
 [[package]]
 name = "proto_builder"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "prost-build 0.14.3",
  "sha2 0.10.9",
@@ -10676,7 +10676,7 @@ dependencies = [
 
 [[package]]
 name = "sqlite_message_logger"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "chrono",
  "diesel",
@@ -11024,7 +11024,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node_client"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "futures-util",
  "log",
@@ -11255,7 +11255,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -11280,7 +11280,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "borsh",
  "minicbor",
@@ -11383,7 +11383,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "blake2 0.10.6",
  "bytes",
@@ -11416,7 +11416,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11446,7 +11446,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_manager"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "log",
@@ -11466,7 +11466,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_oracles"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",
@@ -11512,7 +11512,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -11618,7 +11618,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_lib"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "async-trait",
  "log",
@@ -11716,7 +11716,7 @@ dependencies = [
 
 [[package]]
 name = "tari_networking"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11770,7 +11770,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_app_utilities"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11812,7 +11812,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11841,7 +11841,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_p2p"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "libp2p-identity 0.2.14",
@@ -11865,7 +11865,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -11894,7 +11894,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage_sqlite"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -11947,7 +11947,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_template_provider"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "dashmap 5.5.3",
@@ -11964,7 +11964,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "borsh",
  "hex",
@@ -11990,7 +11990,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction_validation"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -12006,7 +12006,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_cli"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -12129,7 +12129,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk_tests"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "digest 0.10.7",
  "ootle_byte_type",
@@ -12178,7 +12178,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",
@@ -12306,7 +12306,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_framework"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "async-trait",
  "bitflags 2.13.0",
@@ -12330,7 +12330,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_macros"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12339,7 +12339,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_state_sync"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12421,7 +12421,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_store_rocksdb"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12453,7 +12453,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_tree"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "indexmap 2.13.0",
  "log",
@@ -12482,7 +12482,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "libp2p",
  "libp2p-messaging",
@@ -12494,7 +12494,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm_daemon"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12608,7 +12608,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_test_tooling"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "cargo_toml 0.22.3",
@@ -12724,7 +12724,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_manifest"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "proc-macro2",
  "serde_json",
@@ -12759,7 +12759,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -12822,7 +12822,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_client"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "indexmap 2.13.0",
  "multiaddr 0.18.3",
@@ -12846,7 +12846,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_rpc"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12870,7 +12870,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_rollback"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12907,7 +12907,7 @@ dependencies = [
 
 [[package]]
 name = "tari_watcher"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -12936,7 +12936,7 @@ dependencies = [
 
 [[package]]
 name = "tariswap_bench"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13619,7 +13619,7 @@ dependencies = [
 
 [[package]]
 name = "traffic-sim"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13643,7 +13643,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_generator"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "bytes",
@@ -13667,7 +13667,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_submitter"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "clap 4.5.54",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.39.1"
+version = "0.39.2"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-ootle"


### PR DESCRIPTION
Bumps `workspace.package.version` from 0.39.1 to 0.39.2 (patch) and refreshes `Cargo.lock` for all tier-3 workspace crates.

No pinned dependency versions referenced 0.39.1, so no manifest pin updates are required.