### PR TITLE
fix(state-store): bound query range scans to their logical table

### DIFF
--- a/crates/state_store_rocksdb/src/cf_api.rs
+++ b/crates/state_store_rocksdb/src/cf_api.rs
@@ -586,18 +586,19 @@ impl<'db, TQuery: QueryCf, DB: RocksReader> CfContext<'db, DB, TQuery> {
         >(ordering, TableBounds::for_cf::<TQuery::Cf>(None, Some(key)))
     }
 
+    /// Returns the last key/value in the logical table.
     pub fn query_last(&self, operation: &'static str) -> Result<QueryCfKv<TQuery>, RocksDbStorageError> {
-        let mut iter = self.db.iterator_cf(self.handle, IteratorMode::End);
-        let result = iter.next().ok_or_else(|| RocksDbStorageError::QueryError {
+        let mut iter = self.range_iterator_with_codecs::<
+            PrefixedCodec<TQuery::Cf>,
+            <TQuery::Cf as Cf>::Key,
+            <TQuery::Cf as Cf>::ValueCodec,
+            <TQuery::Cf as Cf>::Value,
+        >(Ordering::Descending, TableBounds::for_cf::<TQuery::Cf>(None, None));
+
+        iter.next().transpose()?.ok_or_else(|| RocksDbStorageError::QueryError {
             operation,
             details: format!("No values in TQuery {}", TQuery::name()),
-        })?;
-        let key_codec = TQuery::make_cf_key_codec();
-        let value_codec = TQuery::make_cf_value_codec();
-        let (key, value) = result.map_err(|e| RocksDbStorageError::RocksDbError { operation, source: e })?;
-        let key = key_codec.decode_exact(&key)?;
-        let value = value_codec.decode_exact(&value)?;
-        Ok((key, value))
+        })
     }
 }
 

--- a/crates/state_store_rocksdb/src/cf_api.rs
+++ b/crates/state_store_rocksdb/src/cf_api.rs
@@ -484,40 +484,25 @@ impl<'db, TQuery: QueryCf, DB: RocksReader> CfContext<'db, DB, TQuery> {
         })
     }
 
+    /// Returns an iterator over the keys in the column family that are greater than or equal to the start key.
     pub fn query_start_range_key_iterator(
         &self,
         ordering: Ordering,
         start_key: &TQuery::Key,
-    ) -> Box<dyn Iterator<Item = Result<<TQuery::Cf as Cf>::Key, RocksDbStorageError>> + 'db> {
+    ) -> impl Iterator<Item = Result<<TQuery::Cf as Cf>::Key, RocksDbStorageError>> + 'db {
         let key = self.encode_key(start_key);
-        // If this is 0xFF then we'll read to the end (no end bound)
-        match TQuery::Cf::key_prefix().and_then(|p| p.checked_add(1)) {
-            Some(next_prefix) => {
-                let end = EncodeVec::new_from_array([next_prefix]);
-                let iter = self
-                    .range_iterator_with_codecs::<PrefixedCodec<TQuery::Cf>, <TQuery::Cf as Cf>::Key, UnitCodec, ()>(
-                        ordering,
-                        key..end,
-                    );
-                Box::new(iter.map(|res| {
-                    let (k, _) = res?;
-                    Ok::<_, RocksDbStorageError>(k)
-                }))
-            },
-            None => {
-                let iter = self
-                    .range_iterator_with_codecs::<PrefixedCodec<TQuery::Cf>, <TQuery::Cf as Cf>::Key, UnitCodec, ()>(
-                        ordering,
-                        key..,
-                    );
-                Box::new(iter.map(|res| {
-                    let (k, _) = res?;
-                    Ok::<_, RocksDbStorageError>(k)
-                }))
-            },
-        }
+        let iter = self
+            .range_iterator_with_codecs::<PrefixedCodec<TQuery::Cf>, <TQuery::Cf as Cf>::Key, UnitCodec, ()>(
+                ordering,
+                TableBounds::for_cf::<TQuery::Cf>(Some(key), None),
+            );
+        iter.map(|res| {
+            let (k, _) = res?;
+            Ok::<_, RocksDbStorageError>(k)
+        })
     }
 
+    /// Returns an iterator over the key/values in the column family that are greater than or equal to the start key.
     pub fn query_start_range_iterator(
         &self,
         ordering: Ordering,
@@ -530,7 +515,7 @@ impl<'db, TQuery: QueryCf, DB: RocksReader> CfContext<'db, DB, TQuery> {
                 <TQuery::Cf as Cf>::Key,
                 <TQuery::Cf as Cf>::ValueCodec,
                 <TQuery::Cf as Cf>::Value
-            >(ordering, key..)
+            >(ordering, TableBounds::for_cf::<TQuery::Cf>(Some(key), None))
     }
 
     /// Returns a decoded key value iterator over the range of keys (exclusive).
@@ -575,13 +560,10 @@ impl<'db, TQuery: QueryCf, DB: RocksReader> CfContext<'db, DB, TQuery> {
         end_key: &TQuery::Key,
     ) -> impl Iterator<Item = Result<<TQuery::Cf as Cf>::Key, RocksDbStorageError>> + 'db {
         let key = self.encode_key(end_key);
-        let start = TQuery::Cf::key_prefix()
-            .map(|b| EncodeVec::new_from_array([b]))
-            .unwrap_or_else(EncodeVec::empty);
         let iter = self
             .range_iterator_with_codecs::<PrefixedCodec<TQuery::Cf>, <TQuery::Cf as Cf>::Key, UnitCodec, ()>(
                 ordering,
-                start..key,
+                TableBounds::for_cf::<TQuery::Cf>(None, Some(key)),
             );
         iter.map(|res| {
             let (k, _) = res?;
@@ -601,7 +583,7 @@ impl<'db, TQuery: QueryCf, DB: RocksReader> CfContext<'db, DB, TQuery> {
             <TQuery::Cf as Cf>::Key,
             <TQuery::Cf as Cf>::ValueCodec,
             <TQuery::Cf as Cf>::Value,
-        >(ordering, ..key)
+        >(ordering, TableBounds::for_cf::<TQuery::Cf>(None, Some(key)))
     }
 
     pub fn query_last(&self, operation: &'static str) -> Result<QueryCfKv<TQuery>, RocksDbStorageError> {
@@ -685,6 +667,32 @@ fn create_prefixed_read_opts<P: Into<Vec<u8>>>(prefix: P, mode: IteratorMode) ->
         opts.set_total_order_seek(true);
     }
     opts
+}
+
+/// Iterate bounds for a single logical table. Logical tables share a physical column family and are separated only by
+/// the leading key prefix byte, so a bound the caller leaves open is closed at the extent of the table's prefix.
+struct TableBounds {
+    start: Option<Vec<u8>>,
+    end: Option<Vec<u8>>,
+}
+
+impl TableBounds {
+    fn for_cf<CF: Cf>(start: Option<EncodeVec>, end: Option<EncodeVec>) -> Self {
+        let prefix = CF::key_prefix();
+        Self {
+            start: start.map(Into::into).or_else(|| prefix.map(|p| vec![p])),
+            // A prefix of 0xFF is the last table in the column family, so it has no upper bound.
+            end: end
+                .map(Into::into)
+                .or_else(|| prefix.and_then(|p| p.checked_add(1)).map(|p| vec![p])),
+        }
+    }
+}
+
+impl IterateBounds for TableBounds {
+    fn into_bounds(self) -> (Option<Vec<u8>>, Option<Vec<u8>>) {
+        (self.start, self.end)
+    }
 }
 
 fn range_opts<CF: Cf>(range: impl IterateBounds, mode: IteratorMode) -> rocksdb::ReadOptions {

--- a/crates/state_store_rocksdb/src/reader.rs
+++ b/crates/state_store_rocksdb/src/reader.rs
@@ -988,7 +988,7 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx, R: RocksR
         // NOTE: this only fetches for current epoch
         let ordering = ordering.unwrap_or(Ordering::Ascending);
         let iter: Box<dyn Iterator<Item = Result<_, _>>> = if ordering.is_ascending() {
-            query.query_start_range_key_iterator(ordering, &(locked.epoch, NodeHeight(offset)))
+            Box::new(query.query_start_range_key_iterator(ordering, &(locked.epoch, NodeHeight(offset))))
         } else {
             let leaf_block = self.db().cf(LeafBlockCf)?.get_by_default_key(OPERATION)?;
             Box::new(query.query_end_range_key_iterator(

--- a/crates/state_store_rocksdb/src/store.rs
+++ b/crates/state_store_rocksdb/src/store.rs
@@ -53,7 +53,7 @@ pub fn all_column_families_iter() -> impl Iterator<Item = &'static str> {
     .into_iter()
 }
 
-fn build_default_store_opts() -> rocksdb::Options {
+pub(crate) fn build_default_store_opts() -> rocksdb::Options {
     let mut opts = rocksdb::Options::default();
     // Don't error if the DB exists
     opts.set_error_if_exists(false);

--- a/crates/state_store_rocksdb/src/tests.rs
+++ b/crates/state_store_rocksdb/src/tests.rs
@@ -18,12 +18,13 @@ use crate::{
 pub fn create_rocksdb(cf_names: impl IntoIterator<Item = &'static str>) -> (TransactionDB<SingleThreaded>, TempDir) {
     let temp_dir = tempfile::Builder::new().disable_cleanup(false).tempdir().unwrap();
     let path = temp_dir.path().join("rocksdb");
-    let mut db_opts = rocksdb::Options::default();
-    db_opts.set_error_if_exists(false);
-    db_opts.create_if_missing(true);
-    db_opts.create_missing_column_families(true);
+    // Use the production options so that tests exercise the prefix extractor and memtable prefix bloom
+    let db_opts = crate::store::build_default_store_opts();
     let tx_opts = rocksdb::TransactionDBOptions::default();
-    let db = TransactionDB::open_cf(&db_opts, &tx_opts, path, cf_names)
+    let cf_descriptors = cf_names
+        .into_iter()
+        .map(|name| rocksdb::ColumnFamilyDescriptor::new(name, db_opts.clone()));
+    let db = TransactionDB::open_cf_descriptors(&db_opts, &tx_opts, path, cf_descriptors)
         .map_err(|e| StorageError::ConnectionError {
             reason: e.into_string(),
         })
@@ -257,13 +258,20 @@ fn end_range_iterator_does_not_read_the_preceding_prefix() {
     seed_shared_prefixed_cf(&ctx);
 
     let query = ctx.cf(UpperByEpochQuery).unwrap();
+
     let epochs = query
         .query_end_range_iterator(Ordering::Ascending, &Epoch(3))
         .map(|res| res.map(|((epoch, _), ())| epoch))
         .collect::<Result<Vec<_>, _>>()
         .unwrap();
-
     assert_eq!(epochs, vec![Epoch(0), Epoch(1), Epoch(2)]);
+
+    let epochs = query
+        .query_end_range_key_iterator(Ordering::Descending, &Epoch(3))
+        .map(|res| res.map(|(epoch, _)| epoch))
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    assert_eq!(epochs, vec![Epoch(2), Epoch(1), Epoch(0)]);
 }
 
 #[test]
@@ -274,11 +282,31 @@ fn start_range_iterator_does_not_read_the_following_prefix() {
     seed_shared_prefixed_cf(&ctx);
 
     let query = ctx.cf(LowerByEpochQuery).unwrap();
+
     let epochs = query
         .query_start_range_iterator(Ordering::Ascending, &Epoch(3))
         .map(|res| res.map(|((epoch, _), ())| epoch))
         .collect::<Result<Vec<_>, _>>()
         .unwrap();
-
     assert_eq!(epochs, vec![Epoch(3), Epoch(4)]);
+
+    let epochs = query
+        .query_start_range_key_iterator(Ordering::Descending, &Epoch(3))
+        .map(|res| res.map(|(epoch, _)| epoch))
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    assert_eq!(epochs, vec![Epoch(4), Epoch(3)]);
+}
+
+#[test]
+fn query_last_does_not_read_the_following_prefix() {
+    const OP: &str = "query_last_does_not_read_the_following_prefix";
+    let (db, _tmp) = create_rocksdb([SHARED_CF]);
+    let tx = db.transaction();
+    let ctx = ctx(&db, &tx);
+    seed_shared_prefixed_cf(&ctx);
+
+    let ((epoch, block_id), ()) = ctx.cf(LowerByEpochQuery).unwrap().query_last(OP).unwrap();
+    assert_eq!(epoch, Epoch(4));
+    assert_eq!(block_id, block_id_from_seed(4));
 }

--- a/crates/state_store_rocksdb/src/tests.rs
+++ b/crates/state_store_rocksdb/src/tests.rs
@@ -11,7 +11,7 @@ use tempfile::TempDir;
 
 use crate::{
     cf_api::DbContext,
-    codecs::{BlockIdCodec, BytesCodec, EpochCodec, NumberCodec, UnitCodec},
+    codecs::{BlockIdCodec, BytesCodec, EpochCodec, NumberCodec, Prefixed, UnitCodec},
     traits::{Cf, QueryCf},
 };
 
@@ -95,6 +95,69 @@ impl QueryCf for ByEpochQuery {
     type KeyCodec = EpochCodec;
 }
 
+/// Two logical tables that share one physical column family, separated only by their key prefix byte.
+const SHARED_CF: &str = "shared_prefixed";
+
+pub struct LowerPrefix;
+
+impl Prefixed for LowerPrefix {
+    fn prefix() -> Option<u8> {
+        Some(1)
+    }
+}
+
+pub struct UpperPrefix;
+
+impl Prefixed for UpperPrefix {
+    fn prefix() -> Option<u8> {
+        Some(2)
+    }
+}
+
+pub struct LowerEpochBlockCf;
+
+impl Cf for LowerEpochBlockCf {
+    type Key = (Epoch, BlockId);
+    type KeyCodec = (EpochCodec, BlockIdCodec);
+    type Prefix = LowerPrefix;
+    type Value = ();
+    type ValueCodec = UnitCodec;
+
+    fn name() -> &'static str {
+        SHARED_CF
+    }
+}
+
+pub struct LowerByEpochQuery;
+
+impl QueryCf for LowerByEpochQuery {
+    type Cf = LowerEpochBlockCf;
+    type Key = Epoch;
+    type KeyCodec = EpochCodec;
+}
+
+pub struct UpperEpochBlockCf;
+
+impl Cf for UpperEpochBlockCf {
+    type Key = (Epoch, BlockId);
+    type KeyCodec = (EpochCodec, BlockIdCodec);
+    type Prefix = UpperPrefix;
+    type Value = ();
+    type ValueCodec = UnitCodec;
+
+    fn name() -> &'static str {
+        SHARED_CF
+    }
+}
+
+pub struct UpperByEpochQuery;
+
+impl QueryCf for UpperByEpochQuery {
+    type Cf = UpperEpochBlockCf;
+    type Key = Epoch;
+    type KeyCodec = EpochCodec;
+}
+
 #[test]
 fn it_puts_and_retrieves() {
     const OP: &str = "it_puts_and_retrieves_in_single_transaction";
@@ -174,4 +237,48 @@ fn it_iterates_over_epoch_heights_ordering() {
         assert_eq!(epoch, Epoch(0));
         assert_eq!(height, NodeHeight(i));
     }
+}
+
+fn seed_shared_prefixed_cf(ctx: &DbContext<'_, Transaction<'_, TransactionDB<SingleThreaded>>>) {
+    const OP: &str = "seed_shared_prefixed_cf";
+    let lower = ctx.cf(LowerEpochBlockCf).unwrap();
+    let upper = ctx.cf(UpperEpochBlockCf).unwrap();
+    for i in 0..5u64 {
+        lower.put(&(Epoch(i), block_id_from_seed(i)), &(), OP).unwrap();
+        upper.put(&(Epoch(i), block_id_from_seed(i)), &(), OP).unwrap();
+    }
+}
+
+#[test]
+fn end_range_iterator_does_not_read_the_preceding_prefix() {
+    let (db, _tmp) = create_rocksdb([SHARED_CF]);
+    let tx = db.transaction();
+    let ctx = ctx(&db, &tx);
+    seed_shared_prefixed_cf(&ctx);
+
+    let query = ctx.cf(UpperByEpochQuery).unwrap();
+    let epochs = query
+        .query_end_range_iterator(Ordering::Ascending, &Epoch(3))
+        .map(|res| res.map(|((epoch, _), ())| epoch))
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+
+    assert_eq!(epochs, vec![Epoch(0), Epoch(1), Epoch(2)]);
+}
+
+#[test]
+fn start_range_iterator_does_not_read_the_following_prefix() {
+    let (db, _tmp) = create_rocksdb([SHARED_CF]);
+    let tx = db.transaction();
+    let ctx = ctx(&db, &tx);
+    seed_shared_prefixed_cf(&ctx);
+
+    let query = ctx.cf(LowerByEpochQuery).unwrap();
+    let epochs = query
+        .query_start_range_iterator(Ordering::Ascending, &Epoch(3))
+        .map(|res| res.map(|((epoch, _), ())| epoch))
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+
+    assert_eq!(epochs, vec![Epoch(3), Epoch(4)]);
 }

--- a/crates/state_store_rocksdb/src/writer.rs
+++ b/crates/state_store_rocksdb/src/writer.rs
@@ -1064,10 +1064,10 @@ impl<'tx, TAddr: NodeAddressable + 'tx> StateStoreWriteTransaction for RocksDbSt
 
         {
             let query = self.db().cf(missing_transactions::ByBlockIdQuery)?;
-            let mut iter = query.prefix_range_key_iterator(Ordering::default(), &block_id);
+            let mut iter = query.query_prefix_range_key_iterator(Ordering::default(), &block_id);
 
             // Are there more missing transactions for this block?
-            if iter.next().is_some() {
+            if iter.next().transpose()?.is_some() {
                 return Ok(None);
             }
         }

--- a/crates/state_store_rocksdb/tests/foreign_proposals.rs
+++ b/crates/state_store_rocksdb/tests/foreign_proposals.rs
@@ -127,3 +127,26 @@ fn foreign_proposals_rocksdb() {
 
     tx.rollback().unwrap();
 }
+
+#[test]
+fn epoch_cleanup_prunes_foreign_proposals() {
+    let (db, _tmp) = create_rocksdb();
+    let mut tx = db.create_write_tx().unwrap();
+
+    let network = Network::LocalNet;
+    let zero_block = Block::zero_block(network, NumPreshards::P64);
+    tx.blocks_insert(&zero_block).unwrap();
+
+    let old_proposal = create_foreign_proposal(*zero_block.id(), Epoch(1));
+    tx.foreign_proposals_save(&old_proposal).unwrap();
+    let current_proposal = create_foreign_proposal(*zero_block.id(), Epoch(5));
+    tx.foreign_proposals_save(&current_proposal).unwrap();
+
+    // The default epoch history length is 1, so this prunes epoch 1
+    tx.epoch_cleanup(Epoch(2)).unwrap();
+
+    assert!(!tx.foreign_proposals_exists(old_proposal.block_id()).unwrap());
+    assert!(tx.foreign_proposals_exists(current_proposal.block_id()).unwrap());
+
+    tx.rollback().unwrap();
+}

--- a/crates/state_store_rocksdb/tests/missing_transactions.rs
+++ b/crates/state_store_rocksdb/tests/missing_transactions.rs
@@ -32,6 +32,7 @@ fn missing_transactions_operations(db: impl StateStore) {
     genesis.insert(&mut tx).unwrap();
 
     let atom1 = create_tx_atom();
+    let atom2 = create_tx_atom();
     let block1 = Block::create(
         network,
         *genesis.id(),
@@ -55,19 +56,22 @@ fn missing_transactions_operations(db: impl StateStore) {
     .unwrap();
 
     // missing_transactions_insert
-    let missing_transaction_ids = vec![&atom1.id];
+    let missing_transaction_ids = vec![&atom1.id, &atom2.id];
     tx.parked_block_insert(&block1, &[], missing_transaction_ids).unwrap();
 
-    // blocks_get_pending_transactions
-    // let res = tx.blocks_get_pending_transactions(block1.id()).unwrap();
-    // assert_eq!(res.len(), 1);
-    // assert_eq!(res[0], atom1.id);
-
-    // missing_transactions_remove
-    tx.parked_block_remove_missing_transaction(block1.height(), atom1.id())
+    // The block stays parked while it is still waiting on atom2
+    let unparked = tx
+        .parked_block_remove_missing_transaction(block1.height(), atom1.id())
         .unwrap();
-    // let res = tx.blocks_get_pending_transactions(block1.id()).unwrap();
-    // assert_eq!(res.len(), 0);
+    assert!(unparked.is_none());
+
+    // The last missing transaction unparks the block
+    let (unparked, foreign_proposals) = tx
+        .parked_block_remove_missing_transaction(block1.height(), atom2.id())
+        .unwrap()
+        .expect("block should be unparked once no transactions are missing");
+    assert_eq!(unparked.id(), block1.id());
+    assert!(foreign_proposals.is_empty());
 
     tx.rollback().unwrap();
 }


### PR DESCRIPTION
## Description

Two independent defects in `tari_state_store_rocksdb`, both on the boundary between logical tables that share a physical column family.

### 1. Range query scans were not bounded to their logical table

Logical tables share a physical column family and are separated only by a leading key prefix byte. Two of the four start/end range query methods did not bound the scan to that prefix:

- `query_end_range_iterator` built `..key`, so the scan started at the beginning of the *physical* column family.
- `query_start_range_iterator` built `key..`, so it ran past the end of the table into the next prefix.

`PrefixCodec` hard-validates the prefix byte, so either scan fails with `MalformedData` as soon as a neighbouring table holds a single row.

**Live impact: epoch GC never made progress.** `cleanup::foreign_proposals_for_epoch` scans `foreign_proposal::EpochIndex` (prefix 18), which shares its column family with `ForeignProposalCf` (prefix 17). One stored foreign proposal was enough to fail the scan. The failure rolls back the whole GC write transaction — discarding the block, QC and finalized-transaction pruning already done in it — and the error is only logged at the `tx.epoch_cleanup(..)` call site in `hotstuff::epoch_gc`. The database therefore grew without bound.

`query_start_range_iterator` has no callers today, so its missing upper bound was latent.

The fix introduces `TableBounds`, which closes any bound the caller leaves open at the extent of the column family's key prefix, and uses it for all four start/end range query methods. That also lets `query_start_range_key_iterator` drop its two-branch `Box<dyn Iterator>` return in favour of `impl Iterator`.

### 2. Wrong iterator family when counting remaining missing transactions

`parked_block_remove_missing_transaction` called `prefix_range_key_iterator` — the plain-`Cf` method — on a `CfContext<_, ByBlockIdQuery>`. Via the blanket `impl<T: QueryCf> Cf for T` that decodes stored index keys of `[prefix][block_id][transaction_id]` with the *query's* `BlockIdCodec`, leaving 32 trailing bytes, which errors. The result was tested with `is_some()`, and `Some(Err(_))` is also `is_some()`.

To be clear about severity: the two outcomes happened to coincide, because the decode error can only occur when a row exists — which is exactly when the caller wants "still missing". Blocks did unpark correctly. This is a latent defect, not a live bug: it silently swallowed a storage error and would have produced a wrong answer under any change to the index key shape.

Fixed by using `query_prefix_range_key_iterator` and propagating the result with `.transpose()?`.

This is the only site in the crate that invoked a plain-`Cf` key iterator on a `QueryCf` type. `reader.rs` has one `prefix_range_value_iterator` on a query type, which is fine because it decodes only the value.

## Motivation and Context

Found while auditing every iteration site in `state_store_rocksdb` for mutate-during-iteration hazards. Neither defect is related to that question; both were found on the files being read.

## How Has This Been Tested?

- `epoch_cleanup_prunes_foreign_proposals` (`tests/foreign_proposals.rs`) — end-to-end regression test for issue 1. Verified it fails on the pre-fix code with `Invalid prefix byte. Expected 18, got 17`, and passes after.
- `end_range_iterator_does_not_read_the_preceding_prefix` / `start_range_iterator_does_not_read_the_following_prefix` (`src/tests.rs`) — unit tests over a pair of prefixed column families sharing one physical CF. Both fail on the pre-fix code.
- `tests/missing_transactions.rs` extended to two missing transactions, asserting the first removal leaves the block parked and the second unparks it. This passes before and after, which is what established that issue 2 was latent rather than live.
- `cargo test -p tari_state_store_rocksdb` — all green.
- `cargo lints clippy --all-features --all-targets` — clean.

## What process can a PR reviewer use to test or verify this change?

Revert the `TableBounds::for_cf::<TQuery::Cf>(None, Some(key))` argument in `query_end_range_iterator` back to `..key` and run `cargo test -p tari_state_store_rocksdb --test foreign_proposals`; `epoch_cleanup_prunes_foreign_proposals` fails with a prefix validation error.

## Breaking Changes

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify
