### PR TITLE
fix(consensus): require canonical genesis shape for QC zero-block exemption

### DIFF
--- a/crates/consensus/src/validations/common.rs
+++ b/crates/consensus/src/validations/common.rs
@@ -245,11 +245,14 @@ pub fn check_quorum_certificate_signatures<TConsensusSpec: ConsensusSpec>(
     committee: &Committee<TConsensusSpec::Addr>,
     signing_service: &TConsensusSpec::SignerService,
 ) -> Result<(), ProposalValidationError> {
-    if qc.justifies_zero_block() {
-        // TODO: This is potentially dangerous. There should be a check
-        // to make sure this is the start of the chain.
-
-        return Ok(());
+    // The "zero block" is the deterministic per-epoch genesis, known to every node without a vote, so a
+    // QC that justifies it is exempt from quorum/signature validation. Only a `ProposalCertificate` in
+    // canonical genesis shape (height zero, zero parent, zero header hash) qualifies for the exemption;
+    // everything else - including a `TimeoutCertificate` - falls through to the checks below.
+    if let Some(pc) = qc.as_proposal_certificate() {
+        if pc.justifies_zero_block() && pc.height().is_zero() && pc.parent_id().is_zero() {
+            return Ok(());
+        }
     }
 
     let mut check_dups = HashSet::with_capacity(qc.signatures().len());

--- a/crates/consensus/src/validations/common.rs
+++ b/crates/consensus/src/validations/common.rs
@@ -249,10 +249,13 @@ pub fn check_quorum_certificate_signatures<TConsensusSpec: ConsensusSpec>(
     // QC that justifies it is exempt from quorum/signature validation. Only a `ProposalCertificate` in
     // canonical genesis shape (height zero, zero parent, zero header hash) qualifies for the exemption;
     // everything else - including a `TimeoutCertificate` - falls through to the checks below.
-    if let Some(pc) = qc.as_proposal_certificate() {
-        if pc.justifies_zero_block() && pc.height().is_zero() && pc.parent_id().is_zero() {
-            return Ok(());
-        }
+    if let Some(pc) = qc.as_proposal_certificate() &&
+        pc.height().is_zero() &&
+        pc.signatures().is_empty() &&
+        pc.justifies_zero_block() &&
+        pc.parent_id().is_zero()
+    {
+        return Ok(());
     }
 
     let mut check_dups = HashSet::with_capacity(qc.signatures().len());


### PR DESCRIPTION
## Summary
`check_quorum_certificate_signatures` exempts a quorum certificate from all signature/quorum
validation whenever `qc.justifies_zero_block()` is true, which only checks that `header_hash` is
all-zero. Height and parent are not checked, and both are attacker-controlled fields on an
otherwise-untrusted `ProposalCertificate`/`TimeoutCertificate`, so a peer can submit a QC with
`header_hash = 0x00...00` and an arbitrary height/parent and skip validation entirely.

This PR narrows the exemption to only apply when the QC is a `ProposalCertificate` in genuine
per-epoch-genesis shape — `height() == 0` and `parent_id().is_zero()`, not merely a zero header
hash. Every other case, including a `TimeoutCertificate` (which has no legitimate zero-signature
case at all — height 0 is the deterministic genesis, never subject to a timeout round), now goes
through the normal signature/quorum-power check below.

## Why
Left unrestricted, this lets a single authenticated-but-non-committee peer forge a "valid" QC
pointing at an unknown block at an arbitrary height, which downstream NEWVIEW handling can turn
into a `FallenBehind` catch-up state for the receiving validator — a liveness/DoS issue, not a
fund-safety one, since the exempted branch never touches actual value transfer.

## Change
- `crates/consensus/src/validations/common.rs`: `check_quorum_certificate_signatures` now checks
  `pc.height().is_zero() && pc.parent_id().is_zero()` (via `qc.as_proposal_certificate()`) in
  addition to the existing zero-header-hash check, before exempting from validation.

## Testing
- `cargo check -p tari_consensus` passes.
- `cargo +nightly-2025-12-05 fmt -p tari_consensus -- --check` passes.
- Manually traced `on_receive_new_view.rs`: a forged QC with `header_hash = 0`, `height =
  u64::MAX`, random `parent_id` now fails `validate_qc` (falls through to the normal
  `ValidatorNotInCommittee` signature check) instead of reaching `Block::record_exists` /
  `FallenBehind`.

I'm holding the working exploit reproduction out of this PR and reporting the full writeup
through GitHub's private security advisory process instead, per your disclosure preference — this
PR is scoped to just the fix.