### PR TITLE
fix(consensus): cap MissingTransactionsRequest to 1000 transaction ids

### DIFF
--- a/crates/consensus/src/hotstuff/on_message_validate.rs
+++ b/crates/consensus/src/hotstuff/on_message_validate.rs
@@ -126,6 +126,16 @@ impl<TConsensusSpec: ConsensusSpec> OnMessageValidate<TConsensusSpec> {
                     message: HotstuffMessage::MissingTransactionsResponse(msg),
                 })
             },
+            HotstuffMessage::MissingTransactionsRequest(msg) => {
+                if msg.transactions.len() > 1000 {
+                    warn!(target: LOG_TARGET, "⚠️Peer requested more than the maximum amount of transactions. Discarding message");
+                    return Ok(MessageValidationResult::Discard);
+                }
+                Ok(MessageValidationResult::Ready {
+                    from,
+                    message: HotstuffMessage::MissingTransactionsRequest(msg),
+                })
+            },
             msg @ HotstuffMessage::NewView(_) |
             msg @ HotstuffMessage::Vote(_) |
             msg @ HotstuffMessage::CatchUpSyncRequest(_) |


### PR DESCRIPTION
## Summary
`MissingTransactionsResponse` handling already discards replies over 1000 transactions
(`on_message_validate.rs:120-123`), but the mirror-image request path applied no bound at all:
`on_receive_request_missing_transactions.rs` ran one blocking store lookup per requested id on the
consensus worker thread and echoed every full transaction body back in a single outbound message.

## Why
A committee member (any single Byzantine/faulted validator) can send one small request listing a
very large number of transaction ids. The handler does a sequential DB lookup per id inline on the
consensus message-processing path (head-of-line blocking for consensus), then returns a
correspondingly huge reply. Cheap to send, expensive to process and transmit — repeatable
indefinitely against every committee member.

## Change
- `crates/consensus/src/hotstuff/on_message_validate.rs`: add an explicit
  `HotstuffMessage::MissingTransactionsRequest` arm that discards the message when
  `transactions.len() > 1000`, mirroring the existing response-side check, before it reaches the
  handler.

## Testing
- `cargo check -p tari_consensus` passes.
- `cargo +nightly-2025-12-05 fmt -p tari_consensus -- --check` passes.