### PR TITLE
fix(walletd): derive webrtc session token permissions from caller's own grant

### DIFF
--- a/applications/tari_walletd/src/handlers/webrtc.rs
+++ b/applications/tari_walletd/src/handlers/webrtc.rs
@@ -28,7 +28,7 @@ pub fn handle_start(
     addresses: (SocketAddr, SocketAddr),
 ) -> JrpcResult {
     let answer_id = value.get_answer_id();
-    context.authorize(token, &[Permission::Webrtc]).map_err(|e| {
+    let granted = context.authorize(token, &[Permission::Webrtc]).map_err(|e| {
         JsonRpcResponse::error(
             answer_id.clone(),
             JsonRpcError::new(
@@ -39,16 +39,24 @@ pub fn handle_start(
         )
     })?;
     let webrtc_start_request = value.parse_params::<WebRtcStartRequest>()?;
-    let permissions = serde_json::from_value::<Permissions>(webrtc_start_request.permissions).map_err(|e| {
-        JsonRpcResponse::error(
-            answer_id.clone(),
-            JsonRpcError::new(
-                JsonRpcErrorReason::InvalidRequest,
-                e.to_string(),
-                serde_json::Value::Null,
-            ),
-        )
-    })?;
+    let requested_permissions =
+        serde_json::from_value::<Permissions>(webrtc_start_request.permissions).map_err(|e| {
+            JsonRpcResponse::error(
+                answer_id.clone(),
+                JsonRpcError::new(
+                    JsonRpcErrorReason::InvalidRequest,
+                    e.to_string(),
+                    serde_json::Value::Null,
+                ),
+            )
+        })?;
+    // The session token must never carry more than the caller's own grant, so drop anything
+    // requested that the caller isn't already authorised for instead of trusting it verbatim.
+    let permissions: Permissions = requested_permissions
+        .into_vec()
+        .into_iter()
+        .filter(|p| granted.satisfies(p))
+        .collect();
     let jwt = context.jwt_api();
     let claim = jwt.generate_auth_claims(permissions).map_err(|e| {
         JsonRpcResponse::error(


### PR DESCRIPTION
## Summary
`webrtc.start` authorizes the caller for only `Permission::Webrtc`, then parses a caller-chosen
permission set straight out of the request body and mints a fresh signed JWT carrying it verbatim
- including `Permission::Admin` if the caller asks for it. `Permission::Admin` satisfies every
permission check in the daemon, and the minted token is delivered into the WebRTC session the
caller itself initiates and controls.

## Why
Any integration holding only the deliberately least-powerful `webrtc` scope (e.g. a screen-sharing
or remote-control companion app) could escalate to a full Admin JWT and use it as a normal bearer
token against any other endpoint (`accounts.transfer`, key export, transaction-request approval,
etc).

## Change
- `applications/tari_walletd/src/handlers/webrtc.rs`: bind the `Permissions` already returned by
  `context.authorize(...)` (previously discarded), and filter the caller-requested permission set
  down to only entries `granted.satisfies(..)` covers before minting the session token - the same
  `satisfies` semantics used for every other authorization check in the daemon, so Admin-implies-all
  and scope matching stay consistent rather than reimplemented.

## Testing
- `cargo check -p tari_ootle_walletd` passes.
- `cargo +nightly-2025-12-05 fmt -p tari_ootle_walletd -- --check` passes.