### PR TITLE
fix(engine): bill and cap the stealth verification VaultAction::PayFee runs

### DIFF
--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -2549,9 +2549,8 @@ where
                     return Err(RuntimeError::FeePaymentInMainIntent);
                 }
 
-                // Account and charge for the statement's verification cost up front, exactly like the canonical
-                // `stealth_transfer` path does — this is the same free-compute-credit fee intent, so it must be
-                // capped and billed here too, not just on the `StealthTransfer` instruction route.
+                // Charge for the statement's verification cost, exactly like the
+                // `stealth_transfer` method does.
                 if let Some(ref statement) = arg.statement {
                     self.tracker.account_fee_intent_stealth_transfer()?;
                     let has_view_key = self.tracker.write_with(|state| {
@@ -2561,10 +2560,7 @@ where
                         Ok::<_, RuntimeError>(has_view_key)
                     })?;
                     self.tracker
-                        .charge_native_execution(tari_engine_types::stealth::transfer_native_points(
-                            statement,
-                            has_view_key,
-                        ))?;
+                        .charge_native_execution(stealth::transfer_native_points(statement, has_view_key))?;
                 }
 
                 // Authorise the spent inputs before the fee transfer executes — the same mandatory pre-execute gate as

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -2549,6 +2549,24 @@ where
                     return Err(RuntimeError::FeePaymentInMainIntent);
                 }
 
+                // Account and charge for the statement's verification cost up front, exactly like the canonical
+                // `stealth_transfer` path does — this is the same free-compute-credit fee intent, so it must be
+                // capped and billed here too, not just on the `StealthTransfer` instruction route.
+                if let Some(ref statement) = arg.statement {
+                    self.tracker.account_fee_intent_stealth_transfer()?;
+                    let has_view_key = self.tracker.write_with(|state| {
+                        let resource_lock = state.read_lock_substate(SubstateId::Resource(TARI_TOKEN))?;
+                        let has_view_key = state.get_resource(&resource_lock)?.view_key().is_some();
+                        state.unlock_substate(resource_lock)?;
+                        Ok::<_, RuntimeError>(has_view_key)
+                    })?;
+                    self.tracker
+                        .charge_native_execution(tari_engine_types::stealth::transfer_native_points(
+                            statement,
+                            has_view_key,
+                        ))?;
+                }
+
                 // Authorise the spent inputs before the fee transfer executes — the same mandatory pre-execute gate as
                 // `stealth_transfer`, so a rejection leaves the inputs unspent. Fees are always paid in TARI.
                 if let Some(ref statement) = arg.statement {


### PR DESCRIPTION
## Summary
The canonical stealth-transfer path (`RuntimeInterfaceImpl::stealth_transfer`) accounts for and
pre-charges its bulletproof range-proof + Schnorr balance-proof verification cost, and enforces
the fee-intent transfer cap, before running any of that verification. `VaultAction::PayFee`
reaches the identical `execute_stealth_transfer` verification through a separate code path that
did neither the accounting nor the charge.

## Why
`execute_stealth_transfer` runs aggregated bulletproof + balance-proof validation priced at
several million point-equivalents per statement. Because the fee module computes native-execution
charges purely from accumulated points, and this path never accumulated any, a template could loop
`vault.pay_fee(PayFeeArg { amount: 0, statement })` against an unfunded vault and run full ZK proof
verification on every validator in the committee, free and uncapped by
`max_fee_intent_transfers`.

## Change
- `crates/engine/src/runtime/impl.rs`, `VaultAction::PayFee`: when the arg carries a `statement`,
  run `account_fee_intent_stealth_transfer()` (the same fee-intent-transfer cap check) followed by
  `charge_native_execution(transfer_native_points(&statement, has_view_key))`, mirroring
  `stealth_transfer`'s sequence exactly, before `verify_input_authorizations` runs.

## Testing
- `cargo check -p tari_engine` passes.
- `cargo +nightly-2025-12-05 fmt -p tari_engine -- --check` passes.