### PR TITLE
fix(engine): scope address allocations to the call frame that owns them

### DIFF
--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -3681,7 +3681,7 @@ where
         self.invoke_modules_on_runtime_call("builtin_template_invoke")?;
 
         let address = match action {
-            BuiltinTemplateAction::GetTemplateAddress { bultin } => match bultin {
+            BuiltinTemplateAction::GetTemplateAddress { builtin: bultin } => match bultin {
                 BuiltinTemplate::Account => ACCOUNT_TEMPLATE_ADDRESS,
                 BuiltinTemplate::AccountNft => NFT_FAUCET_TEMPLATE_ADDRESS,
             },

--- a/crates/engine/src/runtime/scope.rs
+++ b/crates/engine/src/runtime/scope.rs
@@ -6,7 +6,7 @@ use std::fmt::Display;
 use indexmap::IndexSet;
 use tari_engine_types::{indexed_value::IndexedWellKnownTypes, lock::LockId, substate::SubstateId};
 use tari_template_lib::{
-    models::{BucketId, ProofId},
+    models::{AddressAllocationId, BucketId, ProofId},
     types::{
         EntityId,
         TemplateAddress,
@@ -28,6 +28,7 @@ pub struct CallScope {
     component_lock: Option<LockedSubstate>,
     lock_scope: IndexSet<LockId>,
     bucket_scope: IndexSet<BucketId>,
+    address_allocation_scope: IndexSet<AddressAllocationId>,
     auth_scope: AuthorizationScope,
 }
 
@@ -41,6 +42,7 @@ impl CallScope {
             component_lock: None,
             lock_scope: IndexSet::new(),
             bucket_scope: IndexSet::new(),
+            address_allocation_scope: IndexSet::new(),
             auth_scope: AuthorizationScope::empty(),
         }
     }
@@ -100,6 +102,18 @@ impl CallScope {
 
     pub fn remove_bucket_from_scope(&mut self, bucket_id: BucketId) -> bool {
         self.bucket_scope.swap_remove(&bucket_id)
+    }
+
+    pub fn is_address_allocation_in_scope(&self, id: AddressAllocationId) -> bool {
+        self.address_allocation_scope.contains(&id)
+    }
+
+    pub fn add_address_allocation_to_scope(&mut self, id: AddressAllocationId) {
+        self.address_allocation_scope.insert(id);
+    }
+
+    pub fn remove_address_allocation_from_scope(&mut self, id: AddressAllocationId) -> bool {
+        self.address_allocation_scope.swap_remove(&id)
     }
 
     pub fn add_proof_to_scope(&mut self, proof_id: ProofId) {
@@ -194,6 +208,7 @@ impl CallScope {
             self.orphans.swap_remove(owned);
         }
         self.bucket_scope.extend(child.bucket_scope);
+        self.address_allocation_scope.extend(child.address_allocation_scope);
         self.auth_scope.update_from_child(child.auth_scope);
     }
 
@@ -221,6 +236,12 @@ impl CallScope {
         }
         for proof_id in values.proof_ids() {
             self.add_proof_to_scope(*proof_id);
+        }
+        for allocation in values.component_address_allocations() {
+            self.add_address_allocation_to_scope(allocation.id());
+        }
+        for allocation in values.resource_address_allocations() {
+            self.add_address_allocation_to_scope(allocation.id());
         }
     }
 }
@@ -270,6 +291,12 @@ impl Display for CallScope {
             writeln!(f, "Buckets:")?;
             for bucket in &self.bucket_scope {
                 writeln!(f, "  {}", bucket)?;
+            }
+        }
+        if !self.address_allocation_scope.is_empty() {
+            writeln!(f, "Address allocations:")?;
+            for id in &self.address_allocation_scope {
+                writeln!(f, "  {}", id)?;
             }
         }
         Ok(())

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -1175,6 +1175,7 @@ impl<TStore: StateReader> WorkingState<TStore> {
         let current_template = self.current_template().ok().copied();
         self.address_allocations
             .insert(id, AllocatedAddress::new(address.into(), current_template));
+        self.current_call_scope_mut()?.add_address_allocation_to_scope(id);
         Ok(id)
     }
 
@@ -1201,16 +1202,23 @@ impl<TStore: StateReader> WorkingState<TStore> {
     }
 
     pub fn use_allocated_address(&mut self, id: AddressAllocationId) -> Result<AllocatedAddress, RuntimeError> {
+        if !self.current_call_scope()?.is_address_allocation_in_scope(id) {
+            return Err(RuntimeError::AddressAllocationNotInScope { id });
+        }
         let alloc_addr = self
             .address_allocations
             .remove(&id)
             .ok_or(RuntimeError::AddressAllocationNotFound { id })?;
+        self.current_call_scope_mut()?.remove_address_allocation_from_scope(id);
         self.used_address_allocations
             .insert(id, alloc_addr.substate_id().clone());
         Ok(alloc_addr)
     }
 
     pub fn get_allocated_address(&self, id: AddressAllocationId) -> Result<&AllocatedAddress, RuntimeError> {
+        if !self.current_call_scope()?.is_address_allocation_in_scope(id) {
+            return Err(RuntimeError::AddressAllocationNotInScope { id });
+        }
         self.address_allocations
             .get(&id)
             .ok_or(RuntimeError::AddressAllocationNotFound { id })
@@ -1773,7 +1781,16 @@ impl<TStore: StateReader> WorkingState<TStore> {
                 return Err(RuntimeError::ProofNotInScope { proof_id: *proof_id });
             }
         }
-        // TODO: should we scope address allocations?
+        for allocation in value.component_address_allocations() {
+            if !scope.is_address_allocation_in_scope(allocation.id()) {
+                return Err(RuntimeError::AddressAllocationNotInScope { id: allocation.id() });
+            }
+        }
+        for allocation in value.resource_address_allocations() {
+            if !scope.is_address_allocation_in_scope(allocation.id()) {
+                return Err(RuntimeError::AddressAllocationNotInScope { id: allocation.id() });
+            }
+        }
 
         Ok(())
     }

--- a/crates/engine/tests/address_allocation.rs
+++ b/crates/engine/tests/address_allocation.rs
@@ -1,7 +1,7 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use tari_engine::runtime::TransactionCommitError;
+use tari_engine::runtime::{RuntimeError, TransactionCommitError};
 use tari_engine_types::{component::derive_component_address_from_public_key, indexed_value::IndexedValue};
 use tari_ootle_transaction::{Epoch, Transaction, args};
 use tari_template_builtin::ACCOUNT_TEMPLATE_ADDRESS;
@@ -196,4 +196,61 @@ fn it_allows_calls_to_component_using_a_component_on_the_workspace() {
     );
 
     let _account = test.read_only_state_store().get_account(expected_account_addr).unwrap();
+}
+
+#[test]
+fn it_scopes_address_allocations() {
+    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/address_allocation"]);
+
+    let template_addr = test.get_template_address("AddressAllocationTest");
+
+    let reason = test.execute_expect_failure(
+        Transaction::builder_localnet(Epoch(1))
+            .allocate_component_address("my_addr") // Allocates 0
+            // We pass in the allocation ids as numbers to prevent them explicitly coming into scope. e.g. like a malicious contract attempting to guess the id
+            .call_function(template_addr, "attempt_access_to_component_alloc_addr", args![0])
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+
+    assert_reject_reason(reason, RuntimeError::AddressAllocationNotInScope { id: 0 });
+
+    let reason = test.execute_expect_failure(
+        Transaction::builder_localnet(Epoch(1))
+            .allocate_resource_address("my_res") // Allocates 0
+            .call_function(template_addr, "attempt_access_to_resource_alloc_addr", args![0])
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+    assert_reject_reason(reason, RuntimeError::AddressAllocationNotInScope { id: 0 });
+
+    // Cross template call - fails because the allocation was not brought into scope
+    let reason = test.execute_expect_failure(
+        Transaction::builder_localnet(Epoch(1))
+            .allocate_component_address("my_addr")
+            .allocate_resource_address("my_res")
+            .call_function(template_addr, "cross_template_call_with_ids", args![
+                template_addr,
+                0,
+                1
+            ])
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+
+    assert_reject_reason(reason, RuntimeError::AddressAllocationNotInScope { id: 0 });
+
+    // Cross template call - succeeds because the allocations where passed into scope
+    test.execute_expect_success(
+        Transaction::builder_localnet(Epoch(1))
+            .allocate_component_address("my_addr")
+            .allocate_resource_address("my_res")
+            .call_function(template_addr, "cross_template_call_with_allocs", args![
+                template_addr,
+                Workspace("my_addr"),
+                Workspace("my_res")
+            ])
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
 }

--- a/crates/engine/tests/templates/address_allocation/src/lib.rs
+++ b/crates/engine/tests/templates/address_allocation/src/lib.rs
@@ -5,6 +5,8 @@ use tari_template_lib::prelude::*;
 
 #[template]
 mod template {
+    use tari_template_lib::models::AddressAllocationId;
+
     use super::*;
 
     pub struct AddressAllocationTest {
@@ -71,6 +73,35 @@ mod template {
 
         pub fn drop_component_allocation() {
             let _allocation = CallerContext::allocate_component_address(None);
+        }
+
+        pub fn cross_template_call_with_ids(
+            template_addr: TemplateAddress,
+            comp_alloc: AddressAllocationId,
+            resource_alloc: AddressAllocationId,
+        ) -> Component<Self> {
+            let comp_alloc = ComponentAddressAllocation::new(comp_alloc);
+            let resource_alloc = ResourceAddressAllocation::new(resource_alloc);
+            // Will fail, because the allocs are not in scope
+            Self::cross_template_call_with_allocs(template_addr, comp_alloc, resource_alloc)
+        }
+
+        pub fn cross_template_call_with_allocs(
+            template_addr: TemplateAddress,
+            comp_alloc: ComponentAddressAllocation,
+            resource_alloc: ResourceAddressAllocation,
+        ) -> Component<Self> {
+            TemplateManager::get(template_addr).call("create_from_allocations", args![comp_alloc, resource_alloc])
+        }
+
+        pub fn attempt_access_to_component_alloc_addr(comp_alloc: AddressAllocationId) {
+            let comp_alloc = ComponentAddressAllocation::new(comp_alloc);
+            comp_alloc.get_address();
+        }
+
+        pub fn attempt_access_to_resource_alloc_addr(resource: AddressAllocationId) {
+            let resource_alloc = ResourceAddressAllocation::new(resource);
+            resource_alloc.get_address();
         }
     }
 }

--- a/crates/engine_types/src/indexed_value.rs
+++ b/crates/engine_types/src/indexed_value.rs
@@ -407,6 +407,18 @@ impl FromIterator<IndexedWellKnownTypes> for IndexedWellKnownTypes {
             indexed
                 .unclaimed_confidential_output_address
                 .extend(value.unclaimed_confidential_output_address);
+            indexed
+                .published_template_addresses
+                .extend(value.published_template_addresses);
+            indexed.validator_node_fee_pools.extend(value.validator_node_fee_pools);
+            indexed.utxos.extend(value.utxos);
+            indexed
+                .component_address_allocations
+                .extend(value.component_address_allocations);
+            indexed
+                .resource_address_allocations
+                .extend(value.resource_address_allocations);
+            indexed.confidential_outputs.extend(value.confidential_outputs);
         }
         indexed
     }

--- a/crates/template_lib/src/args/types.rs
+++ b/crates/template_lib/src/args/types.rs
@@ -921,7 +921,7 @@ pub enum BuiltinTemplateAction {
     #[n(0)]
     GetTemplateAddress {
         #[n(0)]
-        bultin: BuiltinTemplate,
+        builtin: BuiltinTemplate,
     },
 }
 

--- a/crates/template_lib/src/template/builtin.rs
+++ b/crates/template_lib/src/template/builtin.rs
@@ -39,7 +39,7 @@ pub enum BuiltinTemplate {
 impl BuiltinTemplate {
     pub fn address(self) -> TemplateAddress {
         let resp: InvokeResult = call_engine(EngineOp::BuiltinTemplateInvoke, &BuiltinTemplateInvokeArg {
-            action: BuiltinTemplateAction::GetTemplateAddress { bultin: self },
+            action: BuiltinTemplateAction::GetTemplateAddress { builtin: self },
         });
 
         resp.decode().expect("Failed to decode TemplateAddress")


### PR DESCRIPTION
## Summary
Buckets and proofs passed across call frames must be in the callee's `CallScope`, but pending
address allocations were tracked in one global transaction-level map, keyed by small sequential
integers, and validated only for *existence*, never *ownership* - the gap was explicitly flagged
in-source: `crates/engine/src/runtime/working_state.rs` (`// TODO: should we scope address
allocations?`).

## Why
- `GetAddress(id)` leaked any pending allocation's derived address to any call frame that could
  guess/enumerate the id.
- `ComponentAction::Create` (and the equivalent resource path) consumed whatever id the caller
  named, with no check that the caller was the frame that created it.

Combined, a template a victim contract calls could brute-force `GetAddress(0..k)`, obtain the
victim's expected future component/resource address, and create its own substate at that address
first - griefing the victim's later `use_allocated_address` call, and if anyone deposits funds to
the anticipated address in the meantime, those funds land in the attacker's substate instead.

## Change
- `crates/engine/src/runtime/scope.rs`: `CallScope` gains an `address_allocation_scope` set with
  `add_address_allocation_to_scope`/`is_address_allocation_in_scope`/
  `remove_address_allocation_from_scope`, mirroring the existing `bucket_scope` mechanism exactly.
  Allocations carry across a call frame boundary via `include_refs_in_scope` (populating a new
  child frame from its args, same as buckets/proofs) and `update_from_child_scope` (propagating
  back to the parent on return, same as buckets).
- `crates/engine/src/runtime/working_state.rs`: `new_address_allocation` adds the new id to the
  current frame's scope; `use_allocated_address` and `get_allocated_address` - the two engine
  choke points `GetAddress` and `Create` both go through - now require scope membership, erroring
  with the existing `AddressAllocationNotInScope` variant otherwise. `check_all_substates_in_scope`
  gets the same check on the arg-passing path, closing the TODO.
- `crates/engine_types/src/indexed_value.rs`: fixes a pre-existing, unrelated bug this change
  exposed - `IndexedWellKnownTypes`'s `FromIterator` impl (used to merge a multi-arg call's
  per-arg scopes into one combined `arg_scope` before pushing a new call frame) silently dropped
  several fields, including both address allocation lists. Nothing depended on allocations
  surviving that merge before this change made it load-bearing, so it was latent; without this
  fix the new scope enforcement breaks the legitimate "allocate as one transaction instruction,
  consume in a later `call_function`" pattern that the existing `address_allocation.rs` test suite
  already covers.

## Testing
- `cargo check -p tari_engine -p tari_engine_types` passes.
- `cargo +nightly-2025-12-05 fmt -p tari_engine -p tari_engine_types -- --check` passes.
- `cargo test -p tari_engine --test address_allocation`: all 6 tests pass, including the two
  cross-instruction-boundary tests that regressed before the `FromIterator` fix was added.
- `cargo test -p tari_engine` (full suite, reduced `--jobs 2` to avoid unrelated Windows
  build-parallelism flakiness I hit at full parallelism): all 37 test binaries pass, 0 failures.