### PR TITLE
test(cucumber): improve errors for nodes failing to start

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,7 +264,7 @@ jobs:
       CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=mold
     strategy:
       matrix:
-        partition: ["1/3", "2/3", "3/3"]
+        partition: [ "1/3", "2/3", "3/3" ]
 
     steps:
       - name: checkout
@@ -346,7 +346,7 @@ jobs:
 
   integration-test:
     name: integration test
-    runs-on: [ self-hosted, ubuntu-high-cpu ]
+    runs-on: [ ubuntu-latest ]
     container:
       image: ghcr.io/tari-project/ootle-ci:development
       credentials:

--- a/integration_tests/src/base_node.rs
+++ b/integration_tests/src/base_node.rs
@@ -155,7 +155,7 @@ pub async fn spawn_base_node(world: &mut TariWorld, bn_name: String) {
     });
 
     // Wait for node to start up (TCP port open)
-    let handle = wait_listener_on_local_port(handle, grpc_port).await;
+    let handle = wait_listener_on_local_port("Minotari Node", handle, grpc_port).await;
 
     // Wait for gRPC service to be fully ready (not just the readiness server)
     let mut grpc_client = get_base_node_client(grpc_port);

--- a/integration_tests/src/helpers.rs
+++ b/integration_tests/src/helpers.rs
@@ -22,37 +22,47 @@ pub fn get_os_assigned_ports() -> (u16, u16) {
     (get_os_assigned_port(), get_os_assigned_port())
 }
 pub async fn wait_listener_on_local_port_os_thread<T, E: Debug>(
+    name: &'static str,
     handle: std::thread::JoinHandle<Result<T, E>>,
     port: u16,
 ) -> std::thread::JoinHandle<Result<T, E>> {
     let mut i = 0;
-    while let Err(e) = tokio::net::TcpSocket::new_v4()
-        .unwrap()
-        .connect(([127u8, 0, 0, 1], port).into())
-        .await
-    {
-        if handle.is_finished() {
-            handle
-                .join()
-                .expect("Node exited panicked")
-                .expect("Node exited unexpectedly");
-            panic!("Node exited cleanly unexpectedly");
+    loop {
+        match tokio::net::TcpSocket::new_v4()
+            .unwrap()
+            .connect(([127u8, 0, 0, 1], port).into())
+            .await
+        {
+            Ok(mut sock) => {
+                sock.shutdown().await.unwrap();
+                break;
+            },
+            Err(e) => {
+                if handle.is_finished() {
+                    handle
+                        .join()
+                        .expect("Node exited panicked")
+                        .expect("Node exited unexpectedly");
+                    panic!("{name} exited cleanly unexpectedly");
+                }
+                // cucumber_log!("Waiting for base node to start listening on port {}. {}", port, e);
+                if i >= 40 {
+                    // cucumber_log!("Node failed to start listening on port {} within 10s", port);
+                    panic!(
+                        "{name} failed to start listening on port {} within 20s (err: {})",
+                        port, e
+                    );
+                }
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                i += 1;
+            },
         }
-        // cucumber_log!("Waiting for base node to start listening on port {}. {}", port, e);
-        if i >= 20 {
-            // cucumber_log!("Node failed to start listening on port {} within 10s", port);
-            panic!(
-                "Node failed to start listening on port {} within 20s (err: {})",
-                port, e
-            );
-        }
-        tokio::time::sleep(Duration::from_secs(1)).await;
-        i += 1;
     }
     handle
 }
 
 pub async fn wait_listener_on_local_port<T, E: Debug>(
+    name: &'static str,
     handle: JoinHandle<Result<T, E>>,
     port: u16,
 ) -> JoinHandle<Result<T, E>> {
@@ -70,12 +80,12 @@ pub async fn wait_listener_on_local_port<T, E: Debug>(
             Err(e) => {
                 if handle.is_finished() {
                     match handle.await {
-                        Ok(Ok(_)) => panic!("Node exited cleanly unexpectedly"),
-                        Ok(Err(e)) => panic!("Node exited with error: {:?}", e),
+                        Ok(Ok(_)) => panic!("{name} exited cleanly unexpectedly"),
+                        Ok(Err(e)) => panic!("{name} exited with error: {:?}", e),
                         Err(e) => {
                             let panic = e.into_panic();
                             panic!(
-                                "Node panicked {:?}",
+                                "{name} panicked {:?}",
                                 panic
                                     .downcast_ref::<&str>()
                                     .copied()
@@ -86,10 +96,10 @@ pub async fn wait_listener_on_local_port<T, E: Debug>(
                     }
                 }
                 // cucumber_log!("Waiting for base node to start listening on port {}. {}", port, e);
-                if i >= 20 {
-                    // cucumber_log!("Node failed to start listening on port {} within 10s", port);
+                if i >= 40 {
+                    // cucumber_log!("{name} failed to start listening on port {} within 10s", port);
                     panic!(
-                        "Node failed to start listening on port {} within 20s (err: {})",
+                        "{name} failed to start listening on port {} within 20s (err: {})",
                         port, e
                     );
                 }

--- a/integration_tests/src/indexer.rs
+++ b/integration_tests/src/indexer.rs
@@ -212,7 +212,7 @@ pub async fn spawn_indexer(world: &mut TariWorld, indexer_name: String, base_nod
     });
 
     // Wait for node to start up
-    let handle = wait_listener_on_local_port(handle, api_port).await;
+    let handle = wait_listener_on_local_port("Indexer", handle, api_port).await;
     // Check if the task errored/panicked
     let handle = check_join_handle(&name, handle).await;
 

--- a/integration_tests/src/validator_node.rs
+++ b/integration_tests/src/validator_node.rs
@@ -244,7 +244,7 @@ async fn spawn_validator_node_process(spawn: ValidatorSpawn) -> ValidatorNodePro
         }
     });
 
-    let handle = wait_listener_on_local_port(handle, json_rpc_port).await;
+    let handle = wait_listener_on_local_port("Validator", handle, json_rpc_port).await;
     let handle = check_join_handle(&name, handle).await;
     let public_key = get_vn_identity(json_rpc_port).await;
 

--- a/integration_tests/src/wallet.rs
+++ b/integration_tests/src/wallet.rs
@@ -179,7 +179,7 @@ pub async fn spawn_minotari_wallet(world: &mut TariWorld, wallet_name: String, b
     });
 
     // Wait for node to start up
-    let handle = wait_listener_on_local_port_os_thread(handle, grpc_port).await;
+    let handle = wait_listener_on_local_port_os_thread("MinotariWallet", handle, grpc_port).await;
 
     // make the new wallet able to be referenced by other processes
     let wallet_process = WalletProcess {

--- a/integration_tests/src/wallet_daemon.rs
+++ b/integration_tests/src/wallet_daemon.rs
@@ -100,7 +100,7 @@ pub async fn spawn_wallet_daemon(world: &mut TariWorld, wallet_daemon_name: Stri
     let handle = task::spawn(run_tari_ootle_walletd(config, None, shutdown_signal));
 
     // Wait for node to start up
-    let handle = wait_listener_on_local_port(handle, json_rpc_port).await;
+    let handle = wait_listener_on_local_port("WalletDaemon", handle, json_rpc_port).await;
     // Check if the task errored/panicked
     let _handle = check_join_handle(&wallet_daemon_name, handle).await;
 


### PR DESCRIPTION
Description
---
test(cucumber): improve errors for nodes failing to start
run intergation tests on github infra

Motivation and Context
---
Integration tests are failing due to flakiness, and probably limited runner resources. Moved over to github runner.
Improved error messages to make it clear which node failed.

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify