### PR TITLE
ci: preserve artifacts between tag tasks

### DIFF
--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -775,7 +775,7 @@ jobs:
           draft: true
           allowUpdates: true
           updateOnlyUnreleased: true
-          replacesArtifacts: true
+          replacesArtifacts: false
           omitDraftDuringUpdate: true
           omitBodyDuringUpdate: true
           omitNameDuringUpdate: true
@@ -1080,7 +1080,7 @@ jobs:
           draft: true
           allowUpdates: true
           updateOnlyUnreleased: true
-          replacesArtifacts: true
+          replacesArtifacts: false
           omitDraftDuringUpdate: true
           omitBodyDuringUpdate: true
           omitNameDuringUpdate: true

--- a/.github/workflows/ffi_libs.yml
+++ b/.github/workflows/ffi_libs.yml
@@ -146,7 +146,7 @@ jobs:
           draft: true
           allowUpdates: true
           updateOnlyUnreleased: true
-          replacesArtifacts: true
+          replacesArtifacts: false
           omitDraftDuringUpdate: true
           omitBodyDuringUpdate: true
           omitNameDuringUpdate: true


### PR DESCRIPTION
Description
---
ci: preserve artifacts between tag tasks

Motivation and Context
---
Steps overwrite other steps' artifacts

I'm not 100% sure that this works because replaceArtifacts is ambiguous. Does it remove and replace all artifacts? In which case, this should work. Does it replace them on name conflicts only? In which case this shouldnt make a difference.

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify