### PR TITLE
build: drop tari_comms/tari_core from walletd, indexer and VN dependency graphs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11029,7 +11029,6 @@ dependencies = [
  "futures-util",
  "log",
  "minotari_app_grpc",
- "minotari_node_grpc_client",
  "serde",
  "tari_common_types",
  "tari_node_components",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,7 @@ ootle-wasm-core = { path = "crates/ootle_wasm/core", version = "0.39" }
 ootle_sdk_core = { path = "crates/ootle_sdk_core", version = "0.39" }
 
 # external minotari/tari dependencies
-minotari_app_grpc = "5.6.0"
+minotari_app_grpc = { version = "5.6.0", default-features = false }
 minotari_app_utilities = "5.6.0"
 minotari_node_grpc_client = "5.6.0"
 minotari_wallet_grpc_client = "5.6.0"

--- a/clients/base_node_client/Cargo.toml
+++ b/clients/base_node_client/Cargo.toml
@@ -8,7 +8,6 @@ license.workspace = true
 
 [dependencies]
 minotari_app_grpc = { workspace = true }
-minotari_node_grpc_client = { workspace = true }
 tari_common_types = { workspace = true }
 tari_transaction_components = { workspace = true }
 tari_node_components = { workspace = true }

--- a/clients/base_node_client/src/grpc.rs
+++ b/clients/base_node_client/src/grpc.rs
@@ -26,9 +26,8 @@ use futures_util::TryStreamExt;
 use log::*;
 use minotari_app_grpc::{
     tari_rpc,
-    tari_rpc::{self as grpc, GetValidatorNodeChangesRequest},
+    tari_rpc::{self as grpc, GetValidatorNodeChangesRequest, base_node_client::BaseNodeClient as BaseNodeGrpcClient},
 };
-use minotari_node_grpc_client::BaseNodeGrpcClient;
 use tari_common_types::types::FixedHash;
 use tari_node_components::blocks::BlockHeader;
 use tari_ootle_common_types::{Epoch, SubstateAddress};


### PR DESCRIPTION
## Description

`minotari_app_grpc` has `default = ["base_node"]`, and `base_node = ["tari_core", "tari_comms"]`. Because we depend on it with default features, every build of the wallet daemon, indexer and validator node compiled the entire base layer p2p stack — `tari_core`, `tari_comms`, `tari_comms_dht`, `tari_p2p` — even though we only ever use `minotari_app_grpc::tari_rpc`, the generated protobuf types.

How it reached each app:

- indexer → `tari_epoch_oracles` / `tari_base_node_client` → `minotari_app_grpc`
- walletd → `tari_consensus` (dev-dep) → `tari_epoch_manager` → `minotari_app_grpc`

None of the `base_node`-gated modules (`conversions::base_node_state`, `conversions::peer`, `conversions::sidechain_validator`) are used anywhere in the workspace.

## Changes

- Depend on `minotari_app_grpc` with `default-features = false` in the workspace manifest.
- Drop `minotari_node_grpc_client` from `tari_base_node_client`. It is a two-line re-export of `minotari_app_grpc::tari_rpc` that depends on `minotari_app_grpc` with default features, so keeping it would re-enable `base_node` through feature unification. `grpc.rs` now names `tari_rpc::base_node_client::BaseNodeClient` directly.

## Result

`cargo tree -i tari_comms --target all` for `tari_ootle_walletd`, `tari_indexer` and `tari_validator_node` now returns nothing — `tari_comms`, `tari_core` and `tari_p2p` are gone from those graphs, dev-dependencies included.

## Known limitation

`tari_watcher`, `tari_swarm_daemon` and `integration_tests` still use `minotari_node_grpc_client` / `minotari_wallet_grpc_client`, both of which pull `minotari_app_grpc` with default features. A `cargo build --workspace` therefore still unifies `base_node` on and builds `tari_comms`. Targeted `-p <daemon>` builds get the full win. Removing it workspace-wide needs either those three crates to stop using the wrapper crates, or an upstream change setting `default-features = false` in `minotari_node_grpc_client` and `minotari_wallet_grpc_client`.

## Motivation and Context

Large, entirely unused dependency subtree in the three main daemons' build graphs.

## How Has This Been Tested?

`cargo check -p tari_base_node_client -p tari_epoch_manager` passes; dependency graphs verified with `cargo tree -i ... --target all`. Full builds left to CI.

## What process can a PR reviewer use to test or verify this change?

```
cargo tree -p tari_indexer -i tari_comms --target all
cargo tree -p tari_ootle_walletd -i tari_comms --target all
```

Both should report that the package specification did not match any packages.

## Breaking Changes

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other

Note: `tari_base_node_client` no longer re-exports through `minotari_node_grpc_client`, but its own public API (including the `ValidatorNodeChange` re-export) is unchanged.