### PR TITLE
fix(indexer): raise default substate rate limit

### DIFF
--- a/applications/tari_indexer/src/config.rs
+++ b/applications/tari_indexer/src/config.rs
@@ -282,7 +282,7 @@ impl Default for IndexerRateLimitsConfig {
             enabled: false,
             transactions_submit_rate: RefillRate::new(20.0, window).unwrap(),
             transactions_dry_run_submit_rate: RefillRate::new(20.0, window).unwrap(),
-            substates_rate: RefillRate::new(10.0, window).unwrap(),
+            substates_rate: RefillRate::new(20.0, Duration::from_secs(20)).unwrap(),
             utxos_fetch_rate: RefillRate::new(20.0, window).unwrap(),
             non_fungibles_rate: RefillRate::new(10.0, window).unwrap(),
             transactions_rate: RefillRate::new(5.0, window).unwrap(),


### PR DESCRIPTION
Description
---
fix(indexer): raise default substate rate limit

Motivation and Context
---
Wallets query substates and hit the limiter previously when doing a normal poll


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify