### PR TITLE
feat(p2p)!: sync state for many shards over a single stream

### DIFF
--- a/applications/tari_indexer/src/network_state_sync/worker.rs
+++ b/applications/tari_indexer/src/network_state_sync/worker.rs
@@ -533,7 +533,7 @@ impl NetworkWideStateSync {
         shard_group: ShardGroup,
         session: &mut ValidatorRpcSession,
     ) -> Result<(), NetworkStateSyncError> {
-        let requested = cursors.iter().map(|c| Shard::from(c.shard)).collect::<HashSet<_>>();
+        let mut order = StreamOrder::new(&cursors);
 
         info!(
             target: LOG_TARGET,
@@ -569,11 +569,9 @@ impl NetworkWideStateSync {
                 Some(rpc::sync_state_response::Response::Batch(batch)) => batch,
                 Some(rpc::sync_state_response::Response::Complete(complete)) => {
                     let shard = Shard::from(complete.shard);
-                    if !requested.contains(&shard) {
-                        return Err(NetworkStateSyncError::InvalidStateUpdate {
-                            details: format!("Received completion marker for unrequested shard {shard}"),
-                        });
-                    }
+                    order
+                        .accept_marker(shard)
+                        .map_err(|details| NetworkStateSyncError::InvalidStateUpdate { details })?;
                     // Terminal watermark: advance recorded progress to the version the producer is
                     // synced to. This covers trailing versions that streamed no updates because their
                     // substates are all filtered out for our subscription - without it we could never
@@ -617,18 +615,16 @@ impl NetworkWideStateSync {
             };
 
             let shard = Shard::from(batch.shard);
-            if !requested.contains(&shard) {
-                return Err(NetworkStateSyncError::InvalidStateUpdate {
-                    details: format!("Received batch for unrequested shard {shard}"),
-                });
-            }
+            let state_version = StateVersion::new(batch.state_version);
+            order
+                .accept_batch(shard, state_version, batch.has_more)
+                .map_err(|details| NetworkStateSyncError::InvalidStateUpdate { details })?;
             let msg_epoch = batch
                 .epoch
                 .map(Epoch::from)
                 .ok_or_else(|| NetworkStateSyncError::InvalidStateUpdate {
                     details: "Received state update without epoch".to_string(),
                 })?;
-            let state_version = StateVersion::new(batch.state_version);
 
             for update in batch.updates {
                 let update =
@@ -754,6 +750,86 @@ impl NetworkWideStateSync {
             });
         }
 
+        Ok(())
+    }
+}
+
+/// Enforces the ordering a `sync_state` stream promises across the shards it carries: each shard is
+/// streamed contiguously, its versions strictly advance, and nothing for it follows its completion
+/// marker.
+///
+/// The consumer relies on all three. Its buffers hold one `(shard, state version)` at a time, so an
+/// interleaved shard would mix two shards' updates into one commit; and because the running economic
+/// totals are read-modify-write, re-applying a version already committed would double-count it.
+struct StreamOrder {
+    /// Highest version committed per requested shard, seeded from the cursor so a responder cannot
+    /// replay versions the caller already holds.
+    committed_versions: HashMap<Shard, StateVersion>,
+    completed: HashSet<Shard>,
+    /// Set while a version is split across chunks, until the chunk that flushes it.
+    pending_chunk: Option<(Shard, StateVersion)>,
+}
+
+impl StreamOrder {
+    fn new(cursors: &[rpc::ShardCursor]) -> Self {
+        Self {
+            committed_versions: cursors
+                .iter()
+                .map(|c| {
+                    (
+                        Shard::from(c.shard),
+                        StateVersion::new(c.start_state_version.saturating_sub(1)),
+                    )
+                })
+                .collect(),
+            completed: HashSet::new(),
+            pending_chunk: None,
+        }
+    }
+
+    fn accept_batch(&mut self, shard: Shard, state_version: StateVersion, has_more: bool) -> Result<(), String> {
+        let Some(committed_version) = self.committed_versions.get(&shard).copied() else {
+            return Err(format!("Received batch for unrequested shard {shard}"));
+        };
+        if self.completed.contains(&shard) {
+            return Err(format!("Received batch for shard {shard} after its completion marker"));
+        }
+        if state_version <= committed_version {
+            return Err(format!(
+                "Received v{state_version} for shard {shard}, which is not ahead of the committed v{committed_version}"
+            ));
+        }
+        if let Some(pending) = self.pending_chunk &&
+            pending != (shard, state_version)
+        {
+            return Err(format!(
+                "Received v{state_version} of shard {shard} while v{} of shard {} is still incomplete",
+                pending.1, pending.0
+            ));
+        }
+
+        if has_more {
+            self.pending_chunk = Some((shard, state_version));
+        } else {
+            self.pending_chunk = None;
+            self.committed_versions.insert(shard, state_version);
+        }
+        Ok(())
+    }
+
+    fn accept_marker(&mut self, shard: Shard) -> Result<(), String> {
+        if !self.committed_versions.contains_key(&shard) {
+            return Err(format!("Received completion marker for unrequested shard {shard}"));
+        }
+        if let Some((pending_shard, pending_version)) = self.pending_chunk {
+            return Err(format!(
+                "Received completion marker for shard {shard} while v{pending_version} of shard {pending_shard} is \
+                 still incomplete"
+            ));
+        }
+        if !self.completed.insert(shard) {
+            return Err(format!("Received a second completion marker for shard {shard}"));
+        }
         Ok(())
     }
 }
@@ -924,4 +1000,107 @@ fn extend_bufs_from_substate_update(
 
     update_buf.push((msg_epoch, update));
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod stream_order {
+        use super::*;
+
+        const S1: Shard = Shard::from_u32(1);
+        const S2: Shard = Shard::from_u32(2);
+
+        fn order(cursors: &[(u32, u64)]) -> StreamOrder {
+            let cursors = cursors
+                .iter()
+                .map(|&(shard, start_state_version)| rpc::ShardCursor {
+                    shard,
+                    start_state_version,
+                })
+                .collect::<Vec<_>>();
+            StreamOrder::new(&cursors)
+        }
+
+        fn v(n: u64) -> StateVersion {
+            StateVersion::new(n)
+        }
+
+        #[test]
+        fn it_accepts_shards_streamed_one_after_another() {
+            let mut o = order(&[(1, 1), (2, 1)]);
+            o.accept_batch(S1, v(1), false).unwrap();
+            o.accept_batch(S1, v(4), false).unwrap();
+            o.accept_marker(S1).unwrap();
+            o.accept_batch(S2, v(7), false).unwrap();
+            o.accept_marker(S2).unwrap();
+        }
+
+        #[test]
+        fn it_accepts_a_version_split_across_chunks() {
+            let mut o = order(&[(1, 1)]);
+            o.accept_batch(S1, v(3), true).unwrap();
+            o.accept_batch(S1, v(3), true).unwrap();
+            o.accept_batch(S1, v(3), false).unwrap();
+            o.accept_marker(S1).unwrap();
+        }
+
+        #[test]
+        fn it_rejects_a_version_below_the_cursor() {
+            // A cursor of 5 asks to resume at v5, so v5 is wanted and everything under it is already held.
+            assert!(order(&[(1, 5)]).accept_batch(S1, v(3), false).is_err());
+            assert!(order(&[(1, 5)]).accept_batch(S1, v(4), false).is_err());
+            order(&[(1, 5)]).accept_batch(S1, v(5), false).unwrap();
+        }
+
+        #[test]
+        fn it_rejects_a_replayed_version() {
+            let mut o = order(&[(1, 1)]);
+            o.accept_batch(S1, v(9), false).unwrap();
+            assert!(o.accept_batch(S1, v(9), false).is_err());
+        }
+
+        #[test]
+        fn it_rejects_a_regressing_version() {
+            let mut o = order(&[(1, 1)]);
+            o.accept_batch(S1, v(9), false).unwrap();
+            assert!(o.accept_batch(S1, v(8), false).is_err());
+        }
+
+        #[test]
+        fn it_rejects_a_batch_after_the_shards_marker() {
+            let mut o = order(&[(1, 1)]);
+            o.accept_batch(S1, v(2), false).unwrap();
+            o.accept_marker(S1).unwrap();
+            assert!(o.accept_batch(S1, v(3), false).is_err());
+        }
+
+        #[test]
+        fn it_rejects_an_interleaved_shard_mid_version() {
+            let mut o = order(&[(1, 1), (2, 1)]);
+            o.accept_batch(S1, v(3), true).unwrap();
+            assert!(o.accept_batch(S2, v(1), false).is_err());
+        }
+
+        #[test]
+        fn it_rejects_a_marker_while_a_version_is_incomplete() {
+            let mut o = order(&[(1, 1)]);
+            o.accept_batch(S1, v(3), true).unwrap();
+            assert!(o.accept_marker(S1).is_err());
+        }
+
+        #[test]
+        fn it_rejects_a_second_marker_for_a_shard() {
+            let mut o = order(&[(1, 1)]);
+            o.accept_marker(S1).unwrap();
+            assert!(o.accept_marker(S1).is_err());
+        }
+
+        #[test]
+        fn it_rejects_unrequested_shards() {
+            assert!(order(&[(1, 1)]).accept_batch(S2, v(1), false).is_err());
+            assert!(order(&[(1, 1)]).accept_marker(S2).is_err());
+        }
+    }
 }

--- a/applications/tari_indexer/src/network_state_sync/worker.rs
+++ b/applications/tari_indexer/src/network_state_sync/worker.rs
@@ -20,15 +20,7 @@ use tari_epoch_manager::{EpochManagerEvent, EpochManagerReader, service::EpochMa
 use tari_indexer_client::event::{IndexerEvent, NewEpochEvent, TransactionEvent, TransactionFinalizedEvent};
 use tari_indexer_lib::substate_versions::SubstateVersionTracker;
 use tari_networking::NetworkingHandle;
-use tari_ootle_common_types::{
-    Epoch,
-    ShardGroup,
-    StateVersion,
-    VotePower,
-    displayable::Displayable,
-    optional::Optional,
-    shard::Shard,
-};
+use tari_ootle_common_types::{Epoch, ShardGroup, StateVersion, VotePower, optional::Optional, shard::Shard};
 use tari_ootle_p2p::{PeerAddress, TariMessagingSpec, proto::rpc};
 use tari_ootle_storage::{
     StorageError,
@@ -393,17 +385,11 @@ impl NetworkWideStateSync {
 
     async fn sync_state(&mut self, sync_plan_mut: &mut SyncPlan) -> Result<(), NetworkStateSyncError> {
         let committee_pools = sync_plan_mut.committee_pools().clone();
-        let mut update_buf = Vec::new();
-        let mut utxos_buf = Vec::new();
-        let mut transactions_buf = Vec::new();
-        let mut validator_fee_pools_buf = Vec::new();
-        let mut template_catalogue_buf: Vec<(TemplateAddress, PublishedTemplateMetadata)> = Vec::new();
 
         let mut has_synced_global_shard = false;
 
         for (shard_group, mut pool) in committee_pools {
             // TODO: consider syncing shards in epoch chunks rather than one after another
-            // TODO: consider parallelizing shard syncs within a shard group
             let mut session = match pool.new_session().await {
                 Ok(s) => s,
                 Err(e) => {
@@ -426,36 +412,80 @@ impl NetworkWideStateSync {
                     continue;
                 },
             }
-            if !has_synced_global_shard {
-                self.sync_shard_state(
-                    Shard::global(),
-                    sync_plan_mut,
-                    &mut update_buf,
-                    &mut utxos_buf,
-                    &mut transactions_buf,
-                    &mut validator_fee_pools_buf,
-                    &mut template_catalogue_buf,
-                    shard_group,
-                    &mut session,
-                )
-                .await?;
-                has_synced_global_shard = true;
-            }
 
-            for shard in shard_group.shard_iter() {
-                self.sync_shard_state(
-                    shard,
-                    sync_plan_mut,
-                    &mut update_buf,
-                    &mut utxos_buf,
-                    &mut transactions_buf,
-                    &mut validator_fee_pools_buf,
-                    &mut template_catalogue_buf,
-                    shard_group,
-                    &mut session,
-                )
+            // Every committee holds the global shard, so it is synced once per round from whichever
+            // committee is reached first. Shard 0 sorts before every preshard, which keeps the cursor
+            // list ascending as the responder requires.
+            let shards = (!has_synced_global_shard)
+                .then_some(Shard::global())
+                .into_iter()
+                .chain(shard_group.shard_iter());
+
+            self.sync_shard_group_state(shards, sync_plan_mut, shard_group, &mut session)
                 .await?;
+            has_synced_global_shard = true;
+        }
+
+        Ok(())
+    }
+
+    /// Syncs every given shard from `session`, which serves them all over a single stream.
+    ///
+    /// A shard that has never been synced wants only the current head state rather than its full
+    /// history, which is expressed by the `UP_ONLY` filter. Filters apply to the whole request, so
+    /// such shards are streamed separately from the ones being caught up incrementally: two streams
+    /// per shard group at most, and one in the steady state.
+    async fn sync_shard_group_state(
+        &mut self,
+        shards: impl Iterator<Item = Shard>,
+        sync_plan_mut: &mut SyncPlan,
+        shard_group: ShardGroup,
+        session: &mut ValidatorRpcSession,
+    ) -> Result<(), NetworkStateSyncError> {
+        let value_filters = SubstateValueFilterFlags::UTXO |
+            SubstateValueFilterFlags::VALIDATOR_FEE_POOL |
+            SubstateValueFilterFlags::CLAIMED_OUTPUT_TOMBSTONE |
+            SubstateValueFilterFlags::TRANSACTION_RECEIPT |
+            SubstateValueFilterFlags::TEMPLATE_METADATA;
+
+        let mut from_scratch = Vec::new();
+        let mut incremental = Vec::new();
+        for shard in shards {
+            let prev_version = sync_plan_mut
+                .sync_progress()
+                .last_state_versions
+                .get(&shard)
+                .map_or(0, |(v, _)| v.as_u64());
+            let cursor = rpc::ShardCursor {
+                shard: shard.as_u32(),
+                start_state_version: prev_version + 1,
+            };
+            if prev_version == 0 {
+                from_scratch.push(cursor);
+            } else {
+                incremental.push(cursor);
             }
+        }
+
+        if !from_scratch.is_empty() {
+            info!(
+                target: LOG_TARGET,
+                "🌍️ Syncing {} shard(s) in shard group {shard_group} from scratch. Only fetching the head state.",
+                from_scratch.len()
+            );
+            self.stream_shard_state(
+                from_scratch,
+                value_filters | SubstateValueFilterFlags::UP_ONLY,
+                sync_plan_mut,
+                shard_group,
+                session,
+            )
+            .await?;
+        }
+
+        if !incremental.is_empty() {
+            self.stream_shard_state(incremental, value_filters, sync_plan_mut, shard_group, session)
+                .await?;
         }
 
         Ok(())
@@ -489,113 +519,116 @@ impl NetworkWideStateSync {
         Ok(())
     }
 
+    /// Consumes a single `sync_state` stream covering `cursors`.
+    ///
+    /// The responder streams each shard's updates contiguously and closes it off with a completion
+    /// marker, so progress is recorded per shard as the stream advances - an interrupted stream keeps
+    /// everything already committed and simply resumes from the recorded cursors next round.
     #[expect(clippy::too_many_lines)]
-    async fn sync_shard_state(
+    async fn stream_shard_state(
         &mut self,
-        shard: Shard,
+        cursors: Vec<rpc::ShardCursor>,
+        value_filters: SubstateValueFilterFlags,
         sync_plan_mut: &mut SyncPlan,
-        update_buf: &mut Vec<(Epoch, SubstateUpdateProof)>,
-        utxos_buf: &mut Vec<UtxoUpdateRecord>,
-        transactions_buf: &mut Vec<(TransactionReceiptAddress, TransactionReceipt)>,
-        validator_fee_pools_buf: &mut Vec<SubstateData>,
-        template_catalogue_buf: &mut Vec<(TemplateAddress, PublishedTemplateMetadata)>,
         shard_group: ShardGroup,
         session: &mut ValidatorRpcSession,
     ) -> Result<(), NetworkStateSyncError> {
-        // Perform sync operations using the pool and state
-        let (prev_version, prev_epoch) = sync_plan_mut
-            .sync_progress()
-            .last_state_versions
-            .get(&shard)
-            .map(|(v, e)| (v.as_u64(), *e))
-            .unwrap_or_else(|| (0, Epoch::zero()));
-        let from_version = prev_version + 1;
+        let requested = cursors.iter().map(|c| Shard::from(c.shard)).collect::<HashSet<_>>();
 
-        info!(target: LOG_TARGET, "🌍️ Starting state sync for shard {shard} from version {from_version}");
-        let mut value_filters = SubstateValueFilterFlags::UTXO |
-            SubstateValueFilterFlags::VALIDATOR_FEE_POOL |
-            SubstateValueFilterFlags::CLAIMED_OUTPUT_TOMBSTONE |
-            SubstateValueFilterFlags::TRANSACTION_RECEIPT |
-            SubstateValueFilterFlags::TEMPLATE_METADATA;
-
-        if prev_version == 0 {
-            info!(target: LOG_TARGET, "🌍️ Syncing shard {shard} in shard group {shard_group} from scratch (starting from version 0). Only fetching the head state.");
-            // If we are syncing from scratch, only get up states to reduce initial sync size
-            value_filters |= SubstateValueFilterFlags::UP_ONLY;
-        }
+        info!(
+            target: LOG_TARGET,
+            "🌍️ Starting state sync for {} shard(s) in shard group {shard_group} from peer {}",
+            cursors.len(),
+            session.peer_address()
+        );
 
         let mut stream = session
             .sync_state(rpc::SyncStateRequest {
-                start_state_version: from_version,
-                shard: shard.as_u32(),
+                cursors,
                 // Sync to latest epoch
                 until_epoch: None,
                 value_filters: value_filters.bits(),
             })
             .await?;
 
-        let mut is_first_iter = true;
+        // Buffers accumulate a single (shard, state version) at a time: the responder splits an
+        // oversized version into chunks flagged `has_more`, and the last chunk flushes them.
+        let mut update_buf = Vec::new();
+        let mut utxos_buf = Vec::new();
+        let mut transactions_buf = Vec::new();
+        let mut validator_fee_pools_buf = Vec::new();
+        let mut template_catalogue_buf: Vec<(TemplateAddress, PublishedTemplateMetadata)> = Vec::new();
         let mut xtr_claimed = Amount::zero();
         let mut xtr_fees = Amount::zero();
         let mut xtr_receipt_burn = Amount::zero();
-        let mut last_version = StateVersion::new(from_version);
-        let mut last_epoch = None;
+
+        let mut saw_final = false;
         while let Some(result) = stream.next().await {
-            if is_first_iter {
-                // Avoid log spam, only log once per stream
-                debug!(target: LOG_TARGET, "🌍️ Established stream for {shard} in shard group {shard_group} from peer {} (last sync: {prev_epoch} {prev_version})", session.peer_address());
-                is_first_iter = false;
-            }
             let msg = result?;
-            let batch =
-                match msg.response {
-                    Some(rpc::sync_state_response::Response::Batch(batch)) => batch,
-                    Some(rpc::sync_state_response::Response::Complete(complete)) => {
-                        // Terminal watermark: advance recorded progress to the version the producer is
-                        // synced to. This covers trailing versions that streamed no updates because their
-                        // substates are all filtered out for our subscription - without it we could never
-                        // observe that we have caught up to such a shard and would re-sync it from scratch
-                        // every round.
-                        let synced_to = StateVersion::new(complete.synced_to_version);
-                        let msg_epoch = complete.epoch.map(Epoch::from).ok_or_else(|| {
-                            NetworkStateSyncError::InvalidStateUpdate {
-                                details: "Received sync completion without epoch".to_string(),
-                            }
-                        })?;
-                        last_version = synced_to;
-                        last_epoch = Some(msg_epoch);
-                        // Only persist when the watermark advances - a caught-up shard re-sends the same
-                        // version every round, and we must not write on every empty round.
-                        let already_synced = sync_plan_mut
-                            .sync_progress()
-                            .last_state_versions
-                            .get(&shard)
-                            .is_some_and(|(v, _)| synced_to <= *v);
-                        if !already_synced {
-                            sync_plan_mut.add_state_sync_progress(shard, synced_to, msg_epoch);
-                            let sync_progress_snapshot = sync_plan_mut.sync_progress().clone();
-                            self.store
-                                .clone()
-                                .with_write_tx(move |tx| tx.key_value_set(Key::SyncProgress, sync_progress_snapshot))
-                                .await?;
-                        }
-                        break;
-                    },
-                    None => {
+            let batch = match msg.response {
+                Some(rpc::sync_state_response::Response::Batch(batch)) => batch,
+                Some(rpc::sync_state_response::Response::Complete(complete)) => {
+                    let shard = Shard::from(complete.shard);
+                    if !requested.contains(&shard) {
                         return Err(NetworkStateSyncError::InvalidStateUpdate {
-                            details: "Received sync state response with no variant set".to_string(),
+                            details: format!("Received completion marker for unrequested shard {shard}"),
                         });
-                    },
-                };
+                    }
+                    // Terminal watermark: advance recorded progress to the version the producer is
+                    // synced to. This covers trailing versions that streamed no updates because their
+                    // substates are all filtered out for our subscription - without it we could never
+                    // observe that we have caught up to such a shard and would re-sync it from scratch
+                    // every round.
+                    let synced_to = StateVersion::new(complete.synced_to_version);
+                    let msg_epoch =
+                        complete
+                            .epoch
+                            .map(Epoch::from)
+                            .ok_or_else(|| NetworkStateSyncError::InvalidStateUpdate {
+                                details: "Received sync completion without epoch".to_string(),
+                            })?;
+                    // Only persist when the watermark advances - a caught-up shard re-sends the same
+                    // version every round, and we must not write on every empty round.
+                    let already_synced = sync_plan_mut
+                        .sync_progress()
+                        .last_state_versions
+                        .get(&shard)
+                        .is_some_and(|(v, _)| synced_to <= *v);
+                    if !already_synced {
+                        sync_plan_mut.add_state_sync_progress(shard, synced_to, msg_epoch);
+                        let sync_progress_snapshot = sync_plan_mut.sync_progress().clone();
+                        self.store
+                            .clone()
+                            .with_write_tx(move |tx| tx.key_value_set(Key::SyncProgress, sync_progress_snapshot))
+                            .await?;
+                    }
+                    debug!(target: LOG_TARGET, "🌍️ Completed state sync for shard {shard} in shard group {shard_group} to epoch {msg_epoch} and state version {synced_to}");
+                    if complete.is_final {
+                        saw_final = true;
+                        break;
+                    }
+                    continue;
+                },
+                None => {
+                    return Err(NetworkStateSyncError::InvalidStateUpdate {
+                        details: "Received sync state response with no variant set".to_string(),
+                    });
+                },
+            };
+
+            let shard = Shard::from(batch.shard);
+            if !requested.contains(&shard) {
+                return Err(NetworkStateSyncError::InvalidStateUpdate {
+                    details: format!("Received batch for unrequested shard {shard}"),
+                });
+            }
             let msg_epoch = batch
                 .epoch
                 .map(Epoch::from)
                 .ok_or_else(|| NetworkStateSyncError::InvalidStateUpdate {
                     details: "Received state update without epoch".to_string(),
                 })?;
-            last_epoch = Some(msg_epoch);
             let state_version = StateVersion::new(batch.state_version);
-            last_version = state_version;
 
             for update in batch.updates {
                 let update =
@@ -609,11 +642,11 @@ impl NetworkWideStateSync {
                     state_version,
                     update,
                     msg_epoch,
-                    update_buf,
-                    utxos_buf,
-                    transactions_buf,
-                    validator_fee_pools_buf,
-                    template_catalogue_buf,
+                    &mut update_buf,
+                    &mut utxos_buf,
+                    &mut transactions_buf,
+                    &mut validator_fee_pools_buf,
+                    &mut template_catalogue_buf,
                     &mut xtr_claimed,
                     &mut xtr_fees,
                     &mut xtr_receipt_burn,
@@ -628,9 +661,9 @@ impl NetworkWideStateSync {
 
             self.stats.increase_state_updates(update_buf.len());
 
-            let updates = std::mem::take(update_buf);
-            let utxos = std::mem::take(utxos_buf);
-            let transactions = std::mem::take(transactions_buf);
+            let updates = std::mem::take(&mut update_buf);
+            let utxos = std::mem::take(&mut utxos_buf);
+            let transactions = std::mem::take(&mut transactions_buf);
 
             // Upping a substate is the point at which its previous version goes down, so this is the
             // substate cache's only signal that an entry it holds has been superseded.
@@ -640,8 +673,8 @@ impl NetworkWideStateSync {
                     .flat_map(|(_, receipt)| receipt.diff_summary().upped.iter())
                     .map(|up| (&up.substate_id, up.version)),
             );
-            let validator_fee_pools = std::mem::take(validator_fee_pools_buf);
-            let template_catalogue = std::mem::take(template_catalogue_buf);
+            let validator_fee_pools = std::mem::take(&mut validator_fee_pools_buf);
+            let template_catalogue = std::mem::take(&mut template_catalogue_buf);
 
             let updates_len = updates.len();
             let utxos_len = utxos.len();
@@ -712,7 +745,15 @@ impl NetworkWideStateSync {
                 });
             }
         }
-        info!(target: LOG_TARGET, "🌍️ Completed state sync for shard {shard} in shard group {shard_group} to epoch {} and state version {last_version}",last_epoch.display() );
+
+        if !saw_final {
+            return Err(NetworkStateSyncError::InvalidStateUpdate {
+                details: format!(
+                    "State sync stream for shard group {shard_group} ended without a final completion marker"
+                ),
+            });
+        }
+
         Ok(())
     }
 }

--- a/applications/tari_validator_node/src/p2p/rpc/rpc_impl.rs
+++ b/applications/tari_validator_node/src/p2p/rpc/rpc_impl.rs
@@ -495,8 +495,8 @@ impl<TStateStore: StateStore + Clone + Send + Sync + 'static> ValidatorNodeRpcSe
             target: LOG_TARGET,
             "🌍 peer initiated sync with this node for {} shard(s) ({} to {}) to {} (values: {:?})",
             cursors.len(),
-            cursors.first().expect("validate_all rejects an empty list").shard,
-            cursors.last().expect("validate_all rejects an empty list").shard,
+            cursors.first().map(|c| c.shard).display(),
+            cursors.last().map(|c| c.shard).display(),
             end_epoch.display(),
             value_filter_flags
         );

--- a/applications/tari_validator_node/src/p2p/rpc/rpc_impl.rs
+++ b/applications/tari_validator_node/src/p2p/rpc/rpc_impl.rs
@@ -39,7 +39,6 @@ use tari_ootle_common_types::{
     SubstateRequirement,
     displayable::Displayable,
     optional::Optional,
-    shard::Shard,
 };
 use tari_ootle_p2p::{
     PeerAddress,
@@ -90,7 +89,10 @@ use tokio::{sync::mpsc, task};
 use crate::{
     consensus::ConsensusHandle,
     p2p::{
-        rpc::{block_sync_task::BlockSyncTask, state_sync_task::StateSyncTask},
+        rpc::{
+            block_sync_task::BlockSyncTask,
+            state_sync_task::{ShardCursor, StateSyncTask},
+        },
         services::mempool::MempoolHandle,
     },
 };
@@ -478,19 +480,9 @@ impl<TStateStore: StateStore + Clone + Send + Sync + 'static> ValidatorNodeRpcSe
 
         let (sender, receiver) = mpsc::channel(10);
 
-        let shard = Shard::from_u32(req.shard);
-        if shard > NumPreshards::MAX_SHARD {
-            return Err(RpcStatus::bad_request(format!(
-                "Shard {} out of range. Maximum shard is {}",
-                shard,
-                NumPreshards::MAX_SHARD
-            )));
-        }
+        let cursors = ShardCursor::validate_all(req.cursors)?;
 
         let end_epoch = req.until_epoch.map(Epoch::from);
-        if req.start_state_version == 0 {
-            return Err(RpcStatus::bad_request("start_state_version must be greater than 0"));
-        }
 
         let value_filter_flags = SubstateValueFilterFlags::from_bits_truncate(req.value_filters);
         if value_filter_flags.is_empty() {
@@ -501,9 +493,10 @@ impl<TStateStore: StateStore + Clone + Send + Sync + 'static> ValidatorNodeRpcSe
 
         debug!(
             target: LOG_TARGET,
-            "🌍 peer initiated sync with this node (start: v{}, {}) to {} (values: {:?})",
-            req.start_state_version,
-            shard,
+            "🌍 peer initiated sync with this node for {} shard(s) ({} to {}) to {} (values: {:?})",
+            cursors.len(),
+            cursors.first().expect("validate_all rejects an empty list").shard,
+            cursors.last().expect("validate_all rejects an empty list").shard,
             end_epoch.display(),
             value_filter_flags
         );
@@ -512,8 +505,7 @@ impl<TStateStore: StateStore + Clone + Send + Sync + 'static> ValidatorNodeRpcSe
             StateSyncTask::new(
                 self.state_store.clone(),
                 sender,
-                shard,
-                req.start_state_version,
+                cursors,
                 end_epoch,
                 self.consensus.current_epoch(),
                 STATE_SYNC_MAX_BATCH_SIZE

--- a/applications/tari_validator_node/src/p2p/rpc/state_sync_task.rs
+++ b/applications/tari_validator_node/src/p2p/rpc/state_sync_task.rs
@@ -4,7 +4,7 @@
 use std::num::NonZeroUsize;
 
 use log::*;
-use tari_ootle_common_types::{Epoch, optional::Optional, shard::Shard};
+use tari_ootle_common_types::{Epoch, NumPreshards, optional::Optional, shard::Shard};
 use tari_ootle_p2p::proto::rpc;
 use tari_ootle_storage::{
     StateStore,
@@ -18,11 +18,65 @@ use tokio::sync::mpsc;
 
 const LOG_TARGET: &str = "tari::ootle::rpc::sync_task";
 
+/// A validated resume point for a single shard.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShardCursor {
+    pub shard: Shard,
+    pub start_state_version: Version,
+}
+
+impl ShardCursor {
+    /// Validates a caller-supplied cursor list.
+    ///
+    /// Ascending order rules out duplicates and lets the responder stream each shard contiguously,
+    /// which is what allows a consumer to finalise a shard the moment its completion marker arrives.
+    pub fn validate_all(cursors: Vec<rpc::ShardCursor>) -> Result<Vec<Self>, RpcStatus> {
+        if cursors.is_empty() {
+            return Err(RpcStatus::bad_request("At least one shard cursor must be provided"));
+        }
+        // The global shard is streamable alongside every preshard, so one more than the preshard count.
+        let max_cursors = NumPreshards::MAX.num_shards() + 1;
+        if cursors.len() > max_cursors {
+            return Err(RpcStatus::bad_request(format!(
+                "Too many shard cursors: {}. At most {max_cursors} may be requested",
+                cursors.len(),
+            )));
+        }
+
+        let mut validated = Vec::with_capacity(cursors.len());
+        let mut prev_shard = None::<Shard>;
+        for cursor in cursors {
+            let shard = Shard::from_u32(cursor.shard);
+            if shard > NumPreshards::MAX_SHARD {
+                return Err(RpcStatus::bad_request(format!(
+                    "Shard {shard} out of range. Maximum shard is {}",
+                    NumPreshards::MAX_SHARD
+                )));
+            }
+            if prev_shard.is_some_and(|prev| shard <= prev) {
+                return Err(RpcStatus::bad_request(
+                    "Shard cursors must be ordered by strictly ascending shard",
+                ));
+            }
+            // Genesis is committed at version 0 and is never synced - every node bootstraps it.
+            if cursor.start_state_version == 0 {
+                return Err(RpcStatus::bad_request("start_state_version must be greater than 0"));
+            }
+            prev_shard = Some(shard);
+            validated.push(Self {
+                shard,
+                start_state_version: cursor.start_state_version,
+            });
+        }
+
+        Ok(validated)
+    }
+}
+
 pub struct StateSyncTask<TStateStore: StateStore> {
     store: TStateStore,
     sender: mpsc::Sender<Result<rpc::SyncStateResponse, RpcStatus>>,
-    shard: Shard,
-    start_state_version: Version,
+    cursors: Vec<ShardCursor>,
     end_epoch: Option<Epoch>,
     current_epoch: Epoch,
     batch_size: NonZeroUsize,
@@ -33,8 +87,7 @@ impl<TStateStore: StateStore> StateSyncTask<TStateStore> {
     pub fn new(
         store: TStateStore,
         sender: mpsc::Sender<Result<rpc::SyncStateResponse, RpcStatus>>,
-        shard: Shard,
-        start_state_version: Version,
+        cursors: Vec<ShardCursor>,
         end_epoch: Option<Epoch>,
         current_epoch: Epoch,
         batch_size: NonZeroUsize,
@@ -43,8 +96,7 @@ impl<TStateStore: StateStore> StateSyncTask<TStateStore> {
         Self {
             store,
             sender,
-            shard,
-            start_state_version,
+            cursors,
             end_epoch,
             current_epoch,
             batch_size,
@@ -53,15 +105,29 @@ impl<TStateStore: StateStore> StateSyncTask<TStateStore> {
     }
 
     pub async fn run(mut self) -> Result<(), ()> {
+        // Each shard's updates are streamed contiguously, in the order the caller listed them, so a
+        // consumer can finalise a shard the moment its completion marker arrives.
+        let cursors = std::mem::take(&mut self.cursors);
+        let Some(last_index) = cursors.len().checked_sub(1) else {
+            return Ok(());
+        };
+        for (i, cursor) in cursors.into_iter().enumerate() {
+            self.run_for_shard(&cursor, i == last_index).await?;
+        }
+        Ok(())
+    }
+
+    async fn run_for_shard(&mut self, cursor: &ShardCursor, is_final: bool) -> Result<(), ()> {
+        let shard = cursor.shard;
         // For an unbounded (sync-to-tip) request, snapshot the committed tree tip before scanning. The
         // completion marker advances the client over trailing versions that stream no updates (all
         // filtered out for its subscription). Snapshotting first ensures the marker never reports
         // beyond what we streamed: anything committed after this point is left for the next round.
         let tip_at_start = if self.end_epoch.is_none() {
-            match self.read_latest_tree_version() {
+            match self.read_latest_tree_version(shard) {
                 Ok(version) => version,
                 Err(err) => {
-                    error!(target: LOG_TARGET, "🌍 Error reading latest tree version for {}: {}", self.shard, err);
+                    error!(target: LOG_TARGET, "🌍 Error reading latest tree version for {}: {}", shard, err);
                     self.send(Err(RpcStatus::log_internal_error(LOG_TARGET)(err))).await?;
                     return Err(());
                 },
@@ -70,11 +136,11 @@ impl<TStateStore: StateStore> StateSyncTask<TStateStore> {
             None
         };
 
-        let mut current_state_version = self.start_state_version;
+        let mut current_state_version = cursor.start_state_version;
         let mut counter = 0usize;
         let mut last_sent_version: Option<Version> = None;
         loop {
-            match self.fetch_next_batch(current_state_version) {
+            match self.fetch_next_batch(shard, current_state_version) {
                 Ok(Some(transitions)) => {
                     if let Some(end_epoch) = self.end_epoch {
                         // TODO(perf): might be better to not load in the first place, however also might incur the cost
@@ -85,7 +151,7 @@ impl<TStateStore: StateStore> StateSyncTask<TStateStore> {
                         }
                     }
                     if !transitions.updates.is_empty() {
-                        debug!(target: LOG_TARGET, "🌍 Fetched {} state transition(s) up to v{}", transitions.updates.len(), transitions.state_version);
+                        debug!(target: LOG_TARGET, "🌍 Fetched {} state transition(s) for {} up to v{}", transitions.updates.len(), shard, transitions.state_version);
                     }
 
                     current_state_version = transitions.state_version + 1;
@@ -102,7 +168,7 @@ impl<TStateStore: StateStore> StateSyncTask<TStateStore> {
                 },
                 Ok(None) => {
                     // TODO: differentiate between not found and end of stream
-                    debug!(target: LOG_TARGET, "🌍sync complete ({}). {} update(s) sent.", current_state_version, counter);
+                    debug!(target: LOG_TARGET, "🌍sync complete for {} ({}). {} update(s) sent.", shard, current_state_version, counter);
                     break;
                 },
                 Err(err) => {
@@ -113,15 +179,15 @@ impl<TStateStore: StateStore> StateSyncTask<TStateStore> {
             }
         }
 
-        self.send_complete(tip_at_start, last_sent_version).await
+        self.send_complete(cursor, tip_at_start, last_sent_version, is_final)
+            .await
     }
 
-    fn read_latest_tree_version(&self) -> Result<Option<Version>, StorageError> {
-        self.store
-            .with_read_tx(|tx| tx.state_tree_versions_get_latest(self.shard))
+    fn read_latest_tree_version(&self, shard: Shard) -> Result<Option<Version>, StorageError> {
+        self.store.with_read_tx(|tx| tx.state_tree_versions_get_latest(shard))
     }
 
-    /// Terminates every stream with a `SyncComplete` stating the version the client is now synced to.
+    /// Closes off a shard with a `SyncComplete` stating the version the client is now synced to.
     ///
     /// For an unbounded request this is the committed tree tip (capped to what we streamed), letting the
     /// client advance over trailing versions that streamed no updates - e.g. a shard whose latest
@@ -133,20 +199,24 @@ impl<TStateStore: StateStore> StateSyncTask<TStateStore> {
     /// just our last streamed version - the consumer does not trust it as the sync target.
     async fn send_complete(
         &mut self,
+        cursor: &ShardCursor,
         tip_at_start: Option<Version>,
         last_sent_version: Option<Version>,
+        is_final: bool,
     ) -> Result<(), ()> {
         let synced_to_version = match tip_at_start {
             // Unbounded: advance to the committed tip, but never past a version we actually streamed.
             Some(tip) => tip.max(last_sent_version.unwrap_or(0)),
             // Bounded, or an unbounded shard with no committed state: report the last streamed version.
-            None => last_sent_version.unwrap_or_else(|| self.start_state_version.saturating_sub(1)),
+            None => last_sent_version.unwrap_or_else(|| cursor.start_state_version.saturating_sub(1)),
         };
 
         self.send(Ok(rpc::SyncStateResponse {
             response: Some(rpc::sync_state_response::Response::Complete(rpc::SyncComplete {
                 synced_to_version,
                 epoch: Some(self.current_epoch.into()),
+                shard: cursor.shard.as_u32(),
+                is_final,
             })),
         }))
         .await
@@ -154,10 +224,11 @@ impl<TStateStore: StateStore> StateSyncTask<TStateStore> {
 
     fn fetch_next_batch(
         &self,
+        shard: Shard,
         current_state_version: Version,
     ) -> Result<Option<StateVersionTransitions>, StorageError> {
         let transitions = self.store.with_read_tx(|tx| {
-            StateTransition::get_for_shard(tx, self.shard, current_state_version, self.value_filters).optional()
+            StateTransition::get_for_shard(tx, shard, current_state_version, self.value_filters).optional()
         })?;
         Ok(transitions)
     }
@@ -174,6 +245,7 @@ impl<TStateStore: StateStore> StateSyncTask<TStateStore> {
     }
 
     async fn send_batches(&mut self, transitions: StateVersionTransitions) -> Result<(), ()> {
+        let shard = transitions.shard;
         let chunks = transitions.into_chunks(self.batch_size);
         let num_chunks = chunks.len();
 
@@ -186,11 +258,81 @@ impl<TStateStore: StateStore> StateSyncTask<TStateStore> {
                     updates,
                     has_more: i < num_chunks - 1,
                     epoch: Some(chunk.epoch.into()),
+                    shard: shard.as_u32(),
                 })),
             }))
             .await?;
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cursor(shard: u32, start_state_version: u64) -> rpc::ShardCursor {
+        rpc::ShardCursor {
+            shard,
+            start_state_version,
+        }
+    }
+
+    #[test]
+    fn it_accepts_ascending_cursors_including_the_global_shard() {
+        let validated = ShardCursor::validate_all(vec![cursor(0, 1), cursor(1, 5), cursor(256, 9)]).unwrap();
+        assert_eq!(validated, vec![
+            ShardCursor {
+                shard: Shard::global(),
+                start_state_version: 1
+            },
+            ShardCursor {
+                shard: Shard::from_u32(1),
+                start_state_version: 5
+            },
+            ShardCursor {
+                shard: Shard::from_u32(256),
+                start_state_version: 9
+            },
+        ]);
+    }
+
+    #[test]
+    fn it_accepts_a_cursor_for_every_shard_plus_global() {
+        let cursors = (0..=NumPreshards::MAX.as_u32())
+            .map(|s| cursor(s, 1))
+            .collect::<Vec<_>>();
+        assert_eq!(cursors.len(), NumPreshards::MAX.num_shards() + 1);
+        assert!(ShardCursor::validate_all(cursors).is_ok());
+    }
+
+    #[test]
+    fn it_rejects_an_empty_cursor_list() {
+        assert!(ShardCursor::validate_all(vec![]).is_err());
+    }
+
+    #[test]
+    fn it_rejects_more_cursors_than_there_are_shards() {
+        let cursors = (0..=NumPreshards::MAX.as_u32() + 1)
+            .map(|s| cursor(s, 1))
+            .collect::<Vec<_>>();
+        assert!(ShardCursor::validate_all(cursors).is_err());
+    }
+
+    #[test]
+    fn it_rejects_an_out_of_range_shard() {
+        assert!(ShardCursor::validate_all(vec![cursor(NumPreshards::MAX.as_u32() + 1, 1)]).is_err());
+    }
+
+    #[test]
+    fn it_rejects_duplicate_and_out_of_order_shards() {
+        assert!(ShardCursor::validate_all(vec![cursor(1, 1), cursor(1, 2)]).is_err());
+        assert!(ShardCursor::validate_all(vec![cursor(2, 1), cursor(1, 1)]).is_err());
+    }
+
+    #[test]
+    fn it_rejects_a_zero_start_state_version() {
+        assert!(ShardCursor::validate_all(vec![cursor(1, 1), cursor(2, 0)]).is_err());
     }
 }

--- a/applications/tari_validator_node/src/p2p/rpc/state_sync_task.rs
+++ b/applications/tari_validator_node/src/p2p/rpc/state_sync_task.rs
@@ -109,7 +109,11 @@ impl<TStateStore: StateStore> StateSyncTask<TStateStore> {
         // consumer can finalise a shard the moment its completion marker arrives.
         let cursors = std::mem::take(&mut self.cursors);
         let Some(last_index) = cursors.len().checked_sub(1) else {
-            return Ok(());
+            // Every stream must carry a final marker, so an empty request cannot be answered with an
+            // empty stream. `ShardCursor::validate_all` rejects one before it reaches here.
+            self.send(Err(RpcStatus::bad_request("No shard cursors were provided")))
+                .await?;
+            return Err(());
         };
         for (i, cursor) in cursors.into_iter().enumerate() {
             self.run_for_shard(&cursor, i == last_index).await?;

--- a/crates/p2p/proto/rpc.proto
+++ b/crates/p2p/proto/rpc.proto
@@ -239,6 +239,7 @@ message ShardCursor {
 
 message SyncStateRequest {
   reserved 1, 2;
+  reserved "start_state_version", "shard";
   // Optional - If not provided, state will be streamed until the current epoch
   tari.ootle.common.Epoch until_epoch = 3;
   // Bitflags representing which substates to return.

--- a/crates/p2p/proto/rpc.proto
+++ b/crates/p2p/proto/rpc.proto
@@ -229,9 +229,16 @@ message TreeRootSummary {
   uint64 state_version = 2;
 }
 
+// A per-shard resume point. State versions are assigned per shard and only advance when that shard
+// changes, so a shard range cannot share a single start version - each shard carries its own.
+message ShardCursor {
+  uint32 shard = 1;
+  // Must be greater than zero. Genesis is committed at version 0 and is never synced.
+  uint64 start_state_version = 2;
+}
+
 message SyncStateRequest {
-  uint64 start_state_version = 1;
-  uint32 shard = 2;
+  reserved 1, 2;
   // Optional - If not provided, state will be streamed until the current epoch
   tari.ootle.common.Epoch until_epoch = 3;
   // Bitflags representing which substates to return.
@@ -259,6 +266,10 @@ message SyncStateRequest {
   //  TemplateMetadata = 0x0200;
   //}
   uint32 value_filters = 4;
+  // The shards to stream, each with its own resume point. Must be non-empty, free of duplicates and
+  // ordered by ascending shard - the responder streams them in this order and the caller relies on a
+  // shard's updates being contiguous.
+  repeated ShardCursor cursors = 5;
 }
 
 message SyncStateResponse {
@@ -268,23 +279,28 @@ message SyncStateResponse {
   }
 }
 
-// A batch of substate updates at a single state version. A state version whose updates exceed the
-// stream batch size is split into multiple batches, all but the last carrying has_more = true.
+// A batch of substate updates at a single state version of a single shard. A state version whose
+// updates exceed the stream batch size is split into multiple batches, all but the last carrying
+// has_more = true.
 message SubstateBatch {
   uint64 state_version = 1;
   repeated SubstateUpdate updates = 2;
   bool has_more = 3;
   tari.ootle.common.Epoch epoch = 4;
+  uint32 shard = 5;
 }
 
-// Terminal message of every sync_state stream, stating the version the shard is now synced to.
-// For an unbounded (sync-to-tip) request this is the committed state-tree tip and is authoritative
-// for the client's cursor - it advances the client over trailing versions that streamed no updates
-// (filtered out, or tree-only bumps). For a bounded (checkpoint) request the client verifies against
-// its own checkpoint, so this carries the producer's last streamed version.
+// Emitted once per requested cursor, after that shard's last batch, stating the version the shard is
+// now synced to. The message for the final cursor carries is_final = true and terminates the stream.
+// For an unbounded (sync-to-tip) request synced_to_version is the committed state-tree tip and is
+// authoritative for the client's cursor - it advances the client over trailing versions that streamed
+// no updates (filtered out, or tree-only bumps). For a bounded (checkpoint) request the client
+// verifies against its own checkpoint, so this carries the producer's last streamed version.
 message SyncComplete {
   uint64 synced_to_version = 1;
   tari.ootle.common.Epoch epoch = 2;
+  uint32 shard = 3;
+  bool is_final = 4;
 }
 
 enum TemplateType {

--- a/crates/rpc_state_sync/src/state_sync.rs
+++ b/crates/rpc_state_sync/src/state_sync.rs
@@ -30,6 +30,7 @@ use tari_ootle_p2p::{
         GetCheckpointsRequest,
         GetCheckpointsResponse,
         GetHighQcRequest,
+        ShardCursor,
         SyncStateRequest,
         sync_state_response,
     },
@@ -186,8 +187,10 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
         self.stats.total_requests += 1;
         let mut state_stream = client
             .sync_state(SyncStateRequest {
-                start_state_version,
-                shard: shard.as_u32(),
+                cursors: vec![ShardCursor {
+                    shard: shard.as_u32(),
+                    start_state_version,
+                }],
                 until_epoch: Some(checkpoint.epoch().into()),
                 value_filters: SubstateValueFilterFlags::all_substates().bits(),
             })
@@ -203,6 +206,12 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
             let batch = match msg.response {
                 Some(sync_state_response::Response::Batch(batch)) => batch,
                 Some(sync_state_response::Response::Complete(complete)) => {
+                    if complete.shard != shard.as_u32() {
+                        return Err(RpcStateSyncError::InvalidResponse(anyhow!(
+                            "Received completion marker for shard {} but requested {shard}",
+                            complete.shard,
+                        )));
+                    }
                     // The stream always terminates with a completion marker. Verify the synced shard
                     // root against the trusted checkpoint at our last committed version: the producer
                     // streamed every transition up to the checkpoint epoch, so any gap to
@@ -244,6 +253,12 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
                 },
             };
 
+            if batch.shard != shard.as_u32() {
+                return Err(RpcStateSyncError::InvalidResponse(anyhow!(
+                    "Received batch for shard {} but requested {shard}",
+                    batch.shard,
+                )));
+            }
             if batch.updates.is_empty() {
                 return Err(RpcStateSyncError::InvalidResponse(anyhow!(
                     "Received empty state transition batch."


### PR DESCRIPTION
## Problem

`sync_state` serves exactly one shard per call, so both consumers loop shards client-side — the indexer over every shard group, the validator over its intersecting shard group.

With `NumPreshards::P256` that is **257 requests per sync round**, and they are strictly serialized:

- `RpcMultiPool` holds one session per peer,
- the RPC client worker processes requests one at a time (`networking/rpc_framework/src/client/mod.rs:536`),
- the server completes one request per substream before reading the next (`networking/rpc_framework/src/server/mod.rs:743`).

An indexer round therefore costs 257 round-trips **even when every shard is empty** — roughly 21s at 80ms RTT, against a 30s work interval. A validator joining at an epoch boundary pays the same cost.

## Approach

State versions are assigned per shard and only advance when that shard changes (`crates/consensus/src/hotstuff/substate_store/sharded_state_tree.rs:90`), so a shard *range* cannot share a single start version. The request instead carries a list of `(shard, start_state_version)` cursors, and the responder streams each shard contiguously, closing it off with its own completion marker.

Verification granularity is unchanged — checkpoints already carry per-shard tree roots (`shard_tree_summary`), so the validator still verifies each shard against its own root.

No storage change was needed: the RocksDB state transition CF is already keyed `(Shard, Version)` shard-major, and `state_transitions_get_starting_at` already opens a range that scans forward across shards. The responder just loops the existing per-shard query.

## Wire format

```proto
message ShardCursor { uint32 shard = 1; uint64 start_state_version = 2; }
// SyncStateRequest: reserved 1, 2;  repeated ShardCursor cursors = 5;
// SubstateBatch:    uint32 shard = 5;
// SyncComplete:     uint32 shard = 3;  bool is_final = 4;   // one per cursor
```

Cursors must be non-empty, at most `num_preshards + 1`, in range, strictly ascending (which rules out duplicates), and start above version 0. Ascending order is what lets the responder stream each shard contiguously, and hence lets a consumer finalise a shard the moment its marker arrives.

## Indexer

Now issues **at most two streams per shard group** rather than one per shard. Two rather than one because a shard being synced for the first time wants only the head state, expressed by the `UP_ONLY` filter, and filters apply to the whole request; those shards are streamed separately from the ones being caught up incrementally.

It collapses to one stream only once every shard in the group has accumulated some state. A shard whose tree never advanced reports `synced_to = 0`, so the indexer reads `prev_version == 0` next round and puts it back in the from-scratch bucket — on a sparse network a group stays at two streams indefinitely. Harmless, since an empty shard streams nothing either way, but it is two rather than one.

Progress is still recorded per shard as markers arrive, so an interrupted stream keeps everything already committed and resumes from the recorded cursors next round. Stream buffers are now scoped to a single stream rather than shared across shards, which also removes a latent cross-shard carry-over if a stream ended mid-version.

A truncated stream (no final marker) is now an error rather than silent success, matching what the validator client already did. The indexer's supervisor restarts after a `work_interval` cooldown, the same path any RPC error already took.

## Validator

Passes a single-element cursor list, leaving its sync behaviour unchanged, plus guards rejecting a batch or marker for a shard it did not request. Converting it to a genuinely ranged sync — ranged peer failover, per-shard verification across a set — follows in a separate PR. Keeping them apart means the transport is validated in CI before the ranged validator logic lands on top of it.

## A note on rejected hardening

Rejecting shards outside the responder's own shard group looked worthwhile but does not survive contact: a validator syncing at an epoch boundary queries *previous*-epoch committees for shards those peers may no longer hold in the current epoch, so the check would reject legitimate requests. The max-shard bound stays. Requests for unheld shards remain benign — `send_complete` falls back to `start - 1`, so no false progress is recorded.

## Breaking change

`SyncStateRequest` replaces its `shard` and `start_state_version` fields with a `cursors` list, and `SubstateBatch`/`SyncComplete` carry the shard they belong to. The RPC protocol name is unversioned, so **validators and indexers must be upgraded together**.

## Testing

- Workspace `cargo check --all-targets` and `cargo clippy --all-targets` clean.
- `cargo +nightly-2025-12-05 fmt --check` clean.
- 88 unit tests pass across the touched crates, including 7 covering cursor validation and 10 covering the stream-ordering invariants (`StreamOrder`).
- `state_sync.feature` and `indexer.feature` exercise both changed paths end-to-end — CI is the real gate here.
