### PR TITLE
docs: add template testing tutorial

### DIFF
--- a/crates/engine/tests/testing_tutorial.rs
+++ b/crates/engine/tests/testing_tutorial.rs
@@ -1,0 +1,208 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! Worked examples for the "Testing your template" guide
+//! (`docs/developer-docs/src/content/docs/guides/testing-templates.mdx`).
+//!
+//! The guide embeds the code below verbatim, so these tests are what keeps it honest:
+//! if an API in the guide changes, one of these tests stops compiling or stops passing.
+//! [`guide_snippets_match_their_source`] checks that the page and its sources have not drifted
+//! apart.
+
+use std::{fs, path::Path};
+
+use tari_ootle_transaction::args;
+use tari_template_lib::{
+    prelude::TARI_TOKEN,
+    types::{Amount, NonFungibleId},
+};
+use tari_template_test_tooling::{TemplateTest, support::assert_error::assert_reject_reason};
+
+const CRATE_PATH: &str = env!("CARGO_MANIFEST_DIR");
+
+#[test]
+fn create_accounts_and_call_a_component() {
+    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/guessing_game"]);
+    let template = test.get_template_address("GuessingGame");
+
+    // Creates a fresh key pair, publishes an account component for it and funds it from the
+    // built-in XTR faucet.
+    let (player, _player_proof, player_key) = test.create_funded_account();
+
+    let vaults = test.read_only_state_store().get_vaults_for_account(player).unwrap();
+    assert_eq!(
+        vaults[&TARI_TOKEN].balance(),
+        Amount::from(TemplateTest::FUNDED_ACCOUNT_INITIAL_BALANCE)
+    );
+
+    // `start_game` is owner-restricted, so the transaction is sealed by the key that owns the
+    // component - the harness's own key, which created it in the same transaction.
+    test.execute_expect_success(
+        test.transaction()
+            .allocate_component_address("game")
+            .call_function(template, "new", args![Workspace("game")])
+            .call_method("game", "start_game", args![NonFungibleId::from_string("💎")])
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+    let (game, _) = test
+        .read_only_state_store()
+        .get_components_by_template_address(template)
+        .unwrap()
+        .remove(0);
+
+    // The player seals this one with their own key. `guess` is declared `rule![allow_all]`, so no
+    // ownership proof is required: with an empty `proofs` argument the harness derives the proofs
+    // from the transaction signers.
+    test.execute_expect_success(
+        test.transaction()
+            .call_method(game, "guess", args![5u8, player])
+            .build_and_seal(&player_key),
+        vec![],
+    );
+}
+
+#[test]
+fn inspect_component_state_directly() {
+    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/guessing_game"]);
+    let template = test.get_template_address("GuessingGame");
+
+    test.execute_expect_success(
+        test.transaction()
+            .allocate_component_address("game")
+            .call_function(template, "new", args![Workspace("game")])
+            .call_method("game", "start_game", args![NonFungibleId::from_string("💎")])
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+    let (game, _) = test
+        .read_only_state_store()
+        .get_components_by_template_address(template)
+        .unwrap()
+        .remove(0);
+
+    // Component state is encoded field by field, so a path segment is the *index* of the field in
+    // the template struct. `GuessingGame` declares `prize_vault`, `guesses`, `round_number`, so
+    // `$.2` is the round counter that `start_game` incremented.
+    let round_number: u32 = test.extract_component_value(game, "$.2");
+    assert_eq!(round_number, 1);
+
+    // The store also answers typed questions about a component. `start_game` minted the prize NFT
+    // into the component's vault, so that vault now holds exactly one token.
+    let vaults = test.read_only_state_store().get_vaults_for_component(game).unwrap();
+    let prize_vault = vaults.values().next().expect("the game holds a prize vault");
+    assert_eq!(prize_vault.balance(), Amount::from(1u64));
+}
+
+#[test]
+fn assert_on_a_rejected_transaction() {
+    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/guessing_game"]);
+    let template = test.get_template_address("GuessingGame");
+
+    test.execute_expect_success(
+        test.transaction()
+            .allocate_component_address("game")
+            .call_function(template, "new", args![Workspace("game")])
+            .call_method("game", "start_game", args![NonFungibleId::from_string("💎")])
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+    let (game, _) = test
+        .read_only_state_store()
+        .get_components_by_template_address(template)
+        .unwrap()
+        .remove(0);
+
+    let (player, _, player_key) = test.create_funded_account();
+    let (cheat, _, cheat_key) = test.create_funded_account();
+
+    // A guess that the template accepts is recorded in `guesses`. Establishing that first is what
+    // makes the rejection below meaningful: this is the observable a committed `guess` changes.
+    let before_any_guess = test.read_only_state_store().get_component(game).unwrap();
+    test.execute_expect_success(
+        test.transaction()
+            .call_method(game, "guess", args![5u8, player])
+            .build_and_seal(&player_key),
+        vec![],
+    );
+    let after_valid_guess = test.read_only_state_store().get_component(game).unwrap();
+    assert_ne!(
+        after_valid_guess.state(),
+        before_any_guess.state(),
+        "an accepted guess must be visible in the component state"
+    );
+
+    // The template asserts `guess <= 10`, and the panic message reaches the test verbatim.
+    let reason = test.execute_expect_failure(
+        test.transaction()
+            .call_method(game, "guess", args![100u8, cheat])
+            .build_and_seal(&cheat_key),
+        vec![],
+    );
+    assert_reject_reason(reason, "Panic! Guess must be from 0 to 10");
+
+    // A rejected transaction commits nothing: the same state the accepted guess produced.
+    let after_rejection = test.read_only_state_store().get_component(game).unwrap();
+    assert_eq!(
+        after_rejection.state(),
+        after_valid_guess.state(),
+        "a rejected transaction must not commit state"
+    );
+}
+
+/// Every Rust block in the guide carries the path of the file it was copied from. Compare the two,
+/// ignoring indentation, so that an example cannot silently drift away from the code that this
+/// test suite actually compiles and runs.
+#[test]
+fn guide_snippets_match_their_source() {
+    let repo_root = Path::new(CRATE_PATH).join("../..");
+    let guide_path = repo_root.join("docs/developer-docs/src/content/docs/guides/testing-templates.mdx");
+    let guide = fs::read_to_string(&guide_path).expect("guide is missing");
+
+    let mut checked = 0;
+    for (title, snippet) in rust_blocks_with_a_source_path(&guide) {
+        let source = fs::read_to_string(repo_root.join(&title)).unwrap_or_else(|e| panic!("{title}: {e}"));
+        assert!(
+            contains_lines(&source, &snippet),
+            "{}: a snippet in the guide is not present in {title} verbatim:\n{snippet}",
+            guide_path.display()
+        );
+        checked += 1;
+    }
+    assert!(checked > 0, "no source-backed Rust blocks found in the guide");
+}
+
+/// Yields `(title, contents)` for each ```rust block in the guide that names a source file.
+fn rust_blocks_with_a_source_path(guide: &str) -> Vec<(String, String)> {
+    let mut blocks = Vec::new();
+    let mut lines = guide.lines();
+    while let Some(line) = lines.next() {
+        let Some(meta) = line.strip_prefix("```rust ") else {
+            continue;
+        };
+        let Some(title) = meta.split_once("title=\"").and_then(|(_, t)| t.split_once('"')) else {
+            continue;
+        };
+        let contents = lines
+            .by_ref()
+            .take_while(|l| !l.starts_with("```"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        blocks.push((title.0.to_string(), contents));
+    }
+    blocks
+}
+
+/// True if the non-blank lines of `snippet`, trimmed, appear consecutively in `source`.
+fn contains_lines(source: &str, snippet: &str) -> bool {
+    let trimmed = |s: &str| {
+        s.lines()
+            .map(str::trim)
+            .filter(|l| !l.is_empty())
+            .map(str::to_string)
+            .collect::<Vec<_>>()
+    };
+    let source = trimmed(source);
+    let snippet = trimmed(snippet);
+    !snippet.is_empty() && source.windows(snippet.len()).any(|w| w == snippet)
+}

--- a/docs/developer-docs/astro.config.mjs
+++ b/docs/developer-docs/astro.config.mjs
@@ -34,6 +34,7 @@ export default defineConfig({
             { label: "Setup a Wallet", link: "/guides/setup-a-wallet/" },
             { label: "Templates Overview", link: "/guides/template-overview/" },
             { label: "Building a Guessing Game", link: "/guides/build-a-guessing-game/" },
+            { label: "Testing Your Template", link: "/guides/testing-templates/" },
             { label: "Publish the Guessing Game", link: "/guides/publishing-templates/" },
             { label: "Play the Guessing Game", link: "/guides/play-the-guessing-game/" },
             { label: "Transaction Overview", link: "/guides/transaction-overview/" },

--- a/docs/developer-docs/src/content/docs/guides/build-a-guessing-game.mdx
+++ b/docs/developer-docs/src/content/docs/guides/build-a-guessing-game.mdx
@@ -442,9 +442,11 @@ You can use the `tari_template_test_tooling` crate as a `dev-dependency`. This c
 a harness that compiles your template to WASM and allows you to create transactions that call into
 your template/component using the same execution engine that runs on the Tari L2 network.
 
-Writing tests is out of scope for this guide, but the [full annotated code example](#full-annotated-code)
-includes a test that creates a new game, simulates some players making guesses, and then ends the game
-to check that the prize is awarded correctly.
+The <a href={basePath("/guides/testing-templates/")}>Testing Your Template</a> guide walks through
+creating accounts, overriding the epoch, reading component state directly and asserting on rejected
+transactions. The [full annotated code example](#full-annotated-code) below also includes a test that
+creates a new game, simulates some players making guesses, and then ends the game to check that the
+prize is awarded correctly.
 
 To run your tests, simply run `cargo test` in your template crate directory.
 The test harness will compile your template to WASM and run the tests against it.

--- a/docs/developer-docs/src/content/docs/guides/testing-templates.mdx
+++ b/docs/developer-docs/src/content/docs/guides/testing-templates.mdx
@@ -10,7 +10,7 @@ import { basePath } from '../../../helpers/path';
 
 In this guide, you will:
 - Set up a test and create funded accounts to call your component with.
-- Tell transaction signers apart from authorization proofs, and pass proofs only where they are needed.
+- Set up the badges a transaction starts with, and tell them apart from real runtime proofs.
 - Override the current epoch and epoch hash for templates that read them.
 - Read component state directly between transactions.
 - Assert on the error message of a transaction you expect to be rejected.
@@ -68,18 +68,21 @@ Use `create_empty_account` when a test needs an account that holds nothing.
   instruction. Call `test.enable_fees()` when the behaviour you are testing depends on fees.
 </Aside>
 
-### Signers are not proofs
+### Proofs are the transaction's initial auth scope
 
-Two different things authorize a transaction, and mixing them up is the most common source of
-confusing test failures:
+The `proofs` argument to `execute_expect_success` and `execute_expect_failure` supplies the
+transaction's **initial authorization scope**: a set of *virtual badges*, each a
+`NonFungibleAddress`, that are in scope from the moment execution starts and that
+<a href={basePath("/guides/authorization-and-access/")}>access rules</a> are checked against.
 
-- The **signer** is the secret key you pass to `build_and_seal`. It identifies who submitted the
-  transaction, and it is what a template sees in `CallerContext::transaction_signer_public_key()`.
-- An **ownership proof** is a badge presented for the transaction's duration, which is what
-  <a href={basePath("/guides/authorization-and-access/")}>access rules</a> are checked against.
+On the network that scope has exactly one source: the engine derives one badge per transaction
+signer from the signer's public key, and puts **nothing else** there. No other NFT ever lands in a
+real transaction's initial scope — a badge you merely hold in a vault is not a virtual badge, and is
+presented by creating a real `Proof` from that vault instead. The harness's `proofs` vector is the
+only thing that can put a non-signer NFT into an initial scope at all.
 
-When the `proofs` argument is empty, the harness derives the proofs from the transaction's signers,
-so a method that only requires the caller's own badge needs nothing extra:
+`TemplateTest` mirrors production when you leave the vector empty: it derives exactly the same signer
+badges, which is what you want whenever authorization is not what you are testing.
 
 ```rust title="crates/engine/tests/testing_tutorial.rs"
 // `start_game` is owner-restricted, so the transaction is sealed by the key that owns the
@@ -109,10 +112,54 @@ test.execute_expect_success(
 );
 ```
 
-Pass proofs explicitly only when the transaction genuinely presents a badge its signer does not hold
-— an admin badge held by another account, for instance. Adding `test.owner_proof()` to every call
-because it is available hides the authorization bug you are trying to catch: the test passes whether
-or not your access rules are correct.
+A non-empty vector **replaces** those derived signer badges rather than adding to them — the harness
+auto-derives only while the argument is empty — and
+`test.disable_auto_add_proofs_from_signers()` switches the derivation off altogether. So reach for
+the override to *take something away*, not to add something: it is how you run a transaction with a
+required badge deliberately missing and assert that the method is denied. Adding an extra NFT to the
+vector instead builds a scope the network cannot produce, and misrepresents a vault-held badge as
+something it never is on-chain. If you do pass a list and the signer's own authorization is meant to
+stay, include that signer's badge explicitly — `test.owner_proof()` for transactions sealed with
+`test.secret_key()`, or the proof each of `create_funded_account` and `create_empty_account` returns
+alongside the key it generates — otherwise it is silently dropped.
+
+To exercise a badge that lives in a vault, do what a real transaction does rather than reaching for
+the vector: call `create_proof_for_resource` on the account holding it, pass the resulting `Proof` to
+the code that needs it, and have that code authorize with it — `Proof::authorize`, `try_authorize` or
+`authorize_with`. Authorizing adds the proof to the *current* call frame's scope, and access rules
+match a held proof just as readily as a virtual badge.
+
+That difference in reach is the last thing worth knowing: virtual badges are in scope for the
+**top-level call only**. A component reached through another template starts from an empty badge set,
+so a method that passes when called directly can be denied across a template boundary.
+`it_permits_cross_template_calls_using_proofs` in
+[`crates/engine/tests/access_rules.rs`](https://github.com/tari-project/tari-ootle/blob/development/crates/engine/tests/access_rules.rs)
+shows the denial, with the account's own badge in scope the whole time — the cross-template call
+itself is a plain `ComponentManager::get(address).call(...)` inside the `CrossTemplate` fixture:
+
+```rust title="crates/engine/tests/access_rules.rs"
+// Try to take tokens without proof. Even though I'm the owner of the resource, the scope does not carry over
+// when cross-template calls are made.
+let reason = test.execute_expect_failure(
+    Transaction::builder_localnet(Epoch(1))
+        .call_function(cross_call_template, "call_component_with_args", args![
+            component_address,
+            "take_tokens",
+            invoke_args![10],
+        ])
+        .put_last_instruction_output_on_workspace("tokens")
+        .call_method(owner_account, "deposit", args![Workspace("tokens")])
+        .drop_all_proofs_in_workspace()
+        .build_and_seal(&owner_key),
+    vec![owner_proof.clone()],
+);
+
+assert_access_denied_for_action(reason, ResourceAuthAction::Withdraw);
+```
+
+The rest of that test then does it the working way: mint the badge, deposit it into the account,
+create a `Proof` for its resource, and pass that proof across the boundary for the callee to
+authorize with.
 
 ## Overriding the epoch and epoch hash
 

--- a/docs/developer-docs/src/content/docs/guides/testing-templates.mdx
+++ b/docs/developer-docs/src/content/docs/guides/testing-templates.mdx
@@ -1,0 +1,260 @@
+---
+title: Testing Your Template
+description: Write template tests that create accounts, override the epoch, read component state directly and assert on rejected transactions.
+---
+
+import { Aside } from "@astrojs/starlight/components";
+import { basePath } from '../../../helpers/path';
+
+### Covered in this guide
+
+In this guide, you will:
+- Set up a test and create funded accounts to call your component with.
+- Tell transaction signers apart from authorization proofs, and pass proofs only where they are needed.
+- Override the current epoch and epoch hash for templates that read them.
+- Read component state directly between transactions.
+- Assert on the error message of a transaction you expect to be rejected.
+
+`tari_template_test_tooling` compiles your template to WASM and runs transactions against it with the
+same engine the network uses, so a passing test means the engine accepted the transaction, not that a
+mock did. A template crate created with `cargo generate` already declares it; add it yourself if
+yours does not have it:
+
+```toml
+[dev-dependencies]
+tari_template_test_tooling = "0.39"
+```
+
+<Aside type="tip">
+  Template tests spend most of their time in the WASM JIT unless you optimize it in debug builds. The
+  <a href={basePath("/guides/build-a-guessing-game/#speeding-up-template-tests")}>guessing game guide</a>
+  has the `Cargo.toml` profile settings that make these tests roughly 10x faster.
+</Aside>
+
+The examples below are the tests in
+[`crates/engine/tests/testing_tutorial.rs`](https://github.com/tari-project/tari-ootle/blob/development/crates/engine/tests/testing_tutorial.rs),
+which run in this repository's CI against the
+[guessing game template](https://github.com/tari-project/tari-ootle/blob/development/crates/engine/tests/templates/guessing_game/src/lib.rs).
+They load the template by path — `TemplateTest::new(CRATE_PATH, ["tests/templates/guessing_game"])` —
+because the template lives elsewhere in this repository. In your own template crate the template *is*
+the crate, so you use `TemplateTest::my_crate()` instead, and everything else on this page stays the
+same.
+
+## Basic setup and creating accounts
+
+`create_funded_account` generates a fresh key pair, publishes an account component for it and funds
+it from the built-in XTR faucet, all in one call. It returns the account address, an ownership proof
+and the secret key you seal that account's transactions with:
+
+```rust title="crates/engine/tests/testing_tutorial.rs"
+let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/guessing_game"]);
+let template = test.get_template_address("GuessingGame");
+
+// Creates a fresh key pair, publishes an account component for it and funds it from the
+// built-in XTR faucet.
+let (player, _player_proof, player_key) = test.create_funded_account();
+
+let vaults = test.read_only_state_store().get_vaults_for_account(player).unwrap();
+assert_eq!(
+    vaults[&TARI_TOKEN].balance(),
+    Amount::from(TemplateTest::FUNDED_ACCOUNT_INITIAL_BALANCE)
+);
+```
+
+Use `create_empty_account` when a test needs an account that holds nothing.
+
+<Aside type="note">
+  Fees are off by default in `TemplateTest`, so a transaction does not need a fee payment
+  instruction. Call `test.enable_fees()` when the behaviour you are testing depends on fees.
+</Aside>
+
+### Signers are not proofs
+
+Two different things authorize a transaction, and mixing them up is the most common source of
+confusing test failures:
+
+- The **signer** is the secret key you pass to `build_and_seal`. It identifies who submitted the
+  transaction, and it is what a template sees in `CallerContext::transaction_signer_public_key()`.
+- An **ownership proof** is a badge presented for the transaction's duration, which is what
+  <a href={basePath("/guides/authorization-and-access/")}>access rules</a> are checked against.
+
+When the `proofs` argument is empty, the harness derives the proofs from the transaction's signers,
+so a method that only requires the caller's own badge needs nothing extra:
+
+```rust title="crates/engine/tests/testing_tutorial.rs"
+// `start_game` is owner-restricted, so the transaction is sealed by the key that owns the
+// component - the harness's own key, which created it in the same transaction.
+test.execute_expect_success(
+    test.transaction()
+        .allocate_component_address("game")
+        .call_function(template, "new", args![Workspace("game")])
+        .call_method("game", "start_game", args![NonFungibleId::from_string("💎")])
+        .build_and_seal(test.secret_key()),
+    vec![],
+);
+let (game, _) = test
+    .read_only_state_store()
+    .get_components_by_template_address(template)
+    .unwrap()
+    .remove(0);
+
+// The player seals this one with their own key. `guess` is declared `rule![allow_all]`, so no
+// ownership proof is required: with an empty `proofs` argument the harness derives the proofs
+// from the transaction signers.
+test.execute_expect_success(
+    test.transaction()
+        .call_method(game, "guess", args![5u8, player])
+        .build_and_seal(&player_key),
+    vec![],
+);
+```
+
+Pass proofs explicitly only when the transaction genuinely presents a badge its signer does not hold
+— an admin badge held by another account, for instance. Adding `test.owner_proof()` to every call
+because it is available hides the authorization bug you are trying to catch: the test passes whether
+or not your access rules are correct.
+
+## Overriding the epoch and epoch hash
+
+Templates read consensus values through `Consensus::current_epoch()` and
+`Consensus::current_epoch_hash()`. Both are *virtual substates*: values the engine injects into an
+execution rather than reading from the state store. `TemplateTest` seeds them with epoch `0` and a
+zero hash, and `set_virtual_substate` replaces either one for every transaction that follows.
+
+The repository's own consensus tests in
+[`crates/engine/tests/test.rs`](https://github.com/tari-project/tari-ootle/blob/development/crates/engine/tests/test.rs)
+(module `consensus`) show both. The template being called here is a
+[fixture](https://github.com/tari-project/tari-ootle/blob/development/crates/engine/tests/templates/consensus/src/lib.rs)
+whose functions return the two values unchanged, so the assertion observes exactly what the engine
+gave the template:
+
+```rust title="crates/engine/tests/test.rs"
+let mut template_test = TemplateTest::new(CRATE_PATH, vec!["tests/templates/consensus"]);
+
+// the default value for a current epoch in the mocks is 0
+let result: u64 = template_test.call_function("TestConsensus", "current_epoch", args![], vec![]);
+assert_eq!(result, 0);
+
+// set the value of current epoch to "1" and call the template function again to check that it reads the new
+// value
+template_test.set_virtual_substate(VirtualSubstateId::CurrentEpoch, VirtualSubstate::CurrentEpoch(1));
+let result: u64 = template_test.call_function("TestConsensus", "current_epoch", args![], vec![]);
+assert_eq!(result, 1);
+```
+
+The epoch hash is overridden the same way, with `VirtualSubstateId::CurrentEpochHash`:
+
+```rust title="crates/engine/tests/test.rs"
+let injected_hash = [0xABu8; 32];
+template_test.set_virtual_substate(
+    VirtualSubstateId::CurrentEpochHash,
+    VirtualSubstate::CurrentEpochHash(injected_hash.into()),
+);
+
+let result: Hash32 = template_test.call_function("TestConsensus", "current_epoch_hash", args![], vec![]);
+assert_eq!(result.as_slice(), injected_hash);
+```
+
+To do this for your own template, replace the fixture parts: the template name and the function or
+method you call, the return type you decode into, and — if the value is stored rather than returned
+— the state path you read it back from. What must not change is the shape of the check: the
+behaviour you assert on has to be one that actually reads the epoch or the hash. Overriding the
+epoch proves nothing about a method that never calls `Consensus`.
+
+Two related calls are worth knowing:
+
+- `test.current_epoch()` returns the epoch the harness is executing in, which is also the epoch that
+  `test.transaction()` stamps onto the transactions it builds.
+- `remove_virtual_substate` deletes the value entirely. A template that then reads it is rejected
+  with `Virtual substate not found: Virtual(CurrentEpochHash)`, which is what the repository's
+  `test_epoch_hash_not_available_without_injection` test asserts.
+
+## Examining component state directly
+
+`extract_component_value` reads a single value out of a component's state between transactions.
+State is encoded field by field, so a path segment is the *index* of the field in your template
+struct, not its name:
+
+```rust title="crates/engine/tests/testing_tutorial.rs"
+// Component state is encoded field by field, so a path segment is the *index* of the field in
+// the template struct. `GuessingGame` declares `prize_vault`, `guesses`, `round_number`, so
+// `$.2` is the round counter that `start_game` incremented.
+let round_number: u32 = test.extract_component_value(game, "$.2");
+assert_eq!(round_number, 1);
+
+// The store also answers typed questions about a component. `start_game` minted the prize NFT
+// into the component's vault, so that vault now holds exactly one token.
+let vaults = test.read_only_state_store().get_vaults_for_component(game).unwrap();
+let prize_vault = vaults.values().next().expect("the game holds a prize vault");
+assert_eq!(prize_vault.balance(), Amount::from(1u64));
+```
+
+The index is the one thing you must translate when adapting this to your own template: `$.0` is your
+struct's first field, `$.2` its third, and reordering your fields changes the paths. The type you
+decode into has to match the field's own type, and `extract_component_value` panics if the path is
+missing or the value does not decode — which is what you want in a test.
+
+For anything the path syntax cannot express, `test.read_only_state_store()` gives you the store
+itself: `get_component`, `get_vaults_for_component`, `get_account`, `get_vault` and `get_resource`
+all return typed values. `test.print_state()` dumps everything when you are working out what a
+transaction actually did.
+
+## Asserting on a rejected transaction
+
+`execute_expect_failure` panics if the transaction *succeeds* and otherwise hands you the
+`RejectReason`. `assert_reject_reason` then checks that the reason contains the message you expect,
+so a `panic!` or a failed `assert!` in your template is assertable verbatim:
+
+```rust title="crates/engine/tests/testing_tutorial.rs"
+// A guess that the template accepts is recorded in `guesses`. Establishing that first is what
+// makes the rejection below meaningful: this is the observable a committed `guess` changes.
+let before_any_guess = test.read_only_state_store().get_component(game).unwrap();
+test.execute_expect_success(
+    test.transaction()
+        .call_method(game, "guess", args![5u8, player])
+        .build_and_seal(&player_key),
+    vec![],
+);
+let after_valid_guess = test.read_only_state_store().get_component(game).unwrap();
+assert_ne!(
+    after_valid_guess.state(),
+    before_any_guess.state(),
+    "an accepted guess must be visible in the component state"
+);
+
+// The template asserts `guess <= 10`, and the panic message reaches the test verbatim.
+let reason = test.execute_expect_failure(
+    test.transaction()
+        .call_method(game, "guess", args![100u8, cheat])
+        .build_and_seal(&cheat_key),
+    vec![],
+);
+assert_reject_reason(reason, "Panic! Guess must be from 0 to 10");
+
+// A rejected transaction commits nothing: the same state the accepted guess produced.
+let after_rejection = test.read_only_state_store().get_component(game).unwrap();
+assert_eq!(
+    after_rejection.state(),
+    after_valid_guess.state(),
+    "a rejected transaction must not commit state"
+);
+```
+
+Two things make this a real test rather than a green tick:
+
+- **The rejection is for the reason you meant.** A transaction rejected because it was sealed by the
+  wrong key, or because the caller had no funds, also satisfies `execute_expect_failure`. Asserting
+  on the message is what distinguishes "my rule fired" from "the setup was broken".
+- **The state comparison is against something that would have changed.** The accepted guess above
+  proves that `guess` writes to the component; comparing that same state after the rejection is
+  therefore evidence that nothing committed. Comparing a field the method never touches proves
+  nothing at all.
+
+For access-rule failures, `tari_template_test_tooling::support::assert_error` also provides
+`assert_access_denied_for_action` and `assert_insufficient_funds_for_action`, which spell out the
+engine error rather than a template panic.
+
+### Next steps
+
+- Learn how to <a href={basePath("/guides/publishing-templates/")}>publish your template</a> to the Tari Ootle.
+- Read up on <a href={basePath("/guides/authorization-and-access/")}>authorization and access rules</a> to know which proofs your methods actually require.


### PR DESCRIPTION
## Summary

- add a dedicated template-testing guide covering account setup, epoch and epoch-hash overrides, direct component-state inspection, and rejected-transaction error assertions
- back the guide's Rust snippets with executable engine tests and a drift check
- link the guide from the developer-docs sidebar and the guessing-game tutorial

## Testing

- `cargo test -p tari_engine --test testing_tutorial --test guessing_game`
- `cargo test -p tari_engine --test test consensus::`
- `cargo ci-clippy`
- `cargo +nightly fmt --all` (no source changes)
- `npm ci` and `npm run build` in `docs/developer-docs`
- rendered HTML checks for headings, links, captions, substantive content, and raw MDX leakage
- negative control: changing the documented state path from `$.2` to `$.3` makes the snippet-drift test fail

The full workspace test suite was not run; the targeted engine tests, full-workspace Clippy gate, and documentation build cover the changed scope.

## Scope

Documentation and tests only. No protocol, consensus, execution, networking, wallet, dependency, or public-API changes.

Closes #2247