### PR TITLE
feat(engine)!: raise the per-transaction WASM metering budget to 250M points

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,209 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-bn254"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
+]
+
+[[package]]
+name = "ark-crypto-primitives"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0c292754729c8a190e50414fd1a37093c786c709899f29c9f7daccecfa855e"
+dependencies = [
+ "ahash",
+ "ark-crypto-primitives-macros",
+ "ark-ec",
+ "ark-ff",
+ "ark-relations",
+ "ark-serialize",
+ "ark-snark",
+ "ark-std",
+ "blake2 0.10.6",
+ "derivative",
+ "digest 0.10.7",
+ "fnv",
+ "merlin",
+ "rayon",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "ark-crypto-primitives-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e89fe77d1f0f4fe5b96dfc940923d88d17b6a773808124f21e764dfb063c6a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
+dependencies = [
+ "ahash",
+ "ark-ff",
+ "ark-poly",
+ "ark-serialize",
+ "ark-std",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.5",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "rayon",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
+dependencies = [
+ "ark-ff-asm",
+ "ark-ff-macros",
+ "ark-serialize",
+ "ark-std",
+ "arrayvec",
+ "digest 0.10.7",
+ "educe",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rayon",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "ark-groth16"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88f1d0f3a534bb54188b8dcc104307db6c56cdae574ddc3212aec0625740fc7e"
+dependencies = [
+ "ark-crypto-primitives",
+ "ark-ec",
+ "ark-ff",
+ "ark-poly",
+ "ark-relations",
+ "ark-serialize",
+ "ark-std",
+ "rayon",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
+dependencies = [
+ "ahash",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.5",
+ "rayon",
+]
+
+[[package]]
+name = "ark-relations"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec46ddc93e7af44bcab5230937635b06fb5744464dd6a7e7b083e80ebd274384"
+dependencies = [
+ "ark-ff",
+ "ark-std",
+ "tracing",
+ "tracing-subscriber 0.2.25",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
+dependencies = [
+ "ark-serialize-derive",
+ "ark-std",
+ "arrayvec",
+ "digest 0.10.7",
+ "num-bigint",
+ "rayon",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "ark-snark"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d368e2848c2d4c129ce7679a7d0d2d612b6a274d3ea6a13bad4445d61b381b88"
+dependencies = [
+ "ark-ff",
+ "ark-relations",
+ "ark-serialize",
+ "ark-std",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+ "rayon",
+]
+
+[[package]]
 name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1815,7 +2018,7 @@ dependencies = [
  "tonic 0.12.3",
  "tracing",
  "tracing-core",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -3421,6 +3624,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3490,6 +3705,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89dd01549b09589510cf0647475075d12071456586d70f5c75c98ae2a5537677"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a65863d15a4ce2888bd2f0f543cc963d3879c3a022c8ee43f6141d479a3ac815"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4255,6 +4490,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
  "foldhash 0.1.5",
 ]
 
@@ -6574,6 +6810,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "merlin"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
+dependencies = [
+ "byteorder",
+ "keccak",
+ "rand_core 0.6.4",
+ "zeroize",
 ]
 
 [[package]]
@@ -10890,6 +11138,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11384,6 +11643,12 @@ dependencies = [
 name = "tari_engine"
 version = "0.39.3"
 dependencies = [
+ "ark-bn254",
+ "ark-groth16",
+ "ark-relations",
+ "ark-serialize",
+ "ark-snark",
+ "ark-std",
  "blake2 0.10.6",
  "bytes",
  "criterion",
@@ -11580,7 +11845,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-appender",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.22",
  "url",
  "utoipa",
  "utoipa-swagger-ui",
@@ -13569,7 +13834,7 @@ dependencies = [
  "crossbeam-channel",
  "thiserror 2.0.18",
  "time",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -13601,6 +13866,15 @@ checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
  "log",
  "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+dependencies = [
  "tracing-core",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1936,7 +1936,7 @@ dependencies = [
 
 [[package]]
 name = "consensus_tests"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "fern",
  "futures 0.3.31",
@@ -2947,7 +2947,7 @@ dependencies = [
 
 [[package]]
 name = "db-inspector"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -5364,7 +5364,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "integration_tests"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "config",
@@ -6132,7 +6132,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-messaging"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "futures-bounded 0.2.4",
@@ -6310,7 +6310,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-substream"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "libp2p",
  "prometheus-client",
@@ -7960,7 +7960,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-rs"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7991,7 +7991,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -8002,7 +8002,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm-core"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -8062,7 +8062,7 @@ dependencies = [
 
 [[package]]
 name = "ootle_sdk_core"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "blake2 0.10.6",
  "hex",
@@ -8088,7 +8088,7 @@ dependencies = [
 
 [[package]]
 name = "ootle_sdk_ffi_c"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "cbindgen",
  "hex",
@@ -9083,7 +9083,7 @@ dependencies = [
 
 [[package]]
 name = "proto_builder"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "prost-build 0.14.3",
  "sha2 0.10.9",
@@ -10924,7 +10924,7 @@ dependencies = [
 
 [[package]]
 name = "sqlite_message_logger"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "chrono",
  "diesel",
@@ -11283,7 +11283,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node_client"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "futures-util",
  "log",
@@ -11513,7 +11513,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -11538,7 +11538,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "borsh",
  "minicbor",
@@ -11641,7 +11641,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "ark-bn254",
  "ark-groth16",
@@ -11680,7 +11680,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11710,7 +11710,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_manager"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "log",
@@ -11730,7 +11730,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_oracles"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",
@@ -11776,7 +11776,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -11853,7 +11853,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_client"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "bounded-vec",
@@ -11883,7 +11883,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_lib"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "log",
@@ -11981,7 +11981,7 @@ dependencies = [
 
 [[package]]
 name = "tari_networking"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12035,7 +12035,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_app_utilities"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -12077,7 +12077,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -12106,7 +12106,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_p2p"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "libp2p",
@@ -12132,7 +12132,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -12161,7 +12161,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage_sqlite"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -12214,7 +12214,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_template_provider"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "dashmap 5.5.3",
@@ -12231,7 +12231,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "borsh",
  "hex",
@@ -12257,7 +12257,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction_validation"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -12274,7 +12274,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_cli"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -12304,7 +12304,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_crypto"
-version = "0.41.0"
+version = "0.42.0"
 dependencies = [
  "argon2 0.5.3",
  "blake2 0.10.6",
@@ -12334,7 +12334,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk"
-version = "0.41.0"
+version = "0.42.0"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12397,7 +12397,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk_tests"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "digest 0.10.7",
  "ootle_byte_type",
@@ -12422,7 +12422,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_storage_sqlite"
-version = "0.41.0"
+version = "0.42.0"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -12446,7 +12446,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",
@@ -12518,7 +12518,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd_client"
-version = "0.41.0"
+version = "0.42.0"
 dependencies = [
  "hex",
  "ootle_serde",
@@ -12574,7 +12574,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_framework"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "bitflags 2.13.0",
@@ -12598,7 +12598,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_macros"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12607,7 +12607,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_state_sync"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12689,7 +12689,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_store_rocksdb"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12721,7 +12721,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_tree"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "indexmap 2.13.0",
  "log",
@@ -12750,7 +12750,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "libp2p",
  "libp2p-messaging",
@@ -12762,7 +12762,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm_daemon"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12877,7 +12877,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_test_tooling"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "cargo_toml 0.22.3",
@@ -12993,7 +12993,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_manifest"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "proc-macro2",
  "serde_json",
@@ -13028,7 +13028,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -13092,7 +13092,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_client"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "indexmap 2.13.0",
  "multiaddr 0.18.3",
@@ -13116,7 +13116,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_rpc"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -13140,7 +13140,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_rollback"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -13177,7 +13177,7 @@ dependencies = [
 
 [[package]]
 name = "tari_watcher"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -13206,7 +13206,7 @@ dependencies = [
 
 [[package]]
 name = "tariswap_bench"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13898,7 +13898,7 @@ dependencies = [
 
 [[package]]
 name = "traffic-sim"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13922,7 +13922,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_generator"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -13946,7 +13946,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_submitter"
-version = "0.39.3"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "clap 4.5.54",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.39.3"
+version = "0.40.0"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-ootle"
@@ -99,41 +99,41 @@ tari_ootle_app_utilities = { path = "applications/tari_ootle_app_utilities" }
 tari_consensus = { path = "crates/consensus" }
 tari_ootle_address = { path = "crates/ootle_address", version = "0.10" }
 ootle-network = { path = "crates/ootle_network", version = "0.2" }
-tari_engine = { path = "crates/engine", version = "0.39" }
+tari_engine = { path = "crates/engine", version = "0.40" }
 tari_ootle_p2p = { path = "crates/p2p" }
 tari_ootle_storage = { path = "crates/storage" }
 tari_ootle_storage_sqlite = { path = "crates/storage_sqlite" }
-tari_ootle_wallet_crypto = { path = "crates/wallet/crypto", version = "0.41" }
-tari_ootle_wallet_sdk = { path = "crates/wallet/sdk", version = "0.41" }
+tari_ootle_wallet_crypto = { path = "crates/wallet/crypto", version = "0.42" }
+tari_ootle_wallet_sdk = { path = "crates/wallet/sdk", version = "0.42" }
 tari_ootle_wallet_sdk_services = { path = "crates/wallet/sdk_services" }
-tari_ootle_wallet_storage_sqlite = { path = "crates/wallet/storage_sqlite", version = "0.41" }
+tari_ootle_wallet_storage_sqlite = { path = "crates/wallet/storage_sqlite", version = "0.42" }
 tari_epoch_manager = { path = "crates/epoch_manager" }
 tari_epoch_oracles = { path = "crates/epoch_oracles" }
 tari_indexer_lib = { path = "crates/indexer_lib" }
 tari_rpc_state_sync = { path = "crates/rpc_state_sync" }
 tari_state_store_rocksdb = { path = "crates/state_store_rocksdb" }
 tari_state_tree = { path = "crates/state_tree" }
-tari_template_test_tooling = { path = "crates/template_test_tooling", version = "0.39" }
-tari_transaction_manifest = { path = "crates/transaction_manifest", version = "0.39" }
+tari_template_test_tooling = { path = "crates/template_test_tooling", version = "0.40" }
+tari_transaction_manifest = { path = "crates/transaction_manifest", version = "0.40" }
 tari_validator_node_rpc = { path = "crates/validator_node_rpc" }
 sqlite_message_logger = { path = "networking/sqlite_message_logger" }
 tari_base_node_client = { path = "clients/base_node_client" }
-tari_indexer_client = { path = "clients/tari_indexer_client", default-features = false, version = "0.40" }
+tari_indexer_client = { path = "clients/tari_indexer_client", default-features = false, version = "0.41" }
 tari_networking = { path = "networking/core" }
 tari_rpc_framework = { path = "networking/rpc_framework" }
 tari_rpc_macros = { path = "networking/rpc_macros" }
 tari_swarm = { path = "networking/swarm" }
 tari_validator_node_client = { path = "clients/validator_node_client" }
-tari_validator_rollback = { path = "utilities/validator_rollback", version = "0.39" }
-tari_ootle_walletd_client = { path = "clients/wallet_daemon_client", version = "0.41" }
+tari_validator_rollback = { path = "utilities/validator_rollback", version = "0.40" }
+tari_ootle_walletd_client = { path = "clients/wallet_daemon_client", version = "0.42" }
 transaction_generator = { path = "utilities/transaction_generator" }
 
 # Dependency crates on crates.io (update versions here as well when updating the workspace version)
-tari_consensus_types = { path = "crates/consensus_types", version = "0.39" }
-tari_ootle_common_types = { path = "crates/common_types", version = "0.39" }
-tari_engine_types = { path = "crates/engine_types", version = "0.39" }
+tari_consensus_types = { path = "crates/consensus_types", version = "0.40" }
+tari_ootle_common_types = { path = "crates/common_types", version = "0.40" }
+tari_engine_types = { path = "crates/engine_types", version = "0.40" }
 tari_template_builtin = { path = "crates/template_builtin", version = "0.40" }
-tari_ootle_transaction = { path = "crates/transaction", version = "0.39" }
+tari_ootle_transaction = { path = "crates/transaction", version = "0.40" }
 tari_ootle_transaction_validation = { path = "crates/transaction_validation" }
 
 # Template lib
@@ -148,8 +148,8 @@ tari_bor = { version = "0.15.0", path = "crates/tari_bor", default-features = fa
 
 ootle_byte_type = { path = "crates/ootle_byte_type", version = "0.12" }
 ootle_serde = { path = "crates/ootle_serde", version = "0.5", default-features = false }
-ootle-wasm-core = { path = "crates/ootle_wasm/core", version = "0.39" }
-ootle_sdk_core = { path = "crates/ootle_sdk_core", version = "0.39" }
+ootle-wasm-core = { path = "crates/ootle_wasm/core", version = "0.40" }
+ootle_sdk_core = { path = "crates/ootle_sdk_core", version = "0.40" }
 
 # external minotari/tari dependencies
 minotari_app_grpc = { version = "5.6.0", default-features = false }

--- a/clients/tari_indexer_client/Cargo.toml
+++ b/clients/tari_indexer_client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_indexer_client"
 description = "Tari indexer client library"
-version = "0.40.0"
+version = "0.41.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/clients/wallet_daemon_client/Cargo.toml
+++ b/clients/wallet_daemon_client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_walletd_client"
 description = "Tari wallet daemon client library"
-version = "0.41.0"
+version = "0.42.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/consensus/src/consensus_constants.rs
+++ b/crates/consensus/src/consensus_constants.rs
@@ -149,14 +149,16 @@ impl ConsensusConstants {
         // (binary bytes / 3) — with ~2x headroom, while bounding any single transaction's
         // size/execution cost at ingress. A mempool admission bound, not a consensus rule.
         max_transaction_weight: 1_000_000,
-        // ~45 max-compute transactions (100M points each, ~33ms on ~3GHz x86) — ~1.5s of serial WASM
-        // execution with ~3x headroom for slower validator hardware. Provisional pending re-measurement
-        // of the metering costs on x86-class hardware.
+        // ~18 max-compute transactions (`MAX_WASM_POINTS_PER_TRANSACTION` each) — ~536ms of serial
+        // execution at the calibrated ~8.4M points/ms, ~5% of the block time, leaving the rest for
+        // consensus, storage and slower validator hardware. The transaction count is a floor the
+        // per-transaction ceiling is sized against, asserted by
+        // `a_block_admits_enough_max_compute_transactions`.
         max_block_execution_points: 4_500_000_000,
         // Proposal budget + the largest single-transaction overshoot the per-transaction ceilings allow
         // (`MAX_WASM_POINTS_PER_TRANSACTION` + `MAX_NATIVE_POINTS_PER_TRANSACTION`) + margin, so honest
         // proposals are never rejected.
-        max_block_validation_execution_points: 7_100_000_000,
+        max_block_validation_execution_points: 7_250_000_000,
         exhaust_burn_rate: ExhaustBurnRate::new(500), // 5%
         max_transaction_validity_epochs: 2160,
         epoch_end_spread_blocks: 5,
@@ -187,14 +189,16 @@ impl ConsensusConstants {
         // (binary bytes / 3) — with ~2x headroom, while bounding any single transaction's
         // size/execution cost at ingress. A mempool admission bound, not a consensus rule.
         max_transaction_weight: 1_000_000,
-        // ~45 max-compute transactions (100M points each, ~33ms on ~3GHz x86) — ~1.5s of serial WASM
-        // execution with ~3x headroom for slower validator hardware. Provisional pending re-measurement
-        // of the metering costs on x86-class hardware.
+        // ~18 max-compute transactions (`MAX_WASM_POINTS_PER_TRANSACTION` each) — ~536ms of serial
+        // execution at the calibrated ~8.4M points/ms, ~5% of the block time, leaving the rest for
+        // consensus, storage and slower validator hardware. The transaction count is a floor the
+        // per-transaction ceiling is sized against, asserted by
+        // `a_block_admits_enough_max_compute_transactions`.
         max_block_execution_points: 4_500_000_000,
         // Proposal budget + the largest single-transaction overshoot the per-transaction ceilings allow
         // (`MAX_WASM_POINTS_PER_TRANSACTION` + `MAX_NATIVE_POINTS_PER_TRANSACTION`) + margin, so honest
         // proposals are never rejected.
-        max_block_validation_execution_points: 7_100_000_000,
+        max_block_validation_execution_points: 7_250_000_000,
         exhaust_burn_rate: ExhaustBurnRate::new(500), // 5%
         max_transaction_validity_epochs: 2160,
         epoch_end_spread_blocks: 10,
@@ -225,14 +229,16 @@ impl ConsensusConstants {
         // (binary bytes / 3) — with ~2x headroom, while bounding any single transaction's
         // size/execution cost at ingress. A mempool admission bound, not a consensus rule.
         max_transaction_weight: 1_000_000,
-        // ~45 max-compute transactions (100M points each, ~33ms on ~3GHz x86) — ~1.5s of serial WASM
-        // execution with ~3x headroom for slower validator hardware. Provisional pending re-measurement
-        // of the metering costs on x86-class hardware.
+        // ~18 max-compute transactions (`MAX_WASM_POINTS_PER_TRANSACTION` each) — ~536ms of serial
+        // execution at the calibrated ~8.4M points/ms, ~5% of the block time, leaving the rest for
+        // consensus, storage and slower validator hardware. The transaction count is a floor the
+        // per-transaction ceiling is sized against, asserted by
+        // `a_block_admits_enough_max_compute_transactions`.
         max_block_execution_points: 4_500_000_000,
         // Proposal budget + the largest single-transaction overshoot the per-transaction ceilings allow
         // (`MAX_WASM_POINTS_PER_TRANSACTION` + `MAX_NATIVE_POINTS_PER_TRANSACTION`) + margin, so honest
         // proposals are never rejected.
-        max_block_validation_execution_points: 7_100_000_000,
+        max_block_validation_execution_points: 7_250_000_000,
         exhaust_burn_rate: ExhaustBurnRate::new(500), // 5%
         max_transaction_validity_epochs: 2160,
         epoch_end_spread_blocks: 5,
@@ -277,14 +283,16 @@ impl ConsensusConstants {
             // (binary bytes / 3) — with ~2x headroom, while bounding any single transaction's
             // size/execution cost at ingress. A mempool admission bound, not a consensus rule.
             max_transaction_weight: 1_000_000,
-            // ~45 max-compute transactions (100M points each, ~33ms on ~3GHz x86) — ~1.5s of serial WASM
-            // execution with ~3x headroom for slower validator hardware. Provisional pending re-measurement
-            // of the metering costs on x86-class hardware.
+            // ~18 max-compute transactions (`MAX_WASM_POINTS_PER_TRANSACTION` each) — ~536ms of serial
+            // execution at the calibrated ~8.4M points/ms, ~5% of the block time, leaving the rest for
+            // consensus, storage and slower validator hardware. The transaction count is a floor the
+            // per-transaction ceiling is sized against, asserted by
+            // `a_block_admits_enough_max_compute_transactions`.
             max_block_execution_points: 4_500_000_000,
             // Proposal budget + the largest single-transaction overshoot the per-transaction ceilings allow
             // (`MAX_WASM_POINTS_PER_TRANSACTION` + `MAX_NATIVE_POINTS_PER_TRANSACTION`) + margin, so honest
             // proposals are never rejected.
-            max_block_validation_execution_points: 7_100_000_000,
+            max_block_validation_execution_points: 7_250_000_000,
             exhaust_burn_rate: ExhaustBurnRate::new(500), // 5%
             max_transaction_validity_epochs: 2160,
             epoch_end_spread_blocks: 1,
@@ -329,6 +337,7 @@ mod tests {
         ENGINE_LIMITS,
         MAX_NATIVE_POINTS_PER_TRANSACTION,
         MAX_WASM_POINTS_PER_TRANSACTION,
+        MIN_MAX_COMPUTE_TRANSACTIONS_PER_BLOCK,
     };
 
     use super::*;
@@ -367,6 +376,28 @@ mod tests {
                     constants.max_block_execution_points +
                         MAX_WASM_POINTS_PER_TRANSACTION +
                         MAX_NATIVE_POINTS_PER_TRANSACTION
+            );
+        }
+    }
+
+    /// The per-transaction compute ceiling is a fraction of the block's, not an independent knob:
+    /// raising it lets one transaction claim a larger share of a block, and past some point a leader
+    /// packing max-compute transactions starves the block of everything else. This fixes how far
+    /// that can go, so the two constants cannot drift apart silently.
+    #[test]
+    fn a_block_admits_enough_max_compute_transactions() {
+        for constants in [
+            ConsensusConstants::mainnet(),
+            ConsensusConstants::devnet(7),
+            ConsensusConstants::esmeralda(),
+            ConsensusConstants::testnet(),
+        ] {
+            let admitted = constants.max_block_execution_points / MAX_WASM_POINTS_PER_TRANSACTION;
+            assert!(
+                admitted >= MIN_MAX_COMPUTE_TRANSACTIONS_PER_BLOCK,
+                "a block admits only {admitted} max-compute transactions, below the floor of \
+                 {MIN_MAX_COMPUTE_TRANSACTIONS_PER_BLOCK}: either the per-transaction ceiling has outgrown the block \
+                 budget, or the floor needs revisiting",
             );
         }
     }

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -50,6 +50,12 @@ tari_transaction_manifest = { workspace = true }
 tari_ootle_transaction = { workspace = true, features = ["serde"] }
 tari_template_builtin = { workspace = true, features = ["templates", "state"] }
 
+ark-bn254 = { version = "0.5", features = ["curve"] }
+ark-groth16 = { version = "0.5" }
+ark-relations = { version = "0.5" }
+ark-serialize = { version = "0.5" }
+ark-snark = { version = "0.5" }
+ark-std = { version = "0.5" }
 criterion = { version = "0.8.1", features = ["html_reports"] }
 minicbor = { workspace = true, default-features = false, features = ["alloc", "derive"] }
 serde_json = { workspace = true }

--- a/crates/engine/examples/zk_points_calibrate.rs
+++ b/crates/engine/examples/zk_points_calibrate.rs
@@ -1,0 +1,264 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! Measures what a Groth16/BN254 verifier costs when implemented entirely in a WASM template
+//! (`crates/engine/tests/templates/zk_verifier`), against the per-transaction metering budget
+//! ([`MAX_WASM_POINTS_PER_TRANSACTION`]).
+//!
+//! This is the "no engine support" baseline: the number a native verification op has to beat, and
+//! the evidence the per-transaction ceiling is sized against. `tests/zk_verify.rs` asserts the
+//! bounds; this prints the breakdown they come from. Run with:
+//!
+//! ```text
+//! cargo run -p tari_engine --release --example zk_points_calibrate
+//! ```
+//!
+//! Every WASM figure is exact rather than sampled: metering points are deterministic, so one
+//! execution per measurement is the whole answer. Only the millisecond, fee and native columns are
+//! derived — via the calibrated rate in [`POINTS_PER_MS`], the shipped fee schedule, and timing.
+
+use tari_crypto::ristretto::RistrettoSecretKey;
+use tari_engine_types::limits::{MAX_WASM_POINTS_PER_TRANSACTION, NativeExecutionPoints};
+use tari_ootle_transaction::{Epoch, Transaction, args, builder::named_args::NamedArg};
+use tari_template_test_tooling::TemplateTest;
+
+#[path = "../tests/support/groth16.rs"]
+mod groth16;
+
+const CRATE_PATH: &str = env!("CARGO_MANIFEST_DIR");
+const ZK_VERIFIER: &str = "tests/templates/zk_verifier";
+
+/// Metering points per millisecond of validator CPU, from `examples/native_points_calibrate.rs`.
+/// Converts point counts into the wall-clock terms the block budget is reasoned about in.
+const POINTS_PER_MS: f64 = 8_400_000.0;
+
+/// Metering points per microtari under the shipped fee schedule (`per_wasm_point_cost: 1`,
+/// `wasm_points_cost_divisor: 1000` — see `applications/tari_ootle_app_utilities/src/fee_tables.rs`).
+const POINTS_PER_MICROTARI: f64 = 1000.0;
+
+/// Public input counts the per-input marginal is fitted over. The verifier's only input-dependent
+/// work is the `gamma_abc_g1` MSM, which is linear in this.
+const PUBLIC_INPUT_COUNTS: [usize; 4] = [1, 4, 16, 64];
+
+/// Public input count the single-shot breakdown is measured at: a realistic contract statement (a
+/// root, a nullifier, a recipient, an amount).
+const BREAKDOWN_INPUTS: usize = 4;
+
+/// Trials per native measurement. Verification is on the order of a millisecond, so a large sample
+/// is cheap and the minimum it yields is far less contaminated than a small one's.
+const NATIVE_TRIALS: usize = 200;
+
+/// Runs `count` identical calls in one transaction and returns the WASM metering points the whole
+/// transaction consumed, or `None` if it ran out of gas — the answer for anything above the
+/// ceiling, and the case this example exists to detect. Fees stay disabled so the calls get the
+/// full per-transaction budget rather than an allowance bounded by what they have paid; the
+/// question is what the work costs, not what funds it.
+fn measure_stacked(
+    test: &mut TemplateTest,
+    key: &RistrettoSecretKey,
+    func: &str,
+    args: impl Fn() -> Vec<NamedArg>,
+    count: usize,
+) -> Option<u64> {
+    let addr = test.get_template_address("ZkVerifier");
+    let transaction = Transaction::builder_localnet(Epoch(1))
+        .fold(0..count, |builder, _| builder.call_function(addr, func, args()))
+        .build_and_seal(key);
+    let result = test.try_execute(transaction, vec![]).expect("execution");
+    result
+        .finalize
+        .any_reject()
+        .is_none()
+        .then_some(result.wasm_execution_points)
+}
+
+/// Runs one template call. See [`measure_stacked`].
+fn measure(test: &mut TemplateTest, key: &RistrettoSecretKey, func: &str, args: Vec<NamedArg>) -> Option<u64> {
+    measure_stacked(test, key, func, || args.clone(), 1)
+}
+
+#[expect(clippy::too_many_lines)]
+fn main() {
+    let mut test = TemplateTest::new(CRATE_PATH, [ZK_VERIFIER]);
+    let (_account, _owner, key) = test.create_funded_account();
+    let f = groth16::fixture(BREAKDOWN_INPUTS);
+
+    println!("Groth16/BN254 verification in a WASM template");
+    println!(
+        "  budget: {} points/transaction ({:.1} ms at {:.1}M points/ms)\n",
+        MAX_WASM_POINTS_PER_TRANSACTION,
+        MAX_WASM_POINTS_PER_TRANSACTION as f64 / POINTS_PER_MS,
+        POINTS_PER_MS / 1e6,
+    );
+
+    println!("encoded sizes (bytes, {BREAKDOWN_INPUTS} public inputs)");
+    println!(
+        "  vk   compressed {:>6}  uncompressed {:>6}",
+        f.vk_compressed.len(),
+        f.vk_uncompressed.len()
+    );
+    println!(
+        "  pvk                        uncompressed {:>6}",
+        f.pvk_uncompressed.len()
+    );
+    println!(
+        "  proof compressed {:>5}  uncompressed {:>6}",
+        f.proof_compressed.len(),
+        f.proof_uncompressed.len()
+    );
+    println!("  inputs {:>4}\n", f.inputs.len());
+
+    let baseline = measure(&mut test, &key, "noop", args![f.proof_uncompressed.clone()]).expect("noop fits");
+
+    let row = |test: &mut TemplateTest, label: &str, func: &str, args: Vec<NamedArg>| {
+        let Some(total) = measure(test, &key, func, args) else {
+            println!("  {label:<34} {:>12}  out of gas — exceeds the budget", "");
+            return None;
+        };
+        let net = total.saturating_sub(baseline);
+        println!(
+            "  {label:<34} {net:>12} pts  {:>7.2} ms  {:>9.0} uT  {:>6.1}% of budget",
+            net as f64 / POINTS_PER_MS,
+            net as f64 / POINTS_PER_MICROTARI,
+            100.0 * net as f64 / MAX_WASM_POINTS_PER_TRANSACTION as f64,
+        );
+        Some(net)
+    };
+
+    println!("breakdown ({BREAKDOWN_INPUTS} public inputs, net of {baseline} pts call overhead)");
+    row(
+        &mut test,
+        "decode proof (compressed)",
+        "decode_proof_compressed",
+        args![f.proof_compressed.clone()],
+    );
+    row(
+        &mut test,
+        "decode proof (uncompressed)",
+        "decode_proof_uncompressed",
+        args![f.proof_uncompressed.clone()],
+    );
+    row(
+        &mut test,
+        "decode proof (no subgroup check)",
+        "decode_proof_uncompressed_unchecked",
+        args![f.proof_uncompressed.clone()],
+    );
+    row(&mut test, "decode vk (uncompressed)", "decode_vk_uncompressed", args![
+        f.vk_uncompressed.clone()
+    ]);
+    row(&mut test, "prepare vk", "prepare", args![f.vk_uncompressed.clone()]);
+    println!();
+
+    println!("full verify ({BREAKDOWN_INPUTS} public inputs)");
+    let compressed = row(&mut test, "vk compressed, per call", "verify_compressed", args![
+        f.vk_compressed.clone(),
+        f.proof_compressed.clone(),
+        f.inputs.clone()
+    ]);
+    let uncompressed = row(&mut test, "vk uncompressed, per call", "verify_uncompressed", args![
+        f.vk_uncompressed.clone(),
+        f.proof_uncompressed.clone(),
+        f.inputs.clone()
+    ]);
+    let prepared = row(&mut test, "pvk uncompressed, per call", "verify_prepared", args![
+        f.pvk_uncompressed.clone(),
+        f.proof_uncompressed.clone(),
+        f.inputs.clone()
+    ]);
+    println!();
+
+    println!("public input scaling (verify_prepared, net of overhead)");
+    let mut points_by_inputs = Vec::new();
+    for n in PUBLIC_INPUT_COUNTS {
+        let fx = groth16::fixture(n);
+        let Some(total) = measure(&mut test, &key, "verify_prepared", args![
+            fx.pvk_uncompressed,
+            fx.proof_uncompressed,
+            fx.inputs
+        ]) else {
+            println!("  {n:>3} inputs               out of gas — exceeds the budget");
+            continue;
+        };
+        let net = total.saturating_sub(baseline);
+        println!(
+            "  {n:>3} inputs {net:>12} pts  {:>7.2} ms  {:>6.1}% of budget",
+            net as f64 / POINTS_PER_MS,
+            100.0 * net as f64 / MAX_WASM_POINTS_PER_TRANSACTION as f64,
+        );
+        points_by_inputs.push((n, net));
+    }
+    if let (Some(&(n_lo, p_lo)), Some(&(n_hi, p_hi))) = (points_by_inputs.first(), points_by_inputs.last()) &&
+        n_hi > n_lo
+    {
+        let per_input = p_hi.saturating_sub(p_lo) as f64 / (n_hi - n_lo) as f64;
+        println!(
+            "  marginal {per_input:.0} pts/input  ({:.4} ms)",
+            per_input / POINTS_PER_MS
+        );
+    }
+    println!();
+
+    // Each invocation would get a fresh per-call budget were the transaction-wide cap not enforced,
+    // so this is where that cap becomes visible: the count that fits is set by the budget, not by
+    // how the calls are split across instructions.
+    println!("stacked verifies in one transaction ({BREAKDOWN_INPUTS} public inputs)");
+    let mut stacked_fit = 0;
+    for count in 1.. {
+        let args = || {
+            args![
+                f.pvk_uncompressed.clone(),
+                f.proof_uncompressed.clone(),
+                f.inputs.clone()
+            ]
+        };
+        let Some(total) = measure_stacked(&mut test, &key, "verify_prepared", args, count) else {
+            println!("  {count:>3} verifies             out of gas — exceeds the budget");
+            break;
+        };
+        println!(
+            "  {count:>3} verifies {total:>12} pts  {:>7.2} ms  {:>6.1}% of budget",
+            total as f64 / POINTS_PER_MS,
+            100.0 * total as f64 / MAX_WASM_POINTS_PER_TRANSACTION as f64,
+        );
+        stacked_fit = count;
+    }
+    println!();
+
+    println!("native reference (same proofs, verified in-process)");
+    for n in PUBLIC_INPUT_COUNTS {
+        let ms = groth16::native_verify_ms(n, NATIVE_TRIALS);
+        println!(
+            "  {n:>3} inputs {:>12.0} pts  {ms:>7.2} ms  {:>9.0} uT",
+            ms * POINTS_PER_MS,
+            ms * POINTS_PER_MS / POINTS_PER_MICROTARI,
+        );
+    }
+    println!();
+
+    println!("verdict");
+    match prepared {
+        Some(prepared) => {
+            println!(
+                "  cheapest in-WASM verify is {:.1}% of the per-transaction budget; {stacked_fit} fit in one \
+                 transaction",
+                100.0 * prepared as f64 / MAX_WASM_POINTS_PER_TRANSACTION as f64,
+            );
+            if let (Some(compressed), Some(uncompressed)) = (compressed, uncompressed) {
+                println!(
+                    "  compression costs {:.1}x; per-call vk preparation costs {:.1}x over a stored pvk",
+                    compressed as f64 / prepared.max(1) as f64,
+                    uncompressed as f64 / prepared.max(1) as f64,
+                );
+            }
+        },
+        None => println!(
+            "  no in-WASM verify fits the {MAX_WASM_POINTS_PER_TRANSACTION} point per-transaction budget; raise the \
+             ceiling to measure by how much"
+        ),
+    }
+    println!(
+        "  for scale, one stealth output (native bulletproof) is priced at {} pts",
+        NativeExecutionPoints::PER_OUTPUT,
+    );
+}

--- a/crates/engine/src/wasm/cache.rs
+++ b/crates/engine/src/wasm/cache.rs
@@ -52,12 +52,15 @@ const LOG_TARGET: &str = "tari::engine::wasm::cache";
 /// undefined behaviour at worst):
 ///
 /// - [`crate::wasm::WasmModule::create_engine`] config (compiler flags, features bitset, middleware list, tunables).
+/// - [`tari_engine_types::limits::MAX_WASM_POINTS_PER_CALL`], which the metering middleware bakes into the artifact as
+///   the initial remaining-points global. `WasmProcess::metering_allowance` reads it back with `get_remaining_points`,
+///   so a node serving a stale artifact meters against the old cap and diverges from one that compiled fresh.
 /// - The `wasmer` crate version (the serialized artifact format is internal to wasmer and not part of any stable wire
 ///   spec).
 ///
 /// On a bump, old cache files become orphans (different filename suffix)
 /// and the next compile-from-source rewrites under the new key.
-pub const ENGINE_FINGERPRINT: &str = "v2";
+pub const ENGINE_FINGERPRINT: &str = "v3";
 
 /// 8-byte LE length prefix at the head of each cache file holding the original
 /// WASM source byte count. `wasmer::Module::serialize` doesn't preserve this

--- a/crates/engine/tests/metering_budget.rs
+++ b/crates/engine/tests/metering_budget.rs
@@ -6,7 +6,7 @@
 //! could run for far longer than any single call by stacking instructions. These tests prove the
 //! total is capped across calls.
 
-use tari_engine_types::{commit_result::RejectReason, fees::FeeSource};
+use tari_engine_types::{commit_result::RejectReason, limits::MAX_WASM_POINTS_PER_TRANSACTION};
 use tari_ootle_transaction::{Epoch, Transaction, args};
 use tari_template_test_tooling::TemplateTest;
 
@@ -19,11 +19,6 @@ fn per_transaction_budget_caps_total_across_calls() {
     let addr = test.get_template_address("MeteringBench");
     let (account, owner, key) = test.create_funded_account();
 
-    // 1 fee unit == 1 metering point so the WasmExecution charge is the exact point count.
-    let mut fee_table = test.fee_table().clone();
-    fee_table.per_wasm_point_cost = 1;
-    fee_table.wasm_points_cost_divisor = 1;
-    test.set_fee_table(fee_table);
     test.enable_fees();
 
     let call = |rounds: u64, n: usize| {
@@ -36,20 +31,14 @@ fn per_transaction_budget_caps_total_across_calls() {
 
     // Calibrate points per round so we can size a call to a known fraction of the budget.
     let mut points = |rounds: u64| -> u64 {
-        let result = test.execute_expect_success(call(rounds, 1), vec![owner.clone()]);
-        result
-            .finalize
-            .fee_receipt
-            .fee_breakdown()
-            .iter()
-            .find_map(|(s, a)| (*s == FeeSource::WasmExecution).then_some(*a))
-            .expect("WasmExecution charge present")
+        test.execute_expect_success(call(rounds, 1), vec![owner.clone()])
+            .wasm_execution_points
     };
     let per_round = (points(20_000) - points(10_000)) / 10_000;
 
-    // Size one call to ~65M points: comfortably under the 100M budget on its own, but two such
-    // calls in a single transaction sum to ~130M and must exceed it.
-    let rounds = 65_000_000 / per_round;
+    // Size one call to ~65% of the budget: comfortably under it on its own, but two such calls in a
+    // single transaction sum to ~130% and must exceed it.
+    let rounds = MAX_WASM_POINTS_PER_TRANSACTION * 65 / 100 / per_round;
 
     // One call stays under the budget and succeeds.
     test.execute_expect_success(call(rounds, 1), vec![owner.clone()]);

--- a/crates/engine/tests/support/groth16.rs
+++ b/crates/engine/tests/support/groth16.rs
@@ -1,0 +1,150 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! Groth16/BN254 setup, proving and encoding for the `zk_verifier` template, shared by
+//! `tests/zk_verify.rs` and `examples/zk_points_calibrate.rs`. Each consumer uses a subset of the
+//! encodings, hence the blanket `dead_code` allowance.
+
+#![allow(dead_code)]
+
+use ark_bn254::{Bn254, Fr};
+use ark_groth16::{Groth16, prepare_verifying_key};
+use ark_relations::{
+    lc,
+    r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError},
+};
+use ark_serialize::CanonicalSerialize;
+use ark_snark::SNARK;
+use ark_std::{
+    UniformRand,
+    rand::{SeedableRng, rngs::StdRng},
+};
+use tari_template_lib::types::bytes::Bytes;
+
+/// R1CS constraints in the test circuit. Verification cost is independent of circuit size — only of
+/// the public input count — so this only has to be large enough to be a real proof.
+pub const CONSTRAINTS: usize = 64;
+
+/// A circuit with `num_public` public inputs, each constrained to the same witness product. The
+/// shape is irrelevant to verification cost, so this is the cheapest circuit that produces a valid
+/// proof with a chosen public input count.
+#[derive(Clone)]
+pub struct InputCountCircuit {
+    pub a: Fr,
+    pub b: Fr,
+    pub num_public: usize,
+    pub num_constraints: usize,
+}
+
+impl ConstraintSynthesizer<Fr> for InputCountCircuit {
+    fn generate_constraints(self, cs: ConstraintSystemRef<Fr>) -> Result<(), SynthesisError> {
+        let a = cs.new_witness_variable(|| Ok(self.a))?;
+        let b = cs.new_witness_variable(|| Ok(self.b))?;
+        let product = self.a * self.b;
+        for _ in 0..self.num_public {
+            let c = cs.new_input_variable(|| Ok(product))?;
+            cs.enforce_constraint(lc!() + a, lc!() + b, lc!() + c)?;
+        }
+        let filler = cs.new_witness_variable(|| Ok(product))?;
+        for _ in self.num_public..self.num_constraints {
+            cs.enforce_constraint(lc!() + a, lc!() + b, lc!() + filler)?;
+        }
+        Ok(())
+    }
+}
+
+/// One circuit's setup and proof, in every encoding the template accepts.
+///
+/// Held as [`Bytes`] rather than `Vec<u8>` because that is what the template's arguments are:
+/// `Bytes` encodes as a CBOR byte string, where a `Vec<u8>` argument would encode as an array of
+/// integers and make the callee pay to decode one CBOR item per byte — which for the 34 KiB
+/// prepared key costs more than a tenth of the verification itself.
+pub struct Fixture {
+    pub vk_compressed: Bytes,
+    pub vk_uncompressed: Bytes,
+    pub pvk_uncompressed: Bytes,
+    pub proof_compressed: Bytes,
+    pub proof_uncompressed: Bytes,
+    pub inputs: Bytes,
+    /// Public inputs the proof does not attest to. Verification returns `false` for these rather
+    /// than erroring, so they exercise the rejection path without also exercising deserialization
+    /// failure.
+    pub wrong_inputs: Bytes,
+}
+
+/// Builds a verifying key and a valid proof for a circuit with `num_public` public inputs.
+///
+/// Deterministic: the seed is fixed so the fixture — and therefore the metering points a template
+/// spends verifying it — is identical from run to run.
+pub fn fixture(num_public: usize) -> Fixture {
+    let rng = &mut StdRng::from_seed([42u8; 32]);
+    let circuit = InputCountCircuit {
+        a: Fr::rand(rng),
+        b: Fr::rand(rng),
+        num_public,
+        num_constraints: CONSTRAINTS.max(num_public),
+    };
+
+    let (pk, vk) = Groth16::<Bn254>::circuit_specific_setup(circuit.clone(), rng).expect("setup");
+    let proof = Groth16::<Bn254>::prove(&pk, circuit.clone(), rng).expect("prove");
+    let public_inputs = vec![circuit.a * circuit.b; num_public];
+
+    // A measurement taken on a rejection path would miss most of the verification, so the fixture
+    // has to be known-good before the template ever sees it.
+    assert!(
+        Groth16::<Bn254>::verify(&vk, &public_inputs, &proof).expect("verify"),
+        "fixture proof must verify natively"
+    );
+
+    let pvk = prepare_verifying_key(&vk);
+    Fixture {
+        vk_compressed: ser_compressed(&vk),
+        vk_uncompressed: ser_uncompressed(&vk),
+        pvk_uncompressed: ser_uncompressed(&pvk),
+        proof_compressed: ser_compressed(&proof),
+        proof_uncompressed: ser_uncompressed(&proof),
+        inputs: ser_uncompressed(&public_inputs),
+        wrong_inputs: ser_uncompressed(&vec![circuit.a * circuit.b + Fr::from(1u64); num_public]),
+    }
+}
+
+pub fn ser_compressed<T: CanonicalSerialize>(value: &T) -> Bytes {
+    let mut bytes = Vec::new();
+    value.serialize_compressed(&mut bytes).expect("serialize");
+    bytes.into()
+}
+
+pub fn ser_uncompressed<T: CanonicalSerialize>(value: &T) -> Bytes {
+    let mut bytes = Vec::new();
+    value.serialize_uncompressed(&mut bytes).expect("serialize");
+    bytes.into()
+}
+
+/// Verifies natively, timed. Used to express what the same check costs outside the WASM meter.
+pub fn native_verify_ms(num_public: usize, trials: usize) -> f64 {
+    use std::time::Instant;
+
+    let rng = &mut StdRng::from_seed([42u8; 32]);
+    let circuit = InputCountCircuit {
+        a: Fr::rand(rng),
+        b: Fr::rand(rng),
+        num_public,
+        num_constraints: CONSTRAINTS.max(num_public),
+    };
+    let (pk, vk) = Groth16::<Bn254>::circuit_specific_setup(circuit.clone(), rng).expect("setup");
+    let proof = Groth16::<Bn254>::prove(&pk, circuit.clone(), rng).expect("prove");
+    let inputs = vec![circuit.a * circuit.b; num_public];
+    let pvk = prepare_verifying_key(&vk);
+
+    // The minimum over the trials is the estimator, matching `native_points_calibrate`: a scheduler
+    // interruption can only make a sample slower, so the fastest is the least contaminated.
+    let mut best = f64::MAX;
+    for _ in 0..trials {
+        let start = Instant::now();
+        let ok = Groth16::<Bn254>::verify_with_processed_vk(&pvk, &inputs, &proof).expect("verify");
+        let elapsed = start.elapsed().as_secs_f64() * 1000.0;
+        assert!(ok, "proof must verify");
+        best = best.min(elapsed);
+    }
+    best
+}

--- a/crates/engine/tests/templates/zk_verifier/Cargo.toml
+++ b/crates/engine/tests/templates/zk_verifier/Cargo.toml
@@ -1,0 +1,22 @@
+[workspace]
+[package]
+name = "zk_verifier"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+tari_template_lib = { path = "../../../../template_lib" }
+
+ark-bn254 = { version = "0.5", default-features = false, features = ["curve"] }
+ark-groth16 = { version = "0.5", default-features = false }
+ark-serialize = { version = "0.5", default-features = false }
+ark-snark = { version = "0.5", default-features = false }
+
+[profile.release]
+opt-level = 3
+lto = true
+codegen-units = 1
+panic = "abort"
+
+[lib]
+crate-type = ["cdylib"]

--- a/crates/engine/tests/templates/zk_verifier/src/lib.rs
+++ b/crates/engine/tests/templates/zk_verifier/src/lib.rs
@@ -1,0 +1,115 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! Groth16/BN254 verification implemented entirely in WASM, to measure what a pure-template zk
+//! verifier costs against the per-transaction metering budget
+//! (`limits::MAX_WASM_POINTS_PER_TRANSACTION`).
+//!
+//! The functions split the verify into its separately-priced parts so the driver
+//! (`crates/engine/examples/zk_points_calibrate.rs`) can attribute points:
+//!
+//! - `noop` — fixed per-call overhead to subtract from every other measurement.
+//! - `decode_*` — deserialization only, with and without subgroup checks.
+//! - `prepare` — `VerifyingKey` -> `PreparedVerifyingKey` (one `alpha_g1_beta_g2` pairing).
+//! - `verify_*` — the full check, from each of the three input encodings a caller might store.
+//!
+//! `_unchecked` variants skip the subgroup checks on deserialized points. They exist to price
+//! those checks, not to offer a faster path: skipping them on caller-supplied data is unsound.
+
+use ark_bn254::{Bn254, Fr};
+use ark_groth16::{Groth16, PreparedVerifyingKey, Proof, VerifyingKey, prepare_verifying_key};
+use ark_serialize::CanonicalDeserialize;
+use ark_snark::SNARK;
+use tari_template_lib::prelude::*;
+
+fn decode_inputs(bytes: &[u8]) -> Vec<Fr> {
+    Vec::<Fr>::deserialize_uncompressed(bytes).expect("bad public inputs")
+}
+
+#[template]
+mod zk_verifier {
+    use super::*;
+
+    pub struct ZkVerifier {
+        /// Uncompressed `PreparedVerifyingKey`. Held in component state so the stateful path
+        /// measures what a real contract pays: the caller supplies only proof and inputs.
+        pvk: Bytes,
+    }
+
+    impl ZkVerifier {
+        pub fn new(pvk: Bytes) -> Component<Self> {
+            Component::new(Self { pvk })
+                .with_access_rules(AccessRules::allow_all())
+                .create()
+        }
+
+        /// Fixed cost of entering a template call with a byte argument of the same shape.
+        pub fn noop(bytes: Bytes) -> bool {
+            !bytes.is_empty()
+        }
+
+        // --- deserialization only ---------------------------------------------------------
+
+        pub fn decode_proof_compressed(proof: Bytes) -> bool {
+            Proof::<Bn254>::deserialize_compressed(proof.as_slice()).is_ok()
+        }
+
+        pub fn decode_proof_uncompressed(proof: Bytes) -> bool {
+            Proof::<Bn254>::deserialize_uncompressed(proof.as_slice()).is_ok()
+        }
+
+        pub fn decode_proof_uncompressed_unchecked(proof: Bytes) -> bool {
+            Proof::<Bn254>::deserialize_uncompressed_unchecked(proof.as_slice()).is_ok()
+        }
+
+        pub fn decode_vk_uncompressed(vk: Bytes) -> bool {
+            VerifyingKey::<Bn254>::deserialize_uncompressed(vk.as_slice()).is_ok()
+        }
+
+        // --- verifying key preparation ----------------------------------------------------
+
+        /// Decode a `VerifyingKey` and prepare it. The result is what `new` stores, so a contract
+        /// pays this once at deploy rather than per verify.
+        pub fn prepare(vk: Bytes) -> bool {
+            let vk = VerifyingKey::<Bn254>::deserialize_uncompressed(vk.as_slice()).expect("bad vk");
+            let pvk = prepare_verifying_key(&vk);
+            !pvk.vk.gamma_abc_g1.is_empty()
+        }
+
+        // --- full verification ------------------------------------------------------------
+
+        /// Worst case: unprepared verifying key supplied per call, compressed encodings
+        /// throughout. Compression halves the bytes on the wire and pays for it with a square
+        /// root per decompressed point.
+        pub fn verify_compressed(vk: Bytes, proof: Bytes, inputs: Bytes) -> bool {
+            let vk = VerifyingKey::<Bn254>::deserialize_compressed(vk.as_slice()).expect("bad vk");
+            let proof = Proof::<Bn254>::deserialize_compressed(proof.as_slice()).expect("bad proof");
+            Groth16::<Bn254>::verify(&vk, &decode_inputs(inputs.as_slice()), &proof).expect("verify failed")
+        }
+
+        /// Unprepared verifying key, uncompressed encodings.
+        pub fn verify_uncompressed(vk: Bytes, proof: Bytes, inputs: Bytes) -> bool {
+            let vk = VerifyingKey::<Bn254>::deserialize_uncompressed(vk.as_slice()).expect("bad vk");
+            let proof = Proof::<Bn254>::deserialize_uncompressed(proof.as_slice()).expect("bad proof");
+            Groth16::<Bn254>::verify(&vk, &decode_inputs(inputs.as_slice()), &proof).expect("verify failed")
+        }
+
+        /// Prepared verifying key supplied per call, uncompressed encodings. Isolates the verify
+        /// from the `prepare` pairing.
+        pub fn verify_prepared(pvk: Bytes, proof: Bytes, inputs: Bytes) -> bool {
+            let pvk = PreparedVerifyingKey::<Bn254>::deserialize_uncompressed(pvk.as_slice()).expect("bad pvk");
+            let proof = Proof::<Bn254>::deserialize_uncompressed(proof.as_slice()).expect("bad proof");
+            Groth16::<Bn254>::verify_with_processed_vk(&pvk, &decode_inputs(inputs.as_slice()), &proof)
+                .expect("verify failed")
+        }
+
+        /// Best case a contract can reach: prepared key already in component state, so the call
+        /// decodes only the proof and the public inputs.
+        pub fn verify_stateful(&self, proof: Bytes, inputs: Bytes) -> bool {
+            let pvk = PreparedVerifyingKey::<Bn254>::deserialize_uncompressed(self.pvk.as_slice()).expect("bad pvk");
+            let proof = Proof::<Bn254>::deserialize_uncompressed(proof.as_slice()).expect("bad proof");
+            Groth16::<Bn254>::verify_with_processed_vk(&pvk, &decode_inputs(inputs.as_slice()), &proof)
+                .expect("verify failed")
+        }
+    }
+}

--- a/crates/engine/tests/zk_verify.rs
+++ b/crates/engine/tests/zk_verify.rs
@@ -14,6 +14,7 @@ use tari_engine_types::{
     commit_result::RejectReason,
     limits::{FREE_COMPUTE_GRACE_POINTS, MAX_WASM_POINTS_PER_TRANSACTION},
 };
+use tari_ootle_common_types::substate_type::SubstateType;
 use tari_ootle_transaction::{Epoch, Transaction, args};
 use tari_template_lib::types::{ComponentAddress, NonFungibleAddress, TemplateAddress, bytes::Bytes};
 use tari_template_test_tooling::TemplateTest;
@@ -109,6 +110,77 @@ fn groth16_verify_fits_the_budget() {
     );
 }
 
+/// The flow a contract actually uses: the verifying key lives in component state and a caller
+/// supplies only a proof and the statement it attests to. Distinct from the static paths above,
+/// which take the key as an argument — here the key is trusted state the caller cannot substitute.
+#[test]
+fn groth16_verifies_against_a_component_held_key() {
+    let mut h = setup();
+    let f = groth16::fixture(INPUTS);
+
+    let create = h
+        .test
+        .transaction()
+        .call_function(h.template, "new", args![f.pvk_uncompressed.clone()])
+        .build_and_seal(&h.key);
+    h.test.execute_expect_success(create, vec![]);
+    let component = h
+        .test
+        .get_previous_output_address(SubstateType::Component)
+        .as_component_address()
+        .unwrap();
+
+    let verified = h.test.call_method::<bool>(
+        component,
+        "verify_stateful",
+        args![f.proof_uncompressed.clone(), f.inputs.clone()],
+        vec![],
+    );
+    assert!(verified, "a valid proof must verify against the component's key");
+
+    let verified = h.test.call_method::<bool>(
+        component,
+        "verify_stateful",
+        args![f.proof_uncompressed.clone(), f.wrong_inputs.clone()],
+        vec![],
+    );
+    assert!(
+        !verified,
+        "the component's key must not verify a statement the proof does not attest to"
+    );
+}
+
+/// A caller may supply the verifying key itself, in either encoding. Both accept a valid proof and
+/// both fit the budget — compression trades bytes on the wire for point decompression, and
+/// supplying an unprepared key trades a stored 34 KiB prepared key for a pairing per call.
+#[test]
+fn groth16_verifies_from_a_caller_supplied_key() {
+    let mut h = setup();
+    let f = groth16::fixture(INPUTS);
+
+    for (func, vk, proof) in [
+        ("verify_uncompressed", &f.vk_uncompressed, &f.proof_uncompressed),
+        ("verify_compressed", &f.vk_compressed, &f.proof_compressed),
+    ] {
+        let tx = h
+            .test
+            .transaction()
+            .call_function(h.template, func, args![vk.clone(), proof.clone(), f.inputs.clone()])
+            .build_and_seal(&h.key);
+        let result = h.test.execute_expect_success(tx, vec![]);
+
+        assert!(
+            result.finalize.execution_results[0].decode::<bool>().unwrap(),
+            "{func} must verify a valid proof",
+        );
+        assert!(
+            result.wasm_execution_points < MAX_WASM_POINTS_PER_TRANSACTION,
+            "{func} cost {} points, over the {MAX_WASM_POINTS_PER_TRANSACTION} budget",
+            result.wasm_execution_points,
+        );
+    }
+}
+
 /// Public inputs the proof does not attest to are rejected, and rejection is not cheaper than
 /// acceptance — both run the same pairing check, so a caller learns nothing from the cost.
 #[test]
@@ -167,15 +239,17 @@ fn stacked_verifies_exhaust_the_transaction_budget() {
     // Sized off the bound rather than the measured cost, so the count is guaranteed to overrun the
     // budget however the real per-verify cost drifts within it.
     let count = (MAX_WASM_POINTS_PER_TRANSACTION / MIN_EXPECTED_POINTS + 1) as usize;
-    let mut builder = h.test.transaction();
-    for _ in 0..count {
-        builder = builder.call_function(h.template, "verify_prepared", args![
-            f.pvk_uncompressed.clone(),
-            f.proof_uncompressed.clone(),
-            f.inputs.clone()
-        ]);
-    }
-    let tx = builder.build_and_seal(&h.key);
+    let tx = h
+        .test
+        .transaction()
+        .fold(0..count, |builder, _| {
+            builder.call_function(h.template, "verify_prepared", args![
+                f.pvk_uncompressed.clone(),
+                f.proof_uncompressed.clone(),
+                f.inputs.clone()
+            ])
+        })
+        .build_and_seal(&h.key);
 
     let reason = h.test.execute_expect_failure(tx, vec![]);
     assert!(

--- a/crates/engine/tests/zk_verify.rs
+++ b/crates/engine/tests/zk_verify.rs
@@ -138,6 +138,15 @@ fn groth16_verifies_against_a_component_held_key() {
     );
     assert!(verified, "a valid proof must verify against the component's key");
 
+    // Loading the key from state rather than taking it as an argument must not change what the
+    // verification costs — the same decode and the same pairing check, off the same bytes.
+    let points = h.test.last_execution_points().total();
+    assert!(
+        (MIN_EXPECTED_POINTS..MAX_EXPECTED_POINTS).contains(&points),
+        "verifying against a component-held key cost {points} points, outside the \
+         {MIN_EXPECTED_POINTS}..{MAX_EXPECTED_POINTS} band the static paths sit in",
+    );
+
     let verified = h.test.call_method::<bool>(
         component,
         "verify_stateful",

--- a/crates/engine/tests/zk_verify.rs
+++ b/crates/engine/tests/zk_verify.rs
@@ -1,0 +1,221 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! Groth16/BN254 verification performed entirely inside a WASM template, with no engine support
+//! beyond the metering budget. These tests fix what that costs, so the budget
+//! (`limits::MAX_WASM_POINTS_PER_TRANSACTION`) and the metering table cannot drift apart from it
+//! silently: a re-costing or a toolchain change that makes an in-WASM verifier stop fitting is a
+//! deliberate decision, not something to discover from a rejected transaction.
+//!
+//! `examples/zk_points_calibrate.rs` prints the full cost breakdown these bounds come from.
+
+use tari_crypto::ristretto::RistrettoSecretKey;
+use tari_engine_types::{
+    commit_result::RejectReason,
+    limits::{FREE_COMPUTE_GRACE_POINTS, MAX_WASM_POINTS_PER_TRANSACTION},
+};
+use tari_ootle_transaction::{Epoch, Transaction, args};
+use tari_template_lib::types::{ComponentAddress, NonFungibleAddress, TemplateAddress, bytes::Bytes};
+use tari_template_test_tooling::TemplateTest;
+
+#[path = "support/groth16.rs"]
+mod groth16;
+
+const CRATE_PATH: &str = env!("CARGO_MANIFEST_DIR");
+const ZK_VERIFIER: &str = "tests/templates/zk_verifier";
+
+/// Public input count the cost bounds are stated at: a realistic contract statement (a root, a
+/// nullifier, a recipient, an amount).
+const INPUTS: usize = 4;
+
+/// Points a verify at [`INPUTS`] must stay under. The measured cost is ~112M; the headroom absorbs
+/// toolchain and arkworks drift without letting a regression that eats the budget go unnoticed.
+const MAX_EXPECTED_POINTS: u64 = 160_000_000;
+
+/// Points a verify at [`INPUTS`] must exceed. Guards against the assertions passing on a template
+/// that silently stopped doing the work — a verify is pairing-heavy and cannot be cheap.
+const MIN_EXPECTED_POINTS: u64 = 40_000_000;
+
+/// Points a verify must leave unspent for the contract logic around it. A budget that a
+/// verification alone exhausts is not a budget a contract can verify *in*, so this is the property
+/// the per-transaction ceiling was sized on and the one that has to keep holding.
+const MIN_CONTRACT_HEADROOM_POINTS: u64 = 60_000_000;
+
+struct Harness {
+    test: TemplateTest,
+    template: TemplateAddress,
+    account: ComponentAddress,
+    owner: NonFungibleAddress,
+    key: RistrettoSecretKey,
+}
+
+fn setup() -> Harness {
+    let mut test = TemplateTest::new(CRATE_PATH, [ZK_VERIFIER]);
+    let template = test.get_template_address("ZkVerifier");
+    let (account, owner, key) = test.create_funded_account();
+    Harness {
+        test,
+        template,
+        account,
+        owner,
+        key,
+    }
+}
+
+impl Harness {
+    /// Calls `verify_prepared` once and returns whether the proof verified, along with the WASM
+    /// metering points the transaction consumed. Fees stay disabled so the call gets the full
+    /// per-transaction budget rather than an allowance bounded by what it has paid — what is under
+    /// test is the hard cap, not the fee model.
+    fn verify(&mut self, f: &groth16::Fixture, inputs: &Bytes) -> (bool, u64) {
+        let tx = self
+            .test
+            .transaction()
+            .call_function(self.template, "verify_prepared", args![
+                f.pvk_uncompressed.clone(),
+                f.proof_uncompressed.clone(),
+                inputs.clone()
+            ])
+            .build_and_seal(&self.key);
+        let result = self.test.execute_expect_success(tx, vec![]);
+        let verified = result.finalize.execution_results[0].decode::<bool>().unwrap();
+        (verified, result.wasm_execution_points)
+    }
+}
+
+/// A Groth16 proof verifies inside a template, and the whole thing fits the per-transaction budget
+/// with room left for the contract logic that would surround it.
+#[test]
+fn groth16_verify_fits_the_budget() {
+    let mut h = setup();
+    let f = groth16::fixture(INPUTS);
+
+    let (verified, points) = h.verify(&f, &f.inputs);
+
+    assert!(verified, "a valid proof must verify");
+    assert!(
+        points < MAX_EXPECTED_POINTS,
+        "in-WASM Groth16 verify cost {points} points, above the {MAX_EXPECTED_POINTS} bound",
+    );
+    assert!(
+        points > MIN_EXPECTED_POINTS,
+        "in-WASM Groth16 verify cost only {points} points — too cheap to be doing the work",
+    );
+    let headroom = MAX_WASM_POINTS_PER_TRANSACTION.saturating_sub(points);
+    assert!(
+        headroom >= MIN_CONTRACT_HEADROOM_POINTS,
+        "a verify took {points} of {MAX_WASM_POINTS_PER_TRANSACTION} points, leaving only {headroom} for the contract \
+         around it",
+    );
+}
+
+/// Public inputs the proof does not attest to are rejected, and rejection is not cheaper than
+/// acceptance — both run the same pairing check, so a caller learns nothing from the cost.
+#[test]
+fn groth16_rejects_wrong_public_inputs() {
+    let mut h = setup();
+    let f = groth16::fixture(INPUTS);
+
+    let (verified, rejected_points) = h.verify(&f, &f.wrong_inputs);
+    assert!(!verified, "public inputs the proof does not attest to must not verify");
+
+    let (_, accepted_points) = h.verify(&f, &f.inputs);
+    let ratio = rejected_points as f64 / accepted_points as f64;
+    assert!(
+        (0.8..1.2).contains(&ratio),
+        "rejecting cost {rejected_points} points against {accepted_points} to accept",
+    );
+}
+
+/// Verification cost grows with the public input count — the `gamma_abc_g1` MSM is the only
+/// input-dependent work — and stays inside the budget across the range a contract would plausibly
+/// use. Sixteen is the top of that range: cost is linear in the count at ~5.3M points each, so a
+/// statement much wider than this belongs behind a hash, as circuits conventionally put it.
+#[test]
+fn groth16_verify_scales_with_public_inputs() {
+    let mut h = setup();
+
+    let mut measured = Vec::new();
+    for n in [1usize, 4, 16] {
+        let f = groth16::fixture(n);
+        let (verified, points) = h.verify(&f, &f.inputs);
+        assert!(verified, "a valid proof with {n} public inputs must verify");
+        assert!(
+            points < MAX_WASM_POINTS_PER_TRANSACTION,
+            "{n} public inputs cost {points} points, over the {MAX_WASM_POINTS_PER_TRANSACTION} budget",
+        );
+        measured.push((n, points));
+    }
+
+    for pair in measured.windows(2) {
+        let [(lo_n, lo), (hi_n, hi)] = pair else { unreachable!() };
+        assert!(
+            hi > lo,
+            "{hi_n} public inputs cost {hi} points, not more than {lo} at {lo_n}",
+        );
+    }
+}
+
+/// Stacking verifies exhausts the transaction-wide budget rather than getting a fresh per-call one.
+/// Without this a contract could verify unboundedly many proofs in a single transaction by putting
+/// each in its own instruction.
+#[test]
+fn stacked_verifies_exhaust_the_transaction_budget() {
+    let mut h = setup();
+    let f = groth16::fixture(INPUTS);
+
+    // Sized off the bound rather than the measured cost, so the count is guaranteed to overrun the
+    // budget however the real per-verify cost drifts within it.
+    let count = (MAX_WASM_POINTS_PER_TRANSACTION / MIN_EXPECTED_POINTS + 1) as usize;
+    let mut builder = h.test.transaction();
+    for _ in 0..count {
+        builder = builder.call_function(h.template, "verify_prepared", args![
+            f.pvk_uncompressed.clone(),
+            f.proof_uncompressed.clone(),
+            f.inputs.clone()
+        ]);
+    }
+    let tx = builder.build_and_seal(&h.key);
+
+    let reason = h.test.execute_expect_failure(tx, vec![]);
+    assert!(
+        matches!(reason, RejectReason::ExecutionFailure(_)),
+        "expected {count} stacked verifies to run out of gas, got {reason:?}",
+    );
+}
+
+/// A verify cannot be funded by the fee intent's flat compute credit. The credit exists to let a
+/// transaction source its fee before paying; anything this expensive belongs in the main
+/// instructions, where the fee already paid funds it.
+#[test]
+fn verify_does_not_fit_the_fee_intent_credit() {
+    const _: () = assert!(FREE_COMPUTE_GRACE_POINTS < MIN_EXPECTED_POINTS);
+
+    let Harness {
+        mut test,
+        template,
+        account,
+        owner,
+        key,
+    } = setup();
+    let f = groth16::fixture(INPUTS);
+
+    test.enable_fees();
+    let tx = Transaction::builder_localnet(Epoch(1))
+        .with_fee_instructions_builder(|builder| {
+            builder
+                .call_function(template, "verify_prepared", args![
+                    f.pvk_uncompressed.clone(),
+                    f.proof_uncompressed.clone(),
+                    f.inputs.clone()
+                ])
+                .pay_fee_from_component(account, 500_000_000u64)
+        })
+        .build_and_seal(&key);
+
+    let reason = test.execute_expect_failure(tx, vec![owner]);
+    assert!(
+        matches!(&reason, RejectReason::ExecutionFailure(msg) if msg.contains("compute credit")),
+        "expected the fee intent's compute credit to be the binding limit, got {reason:?}",
+    );
+}

--- a/crates/engine_types/src/limits.rs
+++ b/crates/engine_types/src/limits.rs
@@ -22,7 +22,7 @@ pub const WASM_LIMITS: WasmLimits = WasmLimits {
 /// Maximum Wasmer metering points a single template invocation may consume. Enforced by the
 /// metering middleware compiled into the engine (see `tari_engine::wasm::module::create_engine`):
 /// exceeding it traps the call with an out-of-gas error.
-pub const MAX_WASM_POINTS_PER_CALL: u64 = 100_000_000;
+pub const MAX_WASM_POINTS_PER_CALL: u64 = 250_000_000;
 
 /// Maximum Wasmer metering points a whole transaction may consume, summed across every template
 /// invocation it makes (top-level instructions and nested cross-template calls). Each invocation
@@ -31,7 +31,35 @@ pub const MAX_WASM_POINTS_PER_CALL: u64 = 100_000_000;
 /// in `WasmProcess::invoke` by capping each call's allowance to the budget remaining for the
 /// transaction. Kept equal to the per-call cap: a transaction gets one compute budget, shared across
 /// all its calls. The aggregate across a *block* still needs a separate per-block budget.
-pub const MAX_WASM_POINTS_PER_TRANSACTION: u64 = 100_000_000;
+///
+/// ~30ms of validator CPU at the rate [`NativeExecutionPoints`] is calibrated against (~8.4M
+/// points/ms). Two bounds meet here.
+///
+/// From below, a template must be able to carry cryptography heavy enough to be worth writing in
+/// WASM at all. A Groth16/BN254 verification costs ~96M points at one public input and ~176M at
+/// sixteen (`cargo run -p tari_engine --release --example zk_points_calibrate`), so this admits one
+/// with room for the contract logic around it. A transaction may already spend
+/// [`MAX_NATIVE_POINTS_PER_TRANSACTION`] (~286ms) on native verification, so a WASM ceiling far
+/// below that is an asymmetry with nothing behind it — both are real CPU on every replica and both
+/// are priced identically.
+///
+/// From above, no single transaction should be able to claim an outsized share of a block. This is
+/// a fraction of `max_block_execution_points`, so a block always admits at least
+/// `MIN_MAX_COMPUTE_TRANSACTIONS_PER_BLOCK` transactions running flat out — raising it further
+/// trades that granularity away, and buys nothing: the next tier of proving system (PLONK, FRI)
+/// does not fit in WASM at any ceiling the block budget could support.
+pub const MAX_WASM_POINTS_PER_TRANSACTION: u64 = 250_000_000;
+
+/// The granularity floor [`MAX_WASM_POINTS_PER_TRANSACTION`] is sized against:
+/// `max_block_execution_points` must admit at least this many transactions each running the WASM
+/// ceiling flat out, so a leader packing max-compute transactions cannot starve a block of
+/// everything else. Asserted against the shipped consensus constants in `tari_consensus`.
+///
+/// Scoped to the WASM ceiling, which is what it bounds. A transaction's native verification is
+/// governed separately by [`MAX_NATIVE_POINTS_PER_TRANSACTION`] and the structural caps in
+/// [`STEALTH_LIMITS`] and [`CONFIDENTIAL_LIMITS`]; that ceiling is large enough that a block of
+/// native-heavy transactions admits far fewer than this many.
+pub const MIN_MAX_COMPUTE_TRANSACTIONS_PER_BLOCK: u64 = 18;
 
 /// Maximum native-verification points (priced by [`NativeExecutionPoints`]) a whole transaction may consume. The
 /// native counterpart of [`MAX_WASM_POINTS_PER_TRANSACTION`], enforced in `StateTracker::charge_native_execution`.

--- a/crates/ootle_wasm/wasm/Cargo.toml
+++ b/crates/ootle_wasm/wasm/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../NPM_README.md"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-ootle-wasm-core = { path = "../core", version = "0.39" }
+ootle-wasm-core = { path = "../core", version = "0.40" }
 wasm-bindgen = "0.2"
 # getrandom is pulled in transitively via `rand` and `tari_bulletproofs_plus`. The wasm32-unknown-unknown
 # target requires explicit feature opt-in for both major versions used in the graph.

--- a/crates/template_test_tooling/src/lib.rs
+++ b/crates/template_test_tooling/src/lib.rs
@@ -14,7 +14,7 @@ mod track_calls;
 mod wrapped_transaction;
 
 pub use package_builder::Package;
-pub use template_test::{TemplateTest, xtr_faucet_component};
+pub use template_test::{ExecutionPoints, TemplateTest, xtr_faucet_component};
 
 // Re-export types used in public interfaces. This allows users to use these types when writing tests without including
 // the various crates themselves.

--- a/crates/template_test_tooling/src/template_test.rs
+++ b/crates/template_test_tooling/src/template_test.rs
@@ -108,6 +108,7 @@ pub struct TemplateTest {
     secret_key: RistrettoSecretKey,
     public_key: RistrettoPublicKey,
     last_outputs: HashSet<SubstateId>,
+    last_execution_points: ExecutionPoints,
     name_to_template: HashMap<String, TemplateAddress>,
     state_store: MemoryStateStore,
     enable_fees: bool,
@@ -123,6 +124,27 @@ pub struct TemplateTest {
     /// nonce keeps their bodies distinct, and keeps them reproducible across runs the way a random
     /// nonce would not.
     transaction_seq: Cell<u64>,
+}
+
+/// The metering points a transaction consumed, split the way the engine charges them.
+///
+/// Both halves are real CPU on every validator and are priced identically, so a test reasoning
+/// about what a transaction costs a validator wants [`Self::total`]; the split matters only when a
+/// test is attributing cost to WASM execution or to native crypto specifically.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ExecutionPoints {
+    /// Wasmer metering points, bounded per transaction by `limits::MAX_WASM_POINTS_PER_TRANSACTION`.
+    pub wasm: u64,
+    /// Native verification points (stealth transfers, confidential withdraws, burn claims), priced
+    /// by `limits::NativeExecutionPoints` and bounded by `limits::MAX_NATIVE_POINTS_PER_TRANSACTION`.
+    pub native: u64,
+}
+
+impl ExecutionPoints {
+    /// Every point the transaction cost a validator, WASM and native alike.
+    pub fn total(&self) -> u64 {
+        self.wasm.saturating_add(self.native)
+    }
 }
 
 impl TemplateTest {
@@ -238,6 +260,7 @@ impl TemplateTest {
             last_outputs: HashSet::new(),
             state_store: MemoryStateStore::new(),
             virtual_substates,
+            last_execution_points: ExecutionPoints::default(),
             transaction_seq: Cell::new(0),
             enable_fees: false,
             dry_run: false,
@@ -430,6 +453,17 @@ impl TemplateTest {
             .find(|addr| ty.matches(addr))
             .cloned()
             .unwrap_or_else(|| panic!("No output of type {:?}", ty))
+    }
+
+    /// The execution points the most recently executed transaction consumed, whether it was
+    /// accepted or rejected.
+    ///
+    /// [`ExecuteResult`] already carries these, but the convenience callers — [`Self::call_function`],
+    /// [`Self::call_method`] — return only the decoded value, so this is how a test reads the cost of
+    /// a call it made through them. Zero if no transaction has executed yet, or if the last one
+    /// failed before producing a result.
+    pub fn last_execution_points(&self) -> ExecutionPoints {
+        self.last_execution_points
     }
 
     fn commit_diff(&mut self, diff: &SubstateDiff) {
@@ -771,7 +805,13 @@ impl TemplateTest {
         let tx_id = wrapped_transaction.to_id();
         eprintln!("START Transaction id = \"{}\"", tx_id);
 
-        let result = processor.execute(wrapped_transaction)?;
+        let result = processor.execute(wrapped_transaction).inspect_err(|_| {
+            self.last_execution_points = ExecutionPoints::default();
+        })?;
+        self.last_execution_points = ExecutionPoints {
+            wasm: result.wasm_execution_points,
+            native: result.native_execution_points,
+        };
 
         if self.enable_fees {
             let fee = &result.finalize.fee_receipt;

--- a/crates/wallet/crypto/Cargo.toml
+++ b/crates/wallet/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_ootle_wallet_crypto"
-version = "0.41.0"
+version = "0.42.0"
 description = "Cryptographic utilities and types for Tari Ootle wallet"
 edition.workspace = true
 authors.workspace = true

--- a/crates/wallet/ootle-rs/Cargo.toml
+++ b/crates/wallet/ootle-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ootle-rs"
-version = "0.21.0"
+version = "0.22.0"
 description = "A Rust library for interacting with the Tari Ootle network."
 edition.workspace = true
 authors.workspace = true

--- a/crates/wallet/sdk/Cargo.toml
+++ b/crates/wallet/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_wallet_sdk"
 description = "The Tari wallet library"
-version = "0.41.0"
+version = "0.42.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/wallet/storage_sqlite/Cargo.toml
+++ b/crates/wallet/storage_sqlite/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_wallet_storage_sqlite"
 description = "The Tari wallet SQLite storage library"
-version = "0.41.0"
+version = "0.42.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/docs/developer-docs/src/content/docs/reference/fees.mdx
+++ b/docs/developer-docs/src/content/docs/reference/fees.mdx
@@ -241,7 +241,7 @@ Three ceilings apply on top of each other:
 |---|---|---|
 | Payment-funded allowance | derived, see above | out-of-gas reported as `InsufficientFeesForCompute` |
 | Fee-intent credit (stage 1 only) | 32,000,000 points, flat | out-of-gas reported as `FeeIntentComputeExceeded` |
-| `MAX_WASM_POINTS_PER_TRANSACTION` | 100,000,000 | out-of-gas, hard cap |
+| `MAX_WASM_POINTS_PER_TRANSACTION` | 250,000,000 | out-of-gas, hard cap |
 | `MAX_NATIVE_POINTS_PER_TRANSACTION` | 2,400,000,000 | `MaxNativeExecutionPointsExceeded` |
 
 Native verification (stealth transfers, confidential withdrawals, Minotari burn claims) is

--- a/utilities/transaction_generator/manifests/max_compute.rs
+++ b/utilities/transaction_generator/manifests/max_compute.rs
@@ -2,7 +2,7 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 // Generates transactions that call the `max_compute` stress template (templates/max_compute). Each
-// call to `busy_max()` burns ~88M Wasmer metering points — close to the 100M per-call cap — so a
+// call to `busy_max()` burns ~218M Wasmer metering points — close to the 250M per-call cap — so a
 // flood of these transactions stresses transaction execution and consensus under worst-case CPU
 // load.
 //
@@ -21,13 +21,14 @@
 // must be declared explicitly with `--input vault_<hex>` — otherwise execution fails with
 // SubstateNotFound.
 //
-// At the testnet fee rate (1 µT per 1000 points) busy_max() costs ~88_000 µT in execution fees, so
-// the fee paid below leaves head-room for the template-load and per-call charges.
+// At the testnet fee rate (1 µT per 1000 points) busy_max() costs ~218_000 µT in execution fees, so
+// the fee paid below leaves head-room for the template-load and per-call charges. The payment also
+// bounds the compute allowance, so it must fund more points than the call consumes.
 use MaxCompute;
 
 fn fee_main() {
     let account = arg!["account"];
-    account.pay_fee(200_000);
+    account.pay_fee(400_000);
 }
 
 fn main() {

--- a/utilities/transaction_generator/manifests/max_compute_stacked.rs
+++ b/utilities/transaction_generator/manifests/max_compute_stacked.rs
@@ -4,7 +4,7 @@
 // Stacks several `busy_max()` calls into a single transaction to exercise the per-transaction
 // metering budget (`MAX_WASM_POINTS_PER_TRANSACTION`, see crates/engine/src/wasm/process.rs).
 //
-// Each `busy_max()` consumes ~88M of the 100M per-transaction budget, so the SECOND call runs out of
+// Each `busy_max()` consumes ~218M of the 250M per-transaction budget, so the SECOND call runs out of
 // gas and the transaction is REJECTED with an execution failure — even though, on a fresh per-call
 // budget, every call would have succeeded. This is the "stack many heavy calls in one transaction"
 // attack the per-transaction budget is meant to block; expect these transactions to show as
@@ -19,13 +19,14 @@
 //     --input vault_<hex> \
 //     --signer <account_owner_secret_key_hex>
 //
-// The fee covers the ~100M points the transaction burns before tripping the budget, so it is
-// rejected for running out of gas rather than for underpaying fees.
+// The fee covers the ~250M points the transaction burns before tripping the budget, so it is
+// rejected for running out of gas rather than for underpaying fees — the payment also bounds the
+// compute allowance, so underpaying here would change the failure mode.
 use MaxCompute;
 
 fn fee_main() {
     let account = arg!["account"];
-    account.pay_fee(200_000);
+    account.pay_fee(400_000);
 }
 
 fn main() {

--- a/utilities/transaction_generator/templates/max_compute/src/lib.rs
+++ b/utilities/transaction_generator/templates/max_compute/src/lib.rs
@@ -2,9 +2,9 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 //! A template designed to consume as much execution time as possible per call without tripping the
-//! Wasmer metering limit (currently 100_000_000 points per `_main` invocation, see
-//! `tari_engine::wasm::module`). It is used to stress test transaction execution and consensus
-//! throughput under worst-case CPU load.
+//! Wasmer metering limit (`tari_engine_types::limits::MAX_WASM_POINTS_PER_CALL`, applied per `_main`
+//! invocation by `tari_engine::wasm::module`). It is used to stress test transaction execution and
+//! consensus throughput under worst-case CPU load.
 //!
 //! The hot loop is a fully serial chain of 64-bit integer divisions. Division is the cheapest
 //! operation to meter (1 point, the same as an add) yet one of the most expensive to actually
@@ -24,11 +24,13 @@ const DIVISIONS_PER_ROUND: u32 = 8;
 /// each divide keeps hitting the hardware slow path.
 const MIX: u64 = 0x9E37_79B9_7F4A_7C17;
 
-/// Number of outer rounds that lands just under the 100M metering budget. Calibrated empirically
-/// (see `tests/max_compute.rs` in the `transaction_generator` crate): with division re-costed to 30
-/// points (see `wasm/metering.rs`) the measured cost is ~358 points per round, so this targets ~88M
-/// points and leaves ~12% head-room under the 100M cap for compiler/metering drift.
-const MAX_ROUNDS: u64 = 245_000;
+/// Number of outer rounds that lands just under the per-call metering budget
+/// (`MAX_WASM_POINTS_PER_CALL`, 250M). Calibrated empirically (see `tests/max_compute.rs` in the
+/// `transaction_generator` crate): with division re-costed to 30 points (see `wasm/metering.rs`) the
+/// measured cost is ~358 points per round, so this targets ~218M points and leaves ~13% head-room
+/// under the cap for compiler/metering drift. Retune whenever that budget moves — the template's
+/// whole purpose is to sit just below it.
+const MAX_ROUNDS: u64 = 610_000;
 
 #[template]
 mod max_compute {

--- a/utilities/transaction_generator/tests/max_compute.rs
+++ b/utilities/transaction_generator/tests/max_compute.rs
@@ -6,15 +6,17 @@
 //! these tests prove it succeeds, pin how close to the limit it runs, and let `MAX_ROUNDS` be
 //! retuned if the cost drifts.
 
-use tari_engine_types::{commit_result::RejectReason, fees::FeeSource};
+use tari_engine_types::{commit_result::RejectReason, fees::FeeSource, limits::MAX_WASM_POINTS_PER_CALL};
 use tari_ootle_transaction::{Epoch, Transaction, args};
 use tari_template_test_tooling::TemplateTest;
 
 const CRATE_PATH: &str = env!("CARGO_MANIFEST_DIR");
 const MAX_COMPUTE: &str = "templates/max_compute";
 
-/// The per-call Wasmer metering budget (see `tari_engine::wasm::module::create_engine`).
-const METERING_LIMIT: u64 = 100_000_000;
+/// The per-call Wasmer metering budget (see `tari_engine::wasm::module::create_engine`). Read from
+/// the engine rather than restated, so a change to the budget shows up here as a retune of
+/// `MAX_ROUNDS` rather than as a silently stale bound.
+const METERING_LIMIT: u64 = MAX_WASM_POINTS_PER_CALL;
 
 /// `busy_max()` must run as much metered work as possible without exhausting its budget: if a
 /// toolchain change pushed the cost over the cap the call would fail with an out-of-gas trap, so
@@ -111,6 +113,7 @@ fn stacked_busy_max_is_rejected_by_per_transaction_budget() {
 
     // Fees are disabled here on purpose: the per-transaction budget is enforced independently of fee
     // charging, so the rejection must be the out-of-gas execution failure, not insufficient fees.
+    test.disable_fees();
     let reason = test.execute_expect_failure(
         Transaction::builder_localnet(Epoch(1))
             .call_function(addr, "busy_max", args![])


### PR DESCRIPTION
## Why

The per-transaction WASM metering ceiling was 100M points — about 12ms of validator CPU at the calibrated ~8.4M points/ms. That put non-trivial cryptography out of reach of templates entirely, and it is 24x tighter than the native ceiling a single transaction already enjoys (`MAX_NATIVE_POINTS_PER_TRANSACTION`, 2.4e9 points ≈ 286ms of stealth/confidential verification). Both are real CPU on every replica, both are priced the same, and both are bounded at the block level by `max_block_validation_execution_points` — the asymmetry had no basis.

This raises the ceiling to 250M (~30ms) and adds the measurement infrastructure that justifies the number, so the budget and what templates can actually do with it stay tied together.

## What the measurement says

A Groth16/BN254 verifier implemented entirely in WASM, with no engine support beyond the meter (`crates/engine/tests/templates/zk_verifier`, arkworks 0.5, 417 KiB binary):

| public inputs | in-WASM | native | ratio |
|---|---|---|---|
| 1 | 96.4M pts / 11.5 ms | 7.86M / 0.93 ms | 12.3x |
| 4 | 112.4M pts / 13.4 ms | 9.86M / 1.17 ms | 11.5x |
| 16 | 176.2M pts / 21.0 ms | 18.0M / 2.14 ms | 10.0x |
| 64 | 431.3M pts / 51.4 ms | 49.0M / 5.83 ms | 8.9x |

At the old ceiling nothing fitted except the single-input case, at 96% of budget with nothing left for contract logic. At 250M a verification with a sixteen-element statement fits at 70% of budget, and two verifies fit in one transaction (measured, exactly linear — no amortisation from batching). Sixty-four public inputs does not fit, which is the deliberate edge: cost is linear at ~5.3M points each, so a statement that wide belongs behind a hash, as circuits conventionally put it.

Other figures from the breakdown, which `cargo run -p tari_engine --release --example zk_points_calibrate` prints in full:

- Subgroup checks are the entire cost of proof deserialization: 8.67M points against 15.6k unchecked. Not optional, but not the problem either — the pairings are.
- Compression costs 1.5x; supplying an unprepared verifying key per call costs 1.4x over a stored prepared one.
- The per-public-input marginal is 5.32M points (0.63 ms) in WASM against 645k native.

The ~10x penalty is what a native verification op would recover, and is the case for one — but that is a separate change. This makes the WASM path viable in the meantime.

## Budget arithmetic

The block budget absorbs the raise comfortably. At 8.4M points/ms:

| | before | after | % of 10s block |
|---|---|---|---|
| `MAX_WASM_POINTS_PER_TRANSACTION` | 100M (11.9 ms) | 250M (29.8 ms) | — |
| `max_block_execution_points` (propose) | 4.5e9 (536 ms) | unchanged | 5.4% |
| `max_block_validation_execution_points` | 7.1e9 (845 ms) | 7.25e9 (863 ms) | 8.6% |

The ceiling is sized on two bounds, not one. From below, one verification plus the contract logic around it. From above, the share of a block a single transaction may claim — a block still admits at least 18 max-compute transactions, fixed by `MIN_MAX_COMPUTE_TRANSACTIONS_PER_BLOCK` and asserted by `a_block_admits_enough_max_compute_transactions`, so a leader packing heavy transactions cannot starve a block of everything else. Raising it further trades that granularity away and buys nothing: PLONK/FRI do not fit in WASM at any ceiling the block budget could support.

The validation budget moves only to keep the invariant asserted in `consensus_constants.rs` — `validation >= propose + MAX_WASM_POINTS_PER_TRANSACTION + MAX_NATIVE_POINTS_PER_TRANSACTION` — with margin. The proposal budget is unchanged, so a block packs fewer heavy transactions rather than doing more work.

`FREE_COMPUTE_GRACE_POINTS` is deliberately left at 32M. It is the transaction's unpaid compute surface, and nothing this expensive should be fundable before a fee is paid — there is a test for that.

## Tests

`crates/engine/tests/zk_verify.rs`, 7 tests:

- a valid proof verifies and leaves an explicit headroom margin for contract logic
- the flow a contract actually takes: verifying key in component state, caller supplies only proof and statement
- caller-supplied verifying keys, both encodings
- public inputs the proof does not attest to are rejected, at the same cost as acceptance
- cost grows with public input count and stays inside the budget to 16 inputs
- stacked verifies exhaust the transaction-wide budget rather than each getting a fresh per-call one
- a verify cannot be funded by the fee intent's compute credit

Cost bounds are stated as a band rather than an exact point count so toolchain and arkworks drift do not break them, with a floor so the assertions cannot pass on a template that stopped doing the work. Verified by mutation: inverting the template's verdict fails 4 of the 7.

`metering_budget.rs` now sizes its calls off `MAX_WASM_POINTS_PER_TRANSACTION` instead of a hardcoded 65M, and reads `wasm_execution_points` directly rather than reconstructing the count from the fee breakdown.

## Also here

`TemplateTest::last_execution_points()` — `ExecuteResult` carries the points, but `call_function`/`call_method` return only the decoded value and drop the result, so tests using them could not see what a call cost. Recorded in `try_execute` (the single point every execution path funnels through) and exposed alongside `get_previous_output_address`, returning both halves and a `total()`.

## Versioning

Workspace 0.39.2 -> 0.40.0, minor rather than patch: `max_block_validation_execution_points` is a consensus rule requiring network-wide uniformity, so two validators resolving `^0.39` to different patch releases would disagree on block validity. `tari_template_test_tooling` also gains public API. Tier-3 rollup plus minor bumps on the wallet-tier crates that re-expose the changed types, per `scripts/crate_versioning.py impact tari_engine_types --breaking`.

One pin that workflow does not cover: `crates/ootle_wasm/wasm` pins `ootle-wasm-core` directly rather than through `[workspace.dependencies]`, so it is not in the tier-3 pin list and broke resolution until fixed.

## Notes for review

- Template arguments are `Bytes`, not `Vec<u8>`. A `Vec<u8>` argument encodes as a CBOR array of integers and costs ~130 points per byte to decode — for the 34 KiB prepared verifying key that was more than a tenth of the verification. Worth remembering for any future native `ZkVerifyArg`.
- arkworks is a dev-dependency of `tari_engine` only; nothing ships in a published artifact.
- `publish_crates.py --dry-run` has not been run — that belongs before an actual release.
- Measurements are from one x86 machine. The points are deterministic and so reproducible, but the millisecond and native columns are not.


