### PR TITLE
chore: update 0.39.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1733,7 +1733,7 @@ dependencies = [
 
 [[package]]
 name = "consensus_tests"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "fern",
  "futures 0.3.31",
@@ -2744,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "db-inspector"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -5128,7 +5128,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "integration_tests"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "config",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-messaging"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "async-trait",
  "futures-bounded 0.2.4",
@@ -6074,7 +6074,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-substream"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "libp2p",
  "prometheus-client",
@@ -7743,7 +7743,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -7754,7 +7754,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm-core"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -7814,7 +7814,7 @@ dependencies = [
 
 [[package]]
 name = "ootle_sdk_core"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "blake2 0.10.6",
  "hex",
@@ -7840,7 +7840,7 @@ dependencies = [
 
 [[package]]
 name = "ootle_sdk_ffi_c"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "cbindgen",
  "hex",
@@ -8835,7 +8835,7 @@ dependencies = [
 
 [[package]]
 name = "proto_builder"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "prost-build 0.14.3",
  "sha2 0.10.9",
@@ -10676,7 +10676,7 @@ dependencies = [
 
 [[package]]
 name = "sqlite_message_logger"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "chrono",
  "diesel",
@@ -11024,7 +11024,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node_client"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "futures-util",
  "log",
@@ -11254,7 +11254,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -11279,7 +11279,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "borsh",
  "minicbor",
@@ -11382,7 +11382,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "blake2 0.10.6",
  "bytes",
@@ -11415,7 +11415,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11445,7 +11445,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_manager"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "log",
@@ -11465,7 +11465,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_oracles"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",
@@ -11511,7 +11511,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -11618,7 +11618,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_lib"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "async-trait",
  "log",
@@ -11716,7 +11716,7 @@ dependencies = [
 
 [[package]]
 name = "tari_networking"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11770,7 +11770,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_app_utilities"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11812,7 +11812,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11841,7 +11841,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_p2p"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "libp2p",
@@ -11867,7 +11867,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -11896,7 +11896,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage_sqlite"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -11949,7 +11949,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_template_provider"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "dashmap 5.5.3",
@@ -11966,7 +11966,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "borsh",
  "hex",
@@ -11992,7 +11992,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction_validation"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -12009,7 +12009,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_cli"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -12132,7 +12132,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk_tests"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "digest 0.10.7",
  "ootle_byte_type",
@@ -12181,7 +12181,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",
@@ -12309,7 +12309,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_framework"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "async-trait",
  "bitflags 2.13.0",
@@ -12333,7 +12333,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_macros"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12342,7 +12342,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_state_sync"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12424,7 +12424,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_store_rocksdb"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12456,7 +12456,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_tree"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "indexmap 2.13.0",
  "log",
@@ -12485,7 +12485,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "libp2p",
  "libp2p-messaging",
@@ -12497,7 +12497,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm_daemon"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12611,7 +12611,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_test_tooling"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "cargo_toml 0.22.3",
@@ -12727,7 +12727,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_manifest"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "proc-macro2",
  "serde_json",
@@ -12762,7 +12762,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -12826,7 +12826,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_client"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "indexmap 2.13.0",
  "multiaddr 0.18.3",
@@ -12850,7 +12850,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_rpc"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12874,7 +12874,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_rollback"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12911,7 +12911,7 @@ dependencies = [
 
 [[package]]
 name = "tari_watcher"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -12940,7 +12940,7 @@ dependencies = [
 
 [[package]]
 name = "tariswap_bench"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13623,7 +13623,7 @@ dependencies = [
 
 [[package]]
 name = "traffic-sim"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13647,7 +13647,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_generator"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "bytes",
@@ -13671,7 +13671,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_submitter"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "clap 4.5.54",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7712,7 +7712,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-rs"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -11588,7 +11588,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_client"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "bounded-vec",
@@ -12069,7 +12069,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12157,7 +12157,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_storage_sqlite"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -12253,7 +12253,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd_client"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "hex",
  "ootle_serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.39.2"
+version = "0.39.3"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-ootle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,9 +104,9 @@ tari_ootle_p2p = { path = "crates/p2p" }
 tari_ootle_storage = { path = "crates/storage" }
 tari_ootle_storage_sqlite = { path = "crates/storage_sqlite" }
 tari_ootle_wallet_crypto = { path = "crates/wallet/crypto", version = "0.41" }
-tari_ootle_wallet_sdk = { path = "crates/wallet/sdk", version = "0.40" }
+tari_ootle_wallet_sdk = { path = "crates/wallet/sdk", version = "0.41" }
 tari_ootle_wallet_sdk_services = { path = "crates/wallet/sdk_services" }
-tari_ootle_wallet_storage_sqlite = { path = "crates/wallet/storage_sqlite", version = "0.40" }
+tari_ootle_wallet_storage_sqlite = { path = "crates/wallet/storage_sqlite", version = "0.41" }
 tari_epoch_manager = { path = "crates/epoch_manager" }
 tari_epoch_oracles = { path = "crates/epoch_oracles" }
 tari_indexer_lib = { path = "crates/indexer_lib" }
@@ -118,14 +118,14 @@ tari_transaction_manifest = { path = "crates/transaction_manifest", version = "0
 tari_validator_node_rpc = { path = "crates/validator_node_rpc" }
 sqlite_message_logger = { path = "networking/sqlite_message_logger" }
 tari_base_node_client = { path = "clients/base_node_client" }
-tari_indexer_client = { path = "clients/tari_indexer_client", default-features = false, version = "0.39" }
+tari_indexer_client = { path = "clients/tari_indexer_client", default-features = false, version = "0.40" }
 tari_networking = { path = "networking/core" }
 tari_rpc_framework = { path = "networking/rpc_framework" }
 tari_rpc_macros = { path = "networking/rpc_macros" }
 tari_swarm = { path = "networking/swarm" }
 tari_validator_node_client = { path = "clients/validator_node_client" }
 tari_validator_rollback = { path = "utilities/validator_rollback", version = "0.39" }
-tari_ootle_walletd_client = { path = "clients/wallet_daemon_client", version = "0.40" }
+tari_ootle_walletd_client = { path = "clients/wallet_daemon_client", version = "0.41" }
 transaction_generator = { path = "utilities/transaction_generator" }
 
 # Dependency crates on crates.io (update versions here as well when updating the workspace version)

--- a/clients/tari_indexer_client/Cargo.toml
+++ b/clients/tari_indexer_client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_indexer_client"
 description = "Tari indexer client library"
-version = "0.39.0"
+version = "0.40.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/clients/wallet_daemon_client/Cargo.toml
+++ b/clients/wallet_daemon_client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_walletd_client"
 description = "Tari wallet daemon client library"
-version = "0.40.0"
+version = "0.41.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/wallet/ootle-rs/Cargo.toml
+++ b/crates/wallet/ootle-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ootle-rs"
-version = "0.20.0"
+version = "0.21.0"
 description = "A Rust library for interacting with the Tari Ootle network."
 edition.workspace = true
 authors.workspace = true

--- a/crates/wallet/sdk/Cargo.toml
+++ b/crates/wallet/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_wallet_sdk"
 description = "The Tari wallet library"
-version = "0.40.1"
+version = "0.41.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/wallet/storage_sqlite/Cargo.toml
+++ b/crates/wallet/storage_sqlite/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_wallet_storage_sqlite"
 description = "The Tari wallet SQLite storage library"
-version = "0.40.0"
+version = "0.41.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
Description
---
chore: update 0.39.3

Bumps `[workspace.package].version` to `0.39.3`, moving the whole tier-3 (core) cohort.

Also minor-bumps the independently-versioned crates affected by the breaking
`tari_indexer_client` change landed in #2479 — `TransactionEntry` gained a
non-optional `source` field and `ListRecentTransactionsRequest` an optional
`source` filter:

| crate | version |
|---|---|
| `tari_indexer_client` | 0.39.0 → 0.40.0 |
| `ootle-rs` | 0.20.0 → 0.21.0 |
| `tari_ootle_wallet_sdk` | 0.40.1 → 0.41.0 |
| `tari_ootle_wallet_storage_sqlite` | 0.40.0 → 0.41.0 |
| `tari_ootle_walletd_client` | 0.40.0 → 0.41.0 |

The three downstream wallet crates move because each re-exposes the changed
types in its public API. `[workspace.dependencies]` pins updated to match.

Breaking Changes
---

- [ ] None
- [ ] Requires data directory to be deleted
- [x] Other - Please specify

`tari_indexer_client`'s `TransactionEntry` has a new non-optional `source`
field, so struct-literal construction breaks for downstream consumers.
