### PR TITLE
fix(indexer): resolve wasm cache dir against the configured data dir

### DIFF
--- a/applications/tari_indexer/src/bootstrap.rs
+++ b/applications/tari_indexer/src/bootstrap.rs
@@ -287,11 +287,12 @@ pub async fn spawn_services(
     let substate_manager = substate_manager.with_metrics(metrics_registry);
 
     // Template manager
-    let wasm_cache_dir = config.indexer.data_dir.join("wasm_cache");
+    let wasm_cache_dir = config.to_data_dir().join("wasm_cache");
 
     let template_manager = task::spawn_blocking({
         let global_db = global_db.clone();
         let substate_manager = substate_manager.clone();
+        let wasm_cache_dir = wasm_cache_dir.clone();
         move || {
             let wasm_cache = WasmModuleCache::open(&wasm_cache_dir).map_err(|e| {
                 anyhow!(
@@ -319,7 +320,7 @@ pub async fn spawn_services(
         fee_table.clone(),
         epoch_manager.clone(),
         dry_run_substate_manager,
-        config.indexer.data_dir.join("wasm_cache"),
+        wasm_cache_dir,
         // We do not verify the kernel merkle proof, since that requires syncing L1 headers
         // TODO: maybe at least validate the well-formedness of the proof
         KnowledgeProofVerifier::new(


### PR DESCRIPTION
## Description

The indexer built its WASM module cache path from `config.indexer.data_dir` directly. That field is relative by default (`data/indexer`) and, unlike the validator node's, is never absolutised at config load — the VN calls `ValidatorNodeConfig::set_base_path`, the indexer instead exposes `ApplicationConfig::to_data_dir()`.

Result: the indexer's compiled-module cache was created relative to the process working directory rather than `{base_path}/{network}/data/indexer/wasm_cache`. The substate cache alongside it already used `to_data_dir()` correctly.

## Motivation and Context

Cache files land outside the node's data directory, so they are not picked up on restart from a different working directory and are missed by anything that manages the data dir.

## How Has This Been Tested?

`cargo check -p tari_indexer`.

## What process can a PR reviewer use to test or verify this change?

Start an indexer from a working directory other than its base path and confirm `wasm_cache` appears under `{base_path}/{network}/data/indexer/` rather than `./data/indexer/`.

## Breaking Changes

- [x] None