### PR TITLE
fix(consensus)!: report a destroyed substate as not found

### DIFF
--- a/crates/consensus/src/hotstuff/substate_store/error.rs
+++ b/crates/consensus/src/hotstuff/substate_store/error.rs
@@ -8,10 +8,13 @@ use tari_ootle_storage::{StorageError, consensus_models::LockConflict};
 pub enum SubstateStoreError {
     #[error("Lock failure: {0}")]
     LockFailed(#[from] LockFailedError),
-    #[error("Substate {id} not found")]
+    /// The substate has no live version at the requested version - it was destroyed, or was never
+    /// created. Which of the two cannot be distinguished without retaining every version ever created,
+    /// so the two must never be reported apart: the reason string reaches consensus through
+    /// `RejectReason`, and a node that has pruned its history would otherwise abort with a different
+    /// reason than one that has not.
+    #[error("Substate {id} is not found or DOWN")]
     SubstateNotFound { id: VersionedSubstateId },
-    #[error("Substate {id} is DOWN")]
-    SubstateIsDown { id: VersionedSubstateId },
     #[error("Expected substate {id} to be DOWN but it was UP")]
     ExpectedSubstateDown { id: VersionedSubstateId },
 
@@ -38,10 +41,10 @@ impl SubstateStoreError {
     pub fn ok_lock_failed(self) -> Result<LockFailedError, Self> {
         match self {
             SubstateStoreError::LockFailed(err) => Ok(err),
-            // A substate that is DOWN is an expected conflict (its version was already spent by an earlier
-            // transaction), not a fatal store error. Treat it as a lock failure so callers can skip or abort the
-            // transaction rather than aborting consensus.
-            SubstateStoreError::SubstateIsDown { id } => Ok(LockFailedError::SubstateIsDown { id }),
+            // A substate with no live version is an expected conflict (its version was already spent by an
+            // earlier transaction, or it never existed), not a fatal store error. Treat it as a lock failure
+            // so callers can skip or abort the transaction rather than aborting consensus.
+            SubstateStoreError::SubstateNotFound { id } => Ok(LockFailedError::SubstateNotFound { id }),
             other => Err(other),
         }
     }
@@ -49,10 +52,8 @@ impl SubstateStoreError {
 
 #[derive(Debug, thiserror::Error)]
 pub enum LockFailedError {
-    #[error("Substate {id} not found")]
+    #[error("Substate {id} is not found or DOWN")]
     SubstateNotFound { id: VersionedSubstateId },
-    #[error("Substate {id} is DOWN")]
-    SubstateIsDown { id: VersionedSubstateId },
     #[error(
         "Failed to {} lock substate {substate_id} due to conflict with existing {} lock in transaction {}", conflict.requested_lock, conflict.existing_lock, conflict.transaction_id
     )]

--- a/crates/consensus/src/hotstuff/substate_store/pending_store.rs
+++ b/crates/consensus/src/hotstuff/substate_store/pending_store.rs
@@ -190,7 +190,7 @@ impl<'store, TTx: StateStoreReadTransaction> ReadableSubstateStore for PendingSu
             return change
                 .up_substate()
                 .cloned()
-                .ok_or_else(|| SubstateStoreError::SubstateIsDown {
+                .ok_or_else(|| SubstateStoreError::SubstateNotFound {
                     id: change.versioned_substate_id().to_owned(),
                 });
         }
@@ -201,14 +201,14 @@ impl<'store, TTx: StateStoreReadTransaction> ReadableSubstateStore for PendingSu
         {
             return change
                 .into_up()
-                .ok_or_else(|| SubstateStoreError::SubstateIsDown { id: id.to_owned() });
+                .ok_or_else(|| SubstateStoreError::SubstateNotFound { id: id.to_owned() });
         }
 
         let Some(substate) = SubstateRecord::get(self.read_transaction(), &substate_addr).optional()? else {
             return Err(SubstateStoreError::SubstateNotFound { id: id.to_owned() });
         };
         if substate.is_destroyed() {
-            return Err(SubstateStoreError::SubstateIsDown { id: id.to_owned() });
+            return Err(SubstateStoreError::SubstateNotFound { id: id.to_owned() });
         }
         Ok(substate
             .into_substate()
@@ -287,9 +287,9 @@ impl<'a, TTx: StateStoreReadTransaction> WriteableSubstateStore for PendingSubst
                     }
                     Ok(())
                 },
-                // If the substate is down, we cannot withdraw from it
+                // Without a live version there is nothing to withdraw from
                 |maybe_id| match maybe_id {
-                    Some(id) => Err(SubstateStoreError::SubstateIsDown { id: id.to_owned() }),
+                    Some(id) => Err(SubstateStoreError::SubstateNotFound { id: id.to_owned() }),
                     None => Err(SubstateStoreError::SubstateNotFound {
                         id: VersionedSubstateId::new(id.clone(), 0),
                     }),
@@ -416,9 +416,7 @@ impl<'store, TTx: StateStoreReadTransaction> PendingSubstateStore<'store, TTx> {
                 Err(err) => {
                     let error = err.ok_lock_failed()?;
                     match error {
-                        err @ LockFailedError::SubstateIsUp { .. } |
-                        err @ LockFailedError::SubstateIsDown { .. } |
-                        err @ LockFailedError::SubstateNotFound { .. } => {
+                        err @ LockFailedError::SubstateIsUp { .. } | err @ LockFailedError::SubstateNotFound { .. } => {
                             // If the substate does not exist or is not UP (unversioned: previously DOWNed and never
                             // UPed), the transaction is invalid
                             let index = lock_status.add_failed(err);
@@ -752,7 +750,7 @@ impl<'store, TTx: StateStoreReadTransaction> PendingSubstateStore<'store, TTx> {
         );
         if let Some(change) = self.get_pending(&id.to_substate_address()) {
             if change.is_down() {
-                return Err(SubstateStoreError::SubstateIsDown { id: id.to_owned() });
+                return Err(SubstateStoreError::SubstateNotFound { id: id.to_owned() });
             }
             return Ok(());
         }
@@ -770,7 +768,7 @@ impl<'store, TTx: StateStoreReadTransaction> PendingSubstateStore<'store, TTx> {
             if change.is_up() {
                 return Ok(());
             }
-            return Err(SubstateStoreError::SubstateIsDown { id: id.to_owned() });
+            return Err(SubstateStoreError::SubstateNotFound { id: id.to_owned() });
         }
 
         trace!(
@@ -781,8 +779,7 @@ impl<'store, TTx: StateStoreReadTransaction> PendingSubstateStore<'store, TTx> {
 
         match SubstateRecord::substate_is_up(self.read_transaction(), &id.to_substate_address()).optional()? {
             Some(true) => Ok(()),
-            Some(false) => Err(SubstateStoreError::SubstateIsDown { id: id.to_owned() }),
-            None => Err(SubstateStoreError::SubstateNotFound { id: id.to_owned() }),
+            Some(false) | None => Err(SubstateStoreError::SubstateNotFound { id: id.to_owned() }),
         }
     }
 
@@ -790,7 +787,6 @@ impl<'store, TTx: StateStoreReadTransaction> PendingSubstateStore<'store, TTx> {
         match self.assert_is_up(id) {
             Ok(_) => Ok(()),
             // Converts a substate store error to a LockFailedError (TODO: improve)
-            Err(SubstateStoreError::SubstateIsDown { id }) => Err(LockFailedError::SubstateIsDown { id }.into()),
             Err(SubstateStoreError::SubstateNotFound { id }) => Err(LockFailedError::SubstateNotFound { id }.into()),
             Err(err) => Err(err),
         }

--- a/crates/consensus/src/hotstuff/transaction_manager/manager.rs
+++ b/crates/consensus/src/hotstuff/transaction_manager/manager.rs
@@ -209,7 +209,7 @@ impl<TStateStore: StateStore, TExecutor: BlockTransactionExecutor<TStateStore>>
                 None => {
                     let latest = store.get_latest_version(input.substate_id())?;
                     if latest.is_down() {
-                        return Err(SubstateStoreError::SubstateIsDown {
+                        return Err(SubstateStoreError::SubstateNotFound {
                             id: input.with_version(latest.version()).to_owned(),
                         }
                         .into());
@@ -385,7 +385,7 @@ impl<TStateStore: StateStore, TExecutor: BlockTransactionExecutor<TStateStore>>
             Err(err) => {
                 warn!(target: LOG_TARGET, "⚠️ PREPARE: failed to resolve local inputs: {err}");
                 // We only expect not found or down errors here. If we get any other error, this is fatal.
-                if !err.is_not_found_error() && !err.is_substate_down_error() {
+                if !err.is_not_found_error() {
                     return Err(err);
                 }
 

--- a/crates/consensus/src/traits/transaction_executor.rs
+++ b/crates/consensus/src/traits/transaction_executor.rs
@@ -12,7 +12,7 @@ use tari_ootle_storage::{
 };
 use tari_ootle_transaction::Transaction;
 
-use crate::hotstuff::substate_store::{LockFailedError, SubstateStoreError};
+use crate::hotstuff::substate_store::SubstateStoreError;
 
 #[derive(thiserror::Error, Debug)]
 pub enum BlockTransactionExecutorError {
@@ -28,17 +28,6 @@ pub enum BlockTransactionExecutorError {
     TransactionPoolError(#[from] TransactionPoolError),
     #[error("BUG: Invariant error: {0}")]
     InvariantError(String),
-}
-impl BlockTransactionExecutorError {
-    pub fn is_substate_down_error(&self) -> bool {
-        matches!(
-            self,
-            BlockTransactionExecutorError::SubstateStoreError(SubstateStoreError::SubstateIsDown { .. }) |
-                BlockTransactionExecutorError::SubstateStoreError(SubstateStoreError::LockFailed(
-                    LockFailedError::SubstateIsDown { .. }
-                ))
-        )
-    }
 }
 
 impl IsNotFoundError for BlockTransactionExecutorError {

--- a/crates/consensus_tests/src/substate_store.rs
+++ b/crates/consensus_tests/src/substate_store.rs
@@ -3,7 +3,7 @@
 
 use tari_consensus::{
     hotstuff::substate_store::{LockFailedError, PendingSubstateStore, SubstateStoreError},
-    traits::{CertificateStore, ReadableSubstateStore, WriteableSubstateStore},
+    traits::{BlockTransactionExecutorError, CertificateStore, ReadableSubstateStore, WriteableSubstateStore},
 };
 use tari_consensus_types::{BlockId, LeafBlock};
 use tari_engine_types::{
@@ -17,6 +17,7 @@ use tari_ootle_common_types::{
     ShardGroup,
     SubstateLockType,
     VersionedSubstateId,
+    optional::IsNotFoundError,
     shard::Shard,
 };
 use tari_ootle_p2p::PeerAddress;
@@ -209,16 +210,30 @@ fn it_allows_requesting_the_same_lock_within_one_transaction() {
 }
 
 #[test]
-fn substate_is_down_is_classified_as_a_skippable_lock_failure() {
-    // A DOWN substate (e.g. surfaced by put_diff at propose time when an input version was already spent)
-    // must be classified as a recoverable lock failure. The proposer relies on ok_lock_failed() to skip such
-    // transactions instead of propagating the error, which would otherwise crash consensus.
+fn a_substate_with_no_live_version_is_a_skippable_lock_failure() {
+    // A substate with no live version (e.g. surfaced by put_diff at propose time when an input version was
+    // already spent) must be classified as a recoverable lock failure. The proposer relies on
+    // ok_lock_failed() to skip such transactions instead of propagating the error, which would otherwise
+    // crash consensus.
     let id = VersionedSubstateId::new(new_substate_id(0), 0);
-    let err = SubstateStoreError::SubstateIsDown { id };
+    let err = SubstateStoreError::SubstateNotFound { id };
     assert!(matches!(
         err.ok_lock_failed(),
-        Ok(LockFailedError::SubstateIsDown { .. })
+        Ok(LockFailedError::SubstateNotFound { .. })
     ));
+}
+
+#[test]
+fn a_substate_with_no_live_version_is_not_fatal_to_input_resolution() {
+    // prepare() treats anything that is not a not-found error as fatal and propagates it out of consensus.
+    // Resolving an input whose version was already spent must stay on the recoverable side of that test so
+    // the transaction aborts on its own.
+    let id = VersionedSubstateId::new(new_substate_id(0), 0);
+    assert!(SubstateStoreError::SubstateNotFound { id: id.clone() }.is_not_found_error());
+    assert!(
+        BlockTransactionExecutorError::SubstateStoreError(SubstateStoreError::SubstateNotFound { id })
+            .is_not_found_error()
+    );
 }
 
 fn add_substate(store: &TestStore, seed: u8, version: u32) -> VersionedSubstateId {

--- a/integration_tests/tests/features/substates.feature
+++ b/integration_tests/tests/features/substates.feature
@@ -24,7 +24,7 @@ Feature: Substates
 
     # We should get an error if we se as inputs the same component version thas has already been downed from previous transactions
     # We can achieve this by reusing inputs from COUNTER_1 instead of the most recent TX1
-    When I invoke on wallet daemon WALLET_D on account ACC on component COUNTER_1/components/counter the method call "increase" named "TX2", I expect it to fail with "Substate .*? is DOWN"
+    When I invoke on wallet daemon WALLET_D on account ACC on component COUNTER_1/components/counter the method call "increase" named "TX2", I expect it to fail with "Substate .*? is not found or DOWN"
 
     # Check that the counter has NOT been increased by the previous erroneous transaction
     When I invoke on wallet daemon WALLET_D on account ACC on component TX1/components/counter the method call "value" the result is "1"


### PR DESCRIPTION
## Problem

A node can only distinguish *"this substate was destroyed"* from *"this substate never existed"* if it has retained every version ever created. That is a property of **how much history the node kept**, not of the ledger — but the two were reported as different errors, and the distinction reached consensus.

`prepare` stringifies the error into the reject reason:

- `RejectReason::SubstateNotFound(err.to_string())` — `transaction_manager/manager.rs:172`
- `RejectReason::FailedToLockInputs(err.to_string())` — `manager.rs:443`, `:461`, `:535`

Those land in the transaction receipt, which is a substate, which is hashed into the state tree. So two honest nodes that had retained different amounts of history would commit **different receipts for the same transaction**, and their state roots would diverge.

Nothing depended on telling them apart. `try_lock_all` (`pending_store.rs:419-425`) already classified `SubstateNotFound`, `SubstateIsDown` and `SubstateIsUp` in one branch as hard conflicts, and `prepare` accepted both as non-fatal when resolving local inputs. Only the string differed.

## Change

`SubstateStoreError::SubstateIsDown` and `LockFailedError::SubstateIsDown` are folded into their `SubstateNotFound` counterparts, reported as `"Substate {id} is not found or DOWN"`. All nine construction sites collapse; two match arms become redundant and are merged.

The variant carries a doc comment recording *why* the two must never be reported apart, since the reason is not local to any one call site and a future reader would otherwise re-split them.

## The trap this removes

`is_not_found_error()` (`substate_store/error.rs`) never matched `SubstateIsDown` — it fell through to `_ => false`. Meanwhile `prepare` guarded its fatal path with `if !err.is_not_found_error() && !err.is_substate_down_error()`.

So removing the separate `is_substate_down_error()` check — the natural thing to do when merging the reject-reason text — would have turned an input whose version was already spent into a **fatal error propagating out of consensus** rather than a transaction abort. And that is the ordinary stale-submission case: `PendingSubstateStore::get` (`pending_store.rs:209-211`) returns exactly that error when a client submits against a superseded version.

Merging the variant rather than widening `is_not_found_error()` dissolves this: there is no longer a "down" error that can miss a not-found check or render a different string.

`a_substate_with_no_live_version_is_not_fatal_to_input_resolution` guards it, asserting `is_not_found_error()` on both `SubstateStoreError` and the wrapping `BlockTransactionExecutorError`. It fails if anyone reintroduces a down variant that misses the check.

## Why now

This is a prerequisite for any scheme that lets a node retain less history — pruning, or a state sync that stops transferring the values of superseded substate versions. While the reject reason encodes how much history a node kept, a node that has pruned cannot safely participate in consensus with one that has not.

It is worth landing on its own regardless: the divergence is reachable today between nodes with different `epoch_history_length` settings.

## Not addressed

`lock_assert_not_exist` (`pending_store.rs:851`) asserts non-existence via `SubstateRecord::exists`, which is record existence — a destroyed record still counts. That is a genuine **decision** divergence rather than a message one, and it is the anti-resurrection rule, which inherently needs every version ever created. Out of scope here; it gates history pruning, not this change.

## Testing

- Workspace `cargo check --all-targets` and `cargo +nightly-2025-12-05 fmt --check` clean.
- 66 `tari_consensus` and 18 `consensus_tests` tests pass.
- `substate_is_down_is_classified_as_a_skippable_lock_failure` renamed to `a_substate_with_no_live_version_is_a_skippable_lock_failure`; the regression guard above added.
- Pre-existing unrelated failure: the `bounded_spawn.rs` doctest references `tari_comms`, left stale by the earlier dependency-graph commit. Untouched here.

## Breaking change

Transactions that abort because an input has no live version now carry `"Substate {id} is not found or DOWN"` as their reject reason instead of `"Substate {id} is DOWN"`, changing the resulting transaction receipt.