### PR TITLE
fix(storage): decide UP_ONLY liveness by destruction, not value presence

### DIFF
--- a/crates/state_store_rocksdb/src/reader.rs
+++ b/crates/state_store_rocksdb/src/reader.rs
@@ -1758,9 +1758,10 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx, R: RocksR
         for (rec, substate) in data.transitions.iter().zip(substates) {
             let update = match rec.transition {
                 StateTransitionType::Up => {
-                    if up_only && substate.substate_value.is_none() {
-                        // If the client only wants up transitions with values, and this up transition doesn't have a
-                        // value, skip it
+                    if up_only && substate.is_destroyed() {
+                        // The caller wants the set that is live now, so an up whose substate has since been
+                        // destroyed is skipped. Its down is skipped too (see below), so including it would
+                        // leave the caller holding a substate nothing later in the stream takes back down.
                         None
                     } else {
                         let metadata_mode = value_filter.contains(SubstateValueFilterFlags::TEMPLATE_METADATA);

--- a/crates/state_store_rocksdb/tests/state_transitions.rs
+++ b/crates/state_store_rocksdb/tests/state_transitions.rs
@@ -11,7 +11,7 @@ use tari_ootle_storage::{
     StateStore,
     StateStoreReadTransaction,
     StateStoreWriteTransaction,
-    consensus_models::{Block, SubstateValueFilterFlags},
+    consensus_models::{Block, SubstateDestroyed, SubstateValueFilterFlags},
 };
 use tari_ootle_transaction::Network;
 use tari_state_tree::Version;
@@ -75,4 +75,49 @@ fn rocksdb() {
             assert_eq!(transitions.updates.len(), *num_substates);
         }
     }
+}
+
+/// A destroyed substate keeps its value until epoch GC prunes it, so `UP_ONLY` must decide liveness by
+/// whether the substate is destroyed. Deciding it by value presence would return this up - and no down
+/// follows it under `UP_ONLY` - leaving the caller with a substate it believes is still live.
+#[test]
+fn up_only_skips_an_up_whose_substate_was_since_destroyed() {
+    let (db, _tmp) = create_rocksdb();
+    const EPOCH: Epoch = Epoch::zero();
+    let mut tx = db.create_write_tx().unwrap();
+    Block::zero_block(Network::LocalNet, num_preshards())
+        .insert(&mut tx)
+        .unwrap();
+
+    let mut substate = gen_substates_for_shards(EPOCH, 1, 0..1, 0).next().unwrap();
+    let shard = substate.shard();
+    tx.substates_commit_batch(create_substate_update_batch(EPOCH, [&substate]))
+        .unwrap();
+
+    // The up is streamed while the substate is live.
+    let up_only = SubstateValueFilterFlags::all_substates() | SubstateValueFilterFlags::UP_ONLY;
+    let transitions = tx.state_transitions_get_starting_at(shard, 1, up_only).unwrap();
+    assert_eq!(transitions.updates.len(), 1);
+
+    // Destroy it at v2. substates_commit_batch marks the record destroyed but retains its value, which is
+    // what epoch GC would later prune.
+    substate.set_destroyed(SubstateDestroyed {
+        at_epoch: EPOCH,
+        at_state_version: 2,
+    });
+    tx.substates_commit_batch(create_substate_update_batch(EPOCH, [&substate]))
+        .unwrap();
+
+    let transitions = tx.state_transitions_get_starting_at(shard, 1, up_only).unwrap();
+    assert!(
+        transitions.updates.is_empty(),
+        "UP_ONLY returned an up for a destroyed substate: {:?}",
+        transitions.updates
+    );
+
+    // Without UP_ONLY the same up is still streamed - the full transition log is unchanged.
+    let transitions = tx
+        .state_transitions_get_starting_at(shard, 1, SubstateValueFilterFlags::all_substates())
+        .unwrap();
+    assert_eq!(transitions.updates.len(), 1);
 }

--- a/crates/storage/src/consensus_models/state_transition.rs
+++ b/crates/storage/src/consensus_models/state_transition.rs
@@ -73,6 +73,14 @@ bitflags! {
         const TEMPLATE_METADATA = 0x0000_0200;
         /// Include all hashes for substates even if filtered out
         const ALL_HASHES = 0x1000_0000;
+        /// Return the substates that are live at the point the stream is taken, rather than the
+        /// transitions that produced them: ups whose substate is still live are sent, and ups whose
+        /// substate has since been destroyed are skipped along with every down.
+        ///
+        /// Liveness must be decided by whether the substate is destroyed, never by whether it still
+        /// holds a value. A destroyed substate keeps its value until epoch GC prunes it
+        /// (`substates_prune_downed_values`), so a value-based test would report everything destroyed
+        /// within the retention window as live, and no down follows to correct it.
         const UP_ONLY = 0x0100_0000;
     }
 }


### PR DESCRIPTION
## The bug

`UP_ONLY` selects the substates that are **live at the point the stream is taken**, rather than the transitions that produced them: it sends ups and drops every down (`reader.rs:1805`). The caller therefore ends up holding whatever ups it received, with nothing later in the stream to take them back down.

It decided liveness by whether the substate still held a value:

```rust
if up_only && substate.substate_value.is_none() { None }  // skip
```

But a destroyed substate **keeps its value** until epoch GC prunes it. `substates_prune_downed_values` only runs at `epoch - epoch_history_length` (`writer.rs:1791`), which is **one epoch back by default**. So everything destroyed inside that window still had a value, was streamed as an up, had its down filtered out, and had no later transition to correct it.

## Impact

An indexer syncing from scratch recorded those substates as live **permanently**. Later sync rounds resume past that state version, so the stale up is never revisited — a UTXO spent shortly before the sync is reported unspent for the rest of that indexer's life.

The window is `epoch_history_length` epochs wide (default 1) and lands on whatever was destroyed just before a fresh sync, so it is easy to hit on a busy network and invisible once hit.

## The fix

Decide liveness by `is_destroyed()` — the property `UP_ONLY` actually means, and one that does not vary with the retention window or with when GC last ran.

The flag now carries a doc comment stating both the selection semantics and why a value-based test is wrong, since the reason lives in a different crate from the flag and is not recoverable from the call site.

## Testing

`up_only_skips_an_up_whose_substate_was_since_destroyed` commits an up, then destroys the substate via `substates_commit_batch` — which marks the record destroyed while retaining its value, exactly the state epoch GC would later prune — and asserts `UP_ONLY` no longer returns the up, while the unfiltered transition log still does.

Verified the test reproduces the bug: reverting the predicate to `substate_value.is_none()` fails it with the stale up in the assertion message.

`cargo clippy --workspace --all-targets` and `cargo +nightly-2025-12-05 fmt --check` clean.

## Follow-on

With this corrected, `UP_ONLY` genuinely returns the live set, which is what a greenfield validator would need to reconstruct the state tree without replaying full history — a JMT root is a function of its leaf set, so inserting the live set yields the checkpoint root. That is not part of this PR. The remaining blocker there is `lock_assert_not_exist` (`pending_store.rs:851`), which tests existence via `SubstateRecord::exists` and so needs records for destroyed versions to enforce the no-resurrection rule.