### PR TITLE
feat(consensus)!: add a protocol version to the block header and vote signature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6879,9 +6879,9 @@ dependencies = [
 
 [[package]]
 name = "minotari_app_grpc"
-version = "5.6.0"
+version = "5.7.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf43c7778bc46555dd2ad90f6b72d4c351676e35937aded1ae354d7abf9c6d4e"
+checksum = "cc43c88c2c11e75ce58ee9cc5d440d07fa16d387c27616a9bbd350b0fc8f8b9d"
 dependencies = [
  "argon2 0.6.0-rc.8",
  "base64 0.22.1",
@@ -6911,9 +6911,9 @@ dependencies = [
 
 [[package]]
 name = "minotari_app_utilities"
-version = "5.6.0"
+version = "5.7.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15ae6f92c622a8d9db7e233ac1dfbb77dc56944b2911202c4b50aa427a781516"
+checksum = "167bccda762ef8603f274049044688f92ed8819da6c44378527df79c80ccafd4"
 dependencies = [
  "clap 4.5.54",
  "dialoguer 0.10.4",
@@ -6935,9 +6935,9 @@ dependencies = [
 
 [[package]]
 name = "minotari_console_wallet"
-version = "5.6.0"
+version = "5.7.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91f7ce08ace070b0869a3b057bee5c819bb66422f2692177868e12a4828911b7"
+checksum = "a1a3899e395ce5294b97797f51823534a9e187965efb82e613ea15371325392a"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6992,9 +6992,9 @@ dependencies = [
 
 [[package]]
 name = "minotari_ledger_wallet_common"
-version = "5.6.0"
+version = "5.7.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf77dbb08e7a1171ab2c1dcede5c96be82cee38a51a07cb0919278a77f64e878"
+checksum = "25cf92dd63d46fbf6a7f54f378043616c8a09ebd40b0038bae3965ed5068016b"
 dependencies = [
  "borsh",
  "bs58",
@@ -7003,9 +7003,9 @@ dependencies = [
 
 [[package]]
 name = "minotari_ledger_wallet_comms"
-version = "5.6.0"
+version = "5.7.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddd26c4e76ee973b63953974f6aeff5d4780c12311514f4b488f4e86c2a78cf"
+checksum = "2c5e0876b98c67333b0c9a4fca6ee5fa337486dd25ef521c9f65a2027232524d"
 dependencies = [
  "borsh",
  "dialoguer 0.11.0",
@@ -7026,9 +7026,9 @@ dependencies = [
 
 [[package]]
 name = "minotari_node"
-version = "5.6.0"
+version = "5.7.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c0d86939d518eb2c2d21a6570d2e15e89cb2b6e3c0a91bda8dd35b7d0844d2c"
+checksum = "2a57b6a4fc39b9b9855beb6a176d7e561d5f4f71c08783211ddda834063a6312"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7087,18 +7087,18 @@ dependencies = [
 
 [[package]]
 name = "minotari_node_grpc_client"
-version = "5.6.0"
+version = "5.7.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "041d7aeea38f5c17046a28468585e84bb80e611d1c035964b306c10310b3faf0"
+checksum = "9fed967d1e1d772bed299a3b348ac20964b9191137036de73ae2c67c8ff903e8"
 dependencies = [
  "minotari_app_grpc",
 ]
 
 [[package]]
 name = "minotari_node_wallet_client"
-version = "5.6.0"
+version = "5.7.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87af2d0dc032a527c9b60d431a8cf01755df70f42ba826cbd61aa937b878c2cd"
+checksum = "730648bda7111453c42327c5be8df8737fcfb733414705dc7d1d1be6c4791cfd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7115,9 +7115,9 @@ dependencies = [
 
 [[package]]
 name = "minotari_wallet"
-version = "5.6.0"
+version = "5.7.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9abfeb0fe0cc3e6aed375b048d4ffde266967e6784ee8e06fa86d908763177d3"
+checksum = "fdd1c85dd03800c78f39462641dc5e338b49d045dc13d9405c794e7146c8be00"
 dependencies = [
  "anyhow",
  "argon2 0.6.0-rc.8",
@@ -7174,9 +7174,9 @@ dependencies = [
 
 [[package]]
 name = "minotari_wallet_grpc_client"
-version = "5.6.0"
+version = "5.7.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f88ab95235fc67b59ad8edf24759f3b746de9a90e76978dfe55af87641b93ec4"
+checksum = "0e9adb61de06eed8aeff1a697c1856b317ff12ee623e48e86fd24feecac5a5c7"
 dependencies = [
  "minotari_app_grpc",
  "tari_common",
@@ -9356,9 +9356,9 @@ dependencies = [
 
 [[package]]
 name = "randomx-rs"
-version = "1.4.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d108ec2b3f83ea06f8290685fa4a20c8f0803b1de43c2301639d7a0592474554"
+checksum = "34837f0cf043a56a66e7a07f835969714a27fc9b561d4743620c54a165a7fc8f"
 dependencies = [
  "bitflags 1.3.2",
  "cmake",
@@ -11239,9 +11239,9 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "5.6.0"
+version = "5.7.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891495ada8d868186ef8d60086a0395644da58f24aceb0fb1aa9bf202df5f24f"
+checksum = "5bd1ecf6675e475d82cd01776003f288666c783d3683ce6209a460a618943317"
 dependencies = [
  "anyhow",
  "cargo_toml 0.20.5",
@@ -11265,9 +11265,9 @@ dependencies = [
 
 [[package]]
 name = "tari_common_sqlite"
-version = "5.6.0"
+version = "5.7.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03189effa6f218e3c7bedc4d4e78b85fbd5369b9abb82bd96741f2ae7f1254f5"
+checksum = "ab7eca6b184d142cdf0a458ec20bd5e0b4fdbc3fe0efc9f4dd9d06aa973a7cf5"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -11283,9 +11283,9 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "5.6.0"
+version = "5.7.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28c3584f28cc06ad4725623491a21f3b9afff0a7f9c6b96dfcdf20bc773355cf"
+checksum = "5b8e0e188ba9a471c8e3bbe64157805b67fc38df13380c00e5230e4dc9240fe2"
 dependencies = [
  "argon2 0.6.0-rc.8",
  "base64 0.22.1",
@@ -11321,9 +11321,9 @@ dependencies = [
 
 [[package]]
 name = "tari_comms"
-version = "5.6.0"
+version = "5.7.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83b11bec4ea54b75d39556fd6c3a3095b1bec1b6574e68e6ecd9cfd17f998300"
+checksum = "24e254c32979cc1cd900f60f197bcaed172d912166cd8164b6e92f50ecf9aacc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11369,9 +11369,9 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_dht"
-version = "5.6.0"
+version = "5.7.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebdc9dbd8510e97ff7d2624a3d01f19c9953f03dea90d92fa63db410f97564f"
+checksum = "95e18c6b5c7da57c73021d3cbc5a539820b7c6c168b006b13014fc59e033d312"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -11404,9 +11404,9 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_rpc_macros"
-version = "5.6.0"
+version = "5.7.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ac88d504ead15479f1880df52a41b608be011a9a66247f5fddd56410a907756"
+checksum = "100113212a37a68e5e09319ecc98daf8ecdbacf009711289ed919e86d39fcace"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11459,9 +11459,9 @@ dependencies = [
 
 [[package]]
 name = "tari_core"
-version = "5.6.0"
+version = "5.7.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "690b06be2dfa78d3d57efadac97062a642ee5cac4017762ec33f3186dc6c0e35"
+checksum = "0708eefe0015db06850b9fbffe5813f9d3a2f396ec20328e143e036f6267e8cc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11665,15 +11665,15 @@ dependencies = [
 
 [[package]]
 name = "tari_features"
-version = "5.6.0"
+version = "5.7.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39875f334c36182679b236eb41a50baa8c27e21b408b34255a96f9f74e5c2e1"
+checksum = "ba38256b95dabd629a45abc7efbb7ad5addc64f589d0d8ca1cdd4289fad086d8"
 
 [[package]]
 name = "tari_hashing"
-version = "5.6.0"
+version = "5.7.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ec0fa604a4edb14d0d1ae4a63be3e6e13b27b2a2e5b9b49af91a0b56a7de322"
+checksum = "834dd8c98cc56c540d3156fc857b63cfd16bfad573101b9ea4dda2d7f91e912e"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11810,9 +11810,9 @@ dependencies = [
 
 [[package]]
 name = "tari_jellyfish"
-version = "5.6.0"
+version = "5.7.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42fa46c17852162d809dc16af47713740b2d2e84d3b5626b381a98b33550b227"
+checksum = "d5c4ed2a66ded9f3f8dc3202823fae9af034e4be033981e9afcad7b2721c203f"
 dependencies = [
  "borsh",
  "digest 0.10.7",
@@ -11825,9 +11825,9 @@ dependencies = [
 
 [[package]]
 name = "tari_libtor"
-version = "5.6.0"
+version = "5.7.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f75126a6e1178cf3e411e331d9646bcec6d68473d78b3106edc821b5f3be0829"
+checksum = "324422cac72c00c138db31f159399da981b58b7bb1c9cf72c764ebe8e5b7ef20"
 dependencies = [
  "derivative",
  "libtor",
@@ -11841,9 +11841,9 @@ dependencies = [
 
 [[package]]
 name = "tari_max_size"
-version = "5.6.0"
+version = "5.7.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b20b44500ebe7bbde456a14577d38355f9cbb18208ffa5f8f9a47862863e6de"
+checksum = "d29202f6ec85120d2d02604de625266e2bc66b62ff1b29211d79d68111e265d0"
 dependencies = [
  "borsh",
  "serde",
@@ -11865,9 +11865,9 @@ dependencies = [
 
 [[package]]
 name = "tari_metrics"
-version = "5.6.0"
+version = "5.7.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8f69c9e8de78ed07e861d8667dd2737042b2553e5d72560765fb2ad85386eed"
+checksum = "aa4173b9cbf00f568c2093f9e824cdd4d862135e632ef801c87e6004bdaf0021"
 dependencies = [
  "once_cell",
  "prometheus",
@@ -11876,9 +11876,9 @@ dependencies = [
 
 [[package]]
 name = "tari_mmr"
-version = "5.6.0"
+version = "5.7.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9f6f4c934193bc8bb2319cc7c7ca8b473d8326bdc6359762e8b23b35cb7217"
+checksum = "c71bcf1ad1e9eab608c43dbae6eb638ba526d223152450c368377c06e149ff9f"
 dependencies = [
  "borsh",
  "digest 0.10.7",
@@ -11907,9 +11907,9 @@ dependencies = [
 
 [[package]]
 name = "tari_node_components"
-version = "5.6.0"
+version = "5.7.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f2f6d5e40d5328c505483c6c7bf5e16eb65472dff30a438aa4681fff4b7d9fc"
+checksum = "e855e40d6404bc830efed1ca80955646936aaf30ddac6eef5cbc16e27ffa7c52"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -12461,9 +12461,9 @@ dependencies = [
 
 [[package]]
 name = "tari_p2p"
-version = "5.6.0"
+version = "5.7.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf8fb1201fdbed9f39f0f1a001cc942bc54b4e57fffa5670f2fe30086d487ca1"
+checksum = "d3962df533801808c5563e98bd87c17e824f7af62d2d2b228ea1f6358e716993"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12549,9 +12549,9 @@ dependencies = [
 
 [[package]]
 name = "tari_script"
-version = "5.6.0"
+version = "5.7.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce7d78b26eb3efe56ff249f5420664fadc0a5b318b1fae9d320d96ade435495"
+checksum = "f60eb57e141fa7311f202f31624c87ec736151d1c063f7d21f2b96e7b30fa7d4"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -12568,9 +12568,9 @@ dependencies = [
 
 [[package]]
 name = "tari_service_framework"
-version = "5.6.0"
+version = "5.7.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4797b0bfcfa13ae8aae09a58f3c861a8bca3f9fc80a5798ce3c445c447b0f437"
+checksum = "cb071e01c5e419e0be55e0e3dfb3444eec56b335f5a33816575dceae974ae68f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12584,18 +12584,18 @@ dependencies = [
 
 [[package]]
 name = "tari_shutdown"
-version = "5.6.0"
+version = "5.7.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6f116cd1a96d1fc416679b07fb9a0f001052deccf42f6342cffab2df0370fd2"
+checksum = "70ac8074210c173b1e5064df1d5a3ec3fd1cfb803e5ab653270e639651a0477b"
 dependencies = [
  "futures 0.3.31",
 ]
 
 [[package]]
 name = "tari_sidechain"
-version = "5.6.0"
+version = "5.7.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7603aa619b134debd3a2d642ec4b91bf15268b6afbbebfc157f6340bea55c431"
+checksum = "e4a80e814f7d03838addb9fcfd7c974f29eeac839d19f77c20aed06f1a59f687"
 dependencies = [
  "borsh",
  "hex",
@@ -12659,9 +12659,9 @@ dependencies = [
 
 [[package]]
 name = "tari_storage"
-version = "5.6.0"
+version = "5.7.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf31e455ee9622994dfd20372a96e3821c3b288f610c8f2647644c0b56aade2"
+checksum = "cda4de3424d0bc06ea053d7159c2f4a956d74a17abf431e0b2dadbce7cd28861"
 dependencies = [
  "bincode 1.3.3",
  "lmdb-zero",
@@ -12822,9 +12822,9 @@ dependencies = [
 
 [[package]]
 name = "tari_test_utils"
-version = "5.6.0"
+version = "5.7.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5256364e6fe4d35d9bdca00cf67af38db79269ace72849e55ef461ba872b7e6"
+checksum = "d8f8c18d0a133d51feed6f1a99a46637b607444f414b50cd5fb73849bcc54d98"
 dependencies = [
  "futures 0.3.31",
  "rand 0.10.1",
@@ -12835,9 +12835,9 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_components"
-version = "5.6.0"
+version = "5.7.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daeef24384c4397631a545d52b6de6f9978977f5fd74406d1e19f1f43698000f"
+checksum = "2a7200cdbb9ca3ee2b11f494a3226b64d92b9fc050b0212998edce8b04c263f0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -12882,9 +12882,9 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_key_manager"
-version = "5.6.0"
+version = "5.7.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de4cfbc3f3346d3fe3211f2758e35b2aaae14aa70c5e6cb20ac9317792e88ce9"
+checksum = "1cf60b2307ec3ecd3ce24f5d027c33c93135ac5bde78e1301d97feb082b6d371"
 dependencies = [
  "async-trait",
  "blake2 0.10.6",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,24 +153,24 @@ ootle-wasm-core = { path = "crates/ootle_wasm/core", version = "0.41" }
 ootle_sdk_core = { path = "crates/ootle_sdk_core", version = "0.41" }
 
 # external minotari/tari dependencies
-minotari_app_grpc = { version = "5.6.0", default-features = false }
-minotari_app_utilities = "5.6.0"
-minotari_node_grpc_client = "5.6.0"
-minotari_wallet_grpc_client = "5.6.0"
-tari_common = "5.6.0"
-tari_common_sqlite = "5.6.0"
-tari_common_types = "5.6.0"
-tari_jellyfish = "5.6.0"
-tari_metrics = "5.6.0"
-tari_mmr = "5.6.0"
-tari_node_components = "5.6.0"
-tari_shutdown = "5.6.0"
-tari_sidechain = "5.6.0"
-tari_transaction_components = "5.6.0"
+minotari_app_grpc = { version = "5.7.0-pre.5", default-features = false }
+minotari_app_utilities = "5.7.0-pre.5"
+minotari_node_grpc_client = "5.7.0-pre.5"
+minotari_wallet_grpc_client = "5.7.0-pre.5"
+tari_common = "5.7.0-pre.5"
+tari_common_sqlite = "5.7.0-pre.5"
+tari_common_types = "5.7.0-pre.5"
+tari_jellyfish = "5.7.0-pre.5"
+tari_metrics = "5.7.0-pre.5"
+tari_mmr = "5.7.0-pre.5"
+tari_node_components = "5.7.0-pre.5"
+tari_shutdown = "5.7.0-pre.5"
+tari_sidechain = "5.7.0-pre.5"
+tari_transaction_components = "5.7.0-pre.5"
 
 tari_crypto = "0.23"
 tari_utilities = "0.10"
-tari_hashing = "5.6.0"
+tari_hashing = "5.7.0-pre.5"
 
 ## Ledger
 ootle_ledger_common = { path = "crates/wallet/ledger/common", version = "0.2.0" }

--- a/applications/tari_ootle_app_utilities/src/protocol_activation.rs
+++ b/applications/tari_ootle_app_utilities/src/protocol_activation.rs
@@ -39,23 +39,36 @@ where
     let last_known_epoch: Option<Epoch> = metadata
         .get_metadata(MetadataKey::EpochManagerCurrentEpoch.as_key_bytes())
         .map_err(db_error)?;
+    // Absent means V0: every binary predating this key launched every network at V0.
+    let recorded_genesis: ProtocolVersion = metadata
+        .get_metadata(MetadataKey::ProtocolGenesisVersion.as_key_bytes())
+        .map_err(db_error)?
+        .unwrap_or(ProtocolVersion::V0);
 
-    let to_record = match ProtocolVersion::check_activation_schedule(network, &recorded, last_known_epoch) {
-        Ok(schedule) => schedule,
-        Err(err) if allow_past_activation => {
-            warn!(target: LOG_TARGET, "⚠️ {err} Continuing because allow_past_protocol_activation is set.");
-            ProtocolVersion::scheduled_activation_epochs(network)
-        },
-        Err(err) => {
-            error!(target: LOG_TARGET, "🛑 {err}");
-            return Err(ExitError::new(ExitCode::DbInconsistentState, err));
-        },
-    };
+    let genesis = ProtocolVersion::genesis(network);
+    let to_record =
+        match ProtocolVersion::check_activation_schedule(network, &recorded, recorded_genesis, last_known_epoch) {
+            Ok(schedule) => schedule,
+            Err(err) if allow_past_activation => {
+                warn!(target: LOG_TARGET, "⚠️ {err} Continuing because allow_past_protocol_activation is set.");
+                ProtocolVersion::scheduled_activation_epochs(network)
+            },
+            Err(err) => {
+                error!(target: LOG_TARGET, "🛑 {err}");
+                return Err(ExitError::new(ExitCode::DbInconsistentState, err));
+            },
+        };
 
     if to_record != recorded {
         info!(target: LOG_TARGET, "Recording protocol schema activation schedule: {to_record:?}");
         metadata
             .set_metadata(MetadataKey::ProtocolActivationSchedule.as_key_bytes(), &to_record)
+            .map_err(db_error)?;
+    }
+    if genesis != recorded_genesis {
+        info!(target: LOG_TARGET, "Recording genesis protocol version: {genesis}");
+        metadata
+            .set_metadata(MetadataKey::ProtocolGenesisVersion.as_key_bytes(), &genesis)
             .map_err(db_error)?;
     }
     global_db.commit(tx).map_err(db_error)?;

--- a/applications/tari_validator_node/src/consensus/signer_service.rs
+++ b/applications/tari_validator_node/src/consensus/signer_service.rs
@@ -34,7 +34,7 @@ impl ValidatorSignerService for TariSignatureService {
 }
 
 impl ValidatorSignatureVerifierService for TariSignatureService {
-    fn verify<M: SignedMessage>(&self, message: &M) -> bool {
+    fn verify<M: SignedMessage + ToSignatureMessage>(&self, message: &M) -> bool {
         let Ok(public_key) = RistrettoPublicKey::convert_from_byte_type(message.public_key()) else {
             return false;
         };

--- a/applications/tari_validator_node/web_ui/src/routes/Blocks/BlockDetails.tsx
+++ b/applications/tari_validator_node/web_ui/src/routes/Blocks/BlockDetails.tsx
@@ -266,6 +266,10 @@ export default function BlockDetails() {
                             <DataTableCell>{block!.header.height}</DataTableCell>
                           </TableRow>
                           <TableRow>
+                            <TableCell>Protocol version</TableCell>
+                            <DataTableCell>V{block!.header.protocol_version}</DataTableCell>
+                          </TableRow>
+                          <TableRow>
                             <TableCell>Proposal Certificate</TableCell>
                             <DataTableCell>{block!.justify.height} ({block!.justify.signatures.length} signatures)</DataTableCell>
                           </TableRow>

--- a/bindings/src/types/BlockHeader.ts
+++ b/bindings/src/types/BlockHeader.ts
@@ -75,4 +75,13 @@ export type BlockHeader = {
    * Currently, this is used to store the block's sidechain_id (if applicable).
    */
   extra_data: ExtraData;
+  /**
+   * The protocol version this block was produced under, resolved from the network's activation schedule at
+   * [`Self::epoch`]. It makes the block self-describing: [`Self::calculate_hash`] and the L1 verifier in
+   * `tari_sidechain` both select the hash schema from this field rather than from the schedule.
+   *
+   * A header that carries no version is under [`ProtocolVersion::V0`], so blocks written before the field
+   * existed decode and hash unchanged.
+   */
+  protocol_version: number;
 };

--- a/crates/consensus/src/hotstuff/commit_proofs.rs
+++ b/crates/consensus/src/hotstuff/commit_proofs.rs
@@ -219,6 +219,7 @@ pub fn convert_block_to_sidechain_block_header(header: &BlockHeader) -> Result<S
 
     Ok(SidechainBlockHeader {
         network: header.network().as_byte(),
+        protocol_version: header.protocol_version().as_u32(),
         parent_id: *header.parent().hash(),
         justify_id: *header.justify_id().hash(),
         height: header.height().as_u64(),
@@ -296,7 +297,7 @@ mod tests {
     use tari_common_types::types::FixedHash;
     use tari_consensus_types::{ProposalCertificate, ShardGroupAccumulatedData};
     use tari_crypto::tari_utilities::epoch_time::EpochTime;
-    use tari_ootle_common_types::{Epoch, ExtraData, NodeHeight, NumPreshards, ShardGroup};
+    use tari_ootle_common_types::{Epoch, ExtraData, NodeHeight, NumPreshards, ProtocolVersion, ShardGroup};
     use tari_ootle_transaction::Network;
     use tari_sidechain::QuorumDecision;
 
@@ -309,6 +310,12 @@ mod tests {
 
     #[test]
     fn it_hashes_the_header_identically_to_sidechain_header() {
+        for protocol_version in [ProtocolVersion::V0, ProtocolVersion::V1] {
+            assert_hashes_identically_to_sidechain_header(protocol_version);
+        }
+    }
+
+    fn build_header(protocol_version: ProtocolVersion) -> BlockHeader {
         let parent_id = seed_hash(1).into_array().into();
         let shard_group = ShardGroup::all_shards(NumPreshards::P256);
         let qc1 = ProposalCertificate::new(
@@ -323,8 +330,9 @@ mod tests {
 
         let qc1_id = qc1.calculate_id();
         let network = Network::LocalNet;
-        let block = BlockHeader::create(
+        BlockHeader::create(
             network,
+            protocol_version,
             parent_id,
             qc1_id,
             NodeHeight(2),
@@ -340,14 +348,18 @@ mod tests {
             ShardGroupAccumulatedData::default(),
             ExtraData::new(),
         )
-        .unwrap();
+        .unwrap()
+    }
 
+    fn assert_hashes_identically_to_sidechain_header(protocol_version: ProtocolVersion) {
+        let block = build_header(protocol_version);
         let sidechain_header = SidechainBlockHeader {
-            network: network.as_byte(),
-            parent_id: *parent_id.hash(),
-            justify_id: *qc1_id.hash(),
-            height: 2,
-            epoch: 1,
+            network: block.network().as_byte(),
+            protocol_version: block.protocol_version().as_u32(),
+            parent_id: *block.parent().hash(),
+            justify_id: *block.justify_id().hash(),
+            height: block.height().as_u64(),
+            epoch: block.epoch().as_u64(),
             epoch_hash: Default::default(),
             shard_group: tari_sidechain::ShardGroup {
                 start: 1,

--- a/crates/consensus/src/hotstuff/commit_proofs.rs
+++ b/crates/consensus/src/hotstuff/commit_proofs.rs
@@ -5,10 +5,12 @@ use log::*;
 use tari_common_types::types::CompressedPublicKey;
 use tari_consensus_types::ProposalCertificate;
 use tari_crypto::{ristretto::RistrettoSecretKey, tari_utilities::ByteArray};
+use tari_ootle_common_types::ProtocolVersion;
 use tari_ootle_storage::{
     StateStoreReadTransaction,
     consensus_models::{Block, BlockHeader, EndOfEpochCommand},
 };
+use tari_ootle_transaction::Network;
 use tari_sidechain::{
     ChainLink,
     CommandCommitProof,
@@ -126,7 +128,8 @@ pub fn generate_block_commit_proof<TTx: StateStoreReadTransaction>(
     let mut block = Block::get(tx, &commit_qc.calculate_block_id())?;
     debug!(target: LOG_TARGET, "⚙️ START: generate commit proof {} {} -> {} {}", block.height(), block.id(), committed_block.height(), committed_block.id());
     debug!(target: LOG_TARGET, "⚙️ Adding the commit_qc to the proof: {commit_qc}");
-    proof_elements.push(convert_qc_to_proof_element(commit_qc)?);
+    let network = committed_block.network();
+    proof_elements.push(convert_qc_to_proof_element(network, commit_qc)?);
     while block.id() != committed_block.id() {
         // Prevent possibility of endless loop if the IDs never match - which should be impossible.
         if block.height() < committed_block.height() {
@@ -151,7 +154,7 @@ pub fn generate_block_commit_proof<TTx: StateStoreReadTransaction>(
         if block.justifies_parent() {
             // This block justifies the parent, so we add it to the proof
             debug!(target: LOG_TARGET, "⚙️ Add justify: {}", block.justify());
-            proof_elements.push(convert_qc_to_proof_element(block.justify())?);
+            proof_elements.push(convert_qc_to_proof_element(network, block.justify())?);
             block = block.get_parent(tx)?;
         } else {
             // This block does not justify the parent. We'll add link(s) back until we find the block that is justified
@@ -244,11 +247,17 @@ pub fn convert_block_to_sidechain_block_header(header: &BlockHeader) -> Result<S
     })
 }
 
-fn convert_qc_to_proof_element(qc: &ProposalCertificate) -> Result<CommitProofElement, HotStuffError> {
+fn convert_qc_to_proof_element(
+    network: Network,
+    qc: &ProposalCertificate,
+) -> Result<CommitProofElement, HotStuffError> {
     Ok(CommitProofElement::QuorumCertificate(
         tari_sidechain::QuorumCertificate {
             header_hash: *qc.header_hash(),
             parent_id: *qc.parent_id().hash(),
+            epoch: qc.epoch().as_u64(),
+            height: qc.height().as_u64(),
+            protocol_version: ProtocolVersion::at(network, qc.epoch()).as_u32(),
             signatures: qc
                 .signatures()
                 .iter()
@@ -295,11 +304,22 @@ fn convert_validator_block_signature(
 #[cfg(test)]
 mod tests {
     use tari_common_types::types::FixedHash;
-    use tari_consensus_types::{ProposalCertificate, ShardGroupAccumulatedData};
+    use tari_consensus_types::{
+        ProposalCertificate,
+        ShardGroupAccumulatedData,
+        ToSignatureMessage,
+        ValidatorSchnorrSignature,
+    };
     use tari_crypto::tari_utilities::epoch_time::EpochTime;
-    use tari_ootle_common_types::{Epoch, ExtraData, NodeHeight, NumPreshards, ProtocolVersion, ShardGroup};
-    use tari_ootle_transaction::Network;
-    use tari_sidechain::QuorumDecision;
+    use tari_ootle_common_types::{
+        Epoch,
+        ExtraData,
+        NodeHeight,
+        NumPreshards,
+        ShardGroup,
+        crypto::create_key_pair_from_seed,
+    };
+    use tari_sidechain::{ProposalVoteMessage, QuorumDecision, ValidatorQcSignature};
 
     use super::*;
 
@@ -349,6 +369,39 @@ mod tests {
             ExtraData::new(),
         )
         .unwrap()
+    }
+
+    #[test]
+    fn a_vote_signed_here_verifies_in_the_sidechain_crate() {
+        for protocol_version in [ProtocolVersion::V0, ProtocolVersion::V1] {
+            assert_vote_verifies_in_the_sidechain_crate(protocol_version);
+        }
+    }
+
+    fn assert_vote_verifies_in_the_sidechain_crate(protocol_version: ProtocolVersion) {
+        let (secret, public) = create_key_pair_from_seed(5);
+        let (nonce, _) = create_key_pair_from_seed(6);
+        let block_id = seed_hash(3);
+        let (epoch, height) = (7u64, 9u64);
+        let decision = QuorumDecision::Accept;
+
+        let message = ProposalVoteMessage::new(protocol_version.as_u32(), &block_id, decision, epoch, height);
+        let signature =
+            ValidatorSchnorrSignature::sign_with_nonce_and_message(&secret, nonce, message.to_signature_message())
+                .expect("signing is infallible for a valid key");
+
+        let qc_signature = ValidatorQcSignature {
+            public_key: CompressedPublicKey::from_canonical_bytes(public.as_bytes()).unwrap(),
+            signature: ValidatorBlockSignature::new(
+                CompressedPublicKey::from_canonical_bytes(signature.get_public_nonce().as_bytes()).unwrap(),
+                signature.get_signature().clone(),
+            ),
+        };
+
+        assert!(qc_signature.verify(protocol_version.as_u32(), &block_id, decision, epoch, height));
+        // The version selects the message, so a certificate cannot claim a version its members did not sign under.
+        let other_version = protocol_version.as_u32() ^ 1;
+        assert!(!qc_signature.verify(other_version, &block_id, decision, epoch, height));
     }
 
     fn assert_hashes_identically_to_sidechain_header(protocol_version: ProtocolVersion) {

--- a/crates/consensus/src/hotstuff/commit_proofs.rs
+++ b/crates/consensus/src/hotstuff/commit_proofs.rs
@@ -5,12 +5,10 @@ use log::*;
 use tari_common_types::types::CompressedPublicKey;
 use tari_consensus_types::ProposalCertificate;
 use tari_crypto::{ristretto::RistrettoSecretKey, tari_utilities::ByteArray};
-use tari_ootle_common_types::ProtocolVersion;
 use tari_ootle_storage::{
     StateStoreReadTransaction,
     consensus_models::{Block, BlockHeader, EndOfEpochCommand},
 };
-use tari_ootle_transaction::Network;
 use tari_sidechain::{
     ChainLink,
     CommandCommitProof,
@@ -128,8 +126,7 @@ pub fn generate_block_commit_proof<TTx: StateStoreReadTransaction>(
     let mut block = Block::get(tx, &commit_qc.calculate_block_id())?;
     debug!(target: LOG_TARGET, "⚙️ START: generate commit proof {} {} -> {} {}", block.height(), block.id(), committed_block.height(), committed_block.id());
     debug!(target: LOG_TARGET, "⚙️ Adding the commit_qc to the proof: {commit_qc}");
-    let network = committed_block.network();
-    proof_elements.push(convert_qc_to_proof_element(network, commit_qc)?);
+    proof_elements.push(convert_qc_to_proof_element(&block, commit_qc)?);
     while block.id() != committed_block.id() {
         // Prevent possibility of endless loop if the IDs never match - which should be impossible.
         if block.height() < committed_block.height() {
@@ -154,8 +151,9 @@ pub fn generate_block_commit_proof<TTx: StateStoreReadTransaction>(
         if block.justifies_parent() {
             // This block justifies the parent, so we add it to the proof
             debug!(target: LOG_TARGET, "⚙️ Add justify: {}", block.justify());
-            proof_elements.push(convert_qc_to_proof_element(network, block.justify())?);
-            block = block.get_parent(tx)?;
+            let parent = block.get_parent(tx)?;
+            proof_elements.push(convert_qc_to_proof_element(&parent, block.justify())?);
+            block = parent;
         } else {
             // This block does not justify the parent. We'll add link(s) back until we find the block that is justified
             // by the PC. NOTE: That these blocks are not necessarily dummy blocks, they simply do not propose a new
@@ -247,8 +245,10 @@ pub fn convert_block_to_sidechain_block_header(header: &BlockHeader) -> Result<S
     })
 }
 
+/// `justified` is the block `qc` justifies, and its header carries the protocol version the certificate's members
+/// signed under. A proof may span an activation, so each certificate is versioned by its own block.
 fn convert_qc_to_proof_element(
-    network: Network,
+    justified: &Block,
     qc: &ProposalCertificate,
 ) -> Result<CommitProofElement, HotStuffError> {
     Ok(CommitProofElement::QuorumCertificate(
@@ -257,7 +257,7 @@ fn convert_qc_to_proof_element(
             parent_id: *qc.parent_id().hash(),
             epoch: qc.epoch().as_u64(),
             height: qc.height().as_u64(),
-            protocol_version: ProtocolVersion::at(network, qc.epoch()).as_u32(),
+            protocol_version: justified.header().protocol_version().as_u32(),
             signatures: qc
                 .signatures()
                 .iter()
@@ -316,9 +316,11 @@ mod tests {
         ExtraData,
         NodeHeight,
         NumPreshards,
+        ProtocolVersion,
         ShardGroup,
         crypto::create_key_pair_from_seed,
     };
+    use tari_ootle_transaction::Network;
     use tari_sidechain::{ProposalVoteMessage, QuorumDecision, ValidatorQcSignature};
 
     use super::*;

--- a/crates/consensus/src/hotstuff/common.rs
+++ b/crates/consensus/src/hotstuff/common.rs
@@ -13,6 +13,7 @@ use tari_ootle_common_types::{
     NodeAddressable,
     NodeHeight,
     NumPreshards,
+    ProtocolVersion,
     ShardGroup,
     committee::{Committee, CommitteeInfo},
     derive_fee_pool_address,
@@ -211,6 +212,7 @@ fn with_dummy_blocks<TAddr, TLeaderStrategy, F>(
         let (_, leader) = leader_strategy.get_leader(local_committee, view_height);
         let dummy_header = BlockHeader::dummy_block(
             network,
+            ProtocolVersion::at(network, epoch),
             parent_block_id,
             *leader,
             current_block_height,

--- a/crates/consensus/src/hotstuff/error.rs
+++ b/crates/consensus/src/hotstuff/error.rs
@@ -4,7 +4,7 @@
 use tari_common_types::types::FixedHash;
 use tari_consensus_types::{BlockId, LeafBlock, PcId, QcId};
 use tari_epoch_manager::EpochManagerError;
-use tari_ootle_common_types::{Epoch, NodeHeight, ShardGroup, VersionedSubstateIdError, VotePower};
+use tari_ootle_common_types::{Epoch, NodeHeight, ProtocolVersion, ShardGroup, VersionedSubstateIdError, VotePower};
 use tari_ootle_storage::{
     StorageError,
     consensus_models::{
@@ -220,6 +220,16 @@ pub enum ProposalValidationError {
     InvalidNetwork {
         expected_network: String,
         block_network: String,
+        block_id: BlockId,
+    },
+    #[error(
+        "Invalid protocol version in block {block_id}: this node's schedule puts epoch {epoch} at {expected_version} \
+         but the block was produced under {block_version}"
+    )]
+    InvalidProtocolVersion {
+        expected_version: ProtocolVersion,
+        block_version: ProtocolVersion,
+        epoch: Epoch,
         block_id: BlockId,
     },
     #[error("Invalid state merkle root for block {block_id}: calculated {calculated} but block has {from_block}")]

--- a/crates/consensus/src/hotstuff/on_inbound_message.rs
+++ b/crates/consensus/src/hotstuff/on_inbound_message.rs
@@ -7,6 +7,7 @@ use log::*;
 use tari_consensus_types::{ProposalCertificate, Vote};
 use tari_epoch_manager::EpochManagerReader;
 use tari_ootle_common_types::{Epoch, NodeHeight, optional::Optional};
+use tari_ootle_transaction::Network;
 
 use crate::{
     hotstuff::error::HotStuffError,
@@ -26,13 +27,14 @@ pub struct OnInboundMessage<TConsensusSpec: ConsensusSpec> {
 
 impl<TConsensusSpec: ConsensusSpec> OnInboundMessage<TConsensusSpec> {
     pub fn new(
+        network: Network,
         inbound_messaging: TConsensusSpec::InboundMessaging,
         epoch_manager: TConsensusSpec::EpochManager,
         signer_service: TConsensusSpec::SignerService,
         hooks: TConsensusSpec::Hooks,
     ) -> Self {
         Self {
-            message_buffer: MessageBuffer::new(inbound_messaging, epoch_manager, signer_service),
+            message_buffer: MessageBuffer::new(network, inbound_messaging, epoch_manager, signer_service),
             hooks,
         }
     }
@@ -75,6 +77,7 @@ impl<TConsensusSpec: ConsensusSpec> OnInboundMessage<TConsensusSpec> {
 
 type EpochAndHeight = (Epoch, NodeHeight);
 pub struct MessageBuffer<TConsensusSpec: ConsensusSpec> {
+    network: Network,
     buffer: BTreeMap<EpochAndHeight, VecDeque<(TConsensusSpec::Addr, HotstuffMessage)>>,
     inbound_messaging: TConsensusSpec::InboundMessaging,
     epoch_manager: TConsensusSpec::EpochManager,
@@ -83,11 +86,13 @@ pub struct MessageBuffer<TConsensusSpec: ConsensusSpec> {
 
 impl<TConsensusSpec: ConsensusSpec> MessageBuffer<TConsensusSpec> {
     pub fn new(
+        network: Network,
         inbound_messaging: TConsensusSpec::InboundMessaging,
         epoch_manager: TConsensusSpec::EpochManager,
         signer_service: TConsensusSpec::SignerService,
     ) -> Self {
         Self {
+            network,
             buffer: BTreeMap::new(),
             inbound_messaging,
             epoch_manager,
@@ -244,7 +249,12 @@ impl<TConsensusSpec: ConsensusSpec> MessageBuffer<TConsensusSpec> {
             return Ok(None);
         };
 
-        match check_quorum_certificate_signatures::<TConsensusSpec>(qc.into(), &committee, &self.signer_service) {
+        match check_quorum_certificate_signatures::<TConsensusSpec>(
+            self.network,
+            qc.into(),
+            &committee,
+            &self.signer_service,
+        ) {
             Ok(()) => {
                 let reason = format!(
                     "Received valid 2f+1 QC for {} ({} signatures) while consensus view is still in {}: network \

--- a/crates/consensus/src/hotstuff/on_propose.rs
+++ b/crates/consensus/src/hotstuff/on_propose.rs
@@ -19,6 +19,7 @@ use tari_ootle_common_types::{
     Epoch,
     ExtraData,
     NodeHeight,
+    ProtocolVersion,
     committee::CommitteeInfo,
     displayable::Displayable,
     optional::Optional,
@@ -615,6 +616,7 @@ where TConsensusSpec: ConsensusSpec
 
         let mut header = BlockHeader::create_unsigned(
             self.config.network,
+            ProtocolVersion::at(self.config.network, epoch),
             *parent_block.block_id(),
             high_qc_id,
             next_height,

--- a/crates/consensus/src/hotstuff/on_receive_local_proposal.rs
+++ b/crates/consensus/src/hotstuff/on_receive_local_proposal.rs
@@ -21,6 +21,7 @@ use tari_epoch_manager::EpochManagerReader;
 use tari_ootle_common_types::{
     Epoch,
     NodeHeight,
+    ProtocolVersion,
     committee::{Committee, CommitteeInfo},
     optional::Optional,
 };
@@ -600,6 +601,7 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveLocalProposalHandler<TConsensusSpec
                     // Create the next genesis
                     let mut genesis = Block::genesis(
                         network,
+                        ProtocolVersion::at(network, next_epoch),
                         next_epoch,
                         epoch_hash,
                         next_shard_group,

--- a/crates/consensus/src/hotstuff/on_receive_local_proposal.rs
+++ b/crates/consensus/src/hotstuff/on_receive_local_proposal.rs
@@ -38,7 +38,7 @@ use tari_ootle_storage::{
         ValidBlock,
     },
 };
-use tari_sidechain::{ProposalCertificateSignatureFields, QuorumDecision};
+use tari_sidechain::{ProposalVoteMessage, QuorumDecision};
 use tari_template_lib_types::crypto::RistrettoPublicKeyBytes;
 use tokio::{sync::broadcast, task};
 
@@ -817,10 +817,13 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveLocalProposalHandler<TConsensusSpec
     }
 
     fn generate_vote_message(&self, block: &Block, decision: QuorumDecision) -> Result<VoteMessage, HotStuffError> {
-        let msg = ProposalCertificateSignatureFields {
-            block_id: block.id().hash(),
+        let msg = ProposalVoteMessage::new(
+            block.header().protocol_version().as_u32(),
+            block.id().hash(),
             decision,
-        };
+            block.epoch().as_u64(),
+            block.height().as_u64(),
+        );
         let signature = self.signing_service.sign(&msg);
         let signature = ValidatorSignatureBytes {
             public_key: self.signing_service.public_key().to_byte_type(),

--- a/crates/consensus/src/hotstuff/on_receive_new_view.rs
+++ b/crates/consensus/src/hotstuff/on_receive_new_view.rs
@@ -185,6 +185,7 @@ where TConsensusSpec: ConsensusSpec
             });
         }
         check_quorum_certificate_signatures::<TConsensusSpec>(
+            self.proposal_vote_collector.network(),
             qc.into(),
             epoch_state.local_committee(),
             vote_signing_service,

--- a/crates/consensus/src/hotstuff/vote_collector/proposal_collector.rs
+++ b/crates/consensus/src/hotstuff/vote_collector/proposal_collector.rs
@@ -3,21 +3,24 @@
 
 use log::*;
 use tari_consensus_types::{HighPc, ProposalCertificate, ProposalVote, ValidatorSignatureBytes};
-use tari_ootle_common_types::{Epoch, NodeHeight, optional::Optional};
+use tari_ootle_common_types::{Epoch, NodeHeight, ProtocolVersion, optional::Optional};
 use tari_ootle_storage::{StateStore, consensus_models::Block};
-use tari_sidechain::QuorumDecision;
+use tari_ootle_transaction::Network;
+use tari_sidechain::{ProposalVoteMessage, QuorumDecision};
 
 use super::collector::VoteCollector;
 use crate::{
     hotstuff::{epoch_state::EpochState, error::HotStuffError, vote_collector::helpers::check_eligibility},
     tracing::TraceTimer,
     traits::{CertificateStore, ConsensusSpec, ValidatorSignatureVerifierService},
+    validations::signed_vote::SignedProposalVote,
 };
 
 const LOG_TARGET: &str = "tari::consensus::hotstuff::proposal_collector";
 
 #[derive(Clone)]
 pub struct ProposalVoteCollector<TConsensusSpec: ConsensusSpec> {
+    network: Network,
     vote_collector: VoteCollector<ProposalVote>,
     store: TConsensusSpec::StateStore,
     epoch_manager: TConsensusSpec::EpochManager,
@@ -28,11 +31,13 @@ impl<TConsensusSpec> ProposalVoteCollector<TConsensusSpec>
 where TConsensusSpec: ConsensusSpec
 {
     pub fn new(
+        network: Network,
         store: TConsensusSpec::StateStore,
         epoch_manager: TConsensusSpec::EpochManager,
         vote_signer_service: TConsensusSpec::SignerService,
     ) -> Self {
         Self {
+            network,
             store,
             vote_collector: VoteCollector::new(),
             epoch_manager,
@@ -42,6 +47,10 @@ where TConsensusSpec: ConsensusSpec
 
     pub fn signing_service(&self) -> &TConsensusSpec::SignerService {
         &self.vote_signer_service
+    }
+
+    pub fn network(&self) -> Network {
+        self.network
     }
 
     /// Returns Some if quorum is reached
@@ -133,7 +142,18 @@ where TConsensusSpec: ConsensusSpec
             });
         }
 
-        if !self.vote_signer_service.verify(vote) {
+        let message = ProposalVoteMessage::new(
+            ProtocolVersion::at(self.network, vote.epoch).as_u32(),
+            vote.block_id.hash(),
+            vote.decision,
+            vote.epoch.as_u64(),
+            vote.block_height.as_u64(),
+        );
+        let signed_vote = SignedProposalVote {
+            message,
+            signature: &vote.signature,
+        };
+        if !self.vote_signer_service.verify(&signed_vote) {
             return Err(HotStuffError::InvalidVoteSignature {
                 signer_public_key: *vote.signature.public_key(),
             });

--- a/crates/consensus/src/hotstuff/worker.rs
+++ b/crates/consensus/src/hotstuff/worker.rs
@@ -24,6 +24,7 @@ use tari_epoch_manager::{EpochManagerEvent, EpochManagerReader};
 use tari_ootle_common_types::{
     Epoch,
     NodeHeight,
+    ProtocolVersion,
     ShardGroup,
     VersionedSubstateId,
     displayable::Displayable,
@@ -1527,6 +1528,7 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
 
             let mut genesis = Block::genesis(
                 self.config.network,
+                ProtocolVersion::at(self.config.network, epoch),
                 epoch,
                 epoch_hash,
                 shard_group,

--- a/crates/consensus/src/hotstuff/worker.rs
+++ b/crates/consensus/src/hotstuff/worker.rs
@@ -153,8 +153,12 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
     ) -> Self {
         let (tx_missing_transactions, rx_missing_transactions) = mpsc::unbounded_channel();
         let pacemaker = PaceMaker::new(config.consensus_constants.pacemaker_block_time);
-        let proposal_vote_collector =
-            ProposalVoteCollector::new(state_store.clone(), epoch_manager.clone(), signing_service.clone());
+        let proposal_vote_collector = ProposalVoteCollector::new(
+            config.network,
+            state_store.clone(),
+            epoch_manager.clone(),
+            signing_service.clone(),
+        );
         let timeout_vote_collector =
             TimeoutVoteCollector::new(state_store.clone(), epoch_manager.clone(), signing_service.clone());
         let transaction_manager = ConsensusTransactionManager::new(
@@ -170,6 +174,7 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
             rx_missing_transactions,
 
             on_inbound_message: OnInboundMessage::new(
+                config.network,
                 inbound_messaging,
                 epoch_manager.clone(),
                 signing_service.clone(),

--- a/crates/consensus/src/hotstuff/worker.rs
+++ b/crates/consensus/src/hotstuff/worker.rs
@@ -1394,6 +1394,28 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
         }
     }
 
+    /// A protocol version activates on a schedule compiled into the binary, so a proposal under a version this node
+    /// does not expect means this binary's schedule disagrees with the committee's. Every subsequent proposal is
+    /// rejected for the same reason, so raise one loud alarm per distinct disagreement.
+    fn alarm_protocol_version_disagreement(
+        &mut self,
+        epoch: Epoch,
+        expected_version: ProtocolVersion,
+        block_version: ProtocolVersion,
+    ) {
+        let divergence = (epoch, expected_version, block_version);
+        if self.worker_state.last_protocol_version_alarm == Some(divergence) {
+            return;
+        }
+        self.worker_state.last_protocol_version_alarm = Some(divergence);
+        error!(
+            target: LOG_TARGET,
+            "🚨 Protocol version disagreement at {epoch}: this node's schedule expects {expected_version} but the \
+             committee is proposing under {block_version}. Consensus is stalled on this node and stays stalled \
+             until it runs a binary whose activation schedule matches the committee's. Upgrade this node."
+        );
+    }
+
     async fn handle_hotstuff_error(
         &mut self,
         current_height: NodeHeight,
@@ -1436,6 +1458,15 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
                          confirmation depth at the epoch boundary."
                     );
                 }
+                return Ok(());
+            },
+            HotStuffError::ProposalValidationError(ProposalValidationError::InvalidProtocolVersion {
+                expected_version,
+                block_version,
+                epoch,
+                ..
+            }) => {
+                self.alarm_protocol_version_disagreement(*epoch, *expected_version, *block_version);
                 return Ok(());
             },
             HotStuffError::ProposalValidationError(err) => {
@@ -1592,6 +1623,7 @@ struct WorkerState<TAddr> {
     /// Last (epoch, local_hash, remote_hash) we raised an epoch-hash divergence alarm for, used to
     /// emit a single loud alarm per distinct divergence instead of once per rejected proposal.
     pub last_epoch_hash_alarm: Option<(Epoch, FixedHash, FixedHash)>,
+    pub last_protocol_version_alarm: Option<(Epoch, ProtocolVersion, ProtocolVersion)>,
 }
 
 impl<TAddr> WorkerState<TAddr> {
@@ -1606,6 +1638,7 @@ impl<TAddr> Default for WorkerState<TAddr> {
             catch_up: None,
             has_processed_first_block: false,
             last_epoch_hash_alarm: None,
+            last_protocol_version_alarm: None,
         }
     }
 }

--- a/crates/consensus/src/messages/vote.rs
+++ b/crates/consensus/src/messages/vote.rs
@@ -4,8 +4,7 @@
 use std::fmt::Display;
 
 use serde::Serialize;
-use tari_common_types::types::FixedHash;
-use tari_consensus_types::{ProposalVote, SignedMessage, ToSignatureMessage};
+use tari_consensus_types::{ProposalVote, SignedMessage};
 use tari_template_lib_types::crypto::{RistrettoPublicKeyBytes, SchnorrSignatureBytes};
 
 #[derive(Debug, Clone, Serialize)]
@@ -16,12 +15,6 @@ pub struct VoteMessage {
 impl Display for VoteMessage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.vote)
-    }
-}
-
-impl ToSignatureMessage for VoteMessage {
-    fn to_signature_message(&self) -> FixedHash {
-        self.vote.to_signature_message()
     }
 }
 

--- a/crates/consensus/src/traits/signing_service.rs
+++ b/crates/consensus/src/traits/signing_service.rs
@@ -15,7 +15,7 @@ pub trait ValidatorSignerService {
 }
 
 pub trait ValidatorSignatureVerifierService {
-    fn verify<M: SignedMessage>(&self, message: &M) -> bool {
+    fn verify<M: SignedMessage + ToSignatureMessage>(&self, message: &M) -> bool {
         let Ok(public_key) = RistrettoPublicKey::convert_from_byte_type(message.public_key()) else {
             warn!(
                 target: LOG_TARGET,

--- a/crates/consensus/src/validations/block.rs
+++ b/crates/consensus/src/validations/block.rs
@@ -20,6 +20,7 @@ use super::common::{
     check_network,
     check_proposal_certificate,
     check_proposed_by_leader,
+    check_protocol_version,
     check_shard_group_bounds,
     check_shard_group_matches,
     check_sidechain_id,
@@ -85,6 +86,7 @@ fn check_header<TConsensusSpec: ConsensusSpec>(
     signer_service: &TConsensusSpec::SignerService,
 ) -> Result<(), ProposalValidationError> {
     check_network(header, config.network)?;
+    check_protocol_version(header, config.network)?;
     if header.is_genesis() {
         return Err(ProposalValidationError::ProposingGenesisBlock {
             proposed_by: header.proposed_by().to_string(),

--- a/crates/consensus/src/validations/block.rs
+++ b/crates/consensus/src/validations/block.rs
@@ -64,8 +64,8 @@ fn check_proposal<TConsensusSpec: ConsensusSpec>(
 ) -> Result<(), HotStuffError> {
     check_header::<TConsensusSpec>(block.header(), expected_epoch_hash, config, signer_service)?;
     check_block(leader_strategy, committee_for_block, block)?;
-    check_proposal_certificate::<TConsensusSpec>(block, committee_for_block, signer_service)?;
-    check_timeout_certificate::<TConsensusSpec>(block, committee_for_block, signer_service)?;
+    check_proposal_certificate::<TConsensusSpec>(config.network, block, committee_for_block, signer_service)?;
+    check_timeout_certificate::<TConsensusSpec>(config.network, block, committee_for_block, signer_service)?;
 
     Ok(())
 }

--- a/crates/consensus/src/validations/common.rs
+++ b/crates/consensus/src/validations/common.rs
@@ -11,6 +11,7 @@ use tari_ootle_common_types::{
     ExtraFieldKey,
     NodeHeight,
     NumPreshards,
+    ProtocolVersion,
     ShardGroup,
     VotePower,
     committee::Committee,
@@ -49,6 +50,22 @@ pub(super) fn check_network(header: &BlockHeader, network: Network) -> Result<()
         return Err(ProposalValidationError::InvalidNetwork {
             block_network: header.network().to_string(),
             expected_network: network.to_string(),
+            block_id: *header.id(),
+        });
+    }
+    Ok(())
+}
+
+/// The protocol version a block is produced under is fixed by the network's activation schedule at the block's
+/// epoch. A node whose schedule disagrees rejects the block instead of hashing it under a schema the rest of the
+/// network has left behind, which stalls the node rather than forking it.
+pub(super) fn check_protocol_version(header: &BlockHeader, network: Network) -> Result<(), ProposalValidationError> {
+    let expected_version = ProtocolVersion::at(network, header.epoch());
+    if header.protocol_version() != expected_version {
+        return Err(ProposalValidationError::InvalidProtocolVersion {
+            expected_version,
+            block_version: header.protocol_version(),
+            epoch: header.epoch(),
             block_id: *header.id(),
         });
     }

--- a/crates/consensus/src/validations/common.rs
+++ b/crates/consensus/src/validations/common.rs
@@ -18,7 +18,7 @@ use tari_ootle_common_types::{
 };
 use tari_ootle_storage::consensus_models::{Block, BlockHeader};
 use tari_ootle_transaction::Network;
-use tari_sidechain::ProposalCertificateSignatureFields;
+use tari_sidechain::ProposalVoteMessage;
 use tari_template_lib_types::crypto::RistrettoPublicKeyBytes;
 
 use crate::{
@@ -218,6 +218,7 @@ pub(super) fn check_block_signature<TSignerService: ValidatorSignatureVerifierSe
 }
 
 pub(super) fn check_proposal_certificate<TConsensusSpec: ConsensusSpec>(
+    network: Network,
     candidate_block: &Block,
     committee: &Committee<TConsensusSpec::Addr>,
     signing_service: &TConsensusSpec::SignerService,
@@ -230,12 +231,13 @@ pub(super) fn check_proposal_certificate<TConsensusSpec: ConsensusSpec>(
         });
     }
 
-    check_quorum_certificate_signatures::<TConsensusSpec>(qc.into(), committee, signing_service)?;
+    check_quorum_certificate_signatures::<TConsensusSpec>(network, qc.into(), committee, signing_service)?;
 
     Ok(())
 }
 
 pub(super) fn check_timeout_certificate<TConsensusSpec: ConsensusSpec>(
+    network: Network,
     candidate_block: &Block,
     committee: &Committee<TConsensusSpec::Addr>,
     signing_service: &TConsensusSpec::SignerService,
@@ -250,7 +252,7 @@ pub(super) fn check_timeout_certificate<TConsensusSpec: ConsensusSpec>(
         });
     }
 
-    check_quorum_certificate_signatures::<TConsensusSpec>(tc.into(), committee, signing_service)?;
+    check_quorum_certificate_signatures::<TConsensusSpec>(network, tc.into(), committee, signing_service)?;
 
     Ok(())
 }
@@ -258,6 +260,7 @@ pub(super) fn check_timeout_certificate<TConsensusSpec: ConsensusSpec>(
 /// Validates the signatures of the quorum certificate.
 // pub because used in on receive NEWVIEW
 pub fn check_quorum_certificate_signatures<TConsensusSpec: ConsensusSpec>(
+    network: Network,
     qc: QuorumCertificateRef<'_>,
     committee: &Committee<TConsensusSpec::Addr>,
     signing_service: &TConsensusSpec::SignerService,
@@ -299,10 +302,13 @@ pub fn check_quorum_certificate_signatures<TConsensusSpec: ConsensusSpec>(
         match qc {
             QuorumCertificateRef::ProposalCertificate(pc) => {
                 let block_id = pc.calculate_block_id();
-                let message = ProposalCertificateSignatureFields {
-                    block_id: block_id.hash(),
-                    decision: pc.decision(),
-                };
+                let message = ProposalVoteMessage::new(
+                    ProtocolVersion::at(network, pc.epoch()).as_u32(),
+                    block_id.hash(),
+                    pc.decision(),
+                    pc.epoch().as_u64(),
+                    pc.height().as_u64(),
+                );
                 let vote = SignedProposalVote { message, signature };
                 let is_valid = signing_service.verify(&vote);
                 if !is_valid {

--- a/crates/consensus/src/validations/common.rs
+++ b/crates/consensus/src/validations/common.rs
@@ -302,6 +302,8 @@ pub fn check_quorum_certificate_signatures<TConsensusSpec: ConsensusSpec>(
         match qc {
             QuorumCertificateRef::ProposalCertificate(pc) => {
                 let block_id = pc.calculate_block_id();
+                // `check_protocol_version` pins a block's version to `at(network, header.epoch())` before any vote
+                // is cast on it, so resolving from the schedule here yields the version the signers used.
                 let message = ProposalVoteMessage::new(
                     ProtocolVersion::at(network, pc.epoch()).as_u32(),
                     block_id.hash(),

--- a/crates/consensus/src/validations/mod.rs
+++ b/crates/consensus/src/validations/mod.rs
@@ -4,7 +4,7 @@
 mod block;
 mod common;
 mod foreign_proposal;
-mod signed_vote;
+pub(crate) mod signed_vote;
 
 pub use block::*;
 pub use common::*;

--- a/crates/consensus/src/validations/signed_vote.rs
+++ b/crates/consensus/src/validations/signed_vote.rs
@@ -3,11 +3,11 @@
 
 use tari_common_types::types::FixedHash;
 use tari_consensus_types::{SignedMessage, ToSignatureMessage, ValidatorSignatureBytes};
-use tari_sidechain::ProposalCertificateSignatureFields;
+use tari_sidechain::ProposalVoteMessage;
 use tari_template_lib_types::crypto::{RistrettoPublicKeyBytes, SchnorrSignatureBytes};
 
 pub struct SignedProposalVote<'a> {
-    pub message: ProposalCertificateSignatureFields<'a>,
+    pub message: ProposalVoteMessage<'a>,
     pub signature: &'a ValidatorSignatureBytes,
 }
 

--- a/crates/consensus_tests/src/dummy_blocks.rs
+++ b/crates/consensus_tests/src/dummy_blocks.rs
@@ -18,6 +18,7 @@ use tari_ootle_common_types::{
     ExtraData,
     NodeHeight,
     NumPreshards,
+    ProtocolVersion,
     ShardGroup,
     VotePower,
     committee::{Committee, CommitteeMember},
@@ -34,6 +35,7 @@ fn dummy_blocks() {
     let shard_group = ShardGroup::new(1, 127);
     let genesis = Block::genesis(
         Network::LocalNet,
+        ProtocolVersion::V0,
         Epoch(1),
         FixedHash::zero(),
         shard_group,
@@ -99,6 +101,7 @@ fn last_matches_generated_using_real_data() {
 
     let justify = Block::genesis(
         Network::LocalNet,
+        ProtocolVersion::V0,
         candidate.epoch(),
         FixedHash::zero(),
         candidate.shard_group(),
@@ -143,6 +146,7 @@ fn dummy_blocks_from_epoch_genesis_vs_zero_block() {
     // The epoch genesis has real state carried over from the previous epoch
     let epoch_genesis = Block::genesis(
         Network::LocalNet,
+        ProtocolVersion::V0,
         Epoch(100),
         non_zero_epoch_hash,
         shard_group,
@@ -262,9 +266,11 @@ fn proposer_accumulated_data_must_come_from_justify_on_timeout_recovery() {
     let justify_height = NodeHeight(534);
     let justify_header = BlockHeader::create_unsigned(
         Network::LocalNet,
+        ProtocolVersion::V0,
         BlockId::zero(),
         Block::genesis(
             Network::LocalNet,
+            ProtocolVersion::V0,
             Epoch(7991),
             FixedHash::zero(),
             shard_group,
@@ -290,6 +296,7 @@ fn proposer_accumulated_data_must_come_from_justify_on_timeout_recovery() {
         justify_header,
         Block::genesis(
             Network::LocalNet,
+            ProtocolVersion::V0,
             Epoch(7991),
             FixedHash::zero(),
             shard_group,
@@ -386,6 +393,7 @@ fn proposer_must_anchor_recovery_on_justify_not_uncertified_leaf() {
 
     let genesis = Block::genesis(
         Network::LocalNet,
+        ProtocolVersion::V0,
         epoch,
         FixedHash::zero(),
         shard_group,
@@ -396,6 +404,7 @@ fn proposer_must_anchor_recovery_on_justify_not_uncertified_leaf() {
     let make_block = |parent, height, timestamp| {
         let header = BlockHeader::create_unsigned(
             Network::LocalNet,
+            ProtocolVersion::V0,
             parent,
             genesis.justify().calculate_id(),
             height,

--- a/crates/consensus_tests/src/safe_node_predicate.rs
+++ b/crates/consensus_tests/src/safe_node_predicate.rs
@@ -21,7 +21,7 @@ use tari_common_types::types::FixedHash;
 use tari_consensus::traits::CertificateStore;
 use tari_consensus_types::{BlockId, LeafBlock, ProposalCertificate, ShardGroupAccumulatedData};
 use tari_crypto::tari_utilities::epoch_time::EpochTime;
-use tari_ootle_common_types::{Epoch, ExtraData, NodeHeight, NumPreshards, ShardGroup};
+use tari_ootle_common_types::{Epoch, ExtraData, NodeHeight, NumPreshards, ProtocolVersion, ShardGroup};
 use tari_ootle_p2p::PeerAddress;
 use tari_ootle_storage::{
     StateStore,
@@ -73,6 +73,7 @@ fn build_block(parent_id: BlockId, justify: ProposalCertificate, height: NodeHei
     state_root[1] = height.as_u64() as u8;
     let header = BlockHeader::create_unsigned(
         NETWORK,
+        ProtocolVersion::V0,
         parent_id,
         justify.calculate_id(),
         height,

--- a/crates/consensus_types/src/certificates/proposal_vote.rs
+++ b/crates/consensus_types/src/certificates/proposal_vote.rs
@@ -6,9 +6,8 @@ use std::fmt::Display;
 use minicbor::{CborLen, Decode, Encode};
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::FixedHash;
-use tari_hashing::layer2;
 use tari_ootle_common_types::{Epoch, NodeHeight};
-use tari_sidechain::{ProposalCertificateSignatureFields, QuorumDecision};
+use tari_sidechain::{ProposalVoteMessage, QuorumDecision};
 use tari_template_lib::types::crypto::{RistrettoPublicKeyBytes, SchnorrSignatureBytes};
 
 use crate::{SignedMessage, ToSignatureMessage, Vote, ids::BlockId, validator_signature::ValidatorSignatureBytes};
@@ -51,16 +50,6 @@ impl Vote for ProposalVote {
     }
 }
 
-impl ToSignatureMessage for ProposalVote {
-    fn to_signature_message(&self) -> FixedHash {
-        ProposalCertificateSignatureFields {
-            block_id: self.block_id.hash(),
-            decision: self.decision,
-        }
-        .to_signature_message()
-    }
-}
-
 impl SignedMessage for ProposalVote {
     fn signature(&self) -> &SchnorrSignatureBytes {
         &self.signature.signature
@@ -81,9 +70,9 @@ impl Display for ProposalVote {
     }
 }
 
-impl ToSignatureMessage for ProposalCertificateSignatureFields<'_> {
+impl ToSignatureMessage for ProposalVoteMessage<'_> {
     /// Defines the signature message for a proposal vote which is collected into a ProposalCertificate.
     fn to_signature_message(&self) -> FixedHash {
-        layer2::proposal_vote_signature_hasher().chain(self).finalize().into()
+        self.calculate_hash()
     }
 }

--- a/crates/consensus_types/src/certificates/proposal_vote.rs
+++ b/crates/consensus_types/src/certificates/proposal_vote.rs
@@ -18,8 +18,10 @@ pub struct ProposalVote {
     pub epoch: Epoch,
     #[n(1)]
     pub block_id: BlockId,
-    /// The height of the view change - this should correspond to the height of the block.
-    /// NOTE: that this is not validated explicitly and is mainly used to determine message age and ordering.
+    /// The height of the view change - this should correspond to the height of the block. From protocol version 1
+    /// it is part of the signed preimage. Safety here rests on bucketing: votes aggregate by
+    /// `(epoch, block_height)`, so one carrying a height that disagrees with the block lands in its own bucket and
+    /// can never be folded into an honest quorum.
     #[n(2)]
     pub block_height: NodeHeight,
     // QuorumDecision is foreign (tari_sidechain) — bridge through serde.

--- a/crates/consensus_types/src/traits.rs
+++ b/crates/consensus_types/src/traits.rs
@@ -10,7 +10,10 @@ pub trait ToSignatureMessage {
     fn to_signature_message(&self) -> FixedHash;
 }
 
-pub trait SignedMessage: ToSignatureMessage {
+/// A message that carries a validator signature. The signed bytes are not part of this trait: a message whose
+/// preimage depends on context the message itself does not carry (such as the protocol version a proposal vote was
+/// cast under) implements only this, and is paired with its preimage at the point of verification.
+pub trait SignedMessage {
     fn signature(&self) -> &SchnorrSignatureBytes;
     fn public_key(&self) -> &RistrettoPublicKeyBytes;
 }

--- a/crates/engine_types/src/protocol_version.rs
+++ b/crates/engine_types/src/protocol_version.rs
@@ -9,10 +9,18 @@ use serde::{Deserialize, Serialize};
 use crate::Epoch;
 
 #[repr(u32)]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, borsh::BorshSerialize)]
+#[derive(
+    Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, borsh::BorshSerialize,
+)]
 #[borsh(use_discriminant = true)]
 pub enum ProtocolVersion {
+    /// The genesis schema, which every network starts under and which anything carrying no explicit version is
+    /// under.
+    #[default]
     V0 = 0,
+    /// Block headers commit to their own protocol version. No network schedules this version in
+    /// [`Self::activations`]; scheduling it is a deliberate per-network deployment decision.
+    V1 = 1,
 }
 
 impl ProtocolVersion {
@@ -47,6 +55,14 @@ impl ProtocolVersion {
 
     pub const fn as_u32(self) -> u32 {
         self as u32
+    }
+
+    pub const fn from_u32(v: u32) -> Option<Self> {
+        match v {
+            0 => Some(Self::V0),
+            1 => Some(Self::V1),
+            _ => None,
+        }
     }
 
     /// Every activation after genesis on `network`. Genesis is the schema a network starts under, so
@@ -151,6 +167,45 @@ pub enum ActivationScheduleError {
          diverge from the network."
     )]
     RolledBack { activation: Epoch, last_known_epoch: Epoch },
+}
+
+impl TryFrom<u32> for ProtocolVersion {
+    type Error = UnknownProtocolVersionError;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        Self::from_u32(value).ok_or(UnknownProtocolVersionError(value))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("Unknown protocol version {0}")]
+pub struct UnknownProtocolVersionError(pub u32);
+
+/// Encoded as its `u32` value rather than as an enum variant, so that a version this binary does not know is a
+/// decode error naming the version rather than an opaque unknown-variant error, and so the encoding does not move
+/// when variants are added.
+impl<C> minicbor::Encode<C> for ProtocolVersion {
+    fn encode<W: minicbor::encode::Write>(
+        &self,
+        e: &mut minicbor::Encoder<W>,
+        _ctx: &mut C,
+    ) -> Result<(), minicbor::encode::Error<W::Error>> {
+        e.u32(self.as_u32())?;
+        Ok(())
+    }
+}
+
+impl<'b, C> minicbor::Decode<'b, C> for ProtocolVersion {
+    fn decode(d: &mut minicbor::Decoder<'b>, _ctx: &mut C) -> Result<Self, minicbor::decode::Error> {
+        let v = d.u32()?;
+        Self::from_u32(v).ok_or_else(|| minicbor::decode::Error::message(UnknownProtocolVersionError(v)))
+    }
+}
+
+impl<C> minicbor::CborLen<C> for ProtocolVersion {
+    fn cbor_len(&self, ctx: &mut C) -> usize {
+        minicbor::CborLen::cbor_len(&self.as_u32(), ctx)
+    }
 }
 
 impl Display for ProtocolVersion {

--- a/crates/engine_types/src/protocol_version.rs
+++ b/crates/engine_types/src/protocol_version.rs
@@ -8,11 +8,14 @@ use serde::{Deserialize, Serialize};
 
 use crate::Epoch;
 
+/// Encoded as its `u32` value in every representation: borsh by discriminant, minicbor and protobuf as a `u32`,
+/// and serde through `u32` so that a JSON consumer reads the same number the other three write.
 #[repr(u32)]
 #[derive(
     Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, borsh::BorshSerialize,
 )]
 #[borsh(use_discriminant = true)]
+#[serde(into = "u32", try_from = "u32")]
 pub enum ProtocolVersion {
     /// The genesis schema, which every network starts under and which anything carrying no explicit version is
     /// under.
@@ -167,6 +170,12 @@ pub enum ActivationScheduleError {
          diverge from the network."
     )]
     RolledBack { activation: Epoch, last_known_epoch: Epoch },
+}
+
+impl From<ProtocolVersion> for u32 {
+    fn from(value: ProtocolVersion) -> Self {
+        value.as_u32()
+    }
 }
 
 impl TryFrom<u32> for ProtocolVersion {

--- a/crates/engine_types/src/protocol_version.rs
+++ b/crates/engine_types/src/protocol_version.rs
@@ -28,22 +28,25 @@ pub enum ProtocolVersion {
 
 impl ProtocolVersion {
     /// The schema activation schedule for `network`, ordered by activation epoch ascending. Entry at
-    /// index 0 is the genesis schema, which every network starts under.
+    /// index 0 is the genesis schema, which every network starts under. A network with no history to
+    /// preserve may start at any version; one that has already run starts at the version it ran under.
     ///
     /// Networks run at independent epochs, so an activation is scheduled per network: the epoch at
     /// which a schema goes live on esmeralda says nothing about when it goes live on igor.
     ///
     /// NB: entries here are CONSENSUS-BOUND via `hash_substate`. Never reorder or mutate an entry
-    /// after it has activated on a live network — doing so changes every hash derived under it. The
-    /// match is exhaustive so that a new network must state its own schedule rather than inherit one.
+    /// after it has activated on a live network — doing so changes every hash derived under it. A
+    /// network that is reset keeps no history, so its schedule is free to collapse back to a single
+    /// genesis entry at the newest version. The match is exhaustive so that a new network must state
+    /// its own schedule rather than inherit one.
     const fn activations(network: Network) -> &'static [(Epoch, Self)] {
         match network {
-            Network::MainNet => &[(Epoch(0), Self::V0)],
-            Network::StageNet => &[(Epoch(0), Self::V0)],
-            Network::NextNet => &[(Epoch(0), Self::V0)],
-            Network::Igor => &[(Epoch(0), Self::V0)],
+            Network::MainNet => &[(Epoch(0), Self::V1)],
+            Network::StageNet => &[(Epoch(0), Self::V1)],
+            Network::NextNet => &[(Epoch(0), Self::V1)],
+            Network::Igor => &[(Epoch(0), Self::V1)],
             Network::Esmeralda => &[(Epoch(0), Self::V0)],
-            Network::LocalNet => &[(Epoch(0), Self::V0)],
+            Network::LocalNet => &[(Epoch(0), Self::V1)],
         }
     }
 
@@ -236,9 +239,10 @@ mod tests {
     }
 
     #[test]
-    fn every_network_starts_at_v0() {
+    fn every_network_starts_at_its_genesis_schema() {
         for network in all_networks() {
-            assert_eq!(ProtocolVersion::at(network, Epoch(0)), ProtocolVersion::V0, "{network}");
+            let (_, genesis) = ProtocolVersion::activations(network)[0];
+            assert_eq!(ProtocolVersion::at(network, Epoch(0)), genesis, "{network}");
         }
     }
 
@@ -253,11 +257,8 @@ mod tests {
     #[test]
     fn genesis_is_never_a_scheduled_activation() {
         for network in all_networks() {
-            assert_eq!(
-                ProtocolVersion::activations(network)[0],
-                (Epoch(0), ProtocolVersion::V0),
-                "{network}"
-            );
+            let (at, _) = ProtocolVersion::activations(network)[0];
+            assert_eq!(at, Epoch(0), "{network}");
             assert!(
                 !ProtocolVersion::scheduled_activations(network)
                     .iter()

--- a/crates/engine_types/src/protocol_version.rs
+++ b/crates/engine_types/src/protocol_version.rs
@@ -28,8 +28,13 @@ pub enum ProtocolVersion {
 
 impl ProtocolVersion {
     /// The schema activation schedule for `network`, ordered by activation epoch ascending. Entry at
-    /// index 0 is the genesis schema, which every network starts under. A network with no history to
-    /// preserve may start at any version; one that has already run starts at the version it ran under.
+    /// index 0 is the genesis schema, which that network starts under.
+    ///
+    /// Esmeralda is the only network with an Ootle deployment carrying block history, so it is the
+    /// only one whose genesis entry is chain history: it stays at `V0` and takes a scheduled
+    /// activation when one is decided. Mainnet, stagenet and nextnet have never launched; igor and
+    /// localnet are reset before use. Those five are launched directly at the newest version, which
+    /// spares them an activation to coordinate.
     ///
     /// Networks run at independent epochs, so an activation is scheduled per network: the epoch at
     /// which a schema goes live on esmeralda says nothing about when it goes live on igor.
@@ -37,8 +42,10 @@ impl ProtocolVersion {
     /// NB: entries here are CONSENSUS-BOUND via `hash_substate`. Never reorder or mutate an entry
     /// after it has activated on a live network — doing so changes every hash derived under it. A
     /// network that is reset keeps no history, so its schedule is free to collapse back to a single
-    /// genesis entry at the newest version. The match is exhaustive so that a new network must state
-    /// its own schedule rather than inherit one.
+    /// genesis entry at the newest version. Moving a genesis entry is caught for a node that has
+    /// epoch history by [`Self::check_activation_schedule`], and is a fork for one that does not.
+    /// The match is exhaustive so that a new network must state its own schedule rather than inherit
+    /// one.
     const fn activations(network: Network) -> &'static [(Epoch, Self)] {
         match network {
             Network::MainNet => &[(Epoch(0), Self::V1)],
@@ -48,6 +55,12 @@ impl ProtocolVersion {
             Network::Esmeralda => &[(Epoch(0), Self::V0)],
             Network::LocalNet => &[(Epoch(0), Self::V1)],
         }
+    }
+
+    /// The version `network` starts under. A network with no chain to preserve may be launched at any
+    /// version, so this is not `V0` for every network.
+    pub fn genesis(network: Network) -> Self {
+        Self::activations(network)[0].1
     }
 
     pub fn at(network: Network, epoch: Epoch) -> Self {
@@ -109,16 +122,25 @@ impl ProtocolVersion {
     pub fn check_activation_schedule(
         network: Network,
         recorded: &[Epoch],
+        recorded_genesis: Self,
         last_known_epoch: Option<Epoch>,
     ) -> Result<Vec<Epoch>, ActivationScheduleError> {
-        Self::check_schedule(Self::scheduled_activations(network), recorded, last_known_epoch)
+        Self::check_schedule(
+            Self::scheduled_activations(network),
+            Self::genesis(network),
+            recorded,
+            recorded_genesis,
+            last_known_epoch,
+        )
     }
 
     /// [`Self::check_activation_schedule`] against an explicit schedule, so the rule can be exercised
     /// for schedules other than the ones this binary is compiled with.
     fn check_schedule(
         scheduled: &[(Epoch, Self)],
+        genesis: Self,
         recorded: &[Epoch],
+        recorded_genesis: Self,
         last_known_epoch: Option<Epoch>,
     ) -> Result<Vec<Epoch>, ActivationScheduleError> {
         let to_record = || scheduled.iter().map(|(at, _)| *at).collect();
@@ -126,6 +148,16 @@ impl ProtocolVersion {
         let Some(last_known_epoch) = last_known_epoch else {
             return Ok(to_record());
         };
+
+        // The genesis entry is not in `scheduled`, so a binary that moves it would otherwise pass every check
+        // below while hashing every block from height zero under a different schema than the node's own history.
+        if genesis != recorded_genesis {
+            return Err(ActivationScheduleError::GenesisChanged {
+                recorded: recorded_genesis,
+                binary: genesis,
+                last_known_epoch,
+            });
+        }
 
         // An activation this binary schedules at or before the epoch the node reached, that the node
         // never ran under: the epochs between it and now were hashed under the superseded schema.
@@ -173,6 +205,16 @@ pub enum ActivationScheduleError {
          diverge from the network."
     )]
     RolledBack { activation: Epoch, last_known_epoch: Epoch },
+    #[error(
+        "This binary launches the network at protocol version {binary}, but this node has run under {recorded} (last \
+         known epoch {last_known_epoch}). Starting would hash every block under a version the rest of the network is \
+         not using. This binary is meant for a network that has not launched."
+    )]
+    GenesisChanged {
+        recorded: ProtocolVersion,
+        binary: ProtocolVersion,
+        last_known_epoch: Epoch,
+    },
 }
 
 impl From<ProtocolVersion> for u32 {
@@ -239,11 +281,10 @@ mod tests {
     }
 
     #[test]
-    fn every_network_starts_at_its_genesis_schema() {
-        for network in all_networks() {
-            let (_, genesis) = ProtocolVersion::activations(network)[0];
-            assert_eq!(ProtocolVersion::at(network, Epoch(0)), genesis, "{network}");
-        }
+    fn the_live_network_stays_at_its_launched_version() {
+        // Esmeralda is running, so its genesis version is chain history and cannot be moved. Every other network
+        // is free to be launched at whatever version is newest when it starts.
+        assert_eq!(ProtocolVersion::genesis(Network::Esmeralda), ProtocolVersion::V0);
     }
 
     #[test]
@@ -297,11 +338,49 @@ mod tests {
             already_recorded: &[u64],
             last_known_epoch: Option<u64>,
         ) -> Result<Vec<Epoch>, ActivationScheduleError> {
+            check_with_genesis(
+                scheduled,
+                already_recorded,
+                last_known_epoch,
+                ProtocolVersion::V0,
+                ProtocolVersion::V0,
+            )
+        }
+
+        fn check_with_genesis(
+            scheduled: &[u64],
+            already_recorded: &[u64],
+            last_known_epoch: Option<u64>,
+            genesis: ProtocolVersion,
+            recorded_genesis: ProtocolVersion,
+        ) -> Result<Vec<Epoch>, ActivationScheduleError> {
             ProtocolVersion::check_schedule(
                 &schedule(scheduled),
+                genesis,
                 &recorded(already_recorded),
+                recorded_genesis,
                 last_known_epoch.map(Epoch),
             )
+        }
+
+        #[test]
+        fn moving_the_genesis_version_under_a_node_with_history_is_rejected() {
+            assert_eq!(
+                check_with_genesis(&[], &[], Some(6), ProtocolVersion::V1, ProtocolVersion::V0),
+                Err(ActivationScheduleError::GenesisChanged {
+                    recorded: ProtocolVersion::V0,
+                    binary: ProtocolVersion::V1,
+                    last_known_epoch: Epoch(6),
+                })
+            );
+        }
+
+        #[test]
+        fn a_node_with_no_epoch_history_adopts_any_genesis_version() {
+            assert_eq!(
+                check_with_genesis(&[], &[], None, ProtocolVersion::V1, ProtocolVersion::V0),
+                Ok(recorded(&[]))
+            );
         }
 
         #[test]

--- a/crates/engine_types/src/substate_hasher.rs
+++ b/crates/engine_types/src/substate_hasher.rs
@@ -28,7 +28,8 @@ pub enum SubstateHashMessage<'a> {
 impl<'a> SubstateHashMessage<'a> {
     pub fn new(protocol_version: ProtocolVersion, value: &'a SubstateValue) -> Self {
         match protocol_version {
-            ProtocolVersion::V0 => Self::V0(value.into()),
+            // V1 changes the block header preimage only, so substates keep the V0 schema.
+            ProtocolVersion::V0 | ProtocolVersion::V1 => Self::V0(value.into()),
         }
     }
 }

--- a/crates/p2p/proto/consensus.proto
+++ b/crates/p2p/proto/consensus.proto
@@ -89,6 +89,7 @@ message BlockHeader {
   bytes epoch_hash = 12;
   ExtraData extra_data = 13;
   ShardGroupAccumulatedData accumulated_data = 14;
+  uint32 protocol_version = 15;
 }
 
 message Block {

--- a/crates/p2p/src/conversions/consensus.rs
+++ b/crates/p2p/src/conversions/consensus.rs
@@ -57,6 +57,7 @@ use tari_ootle_common_types::{
     Epoch,
     ExtraData,
     NodeHeight,
+    ProtocolVersion,
     ShardGroup,
     ShardStateVersions,
     StateVersion,
@@ -477,6 +478,7 @@ impl From<&consensus_models::BlockHeader> for proto::consensus::BlockHeader {
             epoch_hash: value.epoch_hash().as_bytes().to_vec(),
             extra_data: Some(value.extra_data().into()),
             accumulated_data: Some(value.accumulated_data().into()),
+            protocol_version: value.protocol_version().as_u32(),
         }
     }
 }
@@ -489,6 +491,8 @@ fn try_convert_proto_block_header(
     let network = u8::try_from(value.network)
         .map_err(|_| anyhow!("Block conversion: Invalid network byte {}", value.network))?
         .try_into()?;
+
+    let protocol_version = ProtocolVersion::try_from(value.protocol_version)?;
 
     let shard_group = ShardGroup::decode_from_u32(value.shard_group)
         .ok_or_else(|| anyhow!("Block shard_group ({}) is not a valid", value.shard_group))?;
@@ -507,6 +511,7 @@ fn try_convert_proto_block_header(
     if value.signature.is_none() {
         Ok(consensus_models::BlockHeader::dummy_block(
             network,
+            protocol_version,
             value.parent_id.try_into()?,
             proposed_by,
             NodeHeight(value.height),
@@ -527,6 +532,7 @@ fn try_convert_proto_block_header(
         // If there were a mismatch (perhaps due modified data over the wire) the signature verification will fail.
         let block = consensus_models::BlockHeader::create(
             network,
+            protocol_version,
             value.parent_id.try_into()?,
             justify_id,
             NodeHeight(value.height),

--- a/crates/rpc_state_sync/src/state_sync.rs
+++ b/crates/rpc_state_sync/src/state_sync.rs
@@ -917,6 +917,7 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress> + Send + Sync + 'static
             };
 
             if let Err(e) = check_quorum_certificate_signatures::<TConsensusSpec>(
+                self.network,
                 (&qc).into(),
                 &verify_committee,
                 &self.signer_service,

--- a/crates/state_store_rocksdb/tests/blocks.rs
+++ b/crates/state_store_rocksdb/tests/blocks.rs
@@ -12,6 +12,7 @@ use tari_ootle_common_types::{
     ExtraFieldKey,
     NodeHeight,
     NumPreshards,
+    ProtocolVersion,
     ShardGroup,
     optional::Optional,
 };
@@ -107,6 +108,7 @@ mod block_parent_operations {
         let shard_group = ShardGroup::all_shards(NumPreshards::P64);
         let block1 = Block::create(
             network,
+            ProtocolVersion::V0,
             *zero_block.id(),
             zero_block.justify().clone(),
             None,
@@ -130,6 +132,7 @@ mod block_parent_operations {
 
         let block2 = Block::create(
             network,
+            ProtocolVersion::V0,
             *block1.id(),
             block1.justify().clone(),
             None,
@@ -240,6 +243,7 @@ mod block_query_operations {
         let shard_group = ShardGroup::all_shards(NumPreshards::P64);
         let block1 = Block::create(
             network,
+            ProtocolVersion::V0,
             *zero_block.id(),
             zero_block.justify().clone(),
             None,
@@ -266,6 +270,7 @@ mod block_query_operations {
 
         let block2 = Block::create(
             network,
+            ProtocolVersion::V0,
             *block1.id(),
             block1.justify().clone(),
             None,
@@ -298,6 +303,7 @@ mod block_query_operations {
         );
         let block3 = Block::create(
             network,
+            ProtocolVersion::V0,
             *block1.id(),
             block1.justify().clone(),
             None,

--- a/crates/state_store_rocksdb/tests/foreign_proposals.rs
+++ b/crates/state_store_rocksdb/tests/foreign_proposals.rs
@@ -6,7 +6,7 @@ pub mod helpers;
 use helpers::{assert_eq_debug, create_foreign_proposal, create_random_block_id, create_rocksdb};
 use tari_common_types::types::FixedHash;
 use tari_consensus_types::ShardGroupAccumulatedData;
-use tari_ootle_common_types::{Epoch, ExtraData, NodeHeight, NumPreshards, ShardGroup};
+use tari_ootle_common_types::{Epoch, ExtraData, NodeHeight, NumPreshards, ProtocolVersion, ShardGroup};
 use tari_ootle_storage::{
     StateStore,
     StateStoreReadTransaction,
@@ -36,6 +36,7 @@ fn foreign_proposals_rocksdb() {
 
     let block1 = Block::create(
         network,
+        ProtocolVersion::V0,
         *zero_block.id(),
         zero_block.justify().clone(),
         None,
@@ -62,6 +63,7 @@ fn foreign_proposals_rocksdb() {
     tx.proposal_certificates_save(block1.justify()).unwrap();
     let fork_block = Block::create(
         network,
+        ProtocolVersion::V0,
         *zero_block.id(),
         zero_block.justify().clone(),
         None,

--- a/crates/state_store_rocksdb/tests/helpers.rs
+++ b/crates/state_store_rocksdb/tests/helpers.rs
@@ -16,6 +16,7 @@ use tari_ootle_common_types::{
     ExtraData,
     NodeHeight,
     NumPreshards,
+    ProtocolVersion,
     ShardGroup,
     VersionedSubstateId,
     VersionedSubstateIdRef,
@@ -306,6 +307,7 @@ pub fn create_block(parent: Option<&Block>) -> Block {
 
     Block::create(
         network,
+        ProtocolVersion::V0,
         *parent.id(),
         parent.justify().clone(),
         None,
@@ -340,6 +342,7 @@ pub fn create_block_with_qc(parent: &LeafBlock) -> Block {
 
     Block::create(
         network,
+        ProtocolVersion::V0,
         *parent.block_id(),
         qc,
         None,
@@ -423,6 +426,7 @@ pub fn create_foreign_proposal(parent_id: BlockId, epoch: Epoch) -> ForeignPropo
 
     let foreign_block = Block::create(
         Network::LocalNet,
+        ProtocolVersion::V0,
         parent_id,
         qc1.clone(),
         None,
@@ -443,6 +447,7 @@ pub fn create_foreign_proposal(parent_id: BlockId, epoch: Epoch) -> ForeignPropo
     let commit_proof = CommandsCommitProof::new_latest(vec![], SidechainBlockCommitProof {
         header: SidechainBlockHeader {
             network: foreign_block.network().as_byte(),
+            protocol_version: foreign_block.header().protocol_version().as_u32(),
             parent_id: *parent_id.hash(),
             justify_id: *qc1.calculate_id().hash(),
             height: foreign_block.height().as_u64(),

--- a/crates/state_store_rocksdb/tests/helpers.rs
+++ b/crates/state_store_rocksdb/tests/helpers.rs
@@ -469,6 +469,9 @@ pub fn create_foreign_proposal(parent_id: BlockId, epoch: Epoch) -> ForeignPropo
             tari_sidechain::QuorumCertificate {
                 header_hash: foreign_block.header().calculate_hash(),
                 parent_id: *parent_id.hash(),
+                epoch: foreign_block.epoch().as_u64(),
+                height: foreign_block.height().as_u64(),
+                protocol_version: foreign_block.header().protocol_version().as_u32(),
                 signatures: vec![],
                 decision: QuorumDecision::Accept,
             },

--- a/crates/state_store_rocksdb/tests/misc.rs
+++ b/crates/state_store_rocksdb/tests/misc.rs
@@ -174,6 +174,7 @@ fn miscellaneous_rocksdb() {
     let commit_proof = SidechainBlockCommitProof {
         header: SidechainBlockHeader {
             network: 0,
+            protocol_version: 0,
             parent_id: Default::default(),
             justify_id: Default::default(),
             height: 0,

--- a/crates/state_store_rocksdb/tests/missing_transactions.rs
+++ b/crates/state_store_rocksdb/tests/missing_transactions.rs
@@ -6,7 +6,7 @@ pub mod helpers;
 use helpers::{create_block, create_rocksdb, create_tx_atom};
 use tari_common_types::types::FixedHash;
 use tari_consensus_types::ShardGroupAccumulatedData;
-use tari_ootle_common_types::{Epoch, ExtraData, NodeHeight};
+use tari_ootle_common_types::{Epoch, ExtraData, NodeHeight, ProtocolVersion};
 use tari_ootle_storage::{
     StateStore,
     StateStoreWriteTransaction,
@@ -35,6 +35,7 @@ fn missing_transactions_operations(db: impl StateStore) {
     let atom2 = create_tx_atom();
     let block1 = Block::create(
         network,
+        ProtocolVersion::V0,
         *genesis.id(),
         genesis.justify().clone(),
         None,

--- a/crates/state_store_rocksdb/tests/transactions.rs
+++ b/crates/state_store_rocksdb/tests/transactions.rs
@@ -12,7 +12,7 @@ use tari_engine_types::{
     fees::FeeBreakdown,
     substate::SubstateDiff,
 };
-use tari_ootle_common_types::{Epoch, ExtraData, NodeHeight, SubstateRequirement};
+use tari_ootle_common_types::{Epoch, ExtraData, NodeHeight, ProtocolVersion, SubstateRequirement};
 use tari_ootle_storage::{
     StateStore,
     StateStoreReadTransaction,
@@ -63,6 +63,7 @@ mod confirm_all_transitions {
 
         let block1 = Block::create(
             network,
+            ProtocolVersion::V0,
             *zero_block.id(),
             zero_block.justify().clone(),
             None,
@@ -170,6 +171,7 @@ mod confirm_all_transitions {
 
         let block1 = Block::create(
             network,
+            ProtocolVersion::V0,
             *zero_block.id(),
             zero_block.justify().clone(),
             None,
@@ -690,6 +692,7 @@ mod get_many_ready_weight_budget {
         let atoms: Vec<_> = weights.iter().map(|_| create_tx_atom()).collect();
         let block1 = Block::create(
             network,
+            ProtocolVersion::V0,
             *zero_block.id(),
             zero_block.justify().clone(),
             None,

--- a/crates/storage/src/consensus_models/block.rs
+++ b/crates/storage/src/consensus_models/block.rs
@@ -32,6 +32,7 @@ use tari_ootle_common_types::{
     ExtraFieldKey,
     NodeHeight,
     NumPreshards,
+    ProtocolVersion,
     ShardGroup,
     VersionedSubstateId,
     VersionedSubstateIdRef,
@@ -129,6 +130,7 @@ impl Block {
     #[allow(clippy::too_many_arguments)]
     pub fn create(
         network: Network,
+        protocol_version: ProtocolVersion,
         parent: BlockId,
         justify: ProposalCertificate,
         high_tc: Option<TimeoutCertificate>,
@@ -147,6 +149,7 @@ impl Block {
     ) -> Result<Self, BlockError> {
         let header = BlockHeader::create(
             network,
+            protocol_version,
             parent,
             justify.calculate_id(),
             height,
@@ -185,6 +188,7 @@ impl Block {
 
     pub fn genesis(
         network: Network,
+        protocol_version: ProtocolVersion,
         epoch: Epoch,
         epoch_hash: FixedHash,
         shard_group: ShardGroup,
@@ -204,6 +208,7 @@ impl Block {
         let justify = ProposalCertificate::genesis(epoch, shard_group);
         let header = BlockHeader::genesis(
             network,
+            protocol_version,
             justify.calculate_id(),
             epoch,
             shard_group,

--- a/crates/storage/src/consensus_models/block_header.rs
+++ b/crates/storage/src/consensus_models/block_header.rs
@@ -23,9 +23,9 @@ use tari_consensus_types::{
     ToSignatureMessage,
 };
 use tari_crypto::tari_utilities::epoch_time::EpochTime;
-use tari_ootle_common_types::{Epoch, ExtraData, NodeHeight, NumPreshards, ShardGroup, hashing};
+use tari_ootle_common_types::{Epoch, ExtraData, NodeHeight, NumPreshards, ProtocolVersion, ShardGroup, hashing};
 use tari_ootle_transaction::Network;
-use tari_sidechain::{BlockHeaderHashFields, BlockHeaderHashFieldsV1};
+use tari_sidechain::{BlockHeaderHashFields, BlockHeaderHashFieldsV1, BlockHeaderHashFieldsV2};
 use tari_state_tree::{TreeHash, compute_merkle_root_for_hashes};
 use tari_template_lib_types::crypto::{RistrettoPublicKeyBytes, SchnorrSignatureBytes};
 
@@ -98,12 +98,24 @@ pub struct BlockHeader {
     /// Currently, this is used to store the block's sidechain_id (if applicable).
     #[n(15)]
     extra_data: ExtraData,
+    /// The protocol version this block was produced under, resolved from the network's activation schedule at
+    /// [`Self::epoch`]. It makes the block self-describing: [`Self::calculate_hash`] and the L1 verifier in
+    /// `tari_sidechain` both select the hash schema from this field rather than from the schedule.
+    ///
+    /// A header that carries no version is under [`ProtocolVersion::V0`], so blocks written before the field
+    /// existed decode and hash unchanged.
+    #[cfg_attr(feature = "ts", ts(type = "number"))]
+    #[serde(default)]
+    #[n(16)]
+    #[cbor(default)]
+    protocol_version: ProtocolVersion,
 }
 
 impl BlockHeader {
     #[allow(clippy::too_many_arguments)]
     pub fn create(
         network: Network,
+        protocol_version: ProtocolVersion,
         parent: BlockId,
         justify_id: PcId,
         height: NodeHeight,
@@ -121,6 +133,7 @@ impl BlockHeader {
     ) -> Result<Self, BlockError> {
         let mut header = Self::create_unsigned(
             network,
+            protocol_version,
             parent,
             justify_id,
             height,
@@ -144,6 +157,7 @@ impl BlockHeader {
     #[allow(clippy::too_many_arguments)]
     pub fn create_unsigned(
         network: Network,
+        protocol_version: ProtocolVersion,
         parent: BlockId,
         justify_id: PcId,
         height: NodeHeight,
@@ -162,6 +176,7 @@ impl BlockHeader {
         let mut header = BlockHeader {
             id: BlockId::zero(),
             network,
+            protocol_version,
             parent,
             justify_id,
             height,
@@ -182,8 +197,10 @@ impl BlockHeader {
         Ok(header)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn genesis(
         network: Network,
+        protocol_version: ProtocolVersion,
         justify_id: PcId,
         epoch: Epoch,
         shard_group: ShardGroup,
@@ -194,6 +211,7 @@ impl BlockHeader {
     ) -> Self {
         Self::create(
             network,
+            protocol_version,
             BlockId::zero(),
             justify_id,
             NodeHeight::zero(),
@@ -218,6 +236,7 @@ impl BlockHeader {
         let shard_group = ShardGroup::all_shards(num_preshards);
         Self {
             network,
+            protocol_version: ProtocolVersion::at(network, Epoch::zero()),
             id: BlockId::zero(),
             parent: BlockId::zero(),
             justify_id: ProposalCertificate::genesis(Epoch::zero(), ShardGroup::all_shards(num_preshards))
@@ -238,8 +257,10 @@ impl BlockHeader {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn dummy_block(
         network: Network,
+        protocol_version: ProtocolVersion,
         parent: BlockId,
         proposed_by: RistrettoPublicKeyBytes,
         height: NodeHeight,
@@ -254,6 +275,7 @@ impl BlockHeader {
         let mut block = Self {
             id: BlockId::zero(),
             network,
+            protocol_version,
             parent,
             justify_id,
             height,
@@ -320,22 +342,46 @@ impl BlockHeader {
         let metadata_hash = self.calculate_metadata_hash();
         let accumulated_data = self.accumulated_data.into();
 
-        let fields = BlockHeaderHashFields::V1(BlockHeaderHashFieldsV1 {
-            network: self.network.as_byte(),
-            justify_id: self.justify_id.hash(),
-            height: self.height.as_u64(),
-            epoch: self.epoch.as_u64(),
-            epoch_hash: &self.epoch_hash,
-            shard_group: tari_sidechain::ShardGroup {
-                start: self.shard_group.start().as_u32(),
-                end_inclusive: self.shard_group.end().as_u32(),
-            },
-            proposed_by: self.proposed_by.as_bytes(),
-            state_merkle_root: &self.state_merkle_root,
-            command_merkle_root: &self.command_merkle_root,
-            accumulated_data: &accumulated_data,
-            metadata_hash: &metadata_hash,
-        });
+        let shard_group = tari_sidechain::ShardGroup {
+            start: self.shard_group.start().as_u32(),
+            end_inclusive: self.shard_group.end().as_u32(),
+        };
+
+        // This selection must stay identical to `tari_sidechain::SidechainBlockHeader::calculate_hash`, which is what
+        // the base layer uses to verify a commit proof against the block ID a committee signed.
+        let fields = match self.protocol_version.as_u32() {
+            // Version 0 commits to a preimage that carries no version, so its block IDs stay reproducible.
+            0 => BlockHeaderHashFields::V1(BlockHeaderHashFieldsV1 {
+                network: self.network.as_byte(),
+                justify_id: self.justify_id.hash(),
+                height: self.height.as_u64(),
+                epoch: self.epoch.as_u64(),
+                epoch_hash: &self.epoch_hash,
+                shard_group,
+                proposed_by: self.proposed_by.as_bytes(),
+                state_merkle_root: &self.state_merkle_root,
+                command_merkle_root: &self.command_merkle_root,
+                accumulated_data: &accumulated_data,
+                metadata_hash: &metadata_hash,
+            }),
+            // From version 1 the version is part of the preimage, so that two versions sharing a preimage shape
+            // still produce distinct block IDs and the version a block claims cannot be altered without
+            // invalidating it.
+            protocol_version => BlockHeaderHashFields::V2(BlockHeaderHashFieldsV2 {
+                network: self.network.as_byte(),
+                protocol_version,
+                justify_id: self.justify_id.hash(),
+                height: self.height.as_u64(),
+                epoch: self.epoch.as_u64(),
+                epoch_hash: &self.epoch_hash,
+                shard_group,
+                proposed_by: self.proposed_by.as_bytes(),
+                state_merkle_root: &self.state_merkle_root,
+                command_merkle_root: &self.command_merkle_root,
+                accumulated_data: &accumulated_data,
+                metadata_hash: &metadata_hash,
+            }),
+        };
 
         hashing::block_hasher().chain(&fields).finalize().into()
     }
@@ -392,6 +438,10 @@ impl BlockHeader {
 
     pub fn network(&self) -> Network {
         self.network
+    }
+
+    pub fn protocol_version(&self) -> ProtocolVersion {
+        self.protocol_version
     }
 
     pub fn parent(&self) -> &BlockId {
@@ -518,4 +568,84 @@ struct MetadataHashFieldsV1<'a> {
     total_leader_fee: u64,
     timestamp: u64,
     extra_data: &'a ExtraData,
+}
+
+#[cfg(test)]
+mod tests {
+    use tari_consensus_types::ProposalCertificate;
+
+    use super::*;
+
+    fn header(protocol_version: ProtocolVersion) -> BlockHeader {
+        let shard_group = ShardGroup::all_shards(NumPreshards::P64);
+        BlockHeader::create(
+            Network::LocalNet,
+            protocol_version,
+            BlockId::zero(),
+            ProposalCertificate::genesis(Epoch(1), shard_group).calculate_id(),
+            NodeHeight(2),
+            Epoch(1),
+            shard_group,
+            RistrettoPublicKeyBytes::default(),
+            FixedHash::zero(),
+            &BTreeSet::new(),
+            1,
+            SchnorrSignatureBytes::zero(),
+            1234,
+            FixedHash::zero(),
+            ShardGroupAccumulatedData::default(),
+            ExtraData::new(),
+        )
+        .unwrap()
+    }
+
+    /// The encoding of a header that carries no protocol version: the same array with the trailing element,
+    /// which is `protocol_version`, dropped.
+    fn encode_without_protocol_version(header: &BlockHeader) -> Vec<u8> {
+        let bytes = tari_bor::encode(header).unwrap();
+        let mut decoder = minicbor::Decoder::new(&bytes);
+        let len = decoder
+            .array()
+            .unwrap()
+            .expect("BlockHeader encodes as a definite length array");
+        let body_start = decoder.position();
+        for _ in 0..len - 1 {
+            decoder.skip().unwrap();
+        }
+        let last_element_start = decoder.position();
+
+        let mut out = Vec::new();
+        minicbor::Encoder::new(&mut out).array(len - 1).unwrap();
+        out.extend_from_slice(&bytes[body_start..last_element_start]);
+        out
+    }
+
+    #[test]
+    fn a_header_encoded_without_a_protocol_version_decodes_as_v0() {
+        let header = header(ProtocolVersion::V0);
+        let decoded: BlockHeader = tari_bor::decode(&encode_without_protocol_version(&header)).unwrap();
+
+        assert_eq!(decoded.protocol_version(), ProtocolVersion::V0);
+        assert_eq!(decoded.id(), header.id());
+        assert_eq!(decoded.calculate_hash(), header.calculate_hash());
+    }
+
+    #[test]
+    fn a_header_round_trips_its_protocol_version() {
+        for protocol_version in [ProtocolVersion::V0, ProtocolVersion::V1] {
+            let header = header(protocol_version);
+            let bytes = tari_bor::encode(&header).unwrap();
+            let decoded: BlockHeader = tari_bor::decode(&bytes).unwrap();
+            assert_eq!(decoded.protocol_version(), protocol_version);
+            assert_eq!(decoded.calculate_hash(), header.calculate_hash());
+        }
+    }
+
+    #[test]
+    fn each_protocol_version_hashes_a_header_differently() {
+        assert_ne!(
+            header(ProtocolVersion::V0).calculate_hash(),
+            header(ProtocolVersion::V1).calculate_hash()
+        );
+    }
 }

--- a/crates/storage/src/consensus_models/block_header.rs
+++ b/crates/storage/src/consensus_models/block_header.rs
@@ -236,7 +236,7 @@ impl BlockHeader {
         let shard_group = ShardGroup::all_shards(num_preshards);
         Self {
             network,
-            protocol_version: ProtocolVersion::at(network, Epoch::zero()),
+            protocol_version: ProtocolVersion::V0,
             id: BlockId::zero(),
             parent: BlockId::zero(),
             justify_id: ProposalCertificate::genesis(Epoch::zero(), ShardGroup::all_shards(num_preshards))
@@ -349,9 +349,9 @@ impl BlockHeader {
 
         // This selection must stay identical to `tari_sidechain::SidechainBlockHeader::calculate_hash`, which is what
         // the base layer uses to verify a commit proof against the block ID a committee signed.
-        let fields = match self.protocol_version.as_u32() {
+        let fields = match self.protocol_version {
             // Version 0 commits to a preimage that carries no version, so its block IDs stay reproducible.
-            0 => BlockHeaderHashFields::V1(BlockHeaderHashFieldsV1 {
+            ProtocolVersion::V0 => BlockHeaderHashFields::V1(BlockHeaderHashFieldsV1 {
                 network: self.network.as_byte(),
                 justify_id: self.justify_id.hash(),
                 height: self.height.as_u64(),
@@ -367,9 +367,9 @@ impl BlockHeader {
             // From version 1 the version is part of the preimage, so that two versions sharing a preimage shape
             // still produce distinct block IDs and the version a block claims cannot be altered without
             // invalidating it.
-            protocol_version => BlockHeaderHashFields::V2(BlockHeaderHashFieldsV2 {
+            ProtocolVersion::V1 => BlockHeaderHashFields::V2(BlockHeaderHashFieldsV2 {
                 network: self.network.as_byte(),
-                protocol_version,
+                protocol_version: self.protocol_version.as_u32(),
                 justify_id: self.justify_id.hash(),
                 height: self.height.as_u64(),
                 epoch: self.epoch.as_u64(),

--- a/crates/storage/src/consensus_models/block_header.rs
+++ b/crates/storage/src/consensus_models/block_header.rs
@@ -236,7 +236,7 @@ impl BlockHeader {
         let shard_group = ShardGroup::all_shards(num_preshards);
         Self {
             network,
-            protocol_version: ProtocolVersion::V0,
+            protocol_version: ProtocolVersion::at(network, Epoch::zero()),
             id: BlockId::zero(),
             parent: BlockId::zero(),
             justify_id: ProposalCertificate::genesis(Epoch::zero(), ShardGroup::all_shards(num_preshards))

--- a/crates/storage/src/consensus_models/committed_block_proof.rs
+++ b/crates/storage/src/consensus_models/committed_block_proof.rs
@@ -144,6 +144,7 @@ mod tests {
     fn sample_proof() -> CommittedBlockProof {
         let header = SidechainBlockHeader {
             network: 0,
+            protocol_version: 0,
             parent_id: FixedHash::zero(),
             justify_id: FixedHash::zero(),
             height: 7,

--- a/crates/storage/src/global/metadata_db.rs
+++ b/crates/storage/src/global/metadata_db.rs
@@ -60,6 +60,10 @@ pub enum MetadataKey {
     /// The schema activation schedule the node last started with. Compared against the running
     /// binary's schedule to detect a disagreement about activations the node has already passed.
     ProtocolActivationSchedule,
+    /// The genesis protocol version the node last started with. A network that has not launched may
+    /// have its genesis version changed; this catches a node with history whose binary makes that
+    /// change under it. Absent means V0, which is what every binary predating this key ran under.
+    ProtocolGenesisVersion,
 }
 
 impl MetadataKey {
@@ -73,6 +77,7 @@ impl MetadataKey {
             Self::EpochManagerHighestLockedEpoch => b"epoch_manager.highest_locked_epoch",
             Self::EpochManagerBirthdayEpoch => b"epoch_manager.birthday_epoch",
             Self::ProtocolActivationSchedule => b"protocol.activation_schedule",
+            Self::ProtocolGenesisVersion => b"protocol.genesis_version",
         }
     }
 }

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -46,12 +46,12 @@ tari_ootle_wallet_sdk = { workspace = true }
 ootle_byte_type = { workspace = true }
 
 # Minotari
-minotari_console_wallet = "5.6.0"
-minotari_node = "5.6.0"
-minotari_wallet = "5.6.0"
-tari_comms = "5.6.0"
-tari_comms_dht = "5.6.0"
-tari_p2p = "5.6.0"
+minotari_console_wallet = "5.7.0-pre.5"
+minotari_node = "5.7.0-pre.5"
+minotari_wallet = "5.7.0-pre.5"
+tari_comms = "5.7.0-pre.5"
+tari_comms_dht = "5.7.0-pre.5"
+tari_p2p = "5.7.0-pre.5"
 
 anyhow = { workspace = true }
 config = { workspace = true }


### PR DESCRIPTION
## Description

Adds `protocol_version` to `BlockHeader`, resolved from the network's activation schedule at the block's epoch, and makes both the block hash preimage and the proposal vote signature message select their shape from it. Adds `ProtocolVersion::V1`, which is the version those two preimages change under.

Supersedes #2492, which is folded in here: `tari_sidechain` 5.7.0-pre.5 ships both base-layer changes (tari-project/tari#7983 and tari-project/tari#7982), so the two Ootle halves no longer compile apart.

## Motivation and Context

The base layer verifies a commit proof against the block ID a committee signed. Until now it could only do that by already knowing our activation schedule — an epoch → version table that lives here and moves every fork. A base-layer node with a stale copy silently hashes a post-fork block under the superseded schema and rejects a valid proof.

Making blocks and certificates self-describing moves that decision into the data. `tari_sidechain` reads the schema off the block and never needs the table. On this side, `check_protocol_version` gives a node whose schedule disagrees an explicit error naming both versions, and a deduped alarm telling the operator to upgrade, rather than an opaque signature failure.

Separately, a proposal vote signature covered only `(block_id, decision)`, which is not enough to attribute a vote to a view: two conflicting signatures from one validator were indistinguishable from two honest votes at different heights. From V1 the vote also signs the version, epoch and height, so equivocation is provable from the signatures alone — matching what timeout votes already do.

`SignedMessage` no longer requires `ToSignatureMessage`. A proposal vote's preimage depends on the protocol version, which the vote does not carry, so the vote is paired with its message at the point of verification instead of producing one on its own. Timeout votes, whose preimage is self-contained, are unaffected.

## Which networks move

| Network | Genesis | Basis |
| --- | --- | --- |
| Esmeralda | `V0` | The only network with an Ootle deployment carrying block history. Its genesis version is chain history and cannot move; it takes a scheduled activation when an epoch is decided. |
| Mainnet, Stagenet, Nextnet | `V1` | Never launched. |
| Igor, LocalNet | `V1` | Reset before use. |

The five networks launched directly at `V1` need no activation to coordinate, and a later reset can collapse the table back to a single genesis entry at whatever version is newest then.

**Esmeralda is a rolling upgrade with no reset and no restart coordination**, because it stays on `V0` until an activation is scheduled:

- **Hashing** — `V0` keeps the existing `BlockHeaderHashFieldsV1` preimage and the existing vote message, neither of which carries a version.
- **RocksDB** — `#[cbor(default)]` on the header; epoch checkpoints reach `tari_sidechain` types through `tari_bor::adapters::serde_bridge`, whose new fields are `#[serde(default)]`. Existing rows load and hash unchanged, and an older binary reading a new row ignores the added fields, so a rollback is safe too.
- **p2p** — the new fields are proto3 scalars, so a peer that does not send them reads as `V0`. Old and new nodes produce the same signed bytes and interoperate in either direction.

The other five **do** move at genesis, which is a block-layer fork for any node that already has history on them. `check_activation_schedule` now covers this: it records the genesis version alongside the activation schedule and refuses to start a node with epoch history whose binary launches its network at a different version. Substate hashes are unaffected either way — `SubstateHashMessage::new` maps `V0` and `V1` to the same schema — so this is never state corruption.

When an activation *is* scheduled for esmeralda, every validator must be on the new binary before that epoch, and base nodes and wallets must be on `tari_sidechain` 5.7.0-pre.5+ so that a proof hashed under `BlockHeaderHashFieldsV2` verifies on L1.

## How Has This Been Tested?

`cargo lints clippy --all-targets` clean, and `cargo test` on `tari_ootle_storage`, `tari_consensus`, `tari_consensus_types`, `tari_engine_types`, `tari_state_store_rocksdb` and `consensus_tests` (67 tests, including the `block.json` / `block_with_dummies.json` fixtures, which are unmodified and still hash to the same IDs even though localnet now starts at `V1` — they hash from the stored header field, which is the self-describing property doing its job).

Exercised on a localnet with an activation scheduled mid-run, crossing the boundary with the network live.

Coverage worth pointing at:
- `a_header_encoded_without_a_protocol_version_decodes_as_v0` — strips the trailing element from a real encoding and asserts the decoded header has the same ID and hash.
- `it_hashes_the_header_identically_to_sidechain_header` and `a_vote_signed_here_verifies_in_the_sidechain_crate`, both run for `V0` and `V1`, so the schema selection here and in `tari_sidechain` cannot drift apart.
- `moving_the_genesis_version_under_a_node_with_history_is_rejected`, and `the_live_network_stays_at_its_launched_version` so nobody moves esmeralda without noticing.

## What process can a PR reviewer use to test or verify this change?

Run the tests above. The reviewable claims are that nothing about a `V0` block or vote changes — the untouched fixtures on both sides are the guard — and that the only network with history stays on `V0`.

## Breaking Changes

- [ ] None
- [ ] Requires data directory to be deleted
- [ ] Requires hard fork
- [x] Other - Please specify

`BlockHeader` and `Block` constructors take a `ProtocolVersion`, and `QuorumCertificate` gains three wire fields. Esmeralda is unaffected: existing blocks decode and hash as `V0`. The five networks launched at `V1` require a reset for any node that already has history on them, which the startup guard enforces rather than leaving to chance.
