### PR TITLE
test(walletd): build balance-change fixtures in one transaction

### DIFF
--- a/applications/tari_walletd/src/handlers/accounts.rs
+++ b/applications/tari_walletd/src/handlers/accounts.rs
@@ -1803,7 +1803,8 @@ mod balance_change_handler_tests {
     use tari_ootle_wallet_sdk::{
         WalletSdkConfig,
         cipher_seed::CipherSeedRestore,
-        models::{BalanceChangeSource, EpochBirthday, KeyBranch, KeyId},
+        models::{BalanceChangeSnapshot, BalanceChangeSource, EpochBirthday, KeyBranch, KeyId},
+        storage::{WalletStorageError, WalletStoreWriter, WriteableWalletStore},
     };
     use tari_ootle_wallet_sdk_services::{
         account_monitor::AccountMonitor,
@@ -1939,17 +1940,32 @@ mod balance_change_handler_tests {
                 BalanceChangeSource::Scan,
             )
             .unwrap();
-        for version in 2..=206 {
-            accounts
-                .update_vault_balance_and_record_change(
-                    second_vault,
-                    version,
-                    Amount::from(200u64 + u64::from(version)),
-                    Amount::zero(),
-                    BalanceChangeSource::Scan,
-                )
-                .unwrap();
-        }
+        // Enough rows to exercise MAX_BALANCE_CHANGE_LIMIT. These are bulk fixture data - only their
+        // count is asserted on - so they are inserted in one transaction. Recording them through
+        // update_vault_balance_and_record_change commits each one separately, and the resulting 205
+        // fsyncs dominate the test and scale with disk latency on CI.
+        store
+            .with_write_tx(|tx| {
+                for version in 2..=206u32 {
+                    tx.balance_changes_insert(
+                        BalanceChangeSnapshot {
+                            account_address: account,
+                            vault_address: Some(second_vault),
+                            vault_version: Some(version),
+                            resource_address: second_resource,
+                            token_symbol: Some("TWO".to_string()),
+                            divisibility: 2,
+                            revealed_before: Amount::from(199u64 + u64::from(version)),
+                            revealed_after: Amount::from(200u64 + u64::from(version)),
+                            confidential_before: Amount::zero(),
+                            confidential_after: Amount::zero(),
+                        },
+                        BalanceChangeSource::Scan,
+                    )?;
+                }
+                Ok::<_, WalletStorageError>(())
+            })
+            .unwrap();
 
         let notify = Notify::new(10);
         let mut shutdown = Shutdown::new();


### PR DESCRIPTION
## Symptom

`balance_changes_handler_authorizes_filters_and_paginates` timed out in CI at 60s while passing locally in 4.3s. It is not hanging, and it is not specific to any one branch — it will intermittently hit any PR.

## Measurement

Timing the sections locally:

| Section | Time |
|---|---|
| `initialize_cipher_seed` | 1.49s |
| **205-row fixture loop** | **2.61s** |
| account/vault/resource setup | 0.17s |
| worker construction | 0.7ms |
| **the queries actually asserted on** | **7ms** |

So ~98% of the test is fixture setup, and the largest part is a loop whose cost is disk-bound.

## Cause

The fixture needs more than `MAX_BALANCE_CHANGE_LIMIT` (200) rows to demonstrate that the limit caps a page, so it records 205 of them. Each went through `accounts_api().update_vault_balance_and_record_change`, which wraps every call in its own `store.with_write_tx` (`crates/wallet/sdk/src/apis/accounts.rs:222`).

`SqliteWalletStore::try_open` sets only `PRAGMA foreign_keys = ON` (`crates/wallet/storage_sqlite/src/lib.rs:39`), leaving SQLite's defaults — `synchronous = FULL` with a rollback journal. So the fixture costs **205 real fsyncs**, ~12.7ms each locally. On a CI runner with contended disk, an order of magnitude per commit is enough to blow a 60s budget, which is exactly the failure mode: fine locally, occasionally fatal in CI.

## Change

Those 205 rows are bulk fixture data — only their count is ever asserted (`total == 208`, `changes.len() == 200`). They are now inserted directly through `balance_changes_insert` inside a **single** transaction.

The three balance changes the assertions actually inspect — the two on `first_vault` that the resource filter and `revealed_delta`/`source` checks read, and the first on `second_vault` — still go through the accounts API unchanged, so the behaviour under test is still exercised through its real entry point.

## Result

4.3s → 0.6s, and the runtime no longer scales with fsync latency. Assertions are unchanged and still pass, including the `MAX_BALANCE_CHANGE_LIMIT` cap. Full `tari_ootle_walletd` lib suite: 38 passed in 2.7s.

## Note

Not addressed here: the store leaves SQLite at `synchronous = FULL` with a rollback journal. That is a reasonable default for a real wallet, but it means any test doing many small committed writes pays full fsync cost. Worth a look separately if other wallet tests start showing the same variance.