### PR TITLE
fix(state-sync): start the state stream at the first unpersisted version

### DIFF
--- a/crates/consensus/src/hotstuff/substate_store/sharded_state_tree.rs
+++ b/crates/consensus/src/hotstuff/substate_store/sharded_state_tree.rs
@@ -1,7 +1,7 @@
 //    Copyright 2024 The Tari Project
 //    SPDX-License-Identifier: BSD-3-Clause
 
-use std::collections::HashMap;
+use std::{collections::HashMap, ops::Deref};
 
 use indexmap::IndexMap;
 use log::*;
@@ -176,7 +176,11 @@ impl<TTx: StateStoreReadTransaction> ShardedStateTree<&TTx> {
     }
 }
 
-impl<TTx: StateStoreWriteTransaction> ShardedStateTree<&mut TTx> {
+impl<TTx> ShardedStateTree<&mut TTx>
+where
+    TTx: StateStoreWriteTransaction + Deref,
+    TTx::Target: StateStoreReadTransaction,
+{
     pub fn commit_diffs(
         &mut self,
         diffs: IndexMap<Shard, Vec<PendingShardStateTreeDiff>>,

--- a/crates/rpc_state_sync/src/state_sync.rs
+++ b/crates/rpc_state_sync/src/state_sync.rs
@@ -178,10 +178,14 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
             return Ok(None);
         }
 
-        // Bootstrapped genesis state is committed at version 0; consensus/sync state changes begin at
-        // version 1. A freshly bootstrapped node persists version 0, so clamp the sync start to 1 (the
-        // peer rejects start_state_version 0, and genesis is never synced - every node bootstraps it).
-        let start_state_version = maybe_persisted_state_version.map_or(1, |v| v.max(1));
+        // The stream is inclusive of start_state_version, so it must be the first version we have not
+        // yet persisted. A persisted version must never be written a second time: JMT nodes are keyed
+        // by (version, nibble_path), so rewriting a version overwrites live nodes and records those
+        // very keys as stale at that version, and the stale-node GC then deletes them from under the
+        // current tree. Bootstrapped genesis state is committed at version 0 and is never synced -
+        // every node bootstraps it - so a freshly bootstrapped node starts at version 1, which is also
+        // the minimum the peer accepts.
+        let start_state_version = maybe_persisted_state_version.map_or(1, |v| v + 1);
         let mut last_state_version = start_state_version;
         info!(
             target: LOG_TARGET,

--- a/crates/rpc_state_sync/src/state_sync.rs
+++ b/crates/rpc_state_sync/src/state_sync.rs
@@ -238,7 +238,8 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
                     if local_state_root != checkpoint_shard_root {
                         error!(
                             target: LOG_TARGET,
-                            "❌ State root mismatch for {shard}. Checkpoint {expected} but got {actual}. Rolling back.",
+                            "❌ State root mismatch for {shard}. Checkpoint {expected} but got {actual}. Everything \
+                             streamed so far is already committed; the next peer resumes after it.",
                             expected = checkpoint_shard_root,
                             actual = local_state_root,
                         );

--- a/crates/state_store_rocksdb/tests/state_tree.rs
+++ b/crates/state_store_rocksdb/tests/state_tree.rs
@@ -5,7 +5,13 @@ pub mod helpers;
 
 use helpers::assert_eq_debug;
 use tari_ootle_common_types::{ShardGroup, optional::Optional, shard::Shard};
-use tari_ootle_storage::{StateStore, StateStoreReadTransaction, StateStoreWriteTransaction, StorageError};
+use tari_ootle_storage::{
+    ShardScopedTreeStoreWriter,
+    StateStore,
+    StateStoreReadTransaction,
+    StateStoreWriteTransaction,
+    StorageError,
+};
 use tari_state_store_rocksdb::DatabaseOptions;
 use tari_state_tree::{NibblePath, Node, NodeKey, StaleTreeNode, StateTreePayload};
 use tari_validator_rollback::storage::state_tree_truncate_to_version;
@@ -256,6 +262,44 @@ fn truncate_to_version_zero_keeps_genesis_v0_pointer() {
             assert!(tx.state_tree_nodes_get(empty_shard, key).optional().unwrap().is_none());
         }
         assert_eq!(tx.state_tree_versions_get_latest(empty_shard).unwrap(), None);
+        Ok::<_, StorageError>(())
+    })
+    .unwrap();
+}
+
+#[test]
+fn set_state_version_refuses_to_rewrite_a_committed_version() {
+    const SHARD: Shard = Shard::first();
+    let (db, _tmp) = create_rocksdb_with_opts(DatabaseOptions::default());
+
+    db.with_write_tx(|tx| {
+        let mut store = ShardScopedTreeStoreWriter::new(tx, SHARD);
+        store.set_state_version(1).unwrap();
+        Ok::<_, StorageError>(())
+    })
+    .unwrap();
+
+    // Writing v1 again would put new nodes on the keys the same write records as stale at v1, leaving
+    // the tree pointing at nodes the stale-node GC is free to delete.
+    db.with_write_tx(|tx| {
+        let mut store = ShardScopedTreeStoreWriter::new(tx, SHARD);
+        let err = store.set_state_version(1).unwrap_err();
+        assert!(
+            err.to_string().contains("must be greater than the current version"),
+            "{err}"
+        );
+        let err = store.set_state_version(0).unwrap_err();
+        assert!(
+            err.to_string().contains("must be greater than the current version"),
+            "{err}"
+        );
+        store.set_state_version(2).unwrap();
+        Ok::<_, StorageError>(())
+    })
+    .unwrap();
+
+    db.with_read_tx(|tx| {
+        assert_eq!(tx.state_tree_versions_get_latest(SHARD).unwrap(), Some(2));
         Ok::<_, StorageError>(())
     })
     .unwrap();

--- a/crates/state_tree/src/error.rs
+++ b/crates/state_tree/src/error.rs
@@ -1,13 +1,21 @@
 //   Copyright 2024 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use tari_jellyfish::JmtStorageError;
+use tari_jellyfish::{JmtStorageError, Version};
 use tari_ootle_common_types::optional::IsNotFoundError;
 
 #[derive(Debug, thiserror::Error)]
 pub enum StateTreeError {
     #[error("JMT Storage error: {0}")]
     JmtStorageError(#[from] JmtStorageError),
+    #[error(
+        "Refusing to write state tree version {next_version} on top of current version {current_version}: the next \
+         version must be greater than the current version"
+    )]
+    NonMonotonicVersion {
+        current_version: Version,
+        next_version: Version,
+    },
 }
 
 impl IsNotFoundError for StateTreeError {

--- a/crates/state_tree/src/tree.rs
+++ b/crates/state_tree/src/tree.rs
@@ -184,13 +184,13 @@ fn calculate_substate_changes<
     // JMT nodes are keyed by (version, nibble_path). Writing a version that is not strictly ahead of
     // the base version overwrites live nodes with keys that this same write records as stale, so the
     // stale-node GC later deletes nodes the current tree still points at.
-    if let Some(current_version) = current_version {
-        if version <= current_version {
-            return Err(StateTreeError::NonMonotonicVersion {
-                current_version,
-                next_version: version,
-            });
-        }
+    if let Some(current_version) = current_version &&
+        version <= current_version
+    {
+        return Err(StateTreeError::NonMonotonicVersion {
+            current_version,
+            next_version: version,
+        });
     }
 
     let jmt = JellyfishMerkleTree::new(store);

--- a/crates/state_tree/src/tree.rs
+++ b/crates/state_tree/src/tree.rs
@@ -178,18 +178,20 @@ fn calculate_substate_changes<
 >(
     store: &mut S,
     current_version: Option<Version>,
-    version: Version,
+    next_version: Version,
     changes: I,
 ) -> Result<(TreeHash, TreeUpdateBatch<StateTreePayload>), StateTreeError> {
     // JMT nodes are keyed by (version, nibble_path). Writing a version that is not strictly ahead of
     // the base version overwrites live nodes with keys that this same write records as stale, so the
-    // stale-node GC later deletes nodes the current tree still points at.
+    // stale-node GC later deletes nodes the current tree still points at. Callers that stage changes
+    // and write them later are additionally guarded at the write funnel, in
+    // `ShardScopedTreeStoreWriter::set_state_version`.
     if let Some(current_version) = current_version &&
-        version <= current_version
+        next_version <= current_version
     {
         return Err(StateTreeError::NonMonotonicVersion {
             current_version,
-            next_version: version,
+            next_version,
         });
     }
 
@@ -203,7 +205,7 @@ fn calculate_substate_changes<
         SubstateTreeChange::Down { id } => (M::map_to_leaf_key(&id), None),
     });
 
-    let (root_hash, update_result) = jmt.batch_put_value_set(changes, None, current_version, version)?;
+    let (root_hash, update_result) = jmt.batch_put_value_set(changes, None, current_version, next_version)?;
 
     Ok((root_hash, update_result))
 }

--- a/crates/state_tree/src/tree.rs
+++ b/crates/state_tree/src/tree.rs
@@ -181,6 +181,18 @@ fn calculate_substate_changes<
     version: Version,
     changes: I,
 ) -> Result<(TreeHash, TreeUpdateBatch<StateTreePayload>), StateTreeError> {
+    // JMT nodes are keyed by (version, nibble_path). Writing a version that is not strictly ahead of
+    // the base version overwrites live nodes with keys that this same write records as stale, so the
+    // stale-node GC later deletes nodes the current tree still points at.
+    if let Some(current_version) = current_version {
+        if version <= current_version {
+            return Err(StateTreeError::NonMonotonicVersion {
+                current_version,
+                next_version: version,
+            });
+        }
+    }
+
     let jmt = JellyfishMerkleTree::new(store);
 
     let changes = changes.into_iter().map(|ch| match ch {

--- a/crates/state_tree/tests/support.rs
+++ b/crates/state_tree/tests/support.rs
@@ -6,6 +6,7 @@ use tari_jellyfish::{LeafKey, TreeHash, TreeStore, Version};
 use tari_ootle_common_types::VersionedSubstateId;
 use tari_state_tree::{
     StateTree,
+    StateTreeError,
     StateTreePayload,
     SubstateTreeChange,
     key_mapper::DbKeyMapper,
@@ -78,9 +79,18 @@ impl<S: TreeStore<StateTreePayload>> HashTreeTester<S> {
         next_version: Version,
         changes: impl IntoIterator<Item = SubstateTreeChange>,
     ) -> TreeHash {
+        self.try_put_changes_at_version(current_version, next_version, changes)
+            .unwrap()
+    }
+
+    pub fn try_put_changes_at_version(
+        &mut self,
+        current_version: Option<Version>,
+        next_version: Version,
+        changes: impl IntoIterator<Item = SubstateTreeChange>,
+    ) -> Result<TreeHash, StateTreeError> {
         self.create_state_tree()
             .put_substate_changes(current_version, next_version, changes)
-            .unwrap()
     }
 }
 

--- a/crates/state_tree/tests/test.rs
+++ b/crates/state_tree/tests/test.rs
@@ -6,7 +6,7 @@ use std::collections::{BTreeSet, HashSet};
 
 use tari_jellyfish::{SPARSE_MERKLE_PLACEHOLDER_HASH, SparseMerkleProofExt, StaleTreeNode, TreeHash, Version};
 use tari_ootle_common_types::ToSubstateAddress;
-use tari_state_tree::memory_store::MemoryTreeStore;
+use tari_state_tree::{StateTreeError, memory_store::MemoryTreeStore};
 
 use crate::support::{HashTreeTester, change, hash_value_from_seed, make_value};
 mod support;
@@ -91,29 +91,6 @@ fn hash_computed_consistently_after_adding_higher_tier_sibling() {
 
     // We did [2] + [1] + [3] = [1,2,3] (i.e. same state).
     assert_eq!(root_after_adding_sibling, reference_root);
-}
-
-#[test]
-fn hash_allows_putting_in_same_version() {
-    let mut tester_1 = HashTreeTester::new_empty();
-    tester_1.put_changes_at_version(None, 1, vec![change(1, Some(30))]);
-    tester_1.put_changes_at_version(Some(1), 1, vec![change(2, Some(31))]);
-    tester_1.put_changes_at_version(Some(1), 1, vec![change(3, Some(32))]);
-    tester_1.put_changes_at_version(Some(1), 1, vec![change(4, Some(33))]);
-    tester_1.put_changes_at_version(Some(1), 1, vec![change(5, Some(34))]);
-    let hash_1 = tester_1.put_changes_at_version(Some(1), 1, vec![change(6, Some(35))]);
-    let mut tester_2 = HashTreeTester::new_empty();
-    tester_2.put_changes_at_version(None, 1, vec![
-        change(1, Some(30)),
-        change(2, Some(31)),
-        change(3, Some(32)),
-    ]);
-    let hash_2 = tester_2.put_changes_at_version(Some(1), 2, vec![
-        change(4, Some(33)),
-        change(5, Some(34)),
-        change(6, Some(35)),
-    ]);
-    assert_eq!(hash_1, hash_2);
 }
 
 #[test]
@@ -350,4 +327,37 @@ fn two_level_substate_inclusion_proof_for_genesis_version_zero() {
     proof
         .verify_inclusion(&group_root, &make_value(1), &hash_value_from_seed(200))
         .unwrap_err();
+}
+
+#[test]
+fn rewriting_an_already_written_version_is_rejected() {
+    let mut tester = HashTreeTester::new_empty();
+    tester.put_substate_changes(vec![change(1, Some(30))]);
+
+    // Writing v1 a second time would overwrite the live nodes keyed at v1 while recording those same
+    // keys as stale at v1, leaving the tree pointing at nodes the stale-node GC is free to delete.
+    let err = tester
+        .try_put_changes_at_version(Some(1), 1, vec![change(2, Some(40))])
+        .unwrap_err();
+
+    assert!(matches!(err, StateTreeError::NonMonotonicVersion {
+        current_version: 1,
+        next_version: 1
+    }));
+}
+
+#[test]
+fn writing_a_version_behind_the_current_one_is_rejected() {
+    let mut tester = HashTreeTester::new_empty();
+    tester.put_substate_changes(vec![change(1, Some(30))]);
+    tester.put_substate_changes(vec![change(2, Some(40))]);
+
+    let err = tester
+        .try_put_changes_at_version(Some(2), 1, vec![change(3, Some(50))])
+        .unwrap_err();
+
+    assert!(matches!(err, StateTreeError::NonMonotonicVersion {
+        current_version: 2,
+        next_version: 1
+    }));
 }

--- a/crates/storage/src/state_store/shard_scoped_state_tree.rs
+++ b/crates/storage/src/state_store/shard_scoped_state_tree.rs
@@ -59,7 +59,34 @@ impl<'a, TTx: StateStoreWriteTransaction> ShardScopedTreeStoreWriter<'a, TTx> {
         Self { shard, tx }
     }
 
-    pub fn set_state_version(&mut self, version: Version) -> Result<(), JmtStorageError> {
+    /// Advances the shard's committed tree version.
+    ///
+    /// JMT nodes are keyed by `(version, nibble_path)`, so a version may only ever be written once:
+    /// writing one a second time overwrites live nodes with keys that the same write records as stale,
+    /// and the stale-node GC then deletes them from under the current tree. Every production writer -
+    /// consensus block commit, state sync and genesis - funnels through here, so this is where that is
+    /// enforced. Rewinds reset the pointer through `state_tree_shard_versions_set` directly, after the
+    /// versions above the target no longer exist.
+    pub fn set_state_version(&mut self, version: Version) -> Result<(), JmtStorageError>
+    where
+        TTx: Deref,
+        TTx::Target: StateStoreReadTransaction,
+    {
+        let current_version = self
+            .tx
+            .state_tree_versions_get_latest(self.shard)
+            .map_err(|e| JmtStorageError::UnexpectedError(e.to_string()))?;
+
+        if let Some(current_version) = current_version &&
+            version <= current_version
+        {
+            return Err(JmtStorageError::UnexpectedError(format!(
+                "Refusing to write state tree version {version} for shard {} on top of committed version \
+                 {current_version}: the next version must be greater than the current version",
+                self.shard,
+            )));
+        }
+
         self.tx
             .state_tree_shard_versions_set(self.shard, version)
             .map_err(|e| JmtStorageError::UnexpectedError(e.to_string()))


### PR DESCRIPTION
## Problem

A validator node on 0.39.3 (esmeralda) wedged permanently with:

```
JMT Storage error: A node v6384:f9 expected to exist (according to JMT logic) was not found in the storage
```

Once it appears, the node is unrecoverable without a database wipe — every block evaluation and every subsequent state sync fails on the same missing node, so the consensus state machine loops `CheckSync -> Syncing -> Failure -> Sleeping` forever.

## Root cause

`start_state_sync` opened the stream at the shard's **already-persisted** state version:

```rust
let start_state_version = maybe_persisted_state_version.map_or(1, |v| v.max(1));
```

The stream is inclusive of `start_state_version` (the server's `fetch_next_batch` starts at exactly that version, and the client rejects any batch below it), so the peer replays a version the client has already written, and the client writes it again:

```
🛜Syncing from v6384
🛜 Committing 2 state tree changes batch v6384
Batch inserting 5 new nodes and recording 5 stale tree nodes
```

JMT nodes are keyed by `(version, nibble_path)`. Writing a version a second time overwrites the live nodes at those keys, while `batch_put_substate_changes` records those **same keys** as stale at that version. An hour later the stale-node GC (`state_tree_nodes_clear_stale`) reaches them once `max_version - state_history_length` passes that version and deletes them out from under the current tree:

```
Deleted 1126 stale nodes in shard Shard(1) in 46.57ms to version 6466
```

Note the equal new/stale counts in the sync log — that is the signature of the self-overwrite.

Observed sequence on the affected node (times UTC):

| Time | Event |
|---|---|
| 09:54:25 | last shard-1 diff committed: `v6384` |
| 11:01:54 | epoch rollover sync: `🛜Syncing from v6384`, rewrites v6384 |
| 12:01:57 | GC: `Deleted 1126 stale nodes in shard Shard(1) … to version 6466` |
| 13:05:28 | `A node v6384:f9 expected to exist … was not found` — permanent |

## Fix

- Start at `persisted + 1`. This matches what the indexer's sync worker already does (`network_state_sync/worker.rs`: `start_state_version: prev_version + 1`). The server already terminates cleanly with just a completion marker when the start version is past its tip, so no protocol change is needed. The `Some(0)` (freshly bootstrapped, genesis at v0) case still starts at 1, which is also the minimum the peer accepts.
- Reject a non-monotonic version in `calculate_substate_changes` so a same-version write fails loudly instead of silently corrupting the tree. No production caller writes a version twice — consensus (`sharded_state_tree`) always uses `current + 1`, genesis writes once at `GENESIS_STATE_VERSION`. The existing `hash_allows_putting_in_same_version` test covered that now-forbidden capability and is replaced by tests asserting it is rejected.

## Testing

`cargo test -p tari_state_tree` and `cargo test -p tari_state_store_rocksdb --test substates` pass.

## Not addressed here

The same incident had an earlier, non-fatal trigger that is worth a separate issue: after `Syncing::on_enter` clears the transaction pool, the very next epoch's blocks re-proposed a cleared transaction, and `evaluate_local_only_command` no-votes any block whose transaction is not in the pool ("This is likely a previous transaction that has been re-proposed"). The node was then unable to vote for a whole epoch (~65 min) and its state fell behind — which is what put it into the sync path above. It self-healed at the next epoch boundary, so it is a liveness bug rather than a corruption one, and the fix is a consensus behaviour change that deserves its own PR.