### PR TITLE
fix(consensus): re-sequence a proposal's transaction when its pool record is gone

### DIFF
--- a/crates/consensus/src/hotstuff/on_message_validate.rs
+++ b/crates/consensus/src/hotstuff/on_message_validate.rs
@@ -244,9 +244,10 @@ impl<TConsensusSpec: ConsensusSpec> OnMessageValidate<TConsensusSpec> {
             });
         }
 
-        let missing_tx_ids = self
-            .store
-            .with_write_tx(|tx| self.check_for_missing_transactions(tx, epoch_state, &proposal, new_transactions))?;
+        let missing_tx_ids = self.store.with_write_tx(|tx| {
+            self.resequence_unpooled_transactions(tx, epoch_state, &proposal, new_transactions)?;
+            self.check_for_missing_transactions(tx, epoch_state.local_committee_info(), &proposal)
+        })?;
 
         if missing_tx_ids.is_empty() {
             return Ok(MessageValidationResult::Ready {
@@ -341,9 +342,10 @@ impl<TConsensusSpec: ConsensusSpec> OnMessageValidate<TConsensusSpec> {
         proposal: ProposalMessage,
         new_transactions: &OnReceiveNewTransaction<TConsensusSpec>,
     ) -> Result<MessageValidationResult<TConsensusSpec::Addr>, HotStuffError> {
-        let missing_tx_ids = self
-            .store
-            .with_write_tx(|tx| self.check_for_missing_transactions(tx, epoch_state, &proposal, new_transactions))?;
+        let missing_tx_ids = self.store.with_write_tx(|tx| {
+            self.resequence_unpooled_transactions(tx, epoch_state, &proposal, new_transactions)?;
+            self.check_for_missing_transactions(tx, epoch_state.local_committee_info(), &proposal)
+        })?;
 
         if missing_tx_ids.is_empty() {
             return Ok(MessageValidationResult::Ready {
@@ -366,14 +368,40 @@ impl<TConsensusSpec: ConsensusSpec> OnMessageValidate<TConsensusSpec> {
         })
     }
 
-    fn check_for_missing_transactions(
+    /// Rebuilds pool records for this block's transactions that we hold but that are absent from the
+    /// transaction pool, so that a proposal is not rejected over derived state no peer can resend.
+    ///
+    /// Only the commands the rebuilt `New` stage can serve are offered: a later command is not made
+    /// votable by a `New` record, and that record would then be proposed at a stage the committee has
+    /// moved past. See [`OnReceiveNewTransaction::resequence_known_transactions`].
+    fn resequence_unpooled_transactions(
         &self,
         tx: &mut <TConsensusSpec::StateStore as StateStore>::WriteTransaction<'_>,
         epoch_state: &EpochState<TConsensusSpec::Addr>,
         proposal: &ProposalMessage,
         new_transactions: &OnReceiveNewTransaction<TConsensusSpec>,
+    ) -> Result<(), HotStuffError> {
+        let ids = proposal
+            .block
+            .commands()
+            .iter()
+            .filter_map(|cmd| cmd.local_only().or_else(|| cmd.local_prepare()))
+            .map(|atom| atom.id)
+            .collect::<Vec<_>>();
+
+        if ids.is_empty() {
+            return Ok(());
+        }
+
+        new_transactions.resequence_known_transactions(tx, epoch_state.epoch(), ids, epoch_state.local_committee_info())
+    }
+
+    fn check_for_missing_transactions(
+        &self,
+        tx: &mut <TConsensusSpec::StateStore as StateStore>::WriteTransaction<'_>,
+        local_committee_info: &CommitteeInfo,
+        proposal: &ProposalMessage,
     ) -> Result<HashSet<TransactionId>, HotStuffError> {
-        let local_committee_info = epoch_state.local_committee_info();
         if proposal.block.commands().is_empty() {
             debug!(
                 target: LOG_TARGET,
@@ -382,21 +410,6 @@ impl<TConsensusSpec: ConsensusSpec> OnMessageValidate<TConsensusSpec> {
             return Ok(HashSet::new());
         }
         let mut missing_tx_ids = TransactionRecord::get_missing(&**tx, proposal.block.all_transaction_ids())?;
-
-        // A transaction whose record we hold but whose pool record is gone is not "missing" - no peer can
-        // send back derived local state - so it never parks and would instead no-vote every block that
-        // carries it. Re-derive its pool record from the record we already have.
-        new_transactions.resequence_known_transactions(
-            tx,
-            epoch_state.epoch(),
-            proposal
-                .block
-                .all_transaction_ids()
-                .filter(|id| !missing_tx_ids.contains(*id))
-                .copied()
-                .collect::<Vec<_>>(),
-            local_committee_info,
-        )?;
         // Also park block if it has missing transactions from foreign proposals
         for proposal in &proposal.foreign_proposals {
             let foreign_missing =

--- a/crates/consensus/src/hotstuff/on_message_validate.rs
+++ b/crates/consensus/src/hotstuff/on_message_validate.rs
@@ -29,7 +29,14 @@ use tokio::sync::broadcast;
 
 use super::config::HotstuffConfig;
 use crate::{
-    hotstuff::{CurrentView, HotstuffEvent, ProposalValidationError, epoch_state::EpochState, error::HotStuffError},
+    hotstuff::{
+        CurrentView,
+        HotstuffEvent,
+        ProposalValidationError,
+        epoch_state::EpochState,
+        error::HotStuffError,
+        on_receive_new_transaction::OnReceiveNewTransaction,
+    },
     messages::{ForeignProposalMessage, HotstuffMessage, MissingTransactionsRequest, ProposalMessage},
     tracing::TraceTimer,
     traits::{ConsensusSpec, OutboundMessaging},
@@ -83,6 +90,7 @@ impl<TConsensusSpec: ConsensusSpec> OnMessageValidate<TConsensusSpec> {
         epoch_state: &EpochState<TConsensusSpec::Addr>,
         from: TConsensusSpec::Addr,
         msg: HotstuffMessage,
+        new_transactions: &OnReceiveNewTransaction<TConsensusSpec>,
     ) -> Result<MessageValidationResult<TConsensusSpec::Addr>, HotStuffError> {
         let _timer = TraceTimer::debug(LOG_TARGET, "on_message_validate");
         match msg {
@@ -95,7 +103,7 @@ impl<TConsensusSpec: ConsensusSpec> OnMessageValidate<TConsensusSpec> {
                     );
                     return Ok(MessageValidationResult::Discard);
                 }
-                self.process_local_proposal(current_height, from, epoch_state, *msg)
+                self.process_local_proposal(current_height, from, epoch_state, *msg, new_transactions)
             },
             HotstuffMessage::CatchUpSyncResponse(msg) => {
                 if !epoch_state.local_committee().contains(&from) {
@@ -106,7 +114,7 @@ impl<TConsensusSpec: ConsensusSpec> OnMessageValidate<TConsensusSpec> {
                     );
                     return Ok(MessageValidationResult::Discard);
                 }
-                self.process_catch_up_response(from, epoch_state, *msg)
+                self.process_catch_up_response(from, epoch_state, *msg, new_transactions)
             },
             HotstuffMessage::ForeignProposal(proposal) => {
                 self.process_foreign_proposal(epoch_state, from, proposal).await
@@ -178,6 +186,7 @@ impl<TConsensusSpec: ConsensusSpec> OnMessageValidate<TConsensusSpec> {
         from: TConsensusSpec::Addr,
         epoch_state: &EpochState<TConsensusSpec::Addr>,
         proposal: ProposalMessage,
+        new_transactions: &OnReceiveNewTransaction<TConsensusSpec>,
     ) -> Result<MessageValidationResult<TConsensusSpec::Addr>, HotStuffError> {
         info!(
             target: LOG_TARGET,
@@ -206,7 +215,7 @@ impl<TConsensusSpec: ConsensusSpec> OnMessageValidate<TConsensusSpec> {
             });
         }
 
-        self.handle_missing_transactions_local_block(from, epoch_state.local_committee_info(), proposal)
+        self.handle_missing_transactions_local_block(from, epoch_state, proposal, new_transactions)
     }
 
     /// Validate a block delivered via catch-up sync. This is an ordered block import, so — unlike
@@ -218,6 +227,7 @@ impl<TConsensusSpec: ConsensusSpec> OnMessageValidate<TConsensusSpec> {
         from: TConsensusSpec::Addr,
         epoch_state: &EpochState<TConsensusSpec::Addr>,
         proposal: ProposalMessage,
+        new_transactions: &OnReceiveNewTransaction<TConsensusSpec>,
     ) -> Result<MessageValidationResult<TConsensusSpec::Addr>, HotStuffError> {
         info!(
             target: LOG_TARGET,
@@ -234,9 +244,9 @@ impl<TConsensusSpec: ConsensusSpec> OnMessageValidate<TConsensusSpec> {
             });
         }
 
-        let missing_tx_ids = self.store.with_write_tx(|tx| {
-            self.check_for_missing_transactions(tx, epoch_state.local_committee_info(), &proposal)
-        })?;
+        let missing_tx_ids = self
+            .store
+            .with_write_tx(|tx| self.check_for_missing_transactions(tx, epoch_state, &proposal, new_transactions))?;
 
         if missing_tx_ids.is_empty() {
             return Ok(MessageValidationResult::Ready {
@@ -327,12 +337,13 @@ impl<TConsensusSpec: ConsensusSpec> OnMessageValidate<TConsensusSpec> {
     fn handle_missing_transactions_local_block(
         &mut self,
         from: TConsensusSpec::Addr,
-        local_committee_info: &CommitteeInfo,
+        epoch_state: &EpochState<TConsensusSpec::Addr>,
         proposal: ProposalMessage,
+        new_transactions: &OnReceiveNewTransaction<TConsensusSpec>,
     ) -> Result<MessageValidationResult<TConsensusSpec::Addr>, HotStuffError> {
         let missing_tx_ids = self
             .store
-            .with_write_tx(|tx| self.check_for_missing_transactions(tx, local_committee_info, &proposal))?;
+            .with_write_tx(|tx| self.check_for_missing_transactions(tx, epoch_state, &proposal, new_transactions))?;
 
         if missing_tx_ids.is_empty() {
             return Ok(MessageValidationResult::Ready {
@@ -358,9 +369,11 @@ impl<TConsensusSpec: ConsensusSpec> OnMessageValidate<TConsensusSpec> {
     fn check_for_missing_transactions(
         &self,
         tx: &mut <TConsensusSpec::StateStore as StateStore>::WriteTransaction<'_>,
-        local_committee_info: &CommitteeInfo,
+        epoch_state: &EpochState<TConsensusSpec::Addr>,
         proposal: &ProposalMessage,
+        new_transactions: &OnReceiveNewTransaction<TConsensusSpec>,
     ) -> Result<HashSet<TransactionId>, HotStuffError> {
+        let local_committee_info = epoch_state.local_committee_info();
         if proposal.block.commands().is_empty() {
             debug!(
                 target: LOG_TARGET,
@@ -369,6 +382,21 @@ impl<TConsensusSpec: ConsensusSpec> OnMessageValidate<TConsensusSpec> {
             return Ok(HashSet::new());
         }
         let mut missing_tx_ids = TransactionRecord::get_missing(&**tx, proposal.block.all_transaction_ids())?;
+
+        // A transaction whose record we hold but whose pool record is gone is not "missing" - no peer can
+        // send back derived local state - so it never parks and would instead no-vote every block that
+        // carries it. Re-derive its pool record from the record we already have.
+        new_transactions.resequence_known_transactions(
+            tx,
+            epoch_state.epoch(),
+            proposal
+                .block
+                .all_transaction_ids()
+                .filter(|id| !missing_tx_ids.contains(*id))
+                .copied()
+                .collect::<Vec<_>>(),
+            local_committee_info,
+        )?;
         // Also park block if it has missing transactions from foreign proposals
         for proposal in &proposal.foreign_proposals {
             let foreign_missing =

--- a/crates/consensus/src/hotstuff/on_receive_new_transaction.rs
+++ b/crates/consensus/src/hotstuff/on_receive_new_transaction.rs
@@ -143,6 +143,80 @@ where TConsensusSpec: ConsensusSpec
         })
     }
 
+    /// Rebuilds pool records for transactions that are already in the transaction store but absent from
+    /// the transaction pool, returning the number of records added.
+    ///
+    /// The pool holds derived per-transaction consensus state and is dropped independently of the
+    /// transaction records - a state sync clears it wholesale. A proposal for a transaction whose record
+    /// we still hold but whose pool record is gone is unvotable (`TransactionNotInPool`) and cannot be
+    /// repaired by the missing-transaction request path, which only replaces absent records. Re-deriving
+    /// the pool record from the record we already hold is what makes such a proposal votable again.
+    ///
+    /// Safety comes from [`Self::validate_new_transaction`], which refuses to sequence an id that has
+    /// already committed - by its finalized decision or by its receipt existing in state - so this can
+    /// never resurrect a transaction the synced state has finalised.
+    pub fn resequence_known_transactions<I: IntoIterator<Item = TransactionId>>(
+        &self,
+        tx: &mut <<TConsensusSpec as ConsensusSpec>::StateStore as StateStore>::WriteTransaction<'_>,
+        current_epoch: Epoch,
+        transaction_ids: I,
+        local_committee_info: &CommitteeInfo,
+    ) -> Result<usize, HotStuffError> {
+        let mut unpooled = Vec::new();
+        for id in transaction_ids {
+            if self.transaction_pool.exists(&**tx, &id)? {
+                continue;
+            }
+            // A finalized record means the id has already run its course on this node. Whether an
+            // aborted attempt may be sequenced again is the mempool's call; repairing the pool during
+            // block validation must not resurrect one as a side effect.
+            if TransactionRecord::get_finalized_decision(&**tx, &id)?.is_some() {
+                continue;
+            }
+            unpooled.push(id);
+        }
+        if unpooled.is_empty() {
+            return Ok(0);
+        }
+
+        let (recs, _) = TransactionRecord::get_any(&**tx, unpooled.iter())?;
+        let mut batch = Vec::with_capacity(recs.len());
+        for rec in recs {
+            // A stored record does not carry whether it passed full local validation, and this is a
+            // rare repair path, so validate in full rather than assume.
+            if let Some(validate_data) = self.validate_new_transaction(
+                tx,
+                current_epoch,
+                rec,
+                local_committee_info,
+                TransactionSource::Requested,
+            )? {
+                batch.push(validate_data);
+            }
+        }
+
+        let num_sequenced = batch.iter().filter(|data| data.must_sequence).count();
+        if num_sequenced == 0 {
+            return Ok(0);
+        }
+
+        info!(
+            target: LOG_TARGET,
+            "🎱 Re-sequencing {num_sequenced} known transaction(s) that are missing from the pool",
+        );
+        self.transaction_pool.insert_new_batched(
+            tx,
+            local_committee_info.num_preshards(),
+            local_committee_info.num_committees(),
+            batch
+                .iter()
+                .filter(|data| data.must_sequence)
+                .map(|data| (&data.transaction, data.decision, true)),
+        )?;
+
+        Ok(num_sequenced)
+    }
+
     fn validate_new_transaction(
         &self,
         tx: &mut <<TConsensusSpec as ConsensusSpec>::StateStore as StateStore>::WriteTransaction<'_>,

--- a/crates/consensus/src/hotstuff/on_receive_new_transaction.rs
+++ b/crates/consensus/src/hotstuff/on_receive_new_transaction.rs
@@ -143,14 +143,18 @@ where TConsensusSpec: ConsensusSpec
         })
     }
 
-    /// Rebuilds pool records for transactions that are already in the transaction store but absent from
-    /// the transaction pool, returning the number of records added.
+    /// Rebuilds pool records for transactions this node already holds but that are absent from the
+    /// transaction pool.
     ///
     /// The pool holds derived per-transaction consensus state and is dropped independently of the
-    /// transaction records - a state sync clears it wholesale. A proposal for a transaction whose record
-    /// we still hold but whose pool record is gone is unvotable (`TransactionNotInPool`) and cannot be
-    /// repaired by the missing-transaction request path, which only replaces absent records. Re-deriving
-    /// the pool record from the record we already hold is what makes such a proposal votable again.
+    /// transaction records - a state sync clears it wholesale. A proposal for a transaction whose
+    /// record we still hold but whose pool record is gone is unvotable (`TransactionNotInPool`), and
+    /// the missing-transaction request path cannot repair it because it only replaces absent records.
+    ///
+    /// A rebuilt record enters at the `New` pool stage and is inserted ready, so callers must
+    /// pass only ids whose command in the block being validated is one the `New` stage serves. An id
+    /// carrying a later command gains nothing here - the stage check rejects it either way - and the
+    /// ready record would be proposed, putting a stale-stage command in every block this node leads.
     ///
     /// Safety comes from [`Self::validate_new_transaction`], which refuses to sequence an id that has
     /// already committed - by its finalized decision or by its receipt existing in state - so this can
@@ -161,35 +165,37 @@ where TConsensusSpec: ConsensusSpec
         current_epoch: Epoch,
         transaction_ids: I,
         local_committee_info: &CommitteeInfo,
-    ) -> Result<usize, HotStuffError> {
+    ) -> Result<(), HotStuffError> {
         let mut unpooled = Vec::new();
         for id in transaction_ids {
+            // Cheap membership check first: on the hot path almost every id is already pooled, and
+            // this avoids loading its record to find that out.
             if self.transaction_pool.exists(&**tx, &id)? {
                 continue;
             }
-            // A finalized record means the id has already run its course on this node. Whether an
+            // A finalized marker means the id has already run its course on this node. Whether an
             // aborted attempt may be sequenced again is the mempool's call; repairing the pool during
             // block validation must not resurrect one as a side effect.
-            if TransactionRecord::get_finalized_decision(&**tx, &id)?.is_some() {
+            if TransactionRecord::is_record_finalized(&**tx, &id)? {
                 continue;
             }
             unpooled.push(id);
         }
         if unpooled.is_empty() {
-            return Ok(0);
+            return Ok(());
         }
 
         let (recs, _) = TransactionRecord::get_any(&**tx, unpooled.iter())?;
         let mut batch = Vec::with_capacity(recs.len());
         for rec in recs {
-            // A stored record does not carry whether it passed full local validation, and this is a
-            // rare repair path, so validate in full rather than assume.
+            // A record is only ever persisted by `validate_new_transaction` below, after it has passed
+            // full validation, so reading one back needs the epoch rules re-checked and nothing more.
             if let Some(validate_data) = self.validate_new_transaction(
                 tx,
                 current_epoch,
                 rec,
                 local_committee_info,
-                TransactionSource::Requested,
+                TransactionSource::OwnMempool,
             )? {
                 batch.push(validate_data);
             }
@@ -197,7 +203,7 @@ where TConsensusSpec: ConsensusSpec
 
         let num_sequenced = batch.iter().filter(|data| data.must_sequence).count();
         if num_sequenced == 0 {
-            return Ok(0);
+            return Ok(());
         }
 
         info!(
@@ -214,7 +220,7 @@ where TConsensusSpec: ConsensusSpec
                 .map(|data| (&data.transaction, data.decision, true)),
         )?;
 
-        Ok(num_sequenced)
+        Ok(())
     }
 
     fn validate_new_transaction(

--- a/crates/consensus/src/hotstuff/state_machine/syncing.rs
+++ b/crates/consensus/src/hotstuff/state_machine/syncing.rs
@@ -43,8 +43,9 @@ where
         // State sync only rewrites the state store, not the consensus transaction pool. Drop any pool
         // records so that on re-entering consensus we don't re-propose transactions the freshly-synced
         // state has already finalised (the rest of the committee removed them on commit, so they can
-        // never gather a QC again — this wedges the network). Genuinely-pending transactions return via
-        // mempool gossip.
+        // never gather a QC again - this wedges the network). A still-pending transaction is restored
+        // to the pool from the record we kept, when a proposal for it arrives
+        // (`OnReceiveNewTransaction::resequence_known_transactions`).
         let cleared = context.hotstuff.clear_transaction_pool()?;
         if cleared > 0 {
             info!(target: LOG_TARGET, "🧹 Cleared {cleared} transaction(s) from the pool after state sync");

--- a/crates/consensus/src/hotstuff/worker.rs
+++ b/crates/consensus/src/hotstuff/worker.rs
@@ -541,7 +541,13 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
 
         match self
             .on_message_validate
-            .handle(current_height, epoch_state, from.clone(), msg)
+            .handle(
+                current_height,
+                epoch_state,
+                from.clone(),
+                msg,
+                &self.on_receive_new_transaction,
+            )
             .await?
         {
             MessageValidationResult::Ready { from, message: msg } => {

--- a/crates/consensus_tests/src/consensus.rs
+++ b/crates/consensus_tests/src/consensus.rs
@@ -8,7 +8,13 @@
 //! Use `Test::builder().with_rocks_path("/tmp/test{}")...` to create a database for each validator
 //! where {} is replaced with the node address.
 
-use std::time::Duration;
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
 
 use log::info;
 use ootle_byte_type::ToByteType;
@@ -1851,5 +1857,61 @@ async fn multishard_transaction_epoch_expired() {
     )
     .await;
 
+    test.assert_clean_shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn transaction_missing_from_pool_is_resequenced_from_its_record() {
+    setup_logger();
+    // Hold back proposals so the transaction is pooled but no block can carry it yet, which makes the
+    // point at which the pool record is dropped deterministic.
+    let hold_proposals = Arc::new(AtomicBool::new(true));
+    let hold_proposals_f = hold_proposals.clone();
+    let mut test = Test::builder()
+        .add_committee(0, vec!["1", "2"])
+        .with_message_filter(Box::new(move |_from, _to, msg| {
+            !(hold_proposals_f.load(Ordering::SeqCst) && matches!(msg, HotstuffMessage::Proposal(_)))
+        }))
+        // Holding proposals burns a pacemaker round, so shorten the round and allow more than the
+        // default single-round budget.
+        .modify_consensus_constants(|c| {
+            c.pacemaker_block_time = Duration::from_secs(2);
+        })
+        .with_test_timeout(Duration::from_secs(30))
+        .start()
+        .await;
+    let (tx1, _, _) = test.send_transaction_to_all(Decision::Commit, 1, 1, 1).await;
+    test.start_epoch(Epoch(1)).await;
+    test.wait_for_pool_count(TestVnDestination::All, 1).await;
+
+    // Drop "2"'s pool record while keeping its transaction record, as a state sync does. "2" holds the
+    // transaction, so the missing-transaction request path has nothing to fetch and cannot repair this;
+    // without re-sequencing, "2" no-votes every block carrying tx1 and the committee never reaches quorum.
+    assert_eq!(test.get_validator(&TestAddress::new("2")).clear_transaction_pool(), 1);
+
+    hold_proposals.store(false, Ordering::SeqCst);
+
+    // The loop only advances on committed blocks but any hotstuff event refreshes the harness timeout,
+    // so bound the whole run to keep a stalled committee a test failure.
+    tokio::time::timeout(Duration::from_secs(60), async {
+        loop {
+            test.on_block_committed().await;
+
+            if test.is_transaction_pool_empty() {
+                break;
+            }
+            let leaf = test.get_validator(&TestAddress::new("1")).get_leaf_block();
+            if leaf.height >= NodeHeight(30) {
+                panic!("Transaction not committed after {} blocks", leaf.height);
+            }
+        }
+    })
+    .await
+    .expect("timed out waiting for tx1 to be committed");
+
+    test.stop();
+    test.assert_all_validators_committed(tx1.id());
+    test.assert_all_validators_have_decision(tx1.id(), Decision::Commit)
+        .await;
     test.assert_clean_shutdown().await;
 }

--- a/crates/consensus_tests/src/consensus.rs
+++ b/crates/consensus_tests/src/consensus.rs
@@ -1863,20 +1863,20 @@ async fn multishard_transaction_epoch_expired() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn transaction_missing_from_pool_is_resequenced_from_its_record() {
     setup_logger();
-    // Hold back proposals so the transaction is pooled but no block can carry it yet, which makes the
-    // point at which the pool record is dropped deterministic.
-    let hold_proposals = Arc::new(AtomicBool::new(true));
-    let hold_proposals_f = hold_proposals.clone();
+    // Drop proposals so the transaction is pooled but no block can carry it yet, which makes the point
+    // at which the pool record is dropped deterministic.
+    let drop_proposals = Arc::new(AtomicBool::new(true));
+    let drop_proposals_f = drop_proposals.clone();
     let mut test = Test::builder()
         .add_committee(0, vec!["1", "2"])
         .with_message_filter(Box::new(move |_from, _to, msg| {
-            !(hold_proposals_f.load(Ordering::SeqCst) && matches!(msg, HotstuffMessage::Proposal(_)))
+            !(drop_proposals_f.load(Ordering::SeqCst) && matches!(msg, HotstuffMessage::Proposal(_)))
         }))
-        // Holding proposals burns a pacemaker round, so shorten the round and allow more than the
-        // default single-round budget.
+        // Dropping proposals burns a pacemaker round, so shorten the round...
         .modify_consensus_constants(|c| {
             c.pacemaker_block_time = Duration::from_secs(2);
         })
+        // ...and allow more than the default budget of one round plus two seconds.
         .with_test_timeout(Duration::from_secs(30))
         .start()
         .await;
@@ -1889,7 +1889,7 @@ async fn transaction_missing_from_pool_is_resequenced_from_its_record() {
     // without re-sequencing, "2" no-votes every block carrying tx1 and the committee never reaches quorum.
     assert_eq!(test.get_validator(&TestAddress::new("2")).clear_transaction_pool(), 1);
 
-    hold_proposals.store(false, Ordering::SeqCst);
+    drop_proposals.store(false, Ordering::SeqCst);
 
     // The loop only advances on committed blocks but any hotstuff event refreshes the harness timeout,
     // so bound the whole run to keep a stalled committee a test failure.

--- a/crates/consensus_tests/src/support/validator/instance.rs
+++ b/crates/consensus_tests/src/support/validator/instance.rs
@@ -10,7 +10,7 @@ use tari_ootle_common_types::{NodeHeight, ShardGroup, SubstateAddress, Versioned
 use tari_ootle_storage::{
     StateStore,
     StateStoreReadTransaction,
-    consensus_models::{BookkeepingModel, TransactionExecution},
+    consensus_models::{BookkeepingModel, TransactionExecution, TransactionPool},
 };
 use tari_ootle_transaction::{Transaction, TransactionId};
 use tari_template_lib_types::crypto::RistrettoPublicKeyBytes;
@@ -73,6 +73,19 @@ impl Validator {
         self.state_store
             .with_read_tx(|tx| tx.transaction_pool_count(None, None, false))
             .unwrap()
+    }
+
+    /// Drops every transaction pool record, as consensus does on entering `Syncing` after a state sync.
+    pub fn clear_transaction_pool(&self) -> usize {
+        let pool = TransactionPool::<TestStore>::new();
+        self.state_store
+            .with_write_tx(|tx| {
+                let recs = pool.get_all(&**tx, usize::MAX)?;
+                let ids = recs.iter().map(|rec| rec.id()).collect::<Vec<_>>();
+                pool.remove_all(tx, ids)
+            })
+            .unwrap()
+            .len()
     }
 
     pub fn current_state_machine_state(&self) -> ConsensusCurrentState {


### PR DESCRIPTION
## Problem

A validator node that clears its transaction pool cannot vote on any block carrying a transaction it still holds, for the rest of the epoch.

Seen on esmeralda: after an epoch rollover the node state-synced, `Syncing::on_enter` cleared the pool, and the very next epoch's block 3 re-proposed one of the cleared transactions:

```
🧹 Cleared 2 transaction(s) from the pool after state sync
...
⚠️ Local proposal received ([NodeHeight(3), ... 2 cmd(s)]) for transaction 1e3ee6ff… which is
   not in the pool. This is likely a previous transaction that has been re-proposed. Not voting on block.
❌ State Merkle root disagreement for block [NodeHeight(4) …]
```

From that point its state fell behind the committee and every subsequent block failed the merkle root check. The node was out of consensus for ~65 minutes until the next epoch boundary.

## Why parking does not cover this

The missing-transaction path keys on the transaction **record**: `check_for_missing_transactions` calls `TransactionRecord::get_missing`, which reads the transactions table. `clear_transaction_pool` empties a different table — the **pool record** (stage, evidence, decision).

The body was never gone, so the block logged `✅ has no missing transactions`, was persisted, and only failed later in `evaluate_local_only_command` with `TransactionNotInPool`. There is also nothing to request from a peer: a pool record is derived local state, not something a peer can send.

So the clear is fine; what was missing is any path that re-derives a pool record for a transaction we already hold.

## Fix

Widen the readiness check from "which of this block's transactions do we not have?" to "which are not ready for consensus?":

- missing record → park and request (unchanged)
- record present, pool record absent → re-sequence locally via `OnReceiveNewTransaction::resequence_known_transactions`, which runs the same `validate_new_transaction` → `insert_new_batched` path that `process_requested` already runs for peer-fetched transactions

Safety is enforced where it already was, rather than by wholesale deletion. `validate_new_transaction` refuses to sequence an id whose finalized decision is a commit, or whose `TransactionReceipt` exists in state — explicitly covering freshly-synced nodes. So re-sequencing can never resurrect a transaction the synced state has committed, which is exactly what the clear exists to prevent.

Additionally narrowed: `resequence_known_transactions` skips any id with *any* finalized record. Whether a previously-aborted id may be sequenced again is the mempool's decision; repairing the pool during block validation must not trigger the abort-replay path as a side effect.

All five `TransactionNotInPool` no-vote sites are in `on_ready_to_vote_on_local_block`, reached from both paths this repair covers (live local proposal and catch-up import).

This is also a step toward the `TODO` already sitting above `clear_transaction_pool`: *"the transaction pool only holds pending (derived) state and should not be persisted at all"*. Once the pool is re-derivable on demand, dropping it after a sync is harmless.

## Testing

New `consensus_tests::transaction_missing_from_pool_is_resequenced_from_its_record`: two validators, proposals held back so the drop point is deterministic, validator "2"'s pool record cleared the way a state sync does, then consensus released. Quorum requires "2", so the transaction only commits if "2" re-derives its pool record.

Verified as a real regression test: with the re-sequencing disabled, zero blocks commit and the test fails; with it, the transaction commits on both validators.

## Related

Same incident, separate root cause: #2495 fixes the state-sync off-by-one that corrupted the JMT and permanently wedged the node.
