### PR TITLE
feat(rpc): keep an idle streaming response alive with ACK frames

### DIFF
--- a/networking/rpc_framework/Cargo.toml
+++ b/networking/rpc_framework/Cargo.toml
@@ -27,6 +27,9 @@ tracing = { workspace = true }
 libp2p = { workspace = true }
 libp2p-substream = { workspace = true }
 
+[dev-dependencies]
+tokio = { workspace = true, features = ["io-util", "rt-multi-thread"] }
+
 [build-dependencies]
 proto_builder = { workspace = true }
 

--- a/networking/rpc_framework/proto/rpc.proto
+++ b/networking/rpc_framework/proto/rpc.proto
@@ -13,7 +13,7 @@ message RpcRequest {
     uint32 request_id = 1;
     // The method identifier. The matching method for a given value is defined by each service.
     uint32 method = 2;
-    // Message flags. FIN ends the session, ACK requests a liveness pong.
+    // Message flags. FIN abandons the request without a response, ACK requests a liveness pong.
     uint32 flags = 3;
     // The length of time in seconds that a client is willing to wait for a response
     uint64 deadline = 4;

--- a/networking/rpc_framework/proto/rpc.proto
+++ b/networking/rpc_framework/proto/rpc.proto
@@ -13,10 +13,14 @@ message RpcRequest {
     uint32 request_id = 1;
     // The method identifier. The matching method for a given value is defined by each service.
     uint32 method = 2;
-    // Message flags. Currently this is not used for requests.
+    // Message flags. FIN ends the session, ACK requests a liveness pong.
     uint32 flags = 3;
     // The length of time in seconds that a client is willing to wait for a response
     uint64 deadline = 4;
+    // The interval in seconds at which the client wants the server to emit empty ACK-flagged
+    // responses while a streaming response has nothing to send. Zero means no keepalives, in which
+    // case a stream that produces nothing for `deadline` is simply ended.
+    uint64 keepalive_interval = 5;
 
     // The message payload
     bytes payload = 10;
@@ -28,7 +32,8 @@ message RpcResponse {
     uint32 request_id = 1;
     // The status of the response. A non-zero status indicates an error.
     uint32 status = 2;
-    // Message flags. Currently only used to indicate if a stream of messages has completed.
+    // Message flags. Indicates whether a stream of messages has completed (FIN), or that this is an
+    // empty keepalive frame that carries no payload and does not advance the stream (ACK).
     uint32 flags = 3;
 
     // The message payload. If the status is non-zero, this contains additional error details.

--- a/networking/rpc_framework/src/client/mod.rs
+++ b/networking/rpc_framework/src/client/mod.rs
@@ -767,9 +767,7 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send
                         target: LOG_TARGET,
                         "Request {} (method={}) received an unsolicited keepalive: {}", request_id, method, err
                     );
-                    if !response_tx.is_closed() {
-                        let _result = response_tx.send(Err(RpcStatus::protocol_error(err.to_string()))).await;
-                    }
+                    let _result = response_tx.send(Err(RpcStatus::protocol_error(err.to_string()))).await;
                     break;
                 },
                 Err(err) => {
@@ -968,13 +966,24 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin
     }
 
     /// Reads the pong for a ping. Frames left over from an abandoned request carry the same ACK
-    /// flag, so only one addressed to this request answers the ping.
+    /// flag, so only one addressed to this request answers the ping. Skipping the others is bounded
+    /// by a single timeout over the whole read, because each frame restarts the per-frame one.
     pub async fn read_ack(&mut self) -> Result<proto::RpcResponse, RpcError> {
-        loop {
-            let resp = self.next().await?;
-            if self.check_response(&resp).is_ok() {
-                return Ok(resp);
+        let timeout = self.config.timeout_with_grace_period();
+        let read_pong = async {
+            loop {
+                let resp = self.next().await?;
+                if self.check_response(&resp).is_ok() {
+                    return Ok(resp);
+                }
             }
+        };
+
+        match timeout {
+            Some(timeout) => time::timeout(timeout, read_pong)
+                .await
+                .map_err(|_| RpcError::ReplyTimeout)?,
+            None => read_pong.await,
         }
     }
 
@@ -1209,6 +1218,41 @@ mod keepalive_tests {
             received[0].as_ref().unwrap_err().as_status_code(),
             RpcStatusCode::ProtocolError
         );
+    }
+
+    #[tokio::test]
+    async fn a_peer_that_never_answers_a_ping_cannot_hold_it_open() {
+        let (server, client) = tokio::io::duplex(RPC_MAX_FRAME_SIZE);
+        let server = tokio::spawn(async move {
+            let mut framed = framing::canonical(server.compat(), RPC_MAX_FRAME_SIZE);
+            read_request(&mut framed).await;
+            // Frames the ping must skip, arriving faster than the read timeout they each restart.
+            loop {
+                send_response(&mut framed, RpcResponse::keepalive(9999)).await;
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        });
+
+        let config = RpcClientConfig {
+            deadline: Some(Duration::from_millis(100)),
+            deadline_grace_period: Duration::from_millis(100),
+            ..Default::default()
+        };
+        let mut rpc_client = RpcClient::connect(
+            config,
+            PeerId::random(),
+            framing::canonical(client.compat(), RPC_MAX_FRAME_SIZE),
+            StreamProtocol::new(PROTOCOL),
+        )
+        .await
+        .unwrap();
+
+        let result = tokio::time::timeout(Duration::from_secs(5), rpc_client.ping())
+            .await
+            .expect("ping was held open by frames it was skipping");
+        assert!(result.is_err());
+
+        server.abort();
     }
 
     #[tokio::test]

--- a/networking/rpc_framework/src/client/mod.rs
+++ b/networking/rpc_framework/src/client/mod.rs
@@ -239,6 +239,17 @@ impl<TClient> RpcClientBuilder<TClient> {
         self
     }
 
+    /// Asks the server to emit an empty keepalive frame every `interval` while a streaming response
+    /// has nothing to send, so that an idle stream stays distinguishable from a dead peer. The
+    /// server MAY serve a longer interval than requested, and a server that does not support
+    /// keepalives simply ends an idle stream at the deadline as it otherwise would.
+    ///
+    /// Default: no keepalives
+    pub fn with_keepalive_interval(mut self, interval: Duration) -> Self {
+        self.config.keepalive_interval = Some(interval);
+        self
+    }
+
     /// Set the length of time that the client will wait for a response in the RPC handshake before returning a timeout
     /// error.
     /// Default: 15 seconds
@@ -278,6 +289,7 @@ where TClient: From<RpcClient> + NamedProtocolService
 pub struct RpcClientConfig {
     pub deadline: Option<Duration>,
     pub deadline_grace_period: Duration,
+    pub keepalive_interval: Option<Duration>,
     pub handshake_timeout: Duration,
 }
 
@@ -298,6 +310,7 @@ impl Default for RpcClientConfig {
         Self {
             deadline: Some(Duration::from_secs(120)),
             deadline_grace_period: Duration::from_secs(60),
+            keepalive_interval: None,
             handshake_timeout: Duration::from_secs(90),
         }
     }
@@ -628,6 +641,7 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send
             request_id: u32::from(request_id),
             method,
             deadline: self.config.deadline.map(|t| t.as_secs()).unwrap_or(0),
+            keepalive_interval: self.config.keepalive_interval.map(|t| t.as_secs()).unwrap_or(0),
             flags: 0,
             payload: request.message.to_vec(),
         };
@@ -773,8 +787,7 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send
                     }
                     break;
                 },
-                Err(err @ RpcError::ResponseIdDidNotMatchRequest { .. }) |
-                Err(err @ RpcError::UnexpectedAckResponse) => {
+                Err(err @ RpcError::ResponseIdDidNotMatchRequest { .. }) => {
                     warn!(target: LOG_TARGET, "{}", err);
                     // Ignore the response, this can happen when there is excessive latency. The server sends back a
                     // reply before the deadline but it is only received after the client has timed
@@ -808,6 +821,16 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send
         let mut num_ignored = 0;
         let resp = loop {
             match reader.read_response().await {
+                Ok(resp) if resp.is_keepalive() => {
+                    trace!(
+                        target: LOG_TARGET,
+                        "(peer: {}, {}) Keepalive received for request {}",
+                        peer_id,
+                        protocol_name,
+                        request_id
+                    );
+                    continue;
+                },
                 Ok(resp) => {
                     trace!(
                         target: LOG_TARGET,
@@ -946,18 +969,6 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin
             });
         }
 
-        // let flags =
-        //     RpcMessageFlags::from_bits(u8::try_from(resp.flags).map_err(|_| {
-        //         RpcStatus::protocol_error(&format!("invalid message flag: must be less than {}", u8::MAX))
-        //     })?)
-        //     .ok_or(RpcStatus::protocol_error(&format!(
-        //         "invalid message flag, does not match any flags ({})",
-        //         resp.flags
-        //     )))?;
-        // if flags.contains(RpcMessageFlags::ACK) {
-        //     return Err(RpcError::UnexpectedAckResponse);
-        // }
-
         Ok(())
     }
 
@@ -974,5 +985,94 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin
             Ok(None) => Err(RpcError::ServerClosedRequest),
             Err(_) => Err(RpcError::ReplyTimeout),
         }
+    }
+}
+
+#[cfg(test)]
+mod keepalive_tests {
+    use tokio::io::DuplexStream;
+    use tokio_util::compat::{Compat, TokioAsyncReadCompatExt};
+
+    use super::*;
+    use crate::{
+        Handshake,
+        RPC_MAX_FRAME_SIZE,
+        RpcStatusCode,
+        framing,
+        message::{RpcMessageFlags, RpcResponse},
+    };
+
+    const PROTOCOL: &str = "/test/keepalive/1.0";
+
+    async fn send_response(framed: &mut CanonicalFraming<Compat<DuplexStream>>, resp: RpcResponse) {
+        framed.send(resp.to_proto().encode_to_vec().into()).await.unwrap();
+    }
+
+    /// Replies to one streaming request with `num_keepalives` empty keepalive frames, then a single
+    /// message closing the stream.
+    async fn serve_keepalives_then_message(
+        substream: DuplexStream,
+        num_keepalives: usize,
+        message: Bytes,
+    ) -> proto::RpcRequest {
+        let mut framed = framing::canonical(substream.compat(), RPC_MAX_FRAME_SIZE);
+        Handshake::new(&mut framed).perform_server_handshake().await.unwrap();
+
+        let frame = framed.next().await.unwrap().unwrap();
+        let request = proto::RpcRequest::decode(frame.freeze()).unwrap();
+
+        for _ in 0..num_keepalives {
+            send_response(&mut framed, RpcResponse::keepalive(request.request_id)).await;
+        }
+        send_response(&mut framed, RpcResponse {
+            request_id: request.request_id,
+            status: RpcStatusCode::Ok,
+            flags: RpcMessageFlags::empty(),
+            payload: message,
+        })
+        .await;
+        // The streaming protocol terminates with an empty FIN frame.
+        send_response(&mut framed, RpcResponse {
+            request_id: request.request_id,
+            status: RpcStatusCode::Ok,
+            flags: RpcMessageFlags::FIN,
+            payload: Bytes::new(),
+        })
+        .await;
+
+        request
+    }
+
+    #[tokio::test]
+    async fn keepalive_frames_are_not_delivered_as_stream_messages() {
+        let (server, client) = tokio::io::duplex(RPC_MAX_FRAME_SIZE);
+        let reply = proto::RpcSession {
+            supported_versions: vec![7],
+        };
+        let server = tokio::spawn(serve_keepalives_then_message(server, 3, reply.encode_to_vec().into()));
+
+        let config = RpcClientConfig {
+            keepalive_interval: Some(Duration::from_secs(11)),
+            ..Default::default()
+        };
+        let mut rpc_client = RpcClient::connect(
+            config,
+            PeerId::random(),
+            framing::canonical(client.compat(), RPC_MAX_FRAME_SIZE),
+            StreamProtocol::new(PROTOCOL),
+        )
+        .await
+        .unwrap();
+
+        let stream = rpc_client
+            .server_streaming::<_, _, proto::RpcSession>(proto::RpcSession::default(), 1u32)
+            .await
+            .unwrap();
+        let received = stream.collect::<Vec<_>>().await;
+
+        let request = server.await.unwrap();
+        assert_eq!(request.keepalive_interval, 11);
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].as_ref().unwrap().supported_versions, vec![7]);
     }
 }

--- a/networking/rpc_framework/src/client/mod.rs
+++ b/networking/rpc_framework/src/client/mod.rs
@@ -244,6 +244,10 @@ impl<TClient> RpcClientBuilder<TClient> {
     /// server MAY serve a longer interval than requested, and a server that does not support
     /// keepalives simply ends an idle stream at the deadline as it otherwise would.
     ///
+    /// The interval is carried on the wire in whole seconds and rounds down, with a floor of one
+    /// second. A client that has asked for keepalives also rejects an ACK frame it did not ask for,
+    /// so this is what enables tolerating them at all.
+    ///
     /// Default: no keepalives
     pub fn with_keepalive_interval(mut self, interval: Duration) -> Self {
         self.config.keepalive_interval = Some(interval);
@@ -641,7 +645,7 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send
             request_id: u32::from(request_id),
             method,
             deadline: self.config.deadline.map(|t| t.as_secs()).unwrap_or(0),
-            keepalive_interval: self.config.keepalive_interval.map(|t| t.as_secs()).unwrap_or(0),
+            keepalive_interval: self.config.keepalive_interval.map(|t| t.as_secs().max(1)).unwrap_or(0),
             flags: 0,
             payload: request.message.to_vec(),
         };
@@ -758,6 +762,16 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send
                     self.request_rx.close();
                     break;
                 },
+                Err(err @ RpcError::UnexpectedAckResponse) => {
+                    warn!(
+                        target: LOG_TARGET,
+                        "Request {} (method={}) received an unsolicited keepalive: {}", request_id, method, err
+                    );
+                    if !response_tx.is_closed() {
+                        let _result = response_tx.send(Err(RpcStatus::protocol_error(err.to_string()))).await;
+                    }
+                    break;
+                },
                 Err(err) => {
                     return Err(err);
                 },
@@ -821,16 +835,6 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send
         let mut num_ignored = 0;
         let resp = loop {
             match reader.read_response().await {
-                Ok(resp) if resp.is_keepalive() => {
-                    trace!(
-                        target: LOG_TARGET,
-                        "(peer: {}, {}) Keepalive received for request {}",
-                        peer_id,
-                        protocol_name,
-                        request_id
-                    );
-                    continue;
-                },
                 Ok(resp) => {
                     trace!(
                         target: LOG_TARGET,
@@ -938,7 +942,19 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin
 
     pub async fn read_response(&mut self) -> Result<proto::RpcResponse, RpcError> {
         let timer = Instant::now();
-        let resp = self.next().await?;
+        let resp = loop {
+            let resp = self.next().await?;
+            if resp.is_keepalive() {
+                // A keepalive carries neither payload nor stream position, so its request id is not
+                // policed: one left over from an abandoned request is as harmless as one for this
+                // request, and counting it as a mismatch would spend the leniency budget below.
+                if self.config.keepalive_interval.is_none() {
+                    return Err(RpcError::UnexpectedAckResponse);
+                }
+                continue;
+            }
+            break resp;
+        };
         self.time_to_first_msg = Some(timer.elapsed());
         self.check_response(&resp)?;
         self.bytes_read = resp.payload.len();
@@ -951,9 +967,15 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin
         Ok(resp)
     }
 
+    /// Reads the pong for a ping. Frames left over from an abandoned request carry the same ACK
+    /// flag, so only one addressed to this request answers the ping.
     pub async fn read_ack(&mut self) -> Result<proto::RpcResponse, RpcError> {
-        let resp = self.next().await?;
-        Ok(resp)
+        loop {
+            let resp = self.next().await?;
+            if self.check_response(&resp).is_ok() {
+                return Ok(resp);
+            }
+        }
     }
 
     fn check_response(&self, resp: &proto::RpcResponse) -> Result<(), RpcError> {
@@ -1008,37 +1030,50 @@ mod keepalive_tests {
         framed.send(resp.to_proto().encode_to_vec().into()).await.unwrap();
     }
 
-    /// Replies to one streaming request with `num_keepalives` empty keepalive frames, then a single
-    /// message closing the stream.
-    async fn serve_keepalives_then_message(
-        substream: DuplexStream,
-        num_keepalives: usize,
-        message: Bytes,
-    ) -> proto::RpcRequest {
-        let mut framed = framing::canonical(substream.compat(), RPC_MAX_FRAME_SIZE);
-        Handshake::new(&mut framed).perform_server_handshake().await.unwrap();
-
+    async fn read_request(framed: &mut CanonicalFraming<Compat<DuplexStream>>) -> proto::RpcRequest {
+        Handshake::new(framed).perform_server_handshake().await.unwrap();
         let frame = framed.next().await.unwrap().unwrap();
-        let request = proto::RpcRequest::decode(frame.freeze()).unwrap();
+        proto::RpcRequest::decode(frame.freeze()).unwrap()
+    }
 
-        for _ in 0..num_keepalives {
-            send_response(&mut framed, RpcResponse::keepalive(request.request_id)).await;
-        }
-        send_response(&mut framed, RpcResponse {
-            request_id: request.request_id,
+    /// Sends a stream of exactly one message. The streaming protocol terminates with an empty FIN
+    /// frame, which is not delivered to a consumer.
+    async fn send_message(framed: &mut CanonicalFraming<Compat<DuplexStream>>, request_id: u32, message: Bytes) {
+        send_response(framed, RpcResponse {
+            request_id,
             status: RpcStatusCode::Ok,
             flags: RpcMessageFlags::empty(),
             payload: message,
         })
         .await;
-        // The streaming protocol terminates with an empty FIN frame.
-        send_response(&mut framed, RpcResponse {
-            request_id: request.request_id,
+        send_response(framed, RpcResponse {
+            request_id,
             status: RpcStatusCode::Ok,
             flags: RpcMessageFlags::FIN,
             payload: Bytes::new(),
         })
         .await;
+    }
+
+    /// Replies to one streaming request with `num_keepalives` empty keepalive frames bearing
+    /// `keepalive_id`, then a single message closing the stream.
+    async fn serve_keepalives_then_message(
+        substream: DuplexStream,
+        num_keepalives: usize,
+        keepalive_id: Option<u32>,
+        message: Bytes,
+    ) -> proto::RpcRequest {
+        let mut framed = framing::canonical(substream.compat(), RPC_MAX_FRAME_SIZE);
+        let request = read_request(&mut framed).await;
+
+        for _ in 0..num_keepalives {
+            send_response(
+                &mut framed,
+                RpcResponse::keepalive(keepalive_id.unwrap_or(request.request_id)),
+            )
+            .await;
+        }
+        send_message(&mut framed, request.request_id, message).await;
 
         request
     }
@@ -1049,7 +1084,12 @@ mod keepalive_tests {
         let reply = proto::RpcSession {
             supported_versions: vec![7],
         };
-        let server = tokio::spawn(serve_keepalives_then_message(server, 3, reply.encode_to_vec().into()));
+        let server = tokio::spawn(serve_keepalives_then_message(
+            server,
+            3,
+            None,
+            reply.encode_to_vec().into(),
+        ));
 
         let config = RpcClientConfig {
             keepalive_interval: Some(Duration::from_secs(11)),
@@ -1074,5 +1114,130 @@ mod keepalive_tests {
         assert_eq!(request.keepalive_interval, 11);
         assert_eq!(received.len(), 1);
         assert_eq!(received[0].as_ref().unwrap().supported_versions, vec![7]);
+    }
+
+    #[tokio::test]
+    async fn keepalives_left_over_from_an_abandoned_request_do_not_end_the_session() {
+        let (server, client) = tokio::io::duplex(RPC_MAX_FRAME_SIZE);
+        let reply = proto::RpcSession {
+            supported_versions: vec![7],
+        };
+        let message: Bytes = reply.encode_to_vec().into();
+        let server = tokio::spawn(async move {
+            let mut framed = framing::canonical(server.compat(), RPC_MAX_FRAME_SIZE);
+            // The first request is answered after one more keepalive than MAX_ALLOWED_IGNORED, all
+            // of them bearing an id the client is no longer waiting on.
+            let first = read_request(&mut framed).await;
+            for _ in 0..21 {
+                send_response(&mut framed, RpcResponse::keepalive(9999)).await;
+            }
+            send_message(&mut framed, first.request_id, message.clone()).await;
+
+            // A second request only gets served if the session survived those frames.
+            let frame = framed.next().await.unwrap().unwrap();
+            let second = proto::RpcRequest::decode(frame.freeze()).unwrap();
+            send_message(&mut framed, second.request_id, message).await;
+            first
+        });
+
+        let config = RpcClientConfig {
+            keepalive_interval: Some(Duration::from_secs(5)),
+            ..Default::default()
+        };
+        let mut rpc_client = RpcClient::connect(
+            config,
+            PeerId::random(),
+            framing::canonical(client.compat(), RPC_MAX_FRAME_SIZE),
+            StreamProtocol::new(PROTOCOL),
+        )
+        .await
+        .unwrap();
+
+        let stream = rpc_client
+            .server_streaming::<_, _, proto::RpcSession>(proto::RpcSession::default(), 1u32)
+            .await
+            .unwrap();
+        let received = stream.collect::<Vec<_>>().await;
+
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].as_ref().unwrap().supported_versions, vec![7]);
+
+        let second = rpc_client
+            .server_streaming::<_, _, proto::RpcSession>(proto::RpcSession::default(), 1u32)
+            .await
+            .unwrap()
+            .collect::<Vec<_>>()
+            .await;
+
+        server.await.unwrap();
+        assert_eq!(second.len(), 1);
+        assert_eq!(second[0].as_ref().unwrap().supported_versions, vec![7]);
+    }
+
+    #[tokio::test]
+    async fn a_keepalive_that_was_never_asked_for_is_a_protocol_error() {
+        let (server, client) = tokio::io::duplex(RPC_MAX_FRAME_SIZE);
+        let reply = proto::RpcSession {
+            supported_versions: vec![7],
+        };
+        let server = tokio::spawn(serve_keepalives_then_message(
+            server,
+            1,
+            None,
+            reply.encode_to_vec().into(),
+        ));
+
+        let mut rpc_client = RpcClient::connect(
+            RpcClientConfig::default(),
+            PeerId::random(),
+            framing::canonical(client.compat(), RPC_MAX_FRAME_SIZE),
+            StreamProtocol::new(PROTOCOL),
+        )
+        .await
+        .unwrap();
+
+        let stream = rpc_client
+            .server_streaming::<_, _, proto::RpcSession>(proto::RpcSession::default(), 1u32)
+            .await
+            .unwrap();
+        let received = stream.collect::<Vec<_>>().await;
+
+        let request = server.await.unwrap();
+        assert_eq!(request.keepalive_interval, 0);
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].as_ref().unwrap_err().as_status_code(),
+            RpcStatusCode::ProtocolError
+        );
+    }
+
+    #[tokio::test]
+    async fn a_stale_keepalive_is_not_mistaken_for_a_pong() {
+        let (server, client) = tokio::io::duplex(RPC_MAX_FRAME_SIZE);
+        let server = tokio::spawn(async move {
+            let mut framed = framing::canonical(server.compat(), RPC_MAX_FRAME_SIZE);
+            let ping = read_request(&mut framed).await;
+            send_response(&mut framed, RpcResponse::keepalive(9999)).await;
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            send_response(&mut framed, RpcResponse::keepalive(ping.request_id)).await;
+        });
+
+        let mut rpc_client = RpcClient::connect(
+            RpcClientConfig::default(),
+            PeerId::random(),
+            framing::canonical(client.compat(), RPC_MAX_FRAME_SIZE),
+            StreamProtocol::new(PROTOCOL),
+        )
+        .await
+        .unwrap();
+
+        let latency = rpc_client.ping().await.unwrap();
+
+        server.await.unwrap();
+        assert!(
+            latency >= Duration::from_millis(150),
+            "ping was answered by the stale keepalive ({:.0?})",
+            latency
+        );
     }
 }

--- a/networking/rpc_framework/src/error.rs
+++ b/networking/rpc_framework/src/error.rs
@@ -54,6 +54,8 @@ pub enum RpcError {
     ReplyTimeout,
     #[error("Received an invalid ping response")]
     InvalidPingResponse,
+    #[error("Received an ACK frame for a request that did not ask for keepalives")]
+    UnexpectedAckResponse,
     #[error("Remote peer attempted to send more than {expected} payload chunks")]
     RemotePeerExceededMaxChunkCount { expected: usize },
     #[error("Request body was too large. Expected <= {expected} but got {got}")]
@@ -76,6 +78,7 @@ impl RpcError {
             RpcError::HandshakeError(RpcHandshakeError::Rejected(_)) |
             RpcError::HandshakeError(RpcHandshakeError::TimedOut) |
             RpcError::ServerClosedRequest |
+            RpcError::UnexpectedAckResponse |
             RpcError::ResponseIdDidNotMatchRequest { .. } => true,
 
             // Some of these may be caused by the server, but not with 100% certainty

--- a/networking/rpc_framework/src/error.rs
+++ b/networking/rpc_framework/src/error.rs
@@ -54,8 +54,6 @@ pub enum RpcError {
     ReplyTimeout,
     #[error("Received an invalid ping response")]
     InvalidPingResponse,
-    #[error("Unexpected ACK response. This is likely because of a previous ACK timeout")]
-    UnexpectedAckResponse,
     #[error("Remote peer attempted to send more than {expected} payload chunks")]
     RemotePeerExceededMaxChunkCount { expected: usize },
     #[error("Request body was too large. Expected <= {expected} but got {got}")]
@@ -78,7 +76,6 @@ impl RpcError {
             RpcError::HandshakeError(RpcHandshakeError::Rejected(_)) |
             RpcError::HandshakeError(RpcHandshakeError::TimedOut) |
             RpcError::ServerClosedRequest |
-            RpcError::UnexpectedAckResponse |
             RpcError::ResponseIdDidNotMatchRequest { .. } => true,
 
             // Some of these may be caused by the server, but not with 100% certainty

--- a/networking/rpc_framework/src/message.rs
+++ b/networking/rpc_framework/src/message.rs
@@ -171,6 +171,15 @@ impl proto::RpcRequest {
         Duration::from_secs(self.deadline)
     }
 
+    /// The interval at which the client wants keepalive frames while a streaming response is idle,
+    /// or `None` if it does not want them.
+    pub fn keepalive_interval(&self) -> Option<Duration> {
+        match self.keepalive_interval {
+            0 => None,
+            secs => Some(Duration::from_secs(secs)),
+        }
+    }
+
     pub fn flags(&self) -> Result<RpcMessageFlags, String> {
         RpcMessageFlags::from_bits(
             u8::try_from(self.flags).map_err(|_| format!("invalid message flag: must be less than {}", u8::MAX))?,
@@ -186,9 +195,10 @@ impl fmt::Display for proto::RpcRequest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "RequestID={}, Deadline={:.0?}, Flags={:?}, Message={} byte(s)",
+            "RequestID={}, Deadline={:.0?}, Keepalive={:.0?}, Flags={:?}, Message={} byte(s)",
             self.request_id,
             self.deadline(),
+            self.keepalive_interval(),
             self.flags(),
             self.payload.len()
         )
@@ -211,6 +221,18 @@ impl RpcResponse {
             status: self.status as u32,
             flags: self.flags.bits().into(),
             payload: self.payload.to_vec(),
+        }
+    }
+
+    /// An empty ACK-flagged frame proving the substream is alive while a streaming response has
+    /// nothing to send. It carries no payload and does not advance the stream, so a recipient must
+    /// discard it rather than deliver it as a message.
+    pub fn keepalive(request_id: u32) -> RpcResponse {
+        RpcResponse {
+            request_id,
+            status: RpcStatusCode::Ok,
+            flags: RpcMessageFlags::ACK,
+            payload: Bytes::new(),
         }
     }
 
@@ -253,6 +275,13 @@ impl proto::RpcResponse {
 
     pub fn is_fin(&self) -> bool {
         u8::try_from(self.flags).unwrap() & RpcMessageFlags::FIN.bits() != 0
+    }
+
+    /// True if this is a keepalive frame: ACK-flagged and not terminating the stream.
+    pub fn is_keepalive(&self) -> bool {
+        self.flags()
+            .map(|flags| flags.is_ack() && !flags.is_fin())
+            .unwrap_or(false)
     }
 }
 

--- a/networking/rpc_framework/src/server/mod.rs
+++ b/networking/rpc_framework/src/server/mod.rs
@@ -806,8 +806,10 @@ where
                         target: LOG_TARGET,
                         "({}) Sending keepalive for request #{}", self.logging_context_string, request_id
                     );
-                    let keepalive = RpcResponse::keepalive(request_id).to_proto();
-                    self.framed.send(keepalive.encode_to_vec().into()).await?;
+                    let keepalive = Bytes::from(RpcResponse::keepalive(request_id).to_proto().encode_to_vec());
+                    #[cfg(feature = "metrics")]
+                    metrics::outbound_response_bytes(&self.peer_id, &self.protocol).observe(keepalive.len() as f64);
+                    self.framed.send(keepalive).await?;
                 },
                 Err(_) => {
                     debug!(
@@ -1031,7 +1033,7 @@ mod keepalive_tests {
             service
                 .process_body(
                     1,
-                    Duration::from_millis(200),
+                    Duration::from_millis(600),
                     Some(Duration::from_millis(50)),
                     body_fed_by(rx),
                 )
@@ -1041,11 +1043,11 @@ mod keepalive_tests {
 
         let feeder = tokio::spawn(async move {
             for _ in 0..4 {
-                time::sleep(Duration::from_millis(120)).await;
+                time::sleep(Duration::from_millis(100)).await;
                 tx.send(Ok(Bytes::from_static(b"tick"))).await.unwrap();
             }
             // Holding the sender past the last message lets the deadline expire and end the stream.
-            time::sleep(Duration::from_millis(400)).await;
+            time::sleep(Duration::from_millis(900)).await;
         });
 
         let responses = collect_responses(&mut client_framed).await;

--- a/networking/rpc_framework/src/server/mod.rs
+++ b/networking/rpc_framework/src/server/mod.rs
@@ -48,7 +48,7 @@ use std::{
 };
 
 use bytes::Bytes;
-use futures::{SinkExt, StreamExt, stream::FuturesUnordered};
+use futures::{AsyncRead, AsyncWrite, SinkExt, StreamExt, stream::FuturesUnordered};
 use libp2p::{PeerId, StreamProtocol};
 use libp2p_substream::{ProtocolEvent, ProtocolNotification};
 use log::*;
@@ -162,6 +162,7 @@ pub struct RpcServerBuilder {
     maximum_simultaneous_sessions: Option<usize>,
     maximum_sessions_per_client: Option<usize>,
     minimum_client_deadline: Duration,
+    minimum_keepalive_interval: Duration,
     handshake_timeout: Duration,
 }
 
@@ -195,6 +196,21 @@ impl RpcServerBuilder {
         self
     }
 
+    /// Sets the shortest keepalive interval the server is willing to emit. A client asking for a
+    /// shorter interval is served this one, so that a client cannot make the server produce frames
+    /// at an arbitrary rate.
+    pub fn with_minimum_keepalive_interval(mut self, interval: Duration) -> Self {
+        self.minimum_keepalive_interval = interval;
+        self
+    }
+
+    /// The keepalive interval to serve a request asking for `requested`. Never shorter than the
+    /// configured minimum, so that a client cannot dictate the rate at which the server produces
+    /// frames.
+    fn keepalive_interval_for(&self, requested: Option<Duration>) -> Option<Duration> {
+        requested.map(|interval| cmp::max(interval, self.minimum_keepalive_interval))
+    }
+
     pub fn finish(self) -> RpcServer {
         let (request_tx, request_rx) = mpsc::channel(10);
         RpcServer {
@@ -211,6 +227,7 @@ impl Default for RpcServerBuilder {
             maximum_simultaneous_sessions: None,
             maximum_sessions_per_client: None,
             minimum_client_deadline: Duration::from_secs(1),
+            minimum_keepalive_interval: Duration::from_secs(5),
             handshake_timeout: Duration::from_secs(15),
         }
     }
@@ -477,24 +494,26 @@ where
     }
 }
 
-struct ActivePeerRpcService<TSvc> {
+struct ActivePeerRpcService<TSvc, TSubstream> {
     config: RpcServerBuilder,
     protocol: StreamProtocol,
     peer_id: PeerId,
     service: TSvc,
-    framed: EarlyClose<CanonicalFraming<Substream>>,
+    framed: EarlyClose<CanonicalFraming<TSubstream>>,
     logging_context_string: Arc<String>,
 }
 
-impl<TSvc> ActivePeerRpcService<TSvc>
-where TSvc: Service<Request<Bytes>, Response = Response<Body>, Error = RpcStatus>
+impl<TSvc, TSubstream> ActivePeerRpcService<TSvc, TSubstream>
+where
+    TSvc: Service<Request<Bytes>, Response = Response<Body>, Error = RpcStatus>,
+    TSubstream: AsyncRead + AsyncWrite + Unpin,
 {
     pub(self) fn new(
         config: RpcServerBuilder,
         protocol: StreamProtocol,
         node_id: PeerId,
         service: TSvc,
-        framed: CanonicalFraming<Substream>,
+        framed: CanonicalFraming<TSubstream>,
     ) -> Self {
         Self {
             logging_context_string: Arc::new(format!("peer: {}, protocol: {}", node_id, protocol)),
@@ -654,6 +673,8 @@ where TSvc: Service<Request<Bytes>, Response = Response<Body>, Error = RpcStatus
             method.id()
         );
 
+        let keepalive_interval = self.config.keepalive_interval_for(decoded_msg.keepalive_interval());
+
         let req = Request::new(method, decoded_msg.payload.into());
 
         let service_call = log_timing(
@@ -686,7 +707,8 @@ where TSvc: Service<Request<Bytes>, Response = Response<Body>, Error = RpcStatus
 
         match service_result {
             Ok(body) => {
-                self.process_body(request_id, deadline, body).await?;
+                self.process_body(request_id, deadline, keepalive_interval, body)
+                    .await?;
             },
             Err(err) => {
                 debug!(
@@ -713,10 +735,17 @@ where TSvc: Service<Request<Bytes>, Response = Response<Body>, Error = RpcStatus
         self.protocol.as_ref()
     }
 
+    /// Streams `body` back to the client.
+    ///
+    /// `deadline` bounds the gap between messages that actually carry the response: a stream that
+    /// produces nothing for that long is abandoned. When the client asked for keepalives, an empty
+    /// ACK frame goes out every `keepalive_interval` while that budget is running, so an idle stream
+    /// remains distinguishable from a dead peer without extending how long the server holds it.
     async fn process_body(
         &mut self,
         request_id: u32,
         deadline: Duration,
+        keepalive_interval: Option<Duration>,
         body: Response<Body>,
     ) -> Result<(), RpcServerError> {
         trace!(target: LOG_TARGET, "Service call succeeded");
@@ -740,12 +769,17 @@ where TSvc: Service<Request<Bytes>, Response = Response<Body>, Error = RpcStatus
             })
             .map(|resp| Bytes::from(resp.encode_to_vec()));
 
+        let mut deadline_at = Instant::now() + deadline;
+
         loop {
+            let idle_budget = deadline_at.saturating_duration_since(Instant::now());
+            let wait = keepalive_interval.map_or(idle_budget, |interval| cmp::min(interval, idle_budget));
+
             let next_item = log_timing(
                 self.logging_context_string.clone(),
                 request_id,
                 "message read",
-                time::timeout(deadline, stream.next()),
+                time::timeout(wait, stream.next()),
             );
 
             let result = next_item.await;
@@ -761,10 +795,19 @@ where TSvc: Service<Request<Bytes>, Response = Response<Body>, Error = RpcStatus
                     );
 
                     self.framed.send(msg).await?;
+                    deadline_at = Instant::now() + deadline;
                 },
                 Ok(None) => {
                     debug!(target: LOG_TARGET, "{} Request complete", self.logging_context_string,);
                     break;
+                },
+                Err(_) if keepalive_interval.is_some() && Instant::now() < deadline_at => {
+                    trace!(
+                        target: LOG_TARGET,
+                        "({}) Sending keepalive for request #{}", self.logging_context_string, request_id
+                    );
+                    let keepalive = RpcResponse::keepalive(request_id).to_proto();
+                    self.framed.send(keepalive.encode_to_vec().into()).await?;
                 },
                 Err(_) => {
                     debug!(
@@ -870,5 +913,159 @@ mod tests {
         server.serve().await.unwrap();
 
         assert_eq!(Arc::strong_count(&session_resource), 1);
+    }
+}
+
+#[cfg(test)]
+mod keepalive_tests {
+    use tokio::io::DuplexStream;
+    use tokio_util::compat::{Compat, TokioAsyncReadCompatExt};
+
+    use super::*;
+    use crate::not_found::NeverService;
+
+    type TestSubstream = Compat<DuplexStream>;
+
+    fn framed_pair() -> (CanonicalFraming<TestSubstream>, CanonicalFraming<TestSubstream>) {
+        let (server, client) = tokio::io::duplex(RPC_MAX_FRAME_SIZE);
+        (
+            framing::canonical(server.compat(), RPC_MAX_FRAME_SIZE),
+            framing::canonical(client.compat(), RPC_MAX_FRAME_SIZE),
+        )
+    }
+
+    fn session(framed: CanonicalFraming<TestSubstream>) -> ActivePeerRpcService<NeverService, TestSubstream> {
+        ActivePeerRpcService::new(
+            RpcServerBuilder::default(),
+            StreamProtocol::new("/test/keepalive/1.0"),
+            PeerId::random(),
+            NeverService,
+            framed,
+        )
+    }
+
+    /// A response body fed by the test, which stalls for as long as the test holds the sender
+    /// without sending.
+    fn body_fed_by(rx: mpsc::Receiver<Result<Bytes, RpcStatus>>) -> Response<Body> {
+        Response::new(Body::streaming(futures::stream::unfold(rx, |mut rx| async move {
+            rx.recv().await.map(|item| (item, rx))
+        })))
+    }
+
+    async fn collect_responses(framed: &mut CanonicalFraming<TestSubstream>) -> Vec<proto::RpcResponse> {
+        let mut responses = Vec::new();
+        while let Some(frame) = framed.next().await {
+            responses.push(proto::RpcResponse::decode(frame.unwrap().freeze()).unwrap());
+        }
+        responses
+    }
+
+    #[tokio::test]
+    async fn keepalives_hold_an_idle_stream_open_until_its_deadline() {
+        let (server_framed, mut client_framed) = framed_pair();
+        let (tx, rx) = mpsc::channel(1);
+        tx.send(Ok(Bytes::from_static(b"first"))).await.unwrap();
+
+        let mut service = session(server_framed);
+        let started = Instant::now();
+        let server = tokio::spawn(async move {
+            service
+                .process_body(
+                    1,
+                    Duration::from_millis(400),
+                    Some(Duration::from_millis(50)),
+                    body_fed_by(rx),
+                )
+                .await
+                .unwrap();
+        });
+
+        let responses = collect_responses(&mut client_framed).await;
+        server.await.unwrap();
+        // The stream is only abandoned once the deadline is up, not at the first idle interval.
+        assert!(started.elapsed() >= Duration::from_millis(400));
+
+        let (keepalives, messages): (Vec<_>, Vec<_>) = responses.iter().partition(|r| r.is_keepalive());
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].payload, b"first");
+        assert!(
+            keepalives.len() >= 3,
+            "expected several keepalives, got {}",
+            keepalives.len()
+        );
+        assert!(keepalives.iter().all(|r| r.payload.is_empty() && r.request_id == 1));
+
+        drop(tx);
+    }
+
+    #[tokio::test]
+    async fn an_idle_stream_ends_at_its_deadline_when_no_keepalives_are_asked_for() {
+        let (server_framed, mut client_framed) = framed_pair();
+        let (tx, rx) = mpsc::channel(1);
+        tx.send(Ok(Bytes::from_static(b"first"))).await.unwrap();
+
+        let mut service = session(server_framed);
+        let server = tokio::spawn(async move {
+            service
+                .process_body(1, Duration::from_millis(150), None, body_fed_by(rx))
+                .await
+                .unwrap();
+        });
+
+        let responses = collect_responses(&mut client_framed).await;
+        server.await.unwrap();
+
+        assert_eq!(responses.len(), 1);
+        assert_eq!(responses[0].payload, b"first");
+
+        drop(tx);
+    }
+
+    #[tokio::test]
+    async fn a_message_renews_the_deadline() {
+        let (server_framed, mut client_framed) = framed_pair();
+        let (tx, rx) = mpsc::channel(1);
+
+        let mut service = session(server_framed);
+        let server = tokio::spawn(async move {
+            service
+                .process_body(
+                    1,
+                    Duration::from_millis(200),
+                    Some(Duration::from_millis(50)),
+                    body_fed_by(rx),
+                )
+                .await
+                .unwrap();
+        });
+
+        let feeder = tokio::spawn(async move {
+            for _ in 0..4 {
+                time::sleep(Duration::from_millis(120)).await;
+                tx.send(Ok(Bytes::from_static(b"tick"))).await.unwrap();
+            }
+            // Holding the sender past the last message lets the deadline expire and end the stream.
+            time::sleep(Duration::from_millis(400)).await;
+        });
+
+        let responses = collect_responses(&mut client_framed).await;
+        server.await.unwrap();
+        feeder.await.unwrap();
+
+        assert_eq!(responses.iter().filter(|r| !r.is_keepalive()).count(), 4);
+    }
+
+    #[test]
+    fn a_keepalive_interval_below_the_minimum_is_raised_to_it() {
+        let config = RpcServerBuilder::new().with_minimum_keepalive_interval(Duration::from_secs(10));
+        assert_eq!(config.keepalive_interval_for(None), None);
+        assert_eq!(
+            config.keepalive_interval_for(Some(Duration::from_secs(1))),
+            Some(Duration::from_secs(10))
+        );
+        assert_eq!(
+            config.keepalive_interval_for(Some(Duration::from_secs(30))),
+            Some(Duration::from_secs(30))
+        );
     }
 }


### PR DESCRIPTION
Description
---

Adds an opt-in keepalive mechanism to the RPC framework so that a streaming response can idle without
being torn down.

* **Wire**: a new `keepalive_interval` field on `RpcRequest` (seconds, `0` = off). The response side
  reuses the `RpcMessageFlags::ACK` flag that has always been documented for exactly this —
  *"typically sent with empty contents and used to confirm a substream is alive"* — but was until now
  only reachable via a client-initiated ping, which is useless mid-stream because requests and
  responses alternate on the substream.
* **Server**: while streaming a response, the idle timeout arm emits an empty ACK frame and keeps
  going instead of breaking out of the loop. `deadline` keeps its meaning as the longest gap between
  frames that actually carry the response, so a stream that genuinely produces nothing for that long
  still ends — keepalives prove liveness *within* that budget rather than extending it. A requested
  interval is clamped up to `minimum_keepalive_interval` (5s by default) so a client cannot dictate
  the rate at which the server produces frames.
* **Client**: `RpcClientConfig::keepalive_interval` (default `None`) puts the field on the wire, and
  the reply loop discards ACK frames before they reach a consumer, restarting its read timer on each.

Nothing requests keepalives yet — this is the mechanism only.

`RpcError::UnexpectedAckResponse` changes meaning: the commented-out block in
`RpcResponseReader::check_response` that used to produce it is gone, and it is now raised when a peer
sends an ACK frame to a client that never negotiated keepalives. That fails the offending request
only, not the worker.

Also makes `ActivePeerRpcService` generic over its substream so a session can be driven over an
in-memory duplex in tests.

Motivation and Context
---

Today a responder that has nothing to send is indistinguishable from one that has died: the server
breaks out of its send loop silently, with no error frame, and the client just sees a truncated
stream. Anything that wants to stay current therefore has to re-open the stream on a timer and wear
the full polling interval as staleness.

This is the prerequisite for holding an indexer's `sync_state` stream open instead of polling it
(#2498 follow-up), which takes substate-cache invalidation latency from one sync round (60s by
default) to roughly one block. It is framework-level rather than per-service, so every streaming RPC
can idle.

Both ends are backwards compatible in both directions:

* an old server ignores the unknown proto field and truncates an idle stream exactly as it does now,
  so a new client must still tolerate truncation and cannot rely on keepalives for correctness;
* an old client never sets the field, so a new server never sends it one.

How Has This Been Tested?
---

New unit tests in `tari_rpc_framework`, each verified to fail with the corresponding change backed
out:

* `keepalives_hold_an_idle_stream_open_until_its_deadline` — an idle stream produces several
  keepalives (empty payload, correct request id) and is only abandoned once the deadline is up.
* `a_message_renews_the_deadline` — a stream fed slower than its deadline but faster than nothing
  delivers every message.
* `an_idle_stream_ends_at_its_deadline_when_no_keepalives_are_asked_for` — unchanged behaviour when
  the field is absent.
* `a_keepalive_interval_below_the_minimum_is_raised_to_it` — the clamp.
* `keepalive_frames_are_not_delivered_as_stream_messages` — end-to-end over an in-memory duplex: a
  server that sends three keepalives before its single message yields exactly one item to the
  consumer (four without the fix, three of them empty).
* `keepalives_left_over_from_an_abandoned_request_do_not_end_the_session` — 21 keepalives bearing an
  id the client is no longer waiting on, then the answer; a second request on the same client then
  has to succeed.
* `a_keepalive_that_was_never_asked_for_is_a_protocol_error` — a client with `keepalive_interval:
  None` gets `ProtocolError`, not a default-decoded message and not a hang.
* `a_stale_keepalive_is_not_mistaken_for_a_pong` and
  `a_peer_that_never_answers_a_ping_cannot_hold_it_open` — the ping path skips frames not addressed
  to it, and skipping them is bounded by one timeout over the whole read.

`cargo lints clippy -p tari_rpc_framework --all-targets` is clean; direct dependents
(`tari_validator_node_rpc`, `tari_rpc_state_sync`, `tari_networking`) still build.

What process can a PR reviewer use to test or verify this change?
---

`cargo test -p tari_rpc_framework`.

The behavioural claim worth checking by eye is in `process_body`: `deadline_at` is reset only by a
frame carrying the response, never by a keepalive, so the keepalive path cannot hold a session open
indefinitely. With `keepalive_interval: None` the loop reduces to the previous `time::timeout(deadline,
stream.next())` exactly.

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify

