### PR TITLE
ci: give consensus tests room past the 240s kill

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -5,6 +5,15 @@ default-filter = "not package(integration_tests) and not test(export_bindings)"
 slow-timeout = { period = "60s", terminate-after = 4 }
 default-filter = "not package(integration_tests) and not test(export_bindings)"
 
+# Consensus tests drive real consensus rounds against wall-clock timers - leader failure and epoch
+# change wait for those timers to elapse rather than for work to finish - so they are slow by
+# construction and stretch further when the runner is contended. 240s is a reasonable bound for an
+# ordinary test that has hung; for these it is within the range they legitimately occupy, and a run
+# is failed by the shard that happened to land alongside the heaviest neighbours.
+[[profile.ci.overrides]]
+filter = 'package(consensus_tests)'
+slow-timeout = { period = "120s", terminate-after = 5 }
+
 [profile.ci.junit]  # this can be some other profile, too
 path = "junit.xml"
 


### PR DESCRIPTION
## What

Raises the nextest kill timeout for `consensus_tests` only, from 240s to 600s.

## Why

A test shard fails whenever a single test crosses `terminate-after`, which `[profile.ci]` puts at
`4 x 60s`. This is failing runs on `development`, not just on feature branches — the most recent
example:

```
TERMINATING [>240.000s]  consensus_tests  leader_failure::multi_shard_node_goes_down
Summary [240.210s] 664 tests run: 663 passed (19 slow), 1 timed out, 1854 skipped
error: test run failed
```

663 of 664 passed. The one that died was killed by the clock, not by an assertion.

The shape of the run points at runner contention rather than a pathological test: **nineteen tests
crossed the 60s slow mark within the same second**, and several that were reported slow went on to
pass at 73–93s. Which shard fails is decided by which tests happened to land alongside the heaviest
neighbours.

Consensus tests wait on wall-clock timers rather than on work finishing — leader failure and epoch
change advance by letting timers elapse — so they are slow by construction and stretch further under
load. 240s is a reasonable bound for an ordinary test that has hung, but it sits inside the range
these legitimately occupy.

## The change

```toml
[[profile.ci.overrides]]
filter = 'package(consensus_tests)'
slow-timeout = { period = "120s", terminate-after = 5 }
```

Scoped to the package, so every other test keeps the tighter 240s bound. The 120s period also stops
the `SLOW` lines firing at 60s for tests that routinely take 80–90s.

Scoped by package rather than by test name deliberately: slowness here is a property of the suite,
and a name-based filter would rot as tests are added.

## Notes

- This treats the symptom. If shards routinely take ~17 minutes with tests queueing behind each
  other, nextest's `test-threads` against the self-hosted runner's real core count may be worth
  looking at separately — that has its own risk of making wall-clock time worse.
- Split out of #2498, where it was originally committed to unblock that PR's CI. It is unrelated to
  that change and fixes `development` too.
