### PR TITLE
feat(indexer): cache substates the committee agrees do not exist

### DIFF
--- a/applications/tari_indexer/src/bootstrap.rs
+++ b/applications/tari_indexer/src/bootstrap.rs
@@ -115,6 +115,15 @@ const SUBSTATE_CACHE_JOURNAL_RETENTION: Duration = Duration::from_secs(300);
 
 const SUBSTATE_CACHE_PRUNE_INTERVAL: Duration = Duration::from_secs(60);
 
+/// Keepalives a shard's stream may miss before a record that a substate does not exist stops being
+/// served for it.
+///
+/// Derived from the keepalive interval rather than configured: the bound is not a staleness budget
+/// but a liveness test - a negative is only as true as the stream that would retract it - and a
+/// standalone setting could be left behind when that interval changes. Two may be lost before the
+/// cache closes, which is enough to ride out an ordinary reopen without holding a dead stream open.
+const NEGATIVE_SERVE_KEEPALIVES: u32 = 3;
+
 #[allow(clippy::too_many_lines)]
 pub async fn spawn_services(
     config: &ApplicationConfig,
@@ -294,6 +303,7 @@ pub async fn spawn_services(
         store.clone(),
         shard_watermarks,
         config.indexer.substate_cache_max_serve_lag,
+        config.indexer.state_sync_keepalive_interval * NEGATIVE_SERVE_KEEPALIVES,
         SUBSTATE_CACHE_JOURNAL_RETENTION,
         DEFAULT_CACHE_TTL,
         config.indexer.substate_cache_max_entries,

--- a/applications/tari_indexer/src/bootstrap.rs
+++ b/applications/tari_indexer/src/bootstrap.rs
@@ -333,12 +333,21 @@ pub async fn spawn_services(
     .await
     .context("template manager init thread panicked")??;
 
-    // Dry run - use a shorter cache TTL for more accurate fee estimates. Proof verification is left
-    // off here: dry run only produces a fee estimate, and gating it on proof availability would make
-    // transaction submission fragile when proofs are momentarily unavailable.
+    // Dry run - use a shorter cache TTL for more accurate fee estimates. A nonexistent input is held
+    // for the shorter of the two: an input resolved as absent estimates a transaction that would in
+    // fact have succeeded, which is the same staleness `dry_run_cache_ttl` is set to bound.
+    // Proof verification is left off here: dry run only produces a fee estimate, and gating it on
+    // proof availability would make transaction submission fragile when proofs are momentarily
+    // unavailable.
     let dry_run_substate_manager = substate_manager
         .clone()
         .with_cache_ttl(config.indexer.dry_run_cache_ttl)
+        .with_negative_cache_ttl(
+            config
+                .indexer
+                .dry_run_cache_ttl
+                .min(config.indexer.substate_cache_negative_ttl),
+        )
         .with_substate_proof_verification(false);
     let fee_table = get_fee_table_by_network(config.network);
     let dry_run_transaction_processor = DryRunTransactionProcessor::new(

--- a/applications/tari_indexer/src/bootstrap.rs
+++ b/applications/tari_indexer/src/bootstrap.rs
@@ -306,7 +306,8 @@ pub async fn spawn_services(
         validator_node_client_factory.clone(),
         substate_cache,
     )
-    .with_substate_proof_verification(config.indexer.verify_substate_proofs);
+    .with_substate_proof_verification(config.indexer.verify_substate_proofs)
+    .with_negative_cache_ttl(config.indexer.substate_cache_negative_ttl);
     #[cfg(feature = "metrics")]
     let substate_manager = substate_manager.with_metrics(metrics_registry);
 

--- a/applications/tari_indexer/src/config.rs
+++ b/applications/tari_indexer/src/config.rs
@@ -32,6 +32,7 @@ use tari_common::{
     configuration::{CommonConfig, serializers},
 };
 use tari_crypto::ristretto::RistrettoPublicKey;
+use tari_indexer_lib::cached_substate_manager::DEFAULT_NEGATIVE_CACHE_TTL;
 use tari_ootle_app_utilities::{
     epoch_oracle_config::EpochOracleConfig,
     p2p_config::{P2pConfig, PeerSeedsConfig},
@@ -187,6 +188,15 @@ pub struct IndexerConfig {
     /// are evicted, at the cost of one validator round trip each to fetch again.
     #[serde(default = "default_substate_cache_max_entries")]
     pub substate_cache_max_entries: usize,
+    /// How long the cache serves a substate it has established does not exist. A creation retracts
+    /// that through the transition stream, so this bounds only the case where the stream does not
+    /// deliver.
+    ///
+    /// Held shorter than the other entries because it is the one a caller feels as an absence: a
+    /// substate being waited on stays missing until this expires. Set it to zero to answer every
+    /// nonexistent lookup from the committee, at `f + 1` round trips each.
+    #[serde(default = "default_substate_cache_negative_ttl", with = "serializers::seconds")]
+    pub substate_cache_negative_ttl: Duration,
     /// How many epochs past its terminal epoch a stored transaction is retained before it is pruned.
     /// A transaction's terminal epoch is the epoch it committed in once its receipt has been
     /// indexed, and its `max_epoch` — the last epoch it could still be sequenced in — until then, so
@@ -268,6 +278,10 @@ fn default_substate_cache_max_serve_lag() -> Duration {
 
 fn default_substate_cache_max_entries() -> usize {
     100_000
+}
+
+fn default_substate_cache_negative_ttl() -> Duration {
+    DEFAULT_NEGATIVE_CACHE_TTL
 }
 
 /// The subset of an indexer's configuration that is published over its API, as it affects what
@@ -414,6 +428,7 @@ impl Default for IndexerConfig {
             allow_past_protocol_activation: false,
             substate_cache_max_serve_lag: default_substate_cache_max_serve_lag(),
             substate_cache_max_entries: default_substate_cache_max_entries(),
+            substate_cache_negative_ttl: default_substate_cache_negative_ttl(),
             transaction_retention_epochs: default_transaction_retention_epochs(),
             index_gossiped_transactions: default_index_gossiped_transactions(),
             max_transaction_gossip_queue_bytes: default_max_transaction_gossip_queue_bytes(),

--- a/applications/tari_indexer/src/config.rs
+++ b/applications/tari_indexer/src/config.rs
@@ -189,12 +189,19 @@ pub struct IndexerConfig {
     #[serde(default = "default_substate_cache_max_entries")]
     pub substate_cache_max_entries: usize,
     /// How long the cache serves a substate it has established does not exist. A creation retracts
-    /// that through the transition stream, so this bounds only the case where the stream does not
-    /// deliver.
+    /// that through the transition stream, so ordinary staleness is bounded by the sync round and
+    /// this covers only what that stream cannot correct.
+    ///
+    /// What it cannot correct is an answer that was already wrong when it was cached. The committee
+    /// is chosen from the epoch manager's current epoch, independently of the watermark that gates
+    /// the write, so a lagging view of a shard group split can put the question to a committee that
+    /// honestly no longer holds the substate and agrees it does not exist. Uncached that misleads
+    /// one caller; cached it is served to every caller until this expires.
     ///
     /// Held shorter than the other entries because it is the one a caller feels as an absence: a
-    /// substate being waited on stays missing until this expires. Set it to zero to answer every
-    /// nonexistent lookup from the committee, at `f + 1` round trips each.
+    /// substate being waited on stays missing until this expires. Lowering it towards zero narrows
+    /// that window to sub-second - an entry cached within the current second still answers - at
+    /// `f + 1` committee round trips for every nonexistent lookup.
     #[serde(default = "default_substate_cache_negative_ttl", with = "serializers::seconds")]
     pub substate_cache_negative_ttl: Duration,
     /// How many epochs past its terminal epoch a stored transaction is retained before it is pruned.

--- a/applications/tari_indexer/src/network_state_sync/worker.rs
+++ b/applications/tari_indexer/src/network_state_sync/worker.rs
@@ -1170,8 +1170,8 @@ fn process_watched_substate_events(
 
 /// Sorts one streamed transition into the buffers a commit is assembled from.
 ///
-/// A transition that retires a cached version reaches `invalidations_buf`; a substate's first
-/// creation retires nothing and is dropped. Only those whose substate `value_filters` selects carry a
+/// A transition that retires anything cached reaches `invalidations_buf`, which for a substate's
+/// first creation is the record that it did not exist. Only those whose substate `value_filters` selects carry a
 /// value; the rest arrive as an id and a version under `ALL_HASHES` and must reach nothing else -
 /// indexing one, counting it in the economic totals or emitting an event for it would all be reading
 /// a value that was never sent.

--- a/applications/tari_indexer/src/storage_sqlite/migrations/2026-09-02-000000_substate_cache_nonexistence/down.sql
+++ b/applications/tari_indexer/src/storage_sqlite/migrations/2026-09-02-000000_substate_cache_nonexistence/down.sql
@@ -1,0 +1,12 @@
+drop table substate_cache;
+
+create table substate_cache
+(
+    substate_id      text    not null primary key,
+    version          integer not null,
+    verified         boolean not null,
+    substate_result  blob    not null,
+    cached_at        bigint  not null
+);
+
+create index idx_substate_cache_evict on substate_cache (cached_at);

--- a/applications/tari_indexer/src/storage_sqlite/migrations/2026-09-02-000000_substate_cache_nonexistence/up.sql
+++ b/applications/tari_indexer/src/storage_sqlite/migrations/2026-09-02-000000_substate_cache_nonexistence/up.sql
@@ -1,0 +1,24 @@
+-- Admit "this substate does not exist" as a cache entry, recorded as a row with no version.
+--
+-- A `DoesNotExist` lookup is the one answer that cannot stop at the first good response: it is
+-- settled by f+1 agreement, so it walks that many committee members every time. Caching it removes
+-- the most expensive lookup the indexer makes.
+--
+-- Nullable rather than a sentinel version. A version is a u32 and the column is a signed integer, so
+-- every value that could stand in for "no version" is one a real head could take.
+--
+-- The cache is rebuilt from the committee on demand, so this recreates the table rather than
+-- migrating rows into it.
+drop table substate_cache;
+
+create table substate_cache
+(
+    substate_id      text    not null primary key,
+    -- The substate's head version, or null when the substate does not exist.
+    version          integer null,
+    verified         boolean not null,
+    substate_result  blob    not null,
+    cached_at        bigint  not null
+);
+
+create index idx_substate_cache_evict on substate_cache (cached_at);

--- a/applications/tari_indexer/src/storage_sqlite/models/substate_cache.rs
+++ b/applications/tari_indexer/src/storage_sqlite/models/substate_cache.rs
@@ -2,46 +2,60 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use tari_engine_types::substate::SubstateId;
+use tari_indexer_lib::substate_cache::caches_nonexistence;
 
 #[derive(Debug, Clone, Queryable)]
 pub(crate) struct SubstateCacheRow {
     #[allow(dead_code)]
     pub substate_id: String,
-    pub version: i32,
+    pub version: Option<i32>,
     pub verified: bool,
     pub substate_result: Vec<u8>,
     pub cached_at: i64,
 }
 
-/// A substate a synced transition has retired every cached version of up to and including
-/// `retires_up_to`.
+/// A substate a synced transition has retired cached entries for.
 ///
-/// A substate's first creation retires nothing and is not one of these. Before it there was nothing
-/// to retire and no fetch to veto either: the only result a lookup could have returned is
-/// `DoesNotExist`, which is never cached. Substates that are created once and never updated -
-/// transaction receipts, most of the stream by count - therefore produce none of these at all.
+/// Carries what the transition settles, which is never the whole entry: a creation retires the
+/// versions below it and the claim that the substate does not exist, and a destroy retires the
+/// version it names. Neither touches a head above, which a cached entry can legitimately hold after
+/// being fetched straight from the committee.
 #[derive(Debug, Clone)]
 pub struct SubstateCacheInvalidation {
     substate_id: SubstateId,
-    retires_up_to: u32,
+    retires_up_to: Option<u32>,
+    retires_nonexistence: bool,
 }
 
 impl SubstateCacheInvalidation {
-    /// The substate was created at `version`, so every lower version is spent. `version` itself and
-    /// anything above it are untouched: a cached head can legitimately run ahead of the transition
-    /// stream, having been fetched straight from the committee.
+    /// The substate was created at `version`, so every lower version is spent and it demonstrably
+    /// exists.
+    ///
+    /// A first creation retires no version - there is none below 0 - so all it carries is the
+    /// retraction of a cached nonexistence. Where nothing caches that, it carries nothing, and is
+    /// not one of these at all: emitting it would put a journal row on the sync path for every
+    /// created-once substate in the stream and buy nothing with it.
     pub fn created(substate_id: SubstateId, version: u32) -> Option<Self> {
-        version.checked_sub(1).map(|retires_up_to| Self {
+        let retires_up_to = version.checked_sub(1);
+        if retires_up_to.is_none() && !caches_nonexistence(&substate_id) {
+            return None;
+        }
+        Some(Self {
             substate_id,
             retires_up_to,
+            retires_nonexistence: true,
         })
     }
 
     /// `version` was destroyed, with or without a successor.
+    ///
+    /// A destroy leaves a cached nonexistence alone. `DoesNotExist` says the substate has no live
+    /// version, which a destroy makes more true rather than less.
     pub fn destroyed(substate_id: SubstateId, version: u32) -> Self {
         Self {
             substate_id,
-            retires_up_to: version,
+            retires_up_to: Some(version),
+            retires_nonexistence: false,
         }
     }
 
@@ -49,9 +63,14 @@ impl SubstateCacheInvalidation {
         &self.substate_id
     }
 
-    /// The highest cached head version this retires.
-    pub fn retires_up_to(&self) -> u32 {
+    /// The highest cached head version this retires, if any.
+    pub fn retires_up_to(&self) -> Option<u32> {
         self.retires_up_to
+    }
+
+    /// Whether this retires a cached record that the substate does not exist.
+    pub fn retires_nonexistence(&self) -> bool {
+        self.retires_nonexistence
     }
 }
 
@@ -63,19 +82,38 @@ mod tests {
         format!("component_{:064x}", 1).parse().unwrap()
     }
 
+    fn receipt() -> SubstateId {
+        format!("txreceipt_{:064x}", 1).parse().unwrap()
+    }
+
     #[test]
-    fn a_first_creation_retires_nothing() {
-        assert!(SubstateCacheInvalidation::created(substate(), 0).is_none());
+    fn a_first_creation_retires_nothing_but_the_nonexistence() {
+        let invalidation = SubstateCacheInvalidation::created(substate(), 0).unwrap();
+        assert_eq!(invalidation.retires_up_to(), None);
+        assert!(invalidation.retires_nonexistence());
+    }
+
+    /// The whole reason first creations are journalled at all is to retract a cached nonexistence,
+    /// so one that cannot be cached must not put a row on the sync path.
+    #[test]
+    fn a_first_creation_is_dropped_where_nonexistence_is_not_cached() {
+        assert!(!caches_nonexistence(&receipt()));
+        assert!(SubstateCacheInvalidation::created(receipt(), 0).is_none());
+        // Above the first version it carries a retirement that stands on its own.
+        assert!(SubstateCacheInvalidation::created(receipt(), 1).is_some());
     }
 
     #[test]
     fn a_creation_retires_every_version_below_it() {
         let invalidation = SubstateCacheInvalidation::created(substate(), 6).unwrap();
-        assert_eq!(invalidation.retires_up_to(), 5);
+        assert_eq!(invalidation.retires_up_to(), Some(5));
+        assert!(invalidation.retires_nonexistence());
     }
 
     #[test]
-    fn a_destroy_retires_the_version_it_names() {
-        assert_eq!(SubstateCacheInvalidation::destroyed(substate(), 6).retires_up_to(), 6);
+    fn a_destroy_retires_the_version_it_names_and_no_nonexistence() {
+        let invalidation = SubstateCacheInvalidation::destroyed(substate(), 6);
+        assert_eq!(invalidation.retires_up_to(), Some(6));
+        assert!(!invalidation.retires_nonexistence());
     }
 }

--- a/applications/tari_indexer/src/storage_sqlite/models/substate_cache.rs
+++ b/applications/tari_indexer/src/storage_sqlite/models/substate_cache.rs
@@ -37,13 +37,14 @@ impl SubstateCacheInvalidation {
     /// created-once substate in the stream and buy nothing with it.
     pub fn created(substate_id: SubstateId, version: u32) -> Option<Self> {
         let retires_up_to = version.checked_sub(1);
-        if retires_up_to.is_none() && !caches_nonexistence(&substate_id) {
+        let retires_nonexistence = caches_nonexistence(&substate_id);
+        if retires_up_to.is_none() && !retires_nonexistence {
             return None;
         }
         Some(Self {
             substate_id,
             retires_up_to,
-            retires_nonexistence: true,
+            retires_nonexistence,
         })
     }
 
@@ -68,7 +69,9 @@ impl SubstateCacheInvalidation {
         self.retires_up_to
     }
 
-    /// Whether this retires a cached record that the substate does not exist.
+    /// Whether a record that the substate does not exist may exist to be retired. False where
+    /// nothing caches one, so the retirement is not attempted for the substates that dominate the
+    /// stream by count.
     pub fn retires_nonexistence(&self) -> bool {
         self.retires_nonexistence
     }
@@ -99,8 +102,11 @@ mod tests {
     fn a_first_creation_is_dropped_where_nonexistence_is_not_cached() {
         assert!(!caches_nonexistence(&receipt()));
         assert!(SubstateCacheInvalidation::created(receipt(), 0).is_none());
-        // Above the first version it carries a retirement that stands on its own.
-        assert!(SubstateCacheInvalidation::created(receipt(), 1).is_some());
+        // Above the first version it carries a retirement that stands on its own, and does not
+        // attempt one that could never match.
+        let above = SubstateCacheInvalidation::created(receipt(), 1).unwrap();
+        assert_eq!(above.retires_up_to(), Some(0));
+        assert!(!above.retires_nonexistence());
     }
 
     #[test]

--- a/applications/tari_indexer/src/storage_sqlite/reader.rs
+++ b/applications/tari_indexer/src/storage_sqlite/reader.rs
@@ -1178,7 +1178,7 @@ impl IndexerStoreReadTransaction for SqliteStoreReadTransaction<'_> {
 
         row.map(|row| {
             Ok(SubstateCacheEntry {
-                version: row.version as u32,
+                version: row.version.map(|v| v as u32),
                 substate_result: deserialize_bincode(&row.substate_result)?,
                 cached_at: row.cached_at as u64,
                 verified: row.verified,

--- a/applications/tari_indexer/src/storage_sqlite/schema.rs
+++ b/applications/tari_indexer/src/storage_sqlite/schema.rs
@@ -143,7 +143,7 @@ diesel::table! {
 diesel::table! {
     substate_cache (substate_id) {
         substate_id -> Text,
-        version -> Integer,
+        version -> Nullable<Integer>,
         verified -> Bool,
         substate_result -> Binary,
         cached_at -> BigInt,

--- a/applications/tari_indexer/src/storage_sqlite/store_factory.rs
+++ b/applications/tari_indexer/src/storage_sqlite/store_factory.rs
@@ -164,7 +164,7 @@ mod tests {
         transaction_receipt::{FinalizeOutcome, TransactionReceipt},
     };
     use tari_indexer_client::types::TransactionSource;
-    use tari_indexer_lib::substate_cache::{FetchWatermark, SubstateCacheEntryRef};
+    use tari_indexer_lib::substate_cache::{FetchWatermark, SubstateCacheEntry, SubstateCacheEntryRef};
     use tari_ootle_common_types::{Epoch, NodeHeight, ShardGroup, StateVersion};
     use tari_ootle_transaction::{Transaction, TransactionId};
     use tari_validator_node_rpc::client::SubstateResult;
@@ -1109,7 +1109,7 @@ mod tests {
                 tx.substate_cache_put(
                     &id,
                     SubstateCacheEntryRef {
-                        version,
+                        version: Some(version),
                         substate_result: &result,
                         cached_at,
                         verified,
@@ -1126,13 +1126,40 @@ mod tests {
         put_entry(store, id, version, true, now_secs(), watermark).await
     }
 
+    /// The cached head version. `None` covers both no row at all and a row recording that the
+    /// substate does not exist; use [`read_entry`] where the two must be told apart.
     async fn read(store: &SqliteIndexerStore, id: &SubstateId) -> Option<u32> {
+        read_entry(store, id).await.and_then(|entry| entry.version)
+    }
+
+    async fn read_entry(store: &SqliteIndexerStore, id: &SubstateId) -> Option<SubstateCacheEntry> {
+        let id = id.clone();
+        store.with_read_tx(move |tx| tx.substate_cache_get(&id)).await.unwrap()
+    }
+
+    /// Records that `id` does not exist, as an unversioned entry.
+    async fn put_nonexistent(store: &SqliteIndexerStore, id: &SubstateId, watermark: u64) -> bool {
         let id = id.clone();
         store
-            .with_read_tx(move |tx| tx.substate_cache_get(&id))
+            .with_write_tx(move |tx| {
+                tx.substate_cache_put(
+                    &id,
+                    SubstateCacheEntryRef {
+                        version: None,
+                        substate_result: &SubstateResult::DoesNotExist,
+                        cached_at: now_secs(),
+                        verified: false,
+                    },
+                    FetchWatermark::new(watermark),
+                    HEAD_TTL,
+                )
+            })
             .await
             .unwrap()
-            .map(|entry| entry.version)
+    }
+
+    fn is_nonexistent(entry: &SubstateCacheEntry) -> bool {
+        entry.version.is_none() && matches!(entry.substate_result, SubstateResult::DoesNotExist)
     }
 
     async fn invalidate(store: &SqliteIndexerStore, invalidation: SubstateCacheInvalidation, at: u64) {
@@ -1140,6 +1167,69 @@ mod tests {
             .with_write_tx(move |tx| tx.substate_cache_invalidate([invalidation], StateVersion::new(at)))
             .await
             .unwrap();
+    }
+
+    /// The point of journalling a first creation: it is the only transition that can retract the
+    /// claim that a substate does not exist.
+    #[tokio::test]
+    async fn a_first_creation_retires_the_nonexistence_it_denies() {
+        let (_d, store) = temp_store().await;
+        let id = substate(1);
+        assert!(put_nonexistent(&store, &id, 100).await);
+        assert!(is_nonexistent(&read_entry(&store, &id).await.unwrap()));
+
+        invalidate(&store, SubstateCacheInvalidation::created(id.clone(), 0).unwrap(), 105).await;
+        assert!(read_entry(&store, &id).await.is_none());
+    }
+
+    /// A creation retires the nonexistence whatever version it lands at, not only the first.
+    #[tokio::test]
+    async fn a_later_creation_also_retires_the_nonexistence() {
+        let (_d, store) = temp_store().await;
+        let id = substate(1);
+        assert!(put_nonexistent(&store, &id, 100).await);
+
+        invalidate(&store, SubstateCacheInvalidation::created(id.clone(), 6).unwrap(), 105).await;
+        assert!(read_entry(&store, &id).await.is_none());
+    }
+
+    /// `DoesNotExist` says the substate has no live version, which a destroy makes more true.
+    #[tokio::test]
+    async fn a_destroy_leaves_a_cached_nonexistence_alone() {
+        let (_d, store) = temp_store().await;
+        let id = substate(1);
+        assert!(put_nonexistent(&store, &id, 100).await);
+
+        invalidate(&store, SubstateCacheInvalidation::destroyed(id.clone(), 6), 105).await;
+        assert!(is_nonexistent(&read_entry(&store, &id).await.unwrap()));
+    }
+
+    /// The race the journal exists to close: the substate is created while the committee fetch that
+    /// answered `DoesNotExist` is still in flight, so the delete runs before there is a row to
+    /// delete and only the journal can stop the write.
+    #[tokio::test]
+    async fn a_creation_landing_mid_fetch_vetoes_the_nonexistence() {
+        let (_d, store) = temp_store().await;
+        let id = substate(1);
+
+        // The fetch captured the watermark at 100; the creation commits at 105 while it is in flight.
+        invalidate(&store, SubstateCacheInvalidation::created(id.clone(), 0).unwrap(), 105).await;
+        assert!(!put_nonexistent(&store, &id, 100).await);
+        assert!(read_entry(&store, &id).await.is_none());
+    }
+
+    /// Nonexistence ranks below every version: a real head displaces it, and it never walks one back.
+    #[tokio::test]
+    async fn a_nonexistence_yields_to_any_head() {
+        let (_d, store) = temp_store().await;
+        let id = substate(1);
+        assert!(put_nonexistent(&store, &id, 100).await);
+        assert!(put(&store, &id, 0, 100).await);
+        assert_eq!(read(&store, &id).await, Some(0));
+
+        // ...and cannot displace one that is verified and current.
+        assert!(!put_nonexistent(&store, &id, 100).await);
+        assert_eq!(read(&store, &id).await, Some(0));
     }
 
     #[tokio::test]

--- a/applications/tari_indexer/src/storage_sqlite/store_factory.rs
+++ b/applications/tari_indexer/src/storage_sqlite/store_factory.rs
@@ -1218,6 +1218,16 @@ mod tests {
         assert!(read_entry(&store, &id).await.is_none());
     }
 
+    /// Nothing would ever retract a nonexistence recorded for a substate no first creation journals,
+    /// so the write is refused rather than left to age out.
+    #[tokio::test]
+    async fn a_nonexistence_is_refused_where_no_transition_would_retract_it() {
+        let (_d, store) = temp_store().await;
+        let receipt: SubstateId = format!("txreceipt_{:064x}", 1).parse().unwrap();
+        assert!(!put_nonexistent(&store, &receipt, 100).await);
+        assert!(read_entry(&store, &receipt).await.is_none());
+    }
+
     /// Nonexistence ranks below every version: a real head displaces it, and it never walks one back.
     #[tokio::test]
     async fn a_nonexistence_yields_to_any_head() {

--- a/applications/tari_indexer/src/storage_sqlite/writer.rs
+++ b/applications/tari_indexer/src/storage_sqlite/writer.rs
@@ -18,7 +18,13 @@ use tari_engine_types::{
 };
 use tari_indexer_client::types::TransactionSource;
 use tari_indexer_lib::substate_cache::{FetchWatermark, SubstateCacheEntryRef};
-use tari_ootle_common_types::{Epoch, StateVersion, shard::Shard, substate_type::SubstateType};
+use tari_ootle_common_types::{
+    Epoch,
+    StateVersion,
+    displayable::Displayable,
+    shard::Shard,
+    substate_type::SubstateType,
+};
 use tari_ootle_storage::{
     StorageError,
     consensus_models::{EpochCheckpoint, SubstateData, SubstateUpdateProof},
@@ -537,6 +543,7 @@ impl IndexerStoreWriteTransaction for SqliteStoreWriteTransaction<'_> {
         use crate::storage_sqlite::schema::{substate_cache, substate_cache_invalidations};
 
         let id = substate_id.to_string();
+        let version = entry.version.map(|v| v as i32);
 
         // Read inside this transaction so that the journal and the insert cannot straddle a
         // concurrent invalidation commit.
@@ -551,13 +558,13 @@ impl IndexerStoreWriteTransaction for SqliteStoreWriteTransaction<'_> {
             debug!(
                 target: LOG_TARGET,
                 "Discarding cache write for {substate_id} v{}: its shard advanced past the fetch",
-                entry.version
+                entry.version.display()
             );
             return Ok(false);
         }
 
         // A committee member that is behind can answer with a version below the head already held.
-        let cached: Option<(i32, bool, i64)> = substate_cache::table
+        let cached: Option<(Option<i32>, bool, i64)> = substate_cache::table
             .select((
                 substate_cache::version,
                 substate_cache::verified,
@@ -579,7 +586,9 @@ impl IndexerStoreWriteTransaction for SqliteStoreWriteTransaction<'_> {
             // way one recorded above the real version is ever corrected.
             let outranked = entry.verified && !cached_verified;
             let aged_out = !cached_verified && unix_timestamp().saturating_sub(cached_at) > head_ttl.as_secs() as i64;
-            if cached_version > entry.version as i32 && !outranked && !aged_out {
+            // A substate that does not exist ranks below every version, which `Option`'s own ordering
+            // gives: nonexistence yields to any head, and any head displaces it.
+            if cached_version > version && !outranked && !aged_out {
                 return Ok(false);
             }
         }
@@ -589,7 +598,7 @@ impl IndexerStoreWriteTransaction for SqliteStoreWriteTransaction<'_> {
         diesel::insert_into(substate_cache::table)
             .values((
                 substate_cache::substate_id.eq(&id),
-                substate_cache::version.eq(entry.version as i32),
+                substate_cache::version.eq(version),
                 substate_cache::verified.eq(entry.verified),
                 substate_cache::substate_result.eq(&encoded),
                 substate_cache::cached_at.eq(entry.cached_at as i64),
@@ -597,7 +606,7 @@ impl IndexerStoreWriteTransaction for SqliteStoreWriteTransaction<'_> {
             .on_conflict(substate_cache::substate_id)
             .do_update()
             .set((
-                substate_cache::version.eq(entry.version as i32),
+                substate_cache::version.eq(version),
                 substate_cache::verified.eq(entry.verified),
                 substate_cache::substate_result.eq(&encoded),
                 substate_cache::cached_at.eq(entry.cached_at as i64),
@@ -620,13 +629,25 @@ impl IndexerStoreWriteTransaction for SqliteStoreWriteTransaction<'_> {
         for invalidation in invalidations {
             let id = invalidation.substate_id().to_string();
 
-            diesel::delete(
-                substate_cache::table
-                    .filter(substate_cache::substate_id.eq(&id))
-                    .filter(substate_cache::version.le(invalidation.retires_up_to() as i32)),
-            )
-            .execute(self.connection())
-            .map_err(|e| StorageError::general(OPERATION, e))?;
+            if let Some(retires_up_to) = invalidation.retires_up_to() {
+                diesel::delete(
+                    substate_cache::table
+                        .filter(substate_cache::substate_id.eq(&id))
+                        .filter(substate_cache::version.le(retires_up_to as i32)),
+                )
+                .execute(self.connection())
+                .map_err(|e| StorageError::general(OPERATION, e))?;
+            }
+
+            if invalidation.retires_nonexistence() {
+                diesel::delete(
+                    substate_cache::table
+                        .filter(substate_cache::substate_id.eq(&id))
+                        .filter(substate_cache::version.is_null()),
+                )
+                .execute(self.connection())
+                .map_err(|e| StorageError::general(OPERATION, e))?;
+            }
 
             diesel::insert_into(substate_cache_invalidations::table)
                 .values((

--- a/applications/tari_indexer/src/storage_sqlite/writer.rs
+++ b/applications/tari_indexer/src/storage_sqlite/writer.rs
@@ -17,7 +17,7 @@ use tari_engine_types::{
     transaction_receipt::TransactionReceipt,
 };
 use tari_indexer_client::types::TransactionSource;
-use tari_indexer_lib::substate_cache::{FetchWatermark, SubstateCacheEntryRef};
+use tari_indexer_lib::substate_cache::{FetchWatermark, SubstateCacheEntryRef, caches_nonexistence};
 use tari_ootle_common_types::{
     Epoch,
     StateVersion,
@@ -544,6 +544,17 @@ impl IndexerStoreWriteTransaction for SqliteStoreWriteTransaction<'_> {
 
         let id = substate_id.to_string();
         let version = entry.version.map(|v| v as i32);
+
+        // Nothing journals a first creation for a substate outside `caches_nonexistence`, so a
+        // record here that one does not exist could never be retracted and would stand until it
+        // ages out. The invariant is enforced where it can be broken rather than only at the callers.
+        if version.is_none() && !caches_nonexistence(substate_id) {
+            warn!(
+                target: LOG_TARGET,
+                "Refusing to cache the nonexistence of {substate_id}: no transition would retract it"
+            );
+            return Ok(false);
+        }
 
         // Read inside this transaction so that the journal and the insert cannot straddle a
         // concurrent invalidation commit.

--- a/applications/tari_indexer/src/substate_cache.rs
+++ b/applications/tari_indexer/src/substate_cache.rs
@@ -39,9 +39,10 @@ fn now_unix_secs() -> Result<u64, SubstateCacheError> {
 /// Substate cache backed by the indexer's own database, so that an entry and the sync watermark it
 /// is justified by are written and read under one transaction.
 ///
-/// Holds one entry per substate: its head version. An entry is served until the substate's shard
-/// carries a transition that retires it - not until a timer expires - and that holds only for a shard
-/// whose stream this indexer is demonstrably keeping up with, which [`ShardWatermarks`] decides.
+/// Holds one entry per substate: its head version, or no version at all where the substate does not
+/// exist. An entry is served until the substate's shard carries a transition that retires it - not
+/// until a timer expires - and that holds only for a shard whose stream this indexer is demonstrably
+/// keeping up with, which [`ShardWatermarks`] decides.
 ///
 /// A cached head also settles every version below it, without a validator and without a watermark.
 /// Versions are contiguous and upping a substate downs its predecessor, so a substate that ever
@@ -52,6 +53,10 @@ fn now_unix_secs() -> Result<u64, SubstateCacheError> {
 /// What can be wrong is `L` itself, if it was recorded above any version the substate reached. No
 /// transition corrects that - every transition retires versions below the head, never above it - so
 /// `head_ttl` retires the head instead, and the next lookup replaces it.
+///
+/// An entry with no version settles nothing below it. Nonexistence says only that the substate has
+/// no live version now, and since a destroyed substate whose history has been pruned reports the
+/// same thing, it cannot be read as "never created": a versioned read goes to the committee.
 #[derive(Clone)]
 pub struct SqliteSubstateCache {
     store: SqliteIndexerStore,
@@ -156,8 +161,21 @@ impl SubstateCache for SqliteSubstateCache {
             return Ok(None);
         };
 
+        let Some(head) = entry.version else {
+            // Nonexistence is a claim about the substate's current state and nothing more. It says
+            // there is no live version, never what was true at some version below, so a versioned
+            // read has to go to the committee.
+            if version.is_some() {
+                return Ok(None);
+            }
+            if self.watermarks.get(Self::shard_of(id), self.max_serve_lag).is_none() {
+                return Ok(None);
+            }
+            return Ok(Some(entry));
+        };
+
         if let Some(version) = version &&
-            version < entry.version
+            version < head
         {
             // The conclusion does not age, but the head it rests on does: one recorded above the real
             // version is retired by no transition, so it is aged out here instead.
@@ -165,7 +183,7 @@ impl SubstateCache for SqliteSubstateCache {
                 return Ok(None);
             }
             return Ok(Some(SubstateCacheEntry {
-                version,
+                version: Some(version),
                 substate_result: SubstateResult::Down { version },
                 // Derived now rather than when the head was fetched. The head only has to have been
                 // real at some point for this to hold, so the answer does not age.
@@ -182,7 +200,7 @@ impl SubstateCache for SqliteSubstateCache {
 
         // A version above the head is not something the cache knows anything about: this indexer is
         // behind, or the substate never reached it.
-        if version.is_some_and(|version| version > entry.version) {
+        if version.is_some_and(|version| version > head) {
             return Ok(None);
         }
 
@@ -264,7 +282,7 @@ mod tests {
             .write(
                 &id,
                 SubstateCacheEntryRef {
-                    version,
+                    version: Some(version),
                     substate_result: &result,
                     cached_at: now_unix_secs().unwrap() - head_age.as_secs(),
                     verified: true,
@@ -280,7 +298,7 @@ mod tests {
     async fn a_version_below_the_head_is_reported_down_without_a_committee() {
         let (_d, cache, id) = cache_with_head(6, true, Duration::ZERO).await;
         let entry = cache.read(&id, Some(3)).await.unwrap().expect("no entry");
-        assert_eq!(entry.version, 3);
+        assert_eq!(entry.version, Some(3));
         assert!(matches!(entry.substate_result, SubstateResult::Down { version: 3 }));
     }
 
@@ -299,8 +317,8 @@ mod tests {
     #[tokio::test]
     async fn the_head_answers_for_itself_and_for_an_unversioned_read() {
         let (_d, cache, id) = cache_with_head(6, true, Duration::ZERO).await;
-        assert_eq!(cache.read(&id, None).await.unwrap().unwrap().version, 6);
-        assert_eq!(cache.read(&id, Some(6)).await.unwrap().unwrap().version, 6);
+        assert_eq!(cache.read(&id, None).await.unwrap().unwrap().version, Some(6));
+        assert_eq!(cache.read(&id, Some(6)).await.unwrap().unwrap().version, Some(6));
     }
 
     /// A head recorded above any version the substate reached is retired by no transition, so the
@@ -309,6 +327,64 @@ mod tests {
     async fn the_inference_stops_once_the_head_ages_out() {
         let (_d, cache, id) = cache_with_head(6, true, HEAD_TTL + Duration::from_secs(1)).await;
         assert!(cache.read(&id, Some(3)).await.unwrap().is_none());
+    }
+
+    async fn cache_with_nonexistence(confirm_shard: bool) -> (tempfile::TempDir, SqliteSubstateCache, SubstateId) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = SqliteIndexerStore::try_create(dir.path().join("indexer.db")).unwrap();
+        let watermarks = Arc::new(ShardWatermarks::new());
+        let id = substate(1);
+        if confirm_shard {
+            watermarks.confirm(SqliteSubstateCache::shard_of(&id), StateVersion::new(100));
+        }
+        let cache = SqliteSubstateCache::new(
+            store,
+            watermarks,
+            MAX_SERVE_LAG,
+            Duration::from_secs(300),
+            HEAD_TTL,
+            1000,
+        );
+        cache
+            .write(
+                &id,
+                SubstateCacheEntryRef {
+                    version: None,
+                    substate_result: &SubstateResult::DoesNotExist,
+                    cached_at: now_unix_secs().unwrap(),
+                    verified: false,
+                },
+                FetchWatermark::new(100),
+            )
+            .await
+            .unwrap();
+        (dir, cache, id)
+    }
+
+    #[tokio::test]
+    async fn a_cached_nonexistence_answers_an_unversioned_read() {
+        let (_d, cache, id) = cache_with_nonexistence(true).await;
+        let entry = cache.read(&id, None).await.unwrap().expect("no entry");
+        assert_eq!(entry.version, None);
+        assert!(matches!(entry.substate_result, SubstateResult::DoesNotExist));
+    }
+
+    /// Nonexistence says the substate has no live version now, never what was true at some version
+    /// below - and after a destroyed substate is pruned, a substate that did have those versions can
+    /// answer `DoesNotExist` too. The versioned read goes to the committee.
+    #[tokio::test]
+    async fn a_cached_nonexistence_does_not_answer_a_versioned_read() {
+        let (_d, cache, id) = cache_with_nonexistence(true).await;
+        assert!(cache.read(&id, Some(0)).await.unwrap().is_none());
+        assert!(cache.read(&id, Some(3)).await.unwrap().is_none());
+    }
+
+    /// Unlike the down inference, nonexistence is a claim about current state, so it holds only while
+    /// the shard that would retract it is being kept up with.
+    #[tokio::test]
+    async fn a_cached_nonexistence_needs_a_watermark() {
+        let (_d, cache, id) = cache_with_nonexistence(false).await;
+        assert!(cache.read(&id, None).await.unwrap().is_none());
     }
 
     /// Above the head the cache knows nothing: this indexer is behind, or the substate never got there.

--- a/applications/tari_indexer/src/substate_cache.rs
+++ b/applications/tari_indexer/src/substate_cache.rs
@@ -57,11 +57,21 @@ fn now_unix_secs() -> Result<u64, SubstateCacheError> {
 /// An entry with no version settles nothing below it. Nonexistence says only that the substate has
 /// no live version now, and since a destroyed substate whose history has been pruned reports the
 /// same thing, it cannot be read as "never created": a versioned read goes to the committee.
+///
+/// It is also the one entry that needs the stream to be current, rather than merely recent, which is
+/// why `negative_serve_lag` is tighter than `max_serve_lag`. A head that is behind is still a lower
+/// bound on the real one, so age only makes it more certainly true; nonexistence is correct at the
+/// instant it is taken and false ever after if the substate has since been created. Every version
+/// the stream has not yet delivered is a version in which it may already be wrong, so it is served
+/// only while the stream is demonstrably alive.
 #[derive(Clone)]
 pub struct SqliteSubstateCache {
     store: SqliteIndexerStore,
     watermarks: Arc<ShardWatermarks>,
     max_serve_lag: Duration,
+    /// How recently the shard's stream must have been heard from before a record that a substate does
+    /// not exist may be served. See [`SqliteSubstateCache`].
+    negative_serve_lag: Duration,
     /// How long a substate stays journalled as recently changed. Only has to span a committee fetch.
     journal_retention: Duration,
     /// How long a recorded head is treated as evidence. The backstop for a head no transition can
@@ -74,6 +84,7 @@ impl std::fmt::Debug for SqliteSubstateCache {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SqliteSubstateCache")
             .field("max_serve_lag", &self.max_serve_lag)
+            .field("negative_serve_lag", &self.negative_serve_lag)
             .field("head_ttl", &self.head_ttl)
             .field("max_entries", &self.max_entries)
             .finish_non_exhaustive()
@@ -85,6 +96,7 @@ impl SqliteSubstateCache {
         store: SqliteIndexerStore,
         watermarks: Arc<ShardWatermarks>,
         max_serve_lag: Duration,
+        negative_serve_lag: Duration,
         journal_retention: Duration,
         head_ttl: Duration,
         max_entries: usize,
@@ -93,6 +105,7 @@ impl SqliteSubstateCache {
             store,
             watermarks,
             max_serve_lag,
+            negative_serve_lag,
             journal_retention,
             head_ttl,
             max_entries,
@@ -168,7 +181,11 @@ impl SubstateCache for SqliteSubstateCache {
             if version.is_some() {
                 return Ok(None);
             }
-            if self.watermarks.get(Self::shard_of(id), self.max_serve_lag).is_none() {
+            if self
+                .watermarks
+                .get(Self::shard_of(id), self.negative_serve_lag)
+                .is_none()
+            {
                 return Ok(None);
             }
             return Ok(Some(entry));
@@ -250,6 +267,7 @@ mod tests {
     use crate::storage_sqlite::SqliteIndexerStore;
 
     const MAX_SERVE_LAG: Duration = Duration::from_secs(60);
+    const NEGATIVE_SERVE_LAG: Duration = Duration::from_secs(30);
     const HEAD_TTL: Duration = Duration::from_secs(900);
 
     fn substate(n: u8) -> SubstateId {
@@ -272,6 +290,7 @@ mod tests {
             store,
             watermarks,
             MAX_SERVE_LAG,
+            NEGATIVE_SERVE_LAG,
             Duration::from_secs(300),
             HEAD_TTL,
             1000,
@@ -330,6 +349,13 @@ mod tests {
     }
 
     async fn cache_with_nonexistence(confirm_shard: bool) -> (tempfile::TempDir, SqliteSubstateCache, SubstateId) {
+        cache_with_nonexistence_at(confirm_shard, NEGATIVE_SERVE_LAG).await
+    }
+
+    async fn cache_with_nonexistence_at(
+        confirm_shard: bool,
+        negative_serve_lag: Duration,
+    ) -> (tempfile::TempDir, SqliteSubstateCache, SubstateId) {
         let dir = tempfile::tempdir().unwrap();
         let store = SqliteIndexerStore::try_create(dir.path().join("indexer.db")).unwrap();
         let watermarks = Arc::new(ShardWatermarks::new());
@@ -341,6 +367,7 @@ mod tests {
             store,
             watermarks,
             MAX_SERVE_LAG,
+            negative_serve_lag,
             Duration::from_secs(300),
             HEAD_TTL,
             1000,
@@ -385,6 +412,19 @@ mod tests {
     async fn a_cached_nonexistence_needs_a_watermark() {
         let (_d, cache, id) = cache_with_nonexistence(false).await;
         assert!(cache.read(&id, None).await.unwrap().is_none());
+    }
+
+    /// The two gates are independent, and nonexistence gets the tighter one. A head that is behind
+    /// is still a lower bound on the real one; nonexistence is true only while nothing has been
+    /// created since, which the stream is what tells us.
+    #[tokio::test]
+    async fn a_nonexistence_stops_being_served_before_a_head_does() {
+        let (_d, cache, id) = cache_with_nonexistence_at(true, Duration::ZERO).await;
+        assert!(cache.read(&id, None).await.unwrap().is_none());
+
+        // The same shard, at the same age, still answers for a head.
+        let (_d2, head_cache, head_id) = cache_with_head(6, true, Duration::ZERO).await;
+        assert!(head_cache.read(&head_id, None).await.unwrap().is_some());
     }
 
     /// Above the head the cache knows nothing: this indexer is behind, or the substate never got there.

--- a/applications/tari_indexer/src/substate_manager.rs
+++ b/applications/tari_indexer/src/substate_manager.rs
@@ -152,6 +152,11 @@ impl SubstateManager {
         self
     }
 
+    pub fn with_negative_cache_ttl(mut self, ttl: Duration) -> Self {
+        self.cache_manager = self.cache_manager.with_negative_cache_ttl(ttl);
+        self
+    }
+
     pub fn with_substate_proof_verification(mut self, enabled: bool) -> Self {
         self.cache_manager = self.cache_manager.with_substate_proof_verification(enabled);
         self

--- a/crates/indexer_lib/src/cached_substate_manager.rs
+++ b/crates/indexer_lib/src/cached_substate_manager.rs
@@ -58,7 +58,7 @@ use tari_validator_node_rpc::client::{
 
 use crate::{
     error::IndexerError,
-    substate_cache::{SubstateCache, SubstateCacheEntry, SubstateCacheEntryRef},
+    substate_cache::{SubstateCache, SubstateCacheEntry, SubstateCacheEntryRef, caches_nonexistence},
 };
 
 const LOG_TARGET: &str = "tari::indexer::scanner";
@@ -66,6 +66,13 @@ const LOG_TARGET: &str = "tari::indexer::scanner";
 /// Coarse staleness backstop for everything the cache holds. Correctness rests on invalidation from
 /// the transition stream, so this bounds only the cases that stream cannot correct.
 pub const DEFAULT_CACHE_TTL: Duration = Duration::from_secs(900);
+
+/// Staleness backstop for a cached `DoesNotExist`, held shorter than [`DEFAULT_CACHE_TTL`].
+///
+/// A creation retracts the entry through the transition stream, so this bounds only the case where
+/// that stream does not deliver. It is kept short because it is the one entry whose staleness a
+/// caller feels as an absence: a substate it is waiting for stays missing until this expires.
+pub const DEFAULT_NEGATIVE_CACHE_TTL: Duration = Duration::from_secs(60);
 
 /// A store of committee-validated shard-group state merkle roots that the read path consults to
 /// avoid re-validating a served commit proof's QC chain when its root is already trusted.
@@ -102,6 +109,8 @@ pub struct CachedSubstateManager<TEpochManager, TVnClient, TSubstateCache> {
     /// invalidation, so this exists to bound how long a value may be served if the transitions that
     /// would have retracted it never arrive.
     cache_ttl: Duration,
+    /// Staleness backstop for a cached `DoesNotExist`. See [`DEFAULT_NEGATIVE_CACHE_TTL`].
+    negative_cache_ttl: Duration,
     /// When set, substates fetched from a validator must come with a proof that verifies against the
     /// shard group committee, or they are rejected (fail-closed). The negative `DoesNotExist` case
     /// is not provable and is left to the existing f+1 agreement.
@@ -132,6 +141,7 @@ where
             validator_node_client_factory,
             substate_cache,
             cache_ttl: DEFAULT_CACHE_TTL,
+            negative_cache_ttl: DEFAULT_NEGATIVE_CACHE_TTL,
             verify_substate_proofs: false,
             trusted_root_store: None,
             #[cfg(feature = "metrics")]
@@ -141,6 +151,11 @@ where
 
     pub fn with_cache_ttl(mut self, ttl: Duration) -> Self {
         self.cache_ttl = ttl;
+        self
+    }
+
+    pub fn with_negative_cache_ttl(mut self, ttl: Duration) -> Self {
+        self.negative_cache_ttl = ttl;
         self
     }
 
@@ -177,14 +192,22 @@ where
         debug!(target: LOG_TARGET, "get_substate: {}v{}", substate_id, specific_version.display());
         let cache_res = self.substate_cache.read(substate_id, specific_version).await?;
         if let Some(entry) = cache_res {
-            // An unverified entry (e.g. written by the batch path or before verification was
-            // enabled) is never served while verification is on: refetch so it can be replaced with
-            // a proven copy.
-            if entry.verified || !self.verify_substate_proofs {
+            // Absence has nothing to prove against the state tree, so a cached nonexistence is never
+            // verified and gating it on a proof would mean never serving one. Its evidence is the
+            // f+1 agreement that produced it. Every other entry that is unverified (e.g. written by
+            // the batch path or before verification was enabled) is refetched while verification is
+            // on, so it can be replaced with a proven copy.
+            let is_nonexistence = matches!(entry.substate_result, SubstateResult::DoesNotExist);
+            if is_nonexistence || entry.verified || !self.verify_substate_proofs {
+                let ttl = if is_nonexistence {
+                    self.negative_cache_ttl
+                } else {
+                    self.cache_ttl
+                };
                 let now = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)?.as_secs();
                 let age = now.saturating_sub(entry.cached_at);
-                if age <= self.cache_ttl.as_secs() {
-                    debug!(target: LOG_TARGET, "Substate cache hit for {} with version {}", substate_id, entry.version);
+                if age <= ttl.as_secs() {
+                    debug!(target: LOG_TARGET, "Substate cache hit for {} with version {}", substate_id, entry.version.display());
                     #[cfg(feature = "metrics")]
                     self.metrics.as_ref().inspect(|m| m.inc_cache_hits());
                     return Ok(SubstateLookupResult {
@@ -197,7 +220,7 @@ where
                     target: LOG_TARGET,
                     "Cached substate {} at v{} has aged out ({}s). Fetching from committee.",
                     substate_id,
-                    entry.version,
+                    entry.version.display(),
                     age,
                 );
             }
@@ -213,15 +236,26 @@ where
             .fetch_substate_from_committee(substate_id, specific_version)
             .await?;
 
-        if let (Some(watermark), Some(version)) = (watermark, lookup_result.result.version()) {
+        if let Some(watermark) = watermark {
             // The cache holds each substate's head version. A live version is always the head, and a
             // lookup that named no version answers with the head; a named version that came back down
             // says only that the head is higher.
-            let is_head = specific_version.is_none() || lookup_result.result.up().is_some();
+            let is_head = match &lookup_result.result {
+                SubstateResult::Up { .. } => true,
+                SubstateResult::Down { .. } => specific_version.is_none(),
+                // Having no live version is as much a statement about the head as naming one, but
+                // only for the substates whose nonexistence the stream is able to retract.
+                SubstateResult::DoesNotExist => specific_version.is_none() && caches_nonexistence(substate_id),
+            };
             // Unverified results are not cached while verification is on, so the next read retries
-            // for a proven copy instead of pinning the unverified value.
-            if is_head && (lookup_result.verified || !self.verify_substate_proofs) {
-                debug!(target: LOG_TARGET, "Updating cached substate {} with version {}", substate_id, version);
+            // for a proven copy instead of pinning the unverified value. Nonexistence is exempt: it
+            // has no proof to wait for.
+            let admissible = lookup_result.verified ||
+                !self.verify_substate_proofs ||
+                matches!(lookup_result.result, SubstateResult::DoesNotExist);
+            if is_head && admissible {
+                let version = lookup_result.result.version();
+                debug!(target: LOG_TARGET, "Updating cached substate {} with version {}", substate_id, version.display());
                 let entry = SubstateCacheEntryRef {
                     version,
                     substate_result: &lookup_result.result,
@@ -317,7 +351,7 @@ where
                         };
                         // The batch RPC does not carry proofs, so these entries are always unverified.
                         let entry = SubstateCacheEntryRef {
-                            version: substate.version(),
+                            version: Some(substate.version()),
                             substate_result: &substate_result,
                             cached_at: SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)?.as_secs(),
                             verified: false,

--- a/crates/indexer_lib/src/substate_cache.rs
+++ b/crates/indexer_lib/src/substate_cache.rs
@@ -49,18 +49,38 @@ impl FetchWatermark {
     }
 }
 
+/// Whether the cache holds `DoesNotExist` for this substate.
+///
+/// A cached negative saves the most expensive lookup there is: `DoesNotExist` is the one answer that
+/// cannot short-circuit on the first good response, so it costs a walk of `f + 1` committee members
+/// every time. It is correct only while the transition stream can retract it, and each retraction
+/// costs a journal row for a creation that would otherwise write none, so it is worth holding only
+/// where the saving is repeated.
+///
+/// Transaction receipts are excluded. They are created once and never updated - the bulk of the
+/// stream by count - so they carry nearly all of that journal cost, and a receipt the indexer has
+/// synced is answered from its own tables without a committee walk at all. What is left is the
+/// caller polling for a receipt that does not exist yet, which is the one case a cached negative
+/// delays rather than serves.
+pub fn caches_nonexistence(id: &SubstateId) -> bool {
+    !id.is_transaction_receipt()
+}
+
 #[derive(Debug, Clone)]
 pub struct SubstateCacheEntry {
-    pub version: u32,
+    /// The substate's head version, or `None` when the substate does not exist.
+    pub version: Option<u32>,
     pub substate_result: SubstateResult,
     pub cached_at: u64,
-    /// True if the value was committee-verified when it was fetched.
+    /// True if the value was committee-verified when it was fetched. Never true for a substate that
+    /// does not exist: absence has nothing to prove against the state tree.
     pub verified: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
 pub struct SubstateCacheEntryRef<'a> {
-    pub version: u32,
+    /// The substate's head version, or `None` when the substate does not exist.
+    pub version: Option<u32>,
     pub substate_result: &'a SubstateResult,
     pub cached_at: u64,
     pub verified: bool,
@@ -80,6 +100,9 @@ pub trait SubstateCache: Send + Sync {
     ///
     /// A version below the cached one is answered without any watermark: see
     /// [`SubstateCache::write`] for what the cache holds and why that conclusion cannot go stale.
+    ///
+    /// A cached nonexistence answers an unversioned read only. It says the substate has no live
+    /// version, never what was true at some version below, so a versioned read misses.
     fn read(
         &self,
         id: &SubstateId,
@@ -94,6 +117,11 @@ pub trait SubstateCache: Send + Sync {
     /// be written: an `Up` version is always the head, since upping a substate downs its predecessor,
     /// and a lookup that named no version answers with the head by definition. A named version that
     /// came back `Down` establishes only that the head is higher, not what it is.
+    ///
+    /// An entry with no version records that the substate does not exist, which an unversioned
+    /// lookup establishes as much as any version does. Only substates [`caches_nonexistence`] admits
+    /// may be written that way: the stream retracts such an entry through a journal row that a
+    /// creation writes for no other reason.
     fn write(
         &self,
         id: &SubstateId,


### PR DESCRIPTION
> **Depends on the streaming work.** This was blocked and drafted until #2517 and #2523 merged. Serving a cached nonexistence is only sound while the transition stream that would retract it is current, which the 60s scan interval could not provide. Rebased onto `bfa9c6e43` and un-drafted on that basis.

Follow-up to #2498. Adds the one result the substate cache refused to hold.

## Why

`DoesNotExist` is the most expensive lookup the indexer makes. `Up` and `Down` return on the first acceptable response; absence has nothing to prove against the state tree, so it is settled by `f + 1` agreement and walks that many committee members — every time, because it was also the one result the cache would not keep.

## Recording it

A cache row with **no version**, not a sentinel. A version is a `u32` and the column is a signed integer, so every value that could stand in for "no version" is one a real head could legitimately take — `-1` collides with `u32::MAX`, and the whole top half of the range lands in the negative space with it. Nullable avoids the question, and `Option`'s own ordering then gives the head-ranking rule for free: nonexistence yields to any version, any version displaces it.

Two gates in `CachedSubstateManager` had to admit it:

- **Serve** — exempt from the proof requirement. A cached nonexistence is never `verified`, so gating it on a proof would mean never serving one. Its evidence is the f+1 agreement that produced it, which is exactly what the uncached path returns.
- **Write** — an unversioned lookup that came back absent establishes the head as much as one that named a version.

## The journal row, and why it is scoped

Retracting a cached negative costs a journal row where none was written before. A first creation retires no version — there is none below 0 — so `created()` returned `None` and **neither** the delete nor the journal insert ran. Both are needed, and they do different jobs:

- the **delete** clears an entry already cached;
- only the **journal** stops a fetch that was already in flight when the creation committed, because that delete runs before there is a row to delete.

Emitting one for every creation would put a row on the sync commit path for each created-once substate in the stream, so it is emitted only where the entry it retracts can exist (`caches_nonexistence`, shared by the invalidation builder and the write gate so the two cannot diverge).

**Transaction receipts are excluded.** Created once and never updated, they are the bulk of the stream by count and would carry nearly all of that cost; a synced receipt is answered from the indexer's own tables without a committee walk at all; and what is left is a caller polling for one that does not exist yet — the single case where a cached negative delays rather than serves.

## Versioned reads still miss

Since #2490 a destroyed substate whose history has been pruned also reports `DoesNotExist`, so a cached negative cannot be read as "never created". It answers an unversioned read only.

## TTL

Correctness rests on the retraction, so the TTL is only a backstop for a stream that does not deliver. Nonexistence gets its own shorter one (60s, `substate_cache_negative_ttl`) because it is the entry whose staleness a caller feels as an absence — a substate being waited on stays missing until it expires.

## Migration

`2026-09-02-000000_substate_cache_nonexistence` drops and recreates `substate_cache` with a nullable version. The cache refills from the committee on demand, so there is nothing to migrate. Verified up and down against sqlite directly, including that `version <= N` does not match a null row (hence the separate `is null` delete).

Not added to `PublishedIndexerConfig`, so no openapi or bindings regeneration. A client using the published `substate_cache_max_serve_lag` as its staleness bound over-estimates for negatives, which errs in the safe direction; happy to publish it if you'd rather it be explicit.

## Serving is gated on stream liveness, not on a staleness budget

A cached head and a cached nonexistence age differently, so they get different bounds.

A head that is behind is still a lower bound on the real one — waiting only makes it more certainly true — so it keeps the loose `substate_cache_max_serve_lag` (300s). Nonexistence is correct at the instant it is taken and false ever after if the substate has since been created, so every version the stream has not yet delivered is a version in which it may already be wrong.

It is therefore served only while the shard's stream is demonstrably alive: `negative_serve_lag`, derived as `state_sync_keepalive_interval * 3`. Derived rather than configured because it is a liveness test, not a staleness budget — a standalone setting could be left behind when the keepalive interval changes. Three intervals tolerates two lost keepalives, enough to ride out an ordinary stream reopen without holding a dead one open.

Reusing `max_serve_lag` here would have meant thirty missed keepalives — a dead stream answering "does not exist" for five minutes, which is the failure that blocked this PR in the first place.

## Testing

The unit tests cannot reach the case that matters, so `Test Results (CI)` is the verdict: the two `transfer.feature` scenarios that create an account and immediately use it are the ones this feature can break, and they were red on the pre-streaming heads.

## Tests

107 pass in `tari_indexer`. The new ones cover the first-creation retraction, the mid-fetch race, destroy leaving a negative alone, the `Option` head ordering, the versioned-read miss, and the watermark requirement. Mutation-checked the two load-bearing guards:

- reverting `created()` to skip first creations fails `a_first_creation_retires_the_nonexistence_it_denies`, `a_creation_landing_mid_fetch_vetoes_the_nonexistence` and the model test;
- dropping the versioned-read guard fails `a_cached_nonexistence_does_not_answer_a_versioned_read`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
