### PR TITLE
fix(consensus): re-record justified-block evidence on the surviving branch

### DIFF
--- a/crates/consensus/src/hotstuff/common.rs
+++ b/crates/consensus/src/hotstuff/common.rs
@@ -30,6 +30,7 @@ use tari_ootle_storage::{
         EpochCheckpoint,
         PendingShardStateTreeDiff,
         SubstateChange,
+        TransactionRecord,
         TreeRootSummary,
         ValidatorConsensusStats,
     },
@@ -493,13 +494,24 @@ pub fn process_newly_justified_block<TTx: StateStoreReadTransaction>(
                 .get_transaction_pool_record(tx, new_leaf_block, atom.id())
                 .optional()?
             else {
-                // A transaction that has left the pool has been finalized, so it has no evidence left to update.
-                debug!(
-                    target: LOG_TARGET,
-                    "Transaction {} in newly justified block {} is no longer in the pool",
-                    atom.id(),
-                    new_leaf_block,
-                );
+                // Finalizing a transaction removes its pool record, and a finalized transaction has no evidence
+                // left to update. Any other absence leaves the transaction unable to make progress.
+                if TransactionRecord::is_record_finalized(tx, atom.id())? {
+                    debug!(
+                        target: LOG_TARGET,
+                        "Transaction {} in justified block {} is finalized and no longer in the pool",
+                        atom.id(),
+                        block,
+                    );
+                } else {
+                    warn!(
+                        target: LOG_TARGET,
+                        "❓️ Transaction {} in justified block {} is not in the pool and is not finalized. Its \
+                         evidence cannot be updated.",
+                        atom.id(),
+                        block,
+                    );
+                }
                 continue;
             };
 
@@ -511,7 +523,7 @@ pub fn process_newly_justified_block<TTx: StateStoreReadTransaction>(
                 debug!(
                     target: LOG_TARGET,
                     "🔍 Updating evidence for LocalPrepare command in block {} for transaction {}. {}",
-                    new_leaf_block,
+                    block,
                     atom.id(),
                     pool_tx.evidence()
                 );
@@ -523,7 +535,7 @@ pub fn process_newly_justified_block<TTx: StateStoreReadTransaction>(
                 debug!(
                     target: LOG_TARGET,
                     "🔍 Updating evidence for LocalAccept command in block {} for transaction {}. {}",
-                    new_leaf_block,
+                    block,
                     atom.id(),
                     pool_tx.evidence()
                 );
@@ -537,7 +549,7 @@ pub fn process_newly_justified_block<TTx: StateStoreReadTransaction>(
                     target: LOG_TARGET,
                     "✅ Justified block: Setting READY for transaction {} in block {}",
                     atom.id(),
-                    new_leaf_block,
+                    block,
                 );
                 pool_tx.set_ready(true);
             }

--- a/crates/consensus/src/hotstuff/common.rs
+++ b/crates/consensus/src/hotstuff/common.rs
@@ -438,6 +438,11 @@ pub(crate) fn get_highest_seen_justified_view<TTx: StateStoreReadTransaction>(
     Ok(high_pc.max(high_tc))
 }
 
+/// Records the prepare/accept evidence for the commands in `new_leaf_block` and its not-yet-justified ancestors,
+/// now that `justify_id` justifies them, and marks any transaction that this completes as ready to propose.
+///
+/// The updates are written to `change_set`, which only ever applies to the branch its block is on, so every branch
+/// that justifies `new_leaf_block` must call this for itself.
 #[allow(clippy::too_many_lines)]
 pub fn process_newly_justified_block<TTx: StateStoreReadTransaction>(
     tx: &TTx,
@@ -488,11 +493,14 @@ pub fn process_newly_justified_block<TTx: StateStoreReadTransaction>(
                 .get_transaction_pool_record(tx, new_leaf_block, atom.id())
                 .optional()?
             else {
-                return Err(HotStuffError::InvariantError(format!(
-                    "Transaction {} in newly justified block {} not found in the pool",
+                // A transaction that has left the pool has been finalized, so it has no evidence left to update.
+                debug!(
+                    target: LOG_TARGET,
+                    "Transaction {} in newly justified block {} is no longer in the pool",
                     atom.id(),
                     new_leaf_block,
-                )));
+                );
+                continue;
             };
 
             if cmd.is_local_prepare() {
@@ -539,11 +547,6 @@ pub fn process_newly_justified_block<TTx: StateStoreReadTransaction>(
 
         timer.with_iterations(num_applicable_commands);
         Ok(())
-    }
-
-    // Nothing to do if the block has been marked as justified
-    if new_leaf_block.justify_qc_id() == Some(justify_id) {
-        return Ok(vec![]);
     }
 
     // Update the pending transaction pool state for the chain of newly justified blocks.

--- a/crates/consensus/src/hotstuff/on_propose.rs
+++ b/crates/consensus/src/hotstuff/on_propose.rs
@@ -441,10 +441,8 @@ where TConsensusSpec: ConsensusSpec
             // Add all (ABORT) executions that may have resulted from foreign proposals
             executed_transactions.extend(change_set.take_all_transaction_executions());
 
-            if !justify_block.has_justify_qc() {
-                // TODO: we dont need to process transactions here that are not in the batch
-                process_newly_justified_block(tx, &justify_block, high_qc_id, local_committee_info, &mut change_set)?;
-            }
+            // TODO: we dont need to process transactions here that are not in the batch
+            process_newly_justified_block(tx, &justify_block, high_qc_id, local_committee_info, &mut change_set)?;
         }
 
         let locked_epoch = LockedEpoch::new(

--- a/crates/consensus/src/hotstuff/on_ready_to_vote_on_local_block.rs
+++ b/crates/consensus/src/hotstuff/on_ready_to_vote_on_local_block.rs
@@ -154,18 +154,15 @@ where TConsensusSpec: ConsensusSpec
         // Process newly justified block
         let mut justified_block = Block::get_justified_block(&**tx, valid_block.justify(), valid_block.epoch())?;
         // This comes before decide so that all evidence can be in place before LocalPrepare and LocalAccept
-        if !justified_block.has_justify_qc() {
-            // We need to process this before to ensure that we have the latest state when checking the new block
-            let processed_blocks =
-                process_newly_justified_block(&**tx, &justified_block, block_qc_id, local_committee_info, change_set)?;
-            for mut block in processed_blocks {
-                block.add_justify_qc(tx, &block_qc_id)?;
-            }
-            justified_block.add_justify_qc(tx, &block_qc_id)?;
-            // Even if we do not yet see the next epoch (e.g. race condition), if a majority have, we allow the
-            // epoch end to be proposed.
-            can_propose_epoch_end |= justified_block.is_epoch_end();
+        let processed_blocks =
+            process_newly_justified_block(&**tx, &justified_block, block_qc_id, local_committee_info, change_set)?;
+        for mut block in processed_blocks {
+            block.add_justify_qc(tx, &block_qc_id)?;
         }
+        justified_block.add_justify_qc(tx, &block_qc_id)?;
+        // Even if we do not yet see the next epoch (e.g. race condition), if a majority have, we allow the
+        // epoch end to be proposed.
+        can_propose_epoch_end |= justified_block.is_epoch_end();
 
         if self.should_vote(&**tx, valid_block.block())? {
             let parent = valid_block.block().get_parent(&**tx)?;

--- a/crates/storage/src/consensus_models/block.rs
+++ b/crates/storage/src/consensus_models/block.rs
@@ -418,10 +418,17 @@ impl Block {
         self.timeout_certificate.as_ref()
     }
 
+    /// Whether some branch has justified this block.
+    ///
+    /// This is stamped by a block carrying a QC over this one, before that block is voted on, and stays
+    /// stamped across the whole block store even where that branch is later abandoned. Work whose result
+    /// belongs to one branch must therefore key off that branch rather than off this flag.
     pub fn has_justify_qc(&self) -> bool {
         self.justify_qc_id.is_some()
     }
 
+    /// The id of a QC over this block, as last recorded by [`Self::add_justify_qc`]. Carries the same
+    /// whole-store scope as [`Self::has_justify_qc`].
     pub fn justify_qc_id(&self) -> Option<PcId> {
         self.justify_qc_id
     }


### PR DESCRIPTION
## Summary

Fixes the flaky `consensus_tests leader_failure::multi_shard_node_goes_down`, which is a real consensus liveness bug, not a test artifact.

The prepare/accept evidence for a block's `LocalPrepare`/`LocalAccept` commands is recorded by the block that *justifies* it, into that block's `ProposedBlockChangeSet`. A change set only ever applies to the branch its block is on, but the "already justified" guard was a persisted per-block flag: the first block to justify `B` stamped `B.justify_qc_id` straight to the block store (`Block::add_justify_qc` writes to the write tx directly), whether or not that block went on to be certified. Every later block that justified `B` then skipped `process_newly_justified_block`, so when the branch that stamped it was abandoned the evidence went with it.

A multi-shard transaction whose local accept evidence is lost this way sits in the pool at `LocalAccepted` with `is_ready=false` and local evidence stuck at `PREPARED (need accept)`. The foreign shard group has already sent its `LocalAccept` foreign proposal, so nothing will mark it ready again — the shard group proposes empty blocks forever while `has_ready_or_pending_transaction_updates` reports nothing to do and the pool never drains.

## The failure in CI

From [run 33536033189](https://github.com/tari-project/tari-ootle/actions/runs/33536033189/job/99950450348?pr=2501), where the leader that would have certified the justifying block was the offline validator:

| block | what happened |
|---|---|
| h7 `084ddace` | 10 `LocalAccept` commands, evidence `SG(1-128): PREPARED (need accept)` |
| h8 `50d9ad60` | justifies h7 → evidence `SG(1-128): ACCEPTED`, **and stamps `justify_qc_id` on h7** |
| — | h8 never gets a QC (votes go to the offline node 4, leader of height 8) → TC at h9, dummy h8/h9 built from h7, **h8 orphaned** |
| h10 `ed84e8f7` | justifies h7 again → guard says already justified → **skipped**; record loads back as `PREPARED (need accept)` |
| h16/h17 | foreign `LocalAccept` from `SG(129-256)` arrives → `NOT ready for AllAccept … All Justified: false` |
| h18…h51 | 0 cmd(s) every block, 11 transactions stuck in the pool, test times out at the height limit |

`🔍 Updating evidence for LocalAccept command … NodeHeight(7)` appears exactly once in the whole run — inside the orphaned block.

It is flaky because it needs the block immediately after a `LocalAccept`-carrying block to be orphaned, i.e. the offline validator has to land as leader one height later.

## The fix

Always run `process_newly_justified_block` so each branch records the evidence for itself, and drop the two guards that assumed the flag was branch-local:

- `common.rs` — remove the `new_leaf_block.justify_qc_id() == Some(justify_id)` early return. Both the abandoned block and the block that replaces it carry the *same* QC over the justified block, so this fired on exactly the case that needs re-recording.
- `on_ready_to_vote_on_local_block.rs` / `on_propose.rs` — remove the `!justified_block.has_justify_qc()` guard.

Persisting the flag only on `change_set.save()` would not help: validators voted Accept on the orphaned block and saved its change set; the block died afterwards.

The parent walk still terminates on the first ancestor carrying a justify QC, so the extra work is bounded — in an unforked chain each block justifies a different parent and nothing is recomputed. A transaction that has left the pool is now skipped rather than raising an invariant error, since a finalized transaction has no evidence left to update; that path becomes reachable now that a late sibling can re-justify a block whose transactions have since been finalized.

## Test plan

- [x] `cargo test -p consensus_tests` — 67 passed, 0 failed
- [x] `cargo clippy -p tari_consensus --all-targets` — no new warnings

I could not land a deterministic regression test for this. Reproducing it needs a block to be evaluated by a quorum (so it stamps the flag) and then abandoned, and every way to do that from the harness's message filter runs into the same two walls: dropping the block's votes still lets the next leader build the certificate out of the `last_vote` piggybacked on NEWVIEWs, and withholding the block from enough validators to deny the quorum also denies them the parent's certificate, so whichever of them wins the timeout round forks from further back and the scenario evaporates. Both hinge on which validator wins which timeout round, which is exactly the race that makes `multi_shard_node_goes_down` flaky in the first place. Doing it properly wants a harness hook (suppress voting on a chosen block, or drop `last_vote` while keeping the timeout vote) — happy to add that separately if it is wanted here.
