### PR TITLE
fix(engine): cap wasmer to 7.1.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -287,8 +287,12 @@ ts-rs = { version = "11.0", features = [
     "indexmap-impl",
 ] }
 url = "2.4.1"
-wasmer = "7.1.0"
-wasmer-middlewares = "7.1.0"
+# Capped to 7.1.x. The accepted-module set and memory tunables are consensus-critical and wasmer
+# reshapes both across minor releases, so a bump must be a deliberate, reviewed change. 7.2+ also
+# requires wasm-bindgen >=0.2.120, which cannot coexist with the libp2p fork's `=0.4.58`
+# wasm-bindgen-futures pin.
+wasmer = "~7.1.0"
+wasmer-middlewares = "~7.1.0"
 zeroize = "1"
 webauthn-rs = { version = "0.5.1", features = ["default"] }
 webauthn-rs-proto = { version = "0.5.1", features = ["default"] }


### PR DESCRIPTION
## Problem

`Cargo.toml` declared `wasmer = "7.1.0"`, i.e. `^7.1.0`. Any consumer that resolves `tari_engine` without this workspace's `Cargo.lock` gets **wasmer 7.4.0**, which removed `BaseTunables::for_target`:

```
error[E0599]: no function or associated item named `for_target` found for struct `BaseTunables`
  --> crates/engine/src/wasm/module.rs:171
```

`WasmModule::create_engine` calls it, so the **published `tari_engine` 0.39.3 and 0.40.0 do not compile** against a fresh resolve. This is what breaks the template test steps (verified: all 9 fail identically on `main`; pinning wasmer to 7.3.0 makes the 0.40 stack build and the counter test pass).

## Fix

Cap the requirement at `~7.1.0`.

Verified: `cargo check -p tari_engine` passes with no `Cargo.lock` change, and a scratch crate depending on `tari_engine` by path with **no lockfile** now resolves `wasmer 7.1.0` instead of 7.4.0.

## Why cap rather than migrate to 7.4

1. **Consensus surface.** The accepted-module set and memory tunables are consensus-critical. 7.4.0 didn't just rename an API — `BaseTunables` lost its static-bound/guard-size fields and `MemoryStyle::Static` became field-less. Moving the engine onto that should be a deliberate, reviewed change, not whatever a fresh resolve picks.
2. **7.2+ can't resolve in this workspace anyway.** wasmer ≥ 7.2.1 requires `wasm-bindgen >=0.2.120`; the libp2p fork pins `wasm-bindgen-futures = "=0.4.58"` → `wasm-bindgen =0.2.108`, and the two are semver-incompatible:

```
error: failed to select a version for `wasm-bindgen`.
    ... required by package `wasmer v7.4.0`
  previously selected package `wasm-bindgen v0.2.108`
    ... which satisfies dependency `wasm-bindgen = "=0.2.108"` of package `wasm-bindgen-futures v0.4.58`
    ... of package `libp2p-swarm` (tari-project/rust-libp2p @ e318826)
```

The pin is also present on upstream `libp2p/rust-libp2p` master (it caps wasm-bindgen to keep `gloo-timers 0.2.6` compiling for wasm32), so lifting it is not a local decision.

## Follow-ups

- **Republish `tari_engine`.** The cap only reaches template consumers once published; 0.39.3 / 0.40.0 stay broken until then. `scripts/crate_versioning.py impact tari_engine` says patch bump, no dependent republish required.
- **wasmer 7.4 migration** — blocked on the libp2p wasm-bindgen cap. The engine-side change itself is two lines (`BaseTunables::new()`, drop the `Target` import) and compiles cleanly; confirmed locally by patching the wasm-bindgen pin out of the graph.