### PR TITLE
fix(walletd): answer a missing substate as not found, not a general error

### DIFF
--- a/applications/tari_walletd/src/handlers/error.rs
+++ b/applications/tari_walletd/src/handlers/error.rs
@@ -5,6 +5,4 @@
 pub enum HandlerError {
     #[error("Error: {0}")]
     Anyhow(#[from] anyhow::Error),
-    #[error("Not found")]
-    NotFound,
 }

--- a/applications/tari_walletd/src/handlers/helpers.rs
+++ b/applications/tari_walletd/src/handlers/helpers.rs
@@ -9,7 +9,10 @@ use tari_engine_types::{
     component::derive_component_address_from_public_key,
     confidential::{AbridgedTransactionKernel, EncodedMerkleProof, MinotariBurnClaimProof},
 };
-use tari_ootle_common_types::{SubstateRequirement, optional::Optional};
+use tari_ootle_common_types::{
+    SubstateRequirement,
+    optional::{IsNotFoundError, Optional},
+};
 use tari_ootle_transaction::TransactionId;
 use tari_ootle_wallet_sdk::{
     WalletSdk,
@@ -175,6 +178,30 @@ pub(super) fn not_found<T: Display>(details: T) -> anyhow::Error {
     .into()
 }
 
+/// Answers a missing resource as [`not_found`] rather than as a general error.
+///
+/// A caller asking for something that does not exist yet - an account it has just created, an input
+/// whose creating transaction has not reached the indexer - has to be able to tell that apart from
+/// the wallet failing. Only the first is worth retrying, and a general error tells it the opposite.
+///
+/// The distinction is already carried by [`IsNotFoundError`]; this puts it where the JSON-RPC layer
+/// reads it, keeping the error's own message.
+pub(super) trait OrNotFound<T> {
+    fn or_not_found(self) -> Result<T, anyhow::Error>;
+}
+
+impl<T, E: IsNotFoundError + Into<anyhow::Error>> OrNotFound<T> for Result<T, E> {
+    fn or_not_found(self) -> Result<T, anyhow::Error> {
+        self.map_err(|e| {
+            if e.is_not_found_error() {
+                not_found(e.into())
+            } else {
+                e.into()
+            }
+        })
+    }
+}
+
 pub(super) fn invalid_request<T: Display>(details: T) -> anyhow::Error {
     application_error(
         ApplicationErrorCode::InvalidRequest,
@@ -253,4 +280,44 @@ pub(crate) fn complete_burn_proof_to_contents(proof: CompleteClaimBurnProof) -> 
         },
         encrypted_data,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use axum_jrpc::error::{JsonRpcError, JsonRpcErrorReason};
+
+    use super::*;
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("{0}")]
+    struct TestError(&'static str);
+
+    impl IsNotFoundError for TestError {
+        fn is_not_found_error(&self) -> bool {
+            self.0 == "missing"
+        }
+    }
+
+    fn is_not_found_code(e: &anyhow::Error) -> bool {
+        matches!(
+            e.downcast_ref::<JsonRpcError>().map(|e| e.error_reason()),
+            Some(JsonRpcErrorReason::ApplicationError(code)) if code == ApplicationErrorCode::NotFound as i32
+        )
+    }
+
+    #[test]
+    fn a_missing_resource_is_answered_as_not_found() {
+        let err = Result::<(), _>::Err(TestError("missing")).or_not_found().unwrap_err();
+        assert!(is_not_found_code(&err));
+        // The error keeps its own message rather than being flattened to "not found".
+        assert!(err.to_string().contains("missing"));
+    }
+
+    /// Only a missing resource is retryable, so nothing else may be reported as one.
+    #[test]
+    fn any_other_failure_is_left_alone() {
+        let err = Result::<(), _>::Err(TestError("broken")).or_not_found().unwrap_err();
+        assert!(!is_not_found_code(&err));
+        assert!(err.downcast_ref::<TestError>().is_some());
+    }
 }

--- a/applications/tari_walletd/src/handlers/helpers.rs
+++ b/applications/tari_walletd/src/handlers/helpers.rs
@@ -306,7 +306,7 @@ mod tests {
     }
 
     #[test]
-    fn a_missing_resource_is_answered_as_not_found() {
+    fn a_not_found_error_keeps_its_message() {
         let err = Result::<(), _>::Err(TestError("missing")).or_not_found().unwrap_err();
         assert!(is_not_found_code(&err));
         // The error keeps its own message rather than being flattened to "not found".

--- a/applications/tari_walletd/src/handlers/helpers.rs
+++ b/applications/tari_walletd/src/handlers/helpers.rs
@@ -178,20 +178,21 @@ pub(super) fn not_found<T: Display>(details: T) -> anyhow::Error {
     .into()
 }
 
-/// Answers a missing resource as [`not_found`] rather than as a general error.
+/// Answers a missing thing with the JSON-RPC not-found code rather than as a general error.
 ///
 /// A caller asking for something that does not exist yet - an account it has just created, an input
 /// whose creating transaction has not reached the indexer - has to be able to tell that apart from
 /// the wallet failing. Only the first is worth retrying, and a general error tells it the opposite.
 ///
 /// The distinction is already carried by [`IsNotFoundError`]; this puts it where the JSON-RPC layer
-/// reads it, keeping the error's own message.
-pub(super) trait OrNotFound<T> {
-    fn or_not_found(self) -> Result<T, anyhow::Error>;
+/// reads it, keeping the error's own message. Named for that layer because that is the whole of what
+/// it does: the error it produces means something only to a JSON-RPC caller.
+pub(super) trait OrJrpcNotFound<T> {
+    fn or_jrpc_not_found(self) -> Result<T, anyhow::Error>;
 }
 
-impl<T, E: IsNotFoundError + Into<anyhow::Error>> OrNotFound<T> for Result<T, E> {
-    fn or_not_found(self) -> Result<T, anyhow::Error> {
+impl<T, E: IsNotFoundError + Into<anyhow::Error>> OrJrpcNotFound<T> for Result<T, E> {
+    fn or_jrpc_not_found(self) -> Result<T, anyhow::Error> {
         self.map_err(|e| {
             if e.is_not_found_error() {
                 not_found(e.into())
@@ -307,7 +308,9 @@ mod tests {
 
     #[test]
     fn a_not_found_error_keeps_its_message() {
-        let err = Result::<(), _>::Err(TestError("missing")).or_not_found().unwrap_err();
+        let err = Result::<(), _>::Err(TestError("missing"))
+            .or_jrpc_not_found()
+            .unwrap_err();
         assert!(is_not_found_code(&err));
         // The error keeps its own message rather than being flattened to "not found".
         assert!(err.to_string().contains("missing"));
@@ -316,7 +319,9 @@ mod tests {
     /// Only a missing resource is retryable, so nothing else may be reported as one.
     #[test]
     fn any_other_failure_is_left_alone() {
-        let err = Result::<(), _>::Err(TestError("broken")).or_not_found().unwrap_err();
+        let err = Result::<(), _>::Err(TestError("broken"))
+            .or_jrpc_not_found()
+            .unwrap_err();
         assert!(!is_not_found_code(&err));
         assert!(err.downcast_ref::<TestError>().is_some());
     }

--- a/applications/tari_walletd/src/handlers/transaction.rs
+++ b/applications/tari_walletd/src/handlers/transaction.rs
@@ -47,16 +47,14 @@ use tokio::time;
 use super::context::HandlerContext;
 use crate::{
     WalletSdk,
-    handlers::{
-        HandlerError,
-        helpers::{
-            get_account,
-            get_account_or_default,
-            invalid_params,
-            invalid_request,
-            not_found,
-            transaction_rejected,
-        },
+    handlers::helpers::{
+        OrNotFound,
+        get_account,
+        get_account_or_default,
+        invalid_params,
+        invalid_request,
+        not_found,
+        transaction_rejected,
     },
     services::wasm_optimizer::optimize_wasm_template,
 };
@@ -162,7 +160,8 @@ async fn submit_inner(
         let loaded_substates = sdk
             .substate_api()
             .locate_dependent_substates(&substates, req.detect_inputs_use_unversioned)
-            .await?;
+            .await
+            .or_not_found()?;
         loaded_substates
             .into_iter()
             .map(|input| {
@@ -370,7 +369,8 @@ pub async fn handle_detect_inputs(
     let detected = sdk
         .substate_api()
         .locate_dependent_substates(&substates, req.use_unversioned)
-        .await?
+        .await
+        .or_not_found()?
         .into_iter()
         .map(|input| {
             if req.use_unversioned {
@@ -416,7 +416,8 @@ async fn submit_dry_run_inner(
         let dependencies = sdk
             .substate_api()
             .locate_dependent_substates(&substates, req.detect_inputs_use_unversioned)
-            .await?;
+            .await
+            .or_not_found()?;
         dependencies
             .into_iter()
             .map(|input| {
@@ -537,7 +538,11 @@ pub async fn handle_submit_manifest(
 
     // Detect inputs
     let substates = transaction.to_referenced_substates()?.into_iter().collect::<Vec<_>>();
-    let dependencies = sdk.substate_api().locate_dependent_substates(&substates, true).await?;
+    let dependencies = sdk
+        .substate_api()
+        .locate_dependent_substates(&substates, true)
+        .await
+        .or_not_found()?;
     let inputs = dependencies.into_iter().map(|input| input.into_unversioned());
 
     let transaction = transaction.with_inputs(inputs);
@@ -605,7 +610,7 @@ pub async fn handle_get(
         .transaction_api()
         .get(req.transaction_id)
         .optional()?
-        .ok_or(HandlerError::NotFound)?;
+        .ok_or_else(|| not_found(format!("Transaction {} not found", req.transaction_id)))?;
 
     Ok(TransactionGetResponse {
         transaction: transaction.transaction,
@@ -641,7 +646,7 @@ pub async fn handle_get_result(
         .transaction_api()
         .get(req.transaction_id)
         .optional()?
-        .ok_or(HandlerError::NotFound)?;
+        .ok_or_else(|| not_found(format!("Transaction {} not found", req.transaction_id)))?;
 
     Ok(TransactionGetResultResponse {
         transaction_id: req.transaction_id,
@@ -662,7 +667,7 @@ pub async fn handle_wait_result(
         .transaction_api()
         .get(req.transaction_id)
         .optional()?
-        .ok_or(HandlerError::NotFound)?;
+        .ok_or_else(|| not_found(format!("Transaction {} not found", req.transaction_id)))?;
 
     if let Some(result) = transaction.finalize {
         return Ok(TransactionWaitResultResponse {

--- a/applications/tari_walletd/src/handlers/transaction.rs
+++ b/applications/tari_walletd/src/handlers/transaction.rs
@@ -610,7 +610,7 @@ pub async fn handle_get(
         .transaction_api()
         .get(req.transaction_id)
         .optional()?
-        .ok_or_else(|| not_found(format!("Transaction {} not found", req.transaction_id)))?;
+        .ok_or_else(|| not_found(format!("Transaction {}", req.transaction_id)))?;
 
     Ok(TransactionGetResponse {
         transaction: transaction.transaction,
@@ -646,7 +646,7 @@ pub async fn handle_get_result(
         .transaction_api()
         .get(req.transaction_id)
         .optional()?
-        .ok_or_else(|| not_found(format!("Transaction {} not found", req.transaction_id)))?;
+        .ok_or_else(|| not_found(format!("Transaction {}", req.transaction_id)))?;
 
     Ok(TransactionGetResultResponse {
         transaction_id: req.transaction_id,
@@ -667,7 +667,7 @@ pub async fn handle_wait_result(
         .transaction_api()
         .get(req.transaction_id)
         .optional()?
-        .ok_or_else(|| not_found(format!("Transaction {} not found", req.transaction_id)))?;
+        .ok_or_else(|| not_found(format!("Transaction {}", req.transaction_id)))?;
 
     if let Some(result) = transaction.finalize {
         return Ok(TransactionWaitResultResponse {

--- a/applications/tari_walletd/src/handlers/transaction.rs
+++ b/applications/tari_walletd/src/handlers/transaction.rs
@@ -48,7 +48,7 @@ use super::context::HandlerContext;
 use crate::{
     WalletSdk,
     handlers::helpers::{
-        OrNotFound,
+        OrJrpcNotFound,
         get_account,
         get_account_or_default,
         invalid_params,
@@ -161,7 +161,7 @@ async fn submit_inner(
             .substate_api()
             .locate_dependent_substates(&substates, req.detect_inputs_use_unversioned)
             .await
-            .or_not_found()?;
+            .or_jrpc_not_found()?;
         loaded_substates
             .into_iter()
             .map(|input| {
@@ -370,7 +370,7 @@ pub async fn handle_detect_inputs(
         .substate_api()
         .locate_dependent_substates(&substates, req.use_unversioned)
         .await
-        .or_not_found()?
+        .or_jrpc_not_found()?
         .into_iter()
         .map(|input| {
             if req.use_unversioned {
@@ -417,7 +417,7 @@ async fn submit_dry_run_inner(
             .substate_api()
             .locate_dependent_substates(&substates, req.detect_inputs_use_unversioned)
             .await
-            .or_not_found()?;
+            .or_jrpc_not_found()?;
         dependencies
             .into_iter()
             .map(|input| {
@@ -542,7 +542,7 @@ pub async fn handle_submit_manifest(
         .substate_api()
         .locate_dependent_substates(&substates, true)
         .await
-        .or_not_found()?;
+        .or_jrpc_not_found()?;
     let inputs = dependencies.into_iter().map(|input| input.into_unversioned());
 
     let transaction = transaction.with_inputs(inputs);

--- a/applications/tari_walletd/src/server.rs
+++ b/applications/tari_walletd/src/server.rs
@@ -333,14 +333,6 @@ where
 pub fn resolve_handler_error(answer_id: axum_jrpc::Id, e: &HandlerError) -> JsonRpcResponse {
     match e {
         HandlerError::Anyhow(e) => resolve_any_error(answer_id, e),
-        HandlerError::NotFound => JsonRpcResponse::error(
-            answer_id,
-            JsonRpcError::new(
-                JsonRpcErrorReason::ApplicationError(ApplicationErrorCode::NotFound as i32),
-                e.to_string(),
-                json!({}),
-            ),
-        ),
     }
 }
 

--- a/applications/tari_walletd/src/server.rs
+++ b/applications/tari_walletd/src/server.rs
@@ -336,8 +336,23 @@ pub fn resolve_handler_error(answer_id: axum_jrpc::Id, e: &HandlerError) -> Json
     }
 }
 
+/// True for an error already carrying the not-found code, whatever built it.
+fn is_not_found(e: &anyhow::Error) -> bool {
+    matches!(
+        e.downcast_ref::<JsonRpcError>().map(|e| e.error_reason()),
+        Some(JsonRpcErrorReason::ApplicationError(code)) if code == ApplicationErrorCode::NotFound as i32
+    )
+}
+
 fn resolve_any_error(answer_id: axum_jrpc::Id, e: &anyhow::Error) -> JsonRpcResponse {
-    warn!(target: LOG_TARGET, "🌐 JSON-RPC error: {}", e);
+    // Asking about something that is not there is a normal thing for a caller to do, and one that
+    // polls - `transactions.wait_result` against an id the wallet does not know - would otherwise
+    // warn once per poll. Everything else stays a warning.
+    if is_not_found(e) {
+        debug!(target: LOG_TARGET, "🌐 JSON-RPC not found: {}", e);
+    } else {
+        warn!(target: LOG_TARGET, "🌐 JSON-RPC error: {}", e);
+    }
     if let Some(handler_err) = e.downcast_ref::<HandlerError>() {
         return resolve_handler_error(answer_id, handler_err);
     }


### PR DESCRIPTION
Spun out of the discussion on #2505.

## The problem

Resolving a transaction's inputs against a substate that does not exist returns `ApplicationErrorCode::GeneralError` (500). This is what the failing `transfer.feature` scenarios on #2505 surfaced as `500 Substate component_… does not exist`.

A caller polling for something that does not exist **yet** — an account it has just created, an input whose creating transaction has not yet reached the indexer — cannot distinguish that from the wallet being broken. Only one of the two is worth retrying, and a general error tells the caller the wrong one.

## The fix

The distinction was already carried and simply never reached the JSON-RPC layer. `SubstateApiError` implements `IsNotFoundError` and classifies `SubstateDoesNotExist` correctly; the handler returned it as an opaque `anyhow::Error`, so `resolve_any_error` fell through to the general arm.

`OrNotFound::or_not_found` consults that classification and routes a not-found through the **existing** `helpers::not_found`, which is what ~10 other handlers already use. Applied to the input-resolution paths a caller can reach with a substate that is not there yet (`locate_dependent_substates`, four call sites in `transaction.rs`).

## Net-subtractive on the error plumbing

`HandlerError::NotFound` was a second path to the same error code, and a lossy one — it flattened every message to the literal string `"Not found"`. Its three call sites are all "get transaction by id"; they now say which transaction was not found, via the same helper as everything else. That leaves the variant unused, so it and its arm in `resolve_handler_error` are removed.

## Scope

Deliberately limited to the substate/transaction paths this issue is about. Around twenty error types in the wallet implement `IsNotFoundError`; `or_not_found` generalises to any of them, but converting the rest is a separate sweep with its own review surface, and each one is a behaviour change for whatever client depends on the current code.

## Tests

Two new unit tests pin the classification in both directions — a missing resource gets the `NotFound` code and keeps its own message, and anything else is passed through untouched (so nothing unrelated starts looking retryable). 40 pass in `tari_ootle_walletd`.