### PR TITLE
fix(ootle-rs): resume a truncated UTXO pass from the last delivered version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7901,7 +7901,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-rs"
-version = "0.22.1"
+version = "0.23.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -11756,7 +11756,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_client"
-version = "0.41.0"
+version = "0.42.0"
 dependencies = [
  "anyhow",
  "bounded-vec",
@@ -12238,7 +12238,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12326,7 +12326,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_storage_sqlite"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -12422,7 +12422,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd_client"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "hex",
  "ootle_serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7901,7 +7901,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-rs"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,9 +104,9 @@ tari_ootle_p2p = { path = "crates/p2p" }
 tari_ootle_storage = { path = "crates/storage" }
 tari_ootle_storage_sqlite = { path = "crates/storage_sqlite" }
 tari_ootle_wallet_crypto = { path = "crates/wallet/crypto", version = "0.42" }
-tari_ootle_wallet_sdk = { path = "crates/wallet/sdk", version = "0.42" }
+tari_ootle_wallet_sdk = { path = "crates/wallet/sdk", version = "0.43" }
 tari_ootle_wallet_sdk_services = { path = "crates/wallet/sdk_services" }
-tari_ootle_wallet_storage_sqlite = { path = "crates/wallet/storage_sqlite", version = "0.42" }
+tari_ootle_wallet_storage_sqlite = { path = "crates/wallet/storage_sqlite", version = "0.43" }
 tari_epoch_manager = { path = "crates/epoch_manager" }
 tari_epoch_oracles = { path = "crates/epoch_oracles" }
 tari_indexer_lib = { path = "crates/indexer_lib" }
@@ -118,14 +118,14 @@ tari_transaction_manifest = { path = "crates/transaction_manifest", version = "0
 tari_validator_node_rpc = { path = "crates/validator_node_rpc" }
 sqlite_message_logger = { path = "networking/sqlite_message_logger" }
 tari_base_node_client = { path = "clients/base_node_client" }
-tari_indexer_client = { path = "clients/tari_indexer_client", default-features = false, version = "0.41" }
+tari_indexer_client = { path = "clients/tari_indexer_client", default-features = false, version = "0.42" }
 tari_networking = { path = "networking/core" }
 tari_rpc_framework = { path = "networking/rpc_framework" }
 tari_rpc_macros = { path = "networking/rpc_macros" }
 tari_swarm = { path = "networking/swarm" }
 tari_validator_node_client = { path = "clients/validator_node_client" }
 tari_validator_rollback = { path = "utilities/validator_rollback", version = "0.40" }
-tari_ootle_walletd_client = { path = "clients/wallet_daemon_client", version = "0.42" }
+tari_ootle_walletd_client = { path = "clients/wallet_daemon_client", version = "0.43" }
 transaction_generator = { path = "utilities/transaction_generator" }
 
 # Dependency crates on crates.io (update versions here as well when updating the workspace version)

--- a/applications/tari_indexer/src/rest_api/handlers/indexer_events.rs
+++ b/applications/tari_indexer/src/rest_api/handlers/indexer_events.rs
@@ -3,28 +3,27 @@
 
 use axum::{
     Extension,
-    response::{Sse, sse},
+    response::{IntoResponse, Response, Sse, sse},
 };
-use futures::Stream;
 use log::info;
 use tari_indexer_client::event::IndexerEvent;
 use tokio_stream::StreamExt;
 
-use crate::rest_api::{context::HandlerContext, handlers::HandlerResult};
+use crate::rest_api::{context::HandlerContext, handlers::HandlerResult, streaming::disable_proxy_buffering};
 
 const LOG_TARGET: &str = "tari::indexer::rest_api::handlers::events";
 
 #[utoipa::path(get, path = "/events", description = "SSE events")]
-pub async fn sse_events(
-    Extension(context): Extension<HandlerContext>,
-) -> HandlerResult<Sse<impl Stream<Item = Result<sse::Event, axum::Error>>>> {
+pub async fn sse_events(Extension(context): Extension<HandlerContext>) -> HandlerResult<Response> {
     info!(target: LOG_TARGET, "Client connected to SSE event stream");
     let event_stream = tokio_stream::wrappers::BroadcastStream::new(context.subscribe_events())
         .take_while(|res| res.is_ok())
         .map(|res| res.expect("take_while should prevent errors here"))
         .map(|event| encode_event(&event));
 
-    Ok(Sse::new(event_stream).keep_alive(sse::KeepAlive::new()))
+    let mut response = Sse::new(event_stream).keep_alive(sse::KeepAlive::new()).into_response();
+    disable_proxy_buffering(response.headers_mut());
+    Ok(response)
 }
 
 fn encode_event(event: &IndexerEvent) -> Result<sse::Event, axum::Error> {

--- a/applications/tari_indexer/src/rest_api/handlers/transaction_events.rs
+++ b/applications/tari_indexer/src/rest_api/handlers/transaction_events.rs
@@ -19,7 +19,7 @@ use tokio_stream::StreamExt;
 
 use crate::{
     network_state_sync::EventFilter,
-    rest_api::{context::HandlerContext, handlers::HandlerResult},
+    rest_api::{context::HandlerContext, handlers::HandlerResult, streaming::disable_proxy_buffering},
     storage_sqlite::SqliteIndexerStore,
     store::ReadOnlyStore,
 };
@@ -92,6 +92,7 @@ pub async fn sse_transaction_events(
     response
         .headers_mut()
         .insert(header::VARY, HeaderValue::from_static("last-event-id"));
+    disable_proxy_buffering(response.headers_mut());
     Ok(response)
 }
 

--- a/applications/tari_indexer/src/rest_api/handlers/utxos.rs
+++ b/applications/tari_indexer/src/rest_api/handlers/utxos.rs
@@ -80,7 +80,8 @@ pub async fn stream_utxo_updates(
     let encoder = match accept_header {
         Some(mime) => encoding::from_media_type(mime).ok_or_else(|| {
             ErrorResponse::bad_request(format!(
-                "Unsupported Accept header '{}', supported types are 'application/x-protobuf' and 'application/json'",
+                "Unsupported Accept header '{}', supported types are 'application/x-protobuf', 'application/x-ndjson' \
+                 and 'application/json'",
                 mime
             ))
         })?,

--- a/applications/tari_indexer/src/rest_api/handlers/utxos.rs
+++ b/applications/tari_indexer/src/rest_api/handlers/utxos.rs
@@ -51,6 +51,12 @@ pub async fn stream_utxo_updates(
         ));
     }
 
+    // A shard's updates are served in whole state versions, so a limit of zero would still return
+    // one version rather than the empty response it asks for.
+    if req.per_shard_limit == 0 {
+        return Err(ErrorResponse::bad_request("per_shard_limit must be greater than 0"));
+    }
+
     if req.shard_state_versions.len() > NumPreshards::MAX_SHARD.as_u32() as usize {
         return Err(ErrorResponse::bad_request(format!(
             "shard_state_versions cannot contain more than {} entries",

--- a/applications/tari_indexer/src/rest_api/handlers/utxos.rs
+++ b/applications/tari_indexer/src/rest_api/handlers/utxos.rs
@@ -27,7 +27,7 @@ use crate::rest_api::{
     context::HandlerContext,
     error::ErrorResponse,
     handlers::HandlerResult,
-    streaming::{UtxoUpdateStream, encoding},
+    streaming::{UtxoUpdateStream, disable_proxy_buffering, encoding},
 };
 
 const LOG_TARGET: &str = "tari::ootle::indexer::rest_api::handlers::utxos";
@@ -105,6 +105,7 @@ pub async fn stream_utxo_updates(
     response
         .headers_mut()
         .insert(header::VARY, HeaderValue::from_static("accept"));
+    disable_proxy_buffering(response.headers_mut());
     Ok(response)
 }
 

--- a/applications/tari_indexer/src/rest_api/streaming/encoding.rs
+++ b/applications/tari_indexer/src/rest_api/streaming/encoding.rs
@@ -3,6 +3,7 @@
 
 use std::{io::Write, str::FromStr};
 
+use axum::http::HeaderValue;
 use bytes::{BufMut, Bytes};
 use log::*;
 use mediatype::MediaType;
@@ -54,6 +55,18 @@ impl MimeTypeEncoder {
     pub fn protobuf() -> Self {
         MimeTypeEncoder::Protobuf(ProtobufEncoder)
     }
+
+    /// The media type of the bytes this encoder produces, for the response's `Content-Type`.
+    ///
+    /// Both are streaming framings rather than single documents: a run of length-delimited
+    /// protobuf messages, or newline-delimited JSON. A proxy or client that reads the header to
+    /// decide whether it may buffer a response needs the framing, not the payload's grammar.
+    pub const fn media_type(&self) -> HeaderValue {
+        match self {
+            MimeTypeEncoder::Protobuf(_) => HeaderValue::from_static("application/x-protobuf"),
+            MimeTypeEncoder::Json(_) => HeaderValue::from_static("application/x-ndjson"),
+        }
+    }
 }
 
 impl Encoder for MimeTypeEncoder {
@@ -68,10 +81,17 @@ impl Encoder for MimeTypeEncoder {
 }
 
 pub fn from_media_type(mime_type: &str) -> Option<MimeTypeEncoder> {
+    // Ordered by preference, so a client that expresses none (`*/*`) is served protobuf.
+    // `application/json` and `application/x-ndjson` both select the newline-delimited JSON framing,
+    // which is what the response then declares itself to be.
     const ACCEPTED_TYPES: &[MediaType] = &[
         MediaType::new(
             mediatype::Name::new_unchecked("application"),
             mediatype::Name::new_unchecked("x-protobuf"),
+        ),
+        MediaType::new(
+            mediatype::Name::new_unchecked("application"),
+            mediatype::Name::new_unchecked("x-ndjson"),
         ),
         MediaType::new(
             mediatype::Name::new_unchecked("application"),
@@ -82,7 +102,7 @@ pub fn from_media_type(mime_type: &str) -> Option<MimeTypeEncoder> {
     let accepted = media_type.negotiate(ACCEPTED_TYPES)?;
     match accepted.subty.as_str() {
         "x-protobuf" => Some(MimeTypeEncoder::Protobuf(ProtobufEncoder)),
-        "json" => Some(MimeTypeEncoder::Json(JsonEncoder)),
+        "json" | "x-ndjson" => Some(MimeTypeEncoder::Json(JsonEncoder)),
         _ => None,
     }
 }

--- a/applications/tari_indexer/src/rest_api/streaming/mod.rs
+++ b/applications/tari_indexer/src/rest_api/streaming/mod.rs
@@ -4,4 +4,17 @@
 pub mod encoding;
 mod utxo_stream;
 
+use axum::http::{HeaderMap, HeaderName, HeaderValue};
 pub use utxo_stream::*;
+
+const X_ACCEL_BUFFERING: HeaderName = HeaderName::from_static("x-accel-buffering");
+
+/// Opts a response out of proxy response buffering.
+///
+/// nginx and the proxies that follow its conventions buffer an upstream response by default, so a
+/// stream's frames are held back until the buffer fills or the response ends — on a long-lived
+/// stream, indefinitely. Every streaming endpoint sets this so its frames reach the client as they
+/// are produced rather than in bursts, or never.
+pub fn disable_proxy_buffering(headers: &mut HeaderMap) {
+    headers.insert(X_ACCEL_BUFFERING, HeaderValue::from_static("no"));
+}

--- a/applications/tari_indexer/src/rest_api/streaming/utxo_stream.rs
+++ b/applications/tari_indexer/src/rest_api/streaming/utxo_stream.rs
@@ -7,7 +7,10 @@ use std::{
 };
 
 use async_stream::try_stream;
-use axum::response::{IntoResponse, Response};
+use axum::{
+    http::{HeaderValue, header},
+    response::{IntoResponse, Response},
+};
 use bytes::{Bytes, BytesMut};
 use futures::{Stream, StreamExt};
 use log::*;
@@ -25,11 +28,13 @@ use crate::{
 const LOG_TARGET: &str = "tari::indexer::rest_api::streaming::utxo_stream";
 
 pub struct UtxoUpdateStream {
+    content_type: HeaderValue,
     inner: Pin<Box<dyn Stream<Item = anyhow::Result<Bytes>> + Send>>,
 }
 
 impl UtxoUpdateStream {
     pub fn new(substate_manager: SubstateManager, request: GetUtxoUpdatesRequest, encoder: MimeTypeEncoder) -> Self {
+        let content_type = encoder.media_type();
         let inner = try_stream! {
             let mut buffer = BytesMut::with_capacity(1024);
             for &(shard, state_version) in &request.shard_state_versions {
@@ -121,7 +126,10 @@ impl UtxoUpdateStream {
             }
         };
 
-        Self { inner: Box::pin(inner) }
+        Self {
+            content_type,
+            inner: Box::pin(inner),
+        }
     }
 }
 
@@ -135,10 +143,11 @@ impl Stream for UtxoUpdateStream {
 
 impl IntoResponse for UtxoUpdateStream {
     fn into_response(self) -> Response {
+        let content_type = self.content_type.clone();
         let stream_body = axum::body::Body::from_stream(self);
 
         axum::response::Response::builder()
-            .header("Content-Type", "application/octet-stream")
+            .header(header::CONTENT_TYPE, content_type)
             .body(stream_body)
             .map_err(ErrorResponse::anyhow)
             .into_response()

--- a/applications/tari_indexer/src/rest_api/streaming/utxo_stream.rs
+++ b/applications/tari_indexer/src/rest_api/streaming/utxo_stream.rs
@@ -49,6 +49,7 @@ impl UtxoUpdateStream {
                     updates,
                     max_state_version,
                     max_epoch,
+                    has_more,
                 } = substate_manager
                     .get_utxo_updates(
                         request.resource_address,
@@ -66,14 +67,23 @@ impl UtxoUpdateStream {
                     continue;
                 }
 
-                let high_watermark_state_version = substate_manager
-                    .get_max_state_version(&request.resource_address, shard)
-                    .await
-                    .map_err(anyhow::Error::from)?;
+                // The resume point the client stores for this shard. A drained pass hands back the
+                // shard's high watermark, which carries the cursor past versions this request's own
+                // `from_epoch`/`unspent_only` filters excluded so they are not re-read every pass. A
+                // pass with more to give can only offer its last delivered version — the high
+                // watermark sits above the undelivered remainder.
+                let resume_state_version = if has_more {
+                    max_state_version
+                } else {
+                    substate_manager
+                        .get_max_state_version(&request.resource_address, shard)
+                        .await
+                        .map_err(anyhow::Error::from)?
+                };
 
                 debug!(
                     target: LOG_TARGET,
-                    "Received {} updates for shard {shard}, max_epoch = {max_epoch}, max_state_version {max_state_version} -> {high_watermark_state_version}",
+                    "Received {} updates for shard {shard}, max_epoch = {max_epoch}, max_state_version {max_state_version} -> {resume_state_version} (has_more = {has_more})",
                     updates.len(),
                 );
 
@@ -81,7 +91,8 @@ impl UtxoUpdateStream {
                     sos_emitted: false,
                     shard,
                     updates_state_version: max_state_version,
-                    high_watermark_state_version,
+                    resume_state_version,
+                    has_more,
                     updates,
                     index: 0,
                 };
@@ -94,6 +105,7 @@ impl UtxoUpdateStream {
                             shard: pending.shard.as_u32(),
                             max_state_version: pending.updates_state_version.as_u64(),
                             num_updates: u32::try_from(pending.updates_len()).expect("loaded more than u32::MAX updates"),
+                            has_more: pending.has_more,
                         });
                         pending.sos_emitted = true;
                     }
@@ -104,7 +116,7 @@ impl UtxoUpdateStream {
 
                     if pending.is_empty() {
                         payload.eos = Some(protobuf::EndOfShard {
-                            max_state_version: pending.high_watermark_state_version.as_u64(),
+                            max_state_version: pending.resume_state_version.as_u64(),
                         });
                     }
 
@@ -158,7 +170,8 @@ struct PendingUpdates {
     pub sos_emitted: bool,
     pub shard: Shard,
     pub updates_state_version: StateVersion,
-    pub high_watermark_state_version: StateVersion,
+    pub resume_state_version: StateVersion,
+    pub has_more: bool,
     pub updates: Vec<WalletUtxoUpdate>,
     pub index: usize,
 }

--- a/applications/tari_indexer/src/storage_sqlite/reader.rs
+++ b/applications/tari_indexer/src/storage_sqlite/reader.rs
@@ -805,12 +805,19 @@ impl IndexerStoreReadTransaction for SqliteStoreReadTransaction<'_> {
         const OPERATION: &str = "get_utxo_updates";
         use crate::storage_sqlite::schema::utxos;
 
+        // One state version covers a whole synced batch, so every UTXO touched by the same block on
+        // this shard shares it. `state_version` is therefore not a unique key and the caller's
+        // cursor cannot address a row within a version — it can only say "everything after version
+        // V". A response that ends mid-version would strand the rest of that version above the
+        // cursor the caller then resumes from, so a version is either wholly included or wholly
+        // absent. One row beyond the limit is read to find where that boundary falls.
+        let overshoot_limit = i64::from(limit).saturating_add(1);
         let mut query = utxos::table
             .filter(utxos::resource_address.eq(resource_address.to_string()))
             .filter(utxos::state_version.gt(from_state_version.as_u64() as i64))
             .filter(utxos::epoch.ge(from_epoch.as_u64() as i64))
             .filter(utxos::shard.eq(shard.as_u32() as i32))
-            .limit(i64::from(limit))
+            .limit(overshoot_limit)
             .order_by(utxos::state_version.asc())
             .into_boxed();
         if unspent_only {
@@ -820,29 +827,71 @@ impl IndexerStoreReadTransaction for SqliteStoreReadTransaction<'_> {
                 .filter(utxos::is_burnt.eq(false));
         }
         let rows = query
-            .load_iter::<models::UtxoRecord, _>(self.connection())
+            .load::<models::UtxoRecord>(self.connection())
             .map_err(|e| StorageError::QueryError {
                 reason: format!("{OPERATION}: {}", e),
             })?;
 
-        let mut updates = Vec::new();
-        let mut max_state_version = StateVersion::zero();
+        let has_more = rows.len() as i64 == overshoot_limit;
+        let mut converted = Vec::with_capacity(rows.len());
         let mut max_epoch = Epoch::zero();
         for row in rows {
-            let row = row.map_err(|e| StorageError::QueryError {
-                reason: format!("{OPERATION}: {}", e),
-            })?;
             let epoch = Epoch(row.epoch as u64);
             let (state_version, update) = row.try_convert_to_update()?;
-            max_state_version = max_state_version.max(state_version);
             max_epoch = max_epoch.max(epoch);
-            updates.push(update);
+            converted.push((state_version, update));
         }
 
+        if has_more {
+            // Rows are ordered by state version, so the overshoot row's version is the highest
+            // present and is the only one that can be partial.
+            let partial_version = converted
+                .last()
+                .map(|(state_version, _)| *state_version)
+                .expect("has_more implies at least one row");
+            let complete = converted.partition_point(|(v, _)| *v < partial_version);
+            if complete > 0 {
+                converted.truncate(complete);
+            } else {
+                // The whole read sits at one version, so there is no complete earlier version to
+                // stop at. Returning nothing would leave the caller's cursor where it was and no
+                // way past this shard, so the version is served whole and the limit is overrun.
+                let mut whole_version = utxos::table
+                    .filter(utxos::resource_address.eq(resource_address.to_string()))
+                    .filter(utxos::state_version.eq(partial_version.as_u64() as i64))
+                    .filter(utxos::epoch.ge(from_epoch.as_u64() as i64))
+                    .filter(utxos::shard.eq(shard.as_u32() as i32))
+                    .into_boxed();
+                if unspent_only {
+                    whole_version = whole_version
+                        .filter(utxos::is_spent.eq(false))
+                        .filter(utxos::is_burnt.eq(false));
+                }
+                let rows = whole_version
+                    .load::<models::UtxoRecord>(self.connection())
+                    .map_err(|e| StorageError::QueryError {
+                        reason: format!("{OPERATION}: {}", e),
+                    })?;
+
+                converted.clear();
+                for row in rows {
+                    let epoch = Epoch(row.epoch as u64);
+                    let (state_version, update) = row.try_convert_to_update()?;
+                    max_epoch = max_epoch.max(epoch);
+                    converted.push((state_version, update));
+                }
+            }
+        }
+
+        let max_state_version = converted
+            .last()
+            .map_or_else(StateVersion::zero, |(state_version, _)| *state_version);
+
         Ok(UtxoStateUpdateSet {
-            updates,
+            updates: converted.into_iter().map(|(_, update)| update).collect(),
             max_state_version,
             max_epoch,
+            has_more,
         })
     }
 

--- a/applications/tari_indexer/src/storage_sqlite/store_factory.rs
+++ b/applications/tari_indexer/src/storage_sqlite/store_factory.rs
@@ -193,6 +193,139 @@ mod tests {
         }
     }
 
+    /// One state version covers a whole synced batch, so a shard's UTXOs cluster into version
+    /// groups. These build a shard whose groups straddle the read limit.
+    fn utxo_resource() -> tari_template_lib_types::ResourceAddress {
+        use std::str::FromStr;
+        tari_template_lib_types::ResourceAddress::from_str(
+            "resource_0000000000000000000000000000000000000000000000000000000000000000",
+        )
+        .unwrap()
+    }
+
+    fn unspent_at(seq: u8, state_version: u64) -> crate::storage_sqlite::models::UtxoUpdateRecord {
+        use tari_engine_types::{UtxoOutput, crypto::OutputBody};
+        use tari_template_lib_types::{
+            EncryptedData,
+            UtxoId,
+            crypto::{RistrettoPublicKeyBytes, UtxoTag},
+            stealth::SpendAuthorization,
+        };
+
+        use crate::storage_sqlite::models::{UtxoUnspent, UtxoUpdateRecord};
+
+        let address = tari_template_lib_types::UtxoAddress::new(utxo_resource(), UtxoId::from_array([seq; 32]));
+        UtxoUpdateRecord::Unspent(Box::new(UtxoUnspent {
+            address,
+            version: 0,
+            shard: tari_ootle_common_types::shard::Shard::from(1u32),
+            state_version: StateVersion::new(state_version),
+            utxo_output: UtxoOutput {
+                output: OutputBody {
+                    public_nonce: RistrettoPublicKeyBytes::from_bytes(&[seq; 32]).unwrap(),
+                    encrypted_data: EncryptedData::empty(),
+                    minimum_value_promise: 0,
+                    viewable_balance: None,
+                },
+                auth: SpendAuthorization::Key(RistrettoPublicKeyBytes::from_bytes(&[seq; 32]).unwrap()),
+                tag: UtxoTag::from(0u32),
+            },
+            is_frozen: false,
+        }))
+    }
+
+    async fn store_with_utxos(groups: &[(u64, u8)]) -> (tempfile::TempDir, SqliteIndexerStore) {
+        let (dir, store) = temp_store().await;
+        let mut seq = 0u8;
+        let mut records = Vec::new();
+        for &(state_version, count) in groups {
+            for _ in 0..count {
+                seq += 1;
+                records.push(unspent_at(seq, state_version));
+            }
+        }
+        store
+            .with_write_tx(move |tx| tx.batch_insert_utxo_updates(Epoch(1), records))
+            .await
+            .unwrap();
+        (dir, store)
+    }
+
+    async fn read_updates(
+        store: &SqliteIndexerStore,
+        from: u64,
+        limit: u32,
+    ) -> tari_indexer_client::types::UtxoStateUpdateSet {
+        store
+            .with_read_tx(move |tx| {
+                tx.utxos_get_updates(
+                    utxo_resource(),
+                    Epoch(0),
+                    tari_ootle_common_types::shard::Shard::from(1u32),
+                    StateVersion::new(from),
+                    false,
+                    limit,
+                )
+            })
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn a_read_stops_on_a_version_boundary_not_mid_version() {
+        // Limit 4 falls inside the 3-row group at version 20.
+        let (_dir, store) = store_with_utxos(&[(10, 2), (20, 3), (30, 1)]).await;
+
+        let set = read_updates(&store, 0, 4).await;
+
+        assert!(set.has_more);
+        // Version 20 is held back whole rather than half-served.
+        assert_eq!(set.max_state_version, StateVersion::new(10));
+        assert_eq!(set.updates.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn resuming_from_the_reported_version_loses_no_update() {
+        let (_dir, store) = store_with_utxos(&[(10, 2), (20, 3), (30, 1)]).await;
+
+        let mut seen = 0;
+        let mut cursor = 0;
+        loop {
+            let set = read_updates(&store, cursor, 4).await;
+            seen += set.updates.len();
+            cursor = set.max_state_version.as_u64();
+            if !set.has_more {
+                break;
+            }
+        }
+
+        assert_eq!(seen, 6);
+    }
+
+    #[tokio::test]
+    async fn a_version_wider_than_the_limit_is_served_whole() {
+        // No complete earlier version to stop at, so the limit gives way rather than the read
+        // returning nothing and stranding the cursor.
+        let (_dir, store) = store_with_utxos(&[(10, 5), (20, 1)]).await;
+
+        let set = read_updates(&store, 0, 2).await;
+
+        assert_eq!(set.updates.len(), 5);
+        assert_eq!(set.max_state_version, StateVersion::new(10));
+        assert!(set.has_more);
+    }
+
+    #[tokio::test]
+    async fn a_drained_read_reports_no_more() {
+        let (_dir, store) = store_with_utxos(&[(10, 2), (20, 1)]).await;
+
+        let set = read_updates(&store, 0, 10).await;
+
+        assert!(!set.has_more);
+        assert_eq!(set.updates.len(), 3);
+        assert_eq!(set.max_state_version, StateVersion::new(20));
+    }
+
     async fn temp_store() -> (tempfile::TempDir, SqliteIndexerStore) {
         let dir = tempfile::tempdir().unwrap();
         let store = SqliteIndexerStore::try_create(dir.path().join("indexer.db")).unwrap();

--- a/bindings/src/types/UtxoStateUpdateSet.ts
+++ b/bindings/src/types/UtxoStateUpdateSet.ts
@@ -7,4 +7,5 @@ export type UtxoStateUpdateSet = {
   updates: Array<WalletUtxoUpdate>;
   max_state_version: StateVersion;
   max_epoch: Epoch;
+  has_more: boolean;
 };

--- a/clients/tari_indexer_client/Cargo.toml
+++ b/clients/tari_indexer_client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_indexer_client"
 description = "Tari indexer client library"
-version = "0.41.0"
+version = "0.42.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/clients/tari_indexer_client/src/protobuf.rs
+++ b/clients/tari_indexer_client/src/protobuf.rs
@@ -19,6 +19,10 @@ pub struct StartOfShard {
     pub max_state_version: u64,
     #[prost(uint32, tag = "3")]
     pub num_updates: u32,
+    /// The shard holds further updates beyond this pass. Authoritative: a pass can stop short of
+    /// `per_shard_limit` and still have more to give, so counting `num_updates` cannot answer this.
+    #[prost(bool, tag = "4")]
+    pub has_more: bool,
 }
 
 #[derive(::prost::Message, serde::Serialize, serde::Deserialize)]

--- a/clients/tari_indexer_client/src/types.rs
+++ b/clients/tari_indexer_client/src/types.rs
@@ -639,8 +639,12 @@ pub struct UtxoUpdateSet {
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub struct UtxoStateUpdateSet {
     pub updates: Vec<WalletUtxoUpdate>,
+    /// The highest state version in `updates`. Every update at that version is included, so it is a
+    /// resume point: a later request filtering on `state_version > max_state_version` loses nothing.
     pub max_state_version: StateVersion,
     pub max_epoch: Epoch,
+    /// The shard holds further updates above `max_state_version`.
+    pub has_more: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/clients/wallet_daemon_client/Cargo.toml
+++ b/clients/wallet_daemon_client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_walletd_client"
 description = "Tari wallet daemon client library"
-version = "0.42.0"
+version = "0.43.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/wallet/ootle-rs/Cargo.toml
+++ b/crates/wallet/ootle-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ootle-rs"
-version = "0.22.1"
+version = "0.23.0"
 description = "A Rust library for interacting with the Tari Ootle network."
 edition.workspace = true
 authors.workspace = true

--- a/crates/wallet/ootle-rs/Cargo.toml
+++ b/crates/wallet/ootle-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ootle-rs"
-version = "0.22.0"
+version = "0.22.1"
 description = "A Rust library for interacting with the Tari Ootle network."
 edition.workspace = true
 authors.workspace = true

--- a/crates/wallet/ootle-rs/src/provider/utxo_watcher.rs
+++ b/crates/wallet/ootle-rs/src/provider/utxo_watcher.rs
@@ -30,8 +30,10 @@ pub struct StealthUtxoWatchRequest {
     /// When true, only currently-unspent UTXOs are streamed (no `Spent`/`Burnt` frames).
     /// A monitor that must track spends has to set this to `false`.
     pub unspent_only: bool,
-    /// Maximum updates returned per shard per pass. `StartOfShard::num_updates == per_shard_limit`
-    /// indicates the shard has more updates to drain on a subsequent request.
+    /// Target number of updates returned per shard per pass. A pass may return fewer and still have
+    /// more to give, and may overrun this to keep one state version whole, so
+    /// [`StealthUtxoFrame::StartOfShard::has_more`] — not a count comparison — says whether the
+    /// shard has updates left to drain.
     pub per_shard_limit: u32,
 }
 
@@ -50,15 +52,18 @@ impl StealthUtxoWatchRequest {
 /// A single decoded frame from the stealth UTXO update stream.
 ///
 /// Frames arrive grouped per shard: a `StartOfShard`, then zero or more `Unspent`/`Spent`/`Burnt`
-/// updates, terminated by an `EndOfShard`. `EndOfShard::max_state_version` is always a safe resume
-/// point for that shard — every update at or below it has been delivered — so advance the cursor
-/// from it via [`ShardCursor::observe`].
+/// updates, terminated by an `EndOfShard`. `EndOfShard::max_state_version` is the shard's resume
+/// point — every update at or below it has either been delivered or was excluded by the request's
+/// own filters — so advance the cursor from it via [`ShardCursor::observe`].
 #[derive(Debug, Clone)]
 pub enum StealthUtxoFrame {
     StartOfShard {
         shard: Shard,
         max_state_version: StateVersion,
         num_updates: u32,
+        /// The shard has updates beyond this pass. Poll again to drain it rather than waiting for
+        /// the next scheduled pass.
+        has_more: bool,
     },
     /// A currently-unspent output. Carries only the `(tag, public_nonce)` fetch key — the commitment
     /// and viewable-balance ciphertext must be resolved via
@@ -75,9 +80,9 @@ pub enum StealthUtxoFrame {
         id: UtxoId,
         version: u32,
     },
-    /// Terminates a shard's updates. `max_state_version` is the resume point for the shard: the
-    /// last delivered version while the shard still has updates to drain, and the shard's high
-    /// watermark once it is drained.
+    /// Terminates a shard's updates. `max_state_version` is the resume point for the shard, chosen
+    /// by the indexer: the last delivered state version while the shard has more to drain, and the
+    /// shard's high watermark once it is drained.
     EndOfShard {
         shard: Shard,
         max_state_version: StateVersion,
@@ -124,7 +129,6 @@ impl StealthUtxoStream {
                 },
             };
 
-            let per_shard_limit = self.request.per_shard_limit;
             let mut stream = match client.stream_utxo_updates_protobuf(self.request.into_request()).await {
                 Ok(stream) => stream,
                 Err(err) => {
@@ -134,26 +138,21 @@ impl StealthUtxoStream {
                 },
             };
 
-            // `EndOfShard` on the wire carries neither the shard number nor any notion of how much
-            // of the shard was delivered; both come from the preceding `StartOfShard`, so each pass
-            // is remembered until its `EndOfShard` arrives.
-            let mut current_batch: Option<ShardBatch> = None;
+            // `EndOfShard` on the wire does not carry the shard number; stamp it from the preceding
+            // `StartOfShard` so each frame is self-describing.
+            let mut current_shard: Option<Shard> = None;
             loop {
                 match stream.next().await {
                     Some(Ok(payload)) => {
                         let UtxoUpdatePayload { sos, update, eos } = payload;
                         if let Some(sos) = sos {
                             let shard = Shard::from(sos.shard);
-                            let max_state_version = StateVersion::from(sos.max_state_version);
-                            current_batch = Some(ShardBatch {
-                                shard,
-                                max_state_version,
-                                is_truncated: sos.num_updates >= per_shard_limit,
-                            });
+                            current_shard = Some(shard);
                             yield Ok(StealthUtxoFrame::StartOfShard {
                                 shard,
-                                max_state_version,
+                                max_state_version: StateVersion::from(sos.max_state_version),
                                 num_updates: sos.num_updates,
+                                has_more: sos.has_more,
                             });
                         }
                         if let Some(update) = update {
@@ -166,21 +165,18 @@ impl StealthUtxoStream {
                             }
                         }
                         if let Some(eos) = eos {
-                            // Take the batch so a following `EndOfShard` (or any frame) that is not
+                            // Take the shard so a following `EndOfShard` (or any frame) that is not
                             // preceded by a fresh `StartOfShard` errors out rather than being
                             // misattributed to this shard and corrupting its cursor.
-                            let Some(batch) = current_batch.take() else {
+                            let Some(shard) = current_shard.take() else {
                                 yield Err(UtxoWatcherError::DecodeError(
                                     "EndOfShard received before any StartOfShard".to_string(),
                                 ));
                                 return;
                             };
-                            let shard = batch.shard;
-                            let max_state_version =
-                                resume_watermark(&batch, StateVersion::from(eos.max_state_version));
                             yield Ok(StealthUtxoFrame::EndOfShard {
                                 shard,
-                                max_state_version,
+                                max_state_version: StateVersion::from(eos.max_state_version),
                             });
                         }
                     },
@@ -193,33 +189,6 @@ impl StealthUtxoStream {
                 }
             }
         }
-    }
-}
-
-/// What one pass over a single shard delivered, carried from its `StartOfShard` to its
-/// `EndOfShard`.
-struct ShardBatch {
-    shard: Shard,
-    /// The highest state version actually delivered in the pass.
-    max_state_version: StateVersion,
-    /// The pass filled `per_shard_limit`, so the shard holds further updates above
-    /// `max_state_version`.
-    is_truncated: bool,
-}
-
-/// The state version a shard's cursor may resume from after a pass.
-///
-/// `high_watermark` is the newest state version the indexer holds for the shard, taken over the
-/// whole shard rather than over what the pass returned. It therefore sits above the updates a
-/// truncated pass left undelivered, and resuming from it would step over them for good. Such a pass
-/// resumes from its last delivered version instead; only a pass that drained the shard may take the
-/// high watermark, which additionally carries the cursor past updates the request's own filters
-/// excluded.
-fn resume_watermark(batch: &ShardBatch, high_watermark: StateVersion) -> StateVersion {
-    if batch.is_truncated {
-        batch.max_state_version
-    } else {
-        high_watermark
     }
 }
 
@@ -305,35 +274,6 @@ impl ShardCursor {
 mod tests {
     use super::*;
 
-    fn batch(max_state_version: u64, is_truncated: bool) -> ShardBatch {
-        ShardBatch {
-            shard: Shard::from(1u32),
-            max_state_version: StateVersion::from(max_state_version),
-            is_truncated,
-        }
-    }
-
-    #[test]
-    fn drained_shard_resumes_from_the_high_watermark() {
-        // Carries the cursor past updates the request's filters excluded, so they are not re-read.
-        let watermark = resume_watermark(&batch(100, false), StateVersion::from(250));
-        assert_eq!(watermark, StateVersion::from(250));
-    }
-
-    #[test]
-    fn truncated_pass_resumes_from_the_last_delivered_version() {
-        let watermark = resume_watermark(&batch(100, true), StateVersion::from(250));
-        assert_eq!(watermark, StateVersion::from(100));
-    }
-
-    #[test]
-    fn a_truncated_pass_leaves_every_undelivered_update_above_the_cursor() {
-        let watermark = resume_watermark(&batch(100, true), StateVersion::from(250));
-        for undelivered in [101u64, 175, 250] {
-            assert!(StateVersion::from(undelivered) > watermark);
-        }
-    }
-
     #[test]
     fn cursor_advances_monotonically() {
         let mut cursor = ShardCursor::default();
@@ -341,5 +281,13 @@ mod tests {
         cursor.observe(shard, StateVersion::from(250));
         cursor.observe(shard, StateVersion::from(100));
         assert_eq!(cursor.get(shard), StateVersion::from(250));
+    }
+
+    #[test]
+    fn genesis_covers_every_shard_at_zero() {
+        let cursor = ShardCursor::genesis(NumPreshards::P4);
+        let pairs = cursor.to_pairs();
+        assert_eq!(pairs.len(), 4);
+        assert!(pairs.iter().all(|(_, v)| *v == StateVersion::zero()));
     }
 }

--- a/crates/wallet/ootle-rs/src/provider/utxo_watcher.rs
+++ b/crates/wallet/ootle-rs/src/provider/utxo_watcher.rs
@@ -129,6 +129,7 @@ impl StealthUtxoStream {
                 },
             };
 
+            let per_shard_limit = self.request.per_shard_limit;
             let mut stream = match client.stream_utxo_updates_protobuf(self.request.into_request()).await {
                 Ok(stream) => stream,
                 Err(err) => {
@@ -138,19 +139,25 @@ impl StealthUtxoStream {
                 },
             };
 
-            // `EndOfShard` on the wire does not carry the shard number; stamp it from the preceding
-            // `StartOfShard` so each frame is self-describing.
-            let mut current_shard: Option<Shard> = None;
+            // `EndOfShard` on the wire carries neither the shard number nor what the pass returned;
+            // both come from the preceding `StartOfShard`, so each pass is held until its
+            // `EndOfShard` arrives.
+            let mut current_pass: Option<ShardPass> = None;
             loop {
                 match stream.next().await {
                     Some(Ok(payload)) => {
                         let UtxoUpdatePayload { sos, update, eos } = payload;
                         if let Some(sos) = sos {
                             let shard = Shard::from(sos.shard);
-                            current_shard = Some(shard);
+                            let max_state_version = StateVersion::from(sos.max_state_version);
+                            current_pass = Some(ShardPass {
+                                shard,
+                                max_state_version,
+                                filled_limit: sos.num_updates >= per_shard_limit,
+                            });
                             yield Ok(StealthUtxoFrame::StartOfShard {
                                 shard,
-                                max_state_version: StateVersion::from(sos.max_state_version),
+                                max_state_version,
                                 num_updates: sos.num_updates,
                                 has_more: sos.has_more,
                             });
@@ -165,18 +172,18 @@ impl StealthUtxoStream {
                             }
                         }
                         if let Some(eos) = eos {
-                            // Take the shard so a following `EndOfShard` (or any frame) that is not
+                            // Take the pass so a following `EndOfShard` (or any frame) that is not
                             // preceded by a fresh `StartOfShard` errors out rather than being
                             // misattributed to this shard and corrupting its cursor.
-                            let Some(shard) = current_shard.take() else {
+                            let Some(pass) = current_pass.take() else {
                                 yield Err(UtxoWatcherError::DecodeError(
                                     "EndOfShard received before any StartOfShard".to_string(),
                                 ));
                                 return;
                             };
                             yield Ok(StealthUtxoFrame::EndOfShard {
-                                shard,
-                                max_state_version: StateVersion::from(eos.max_state_version),
+                                shard: pass.shard,
+                                max_state_version: pass.resume_from(StateVersion::from(eos.max_state_version)),
                             });
                         }
                     },
@@ -188,6 +195,32 @@ impl StealthUtxoStream {
                     None => return,
                 }
             }
+        }
+    }
+}
+
+/// What one pass over a single shard returned, held from its `StartOfShard` to its `EndOfShard`.
+struct ShardPass {
+    shard: Shard,
+    /// The highest state version delivered in the pass.
+    max_state_version: StateVersion,
+    /// The pass returned `per_shard_limit` updates or more.
+    filled_limit: bool,
+}
+
+impl ShardPass {
+    /// The state version to resume this shard from, given the `EndOfShard` watermark.
+    ///
+    /// An indexer that chooses the resume point itself already accounts for what it withheld, and
+    /// the cap below is inert against one. An indexer predating that reports the shard's high
+    /// watermark unconditionally — the newest version it holds, taken over the whole shard — which
+    /// on a pass that filled the limit sits above updates it did not send. A pass that filled the
+    /// limit is therefore never resumed above its own last delivered version.
+    fn resume_from(&self, watermark: StateVersion) -> StateVersion {
+        if self.filled_limit {
+            watermark.min(self.max_state_version)
+        } else {
+            watermark
         }
     }
 }
@@ -273,6 +306,41 @@ impl ShardCursor {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn pass(max_state_version: u64, filled_limit: bool) -> ShardPass {
+        ShardPass {
+            shard: Shard::from(1u32),
+            max_state_version: StateVersion::from(max_state_version),
+            filled_limit,
+        }
+    }
+
+    #[test]
+    fn a_pass_that_filled_the_limit_is_capped_at_its_last_delivered_version() {
+        // An indexer that reports the shard's high watermark regardless of what it withheld.
+        assert_eq!(
+            pass(100, true).resume_from(StateVersion::from(250)),
+            StateVersion::from(100)
+        );
+    }
+
+    #[test]
+    fn a_short_pass_takes_the_watermark_whole() {
+        // Nothing was withheld, so the watermark also carries the cursor past filtered-out versions.
+        assert_eq!(
+            pass(100, false).resume_from(StateVersion::from(250)),
+            StateVersion::from(250)
+        );
+    }
+
+    #[test]
+    fn the_cap_is_inert_when_the_indexer_chose_the_resume_point() {
+        // Such an indexer sends its last delivered version as the watermark on a truncated pass.
+        assert_eq!(
+            pass(100, true).resume_from(StateVersion::from(100)),
+            StateVersion::from(100)
+        );
+    }
 
     #[test]
     fn cursor_advances_monotonically() {

--- a/crates/wallet/ootle-rs/src/provider/utxo_watcher.rs
+++ b/crates/wallet/ootle-rs/src/provider/utxo_watcher.rs
@@ -129,7 +129,6 @@ impl StealthUtxoStream {
                 },
             };
 
-            let per_shard_limit = self.request.per_shard_limit;
             let mut stream = match client.stream_utxo_updates_protobuf(self.request.into_request()).await {
                 Ok(stream) => stream,
                 Err(err) => {
@@ -139,25 +138,19 @@ impl StealthUtxoStream {
                 },
             };
 
-            // `EndOfShard` on the wire carries neither the shard number nor what the pass returned;
-            // both come from the preceding `StartOfShard`, so each pass is held until its
-            // `EndOfShard` arrives.
-            let mut current_pass: Option<ShardPass> = None;
+            // `EndOfShard` on the wire does not carry the shard number; stamp it from the preceding
+            // `StartOfShard` so each frame is self-describing.
+            let mut current_shard: Option<Shard> = None;
             loop {
                 match stream.next().await {
                     Some(Ok(payload)) => {
                         let UtxoUpdatePayload { sos, update, eos } = payload;
                         if let Some(sos) = sos {
                             let shard = Shard::from(sos.shard);
-                            let max_state_version = StateVersion::from(sos.max_state_version);
-                            current_pass = Some(ShardPass {
-                                shard,
-                                max_state_version,
-                                filled_limit: sos.num_updates >= per_shard_limit,
-                            });
+                            current_shard = Some(shard);
                             yield Ok(StealthUtxoFrame::StartOfShard {
                                 shard,
-                                max_state_version,
+                                max_state_version: StateVersion::from(sos.max_state_version),
                                 num_updates: sos.num_updates,
                                 has_more: sos.has_more,
                             });
@@ -172,18 +165,18 @@ impl StealthUtxoStream {
                             }
                         }
                         if let Some(eos) = eos {
-                            // Take the pass so a following `EndOfShard` (or any frame) that is not
+                            // Take the shard so a following `EndOfShard` (or any frame) that is not
                             // preceded by a fresh `StartOfShard` errors out rather than being
                             // misattributed to this shard and corrupting its cursor.
-                            let Some(pass) = current_pass.take() else {
+                            let Some(shard) = current_shard.take() else {
                                 yield Err(UtxoWatcherError::DecodeError(
                                     "EndOfShard received before any StartOfShard".to_string(),
                                 ));
                                 return;
                             };
                             yield Ok(StealthUtxoFrame::EndOfShard {
-                                shard: pass.shard,
-                                max_state_version: pass.resume_from(StateVersion::from(eos.max_state_version)),
+                                shard,
+                                max_state_version: StateVersion::from(eos.max_state_version),
                             });
                         }
                     },
@@ -195,32 +188,6 @@ impl StealthUtxoStream {
                     None => return,
                 }
             }
-        }
-    }
-}
-
-/// What one pass over a single shard returned, held from its `StartOfShard` to its `EndOfShard`.
-struct ShardPass {
-    shard: Shard,
-    /// The highest state version delivered in the pass.
-    max_state_version: StateVersion,
-    /// The pass returned `per_shard_limit` updates or more.
-    filled_limit: bool,
-}
-
-impl ShardPass {
-    /// The state version to resume this shard from, given the `EndOfShard` watermark.
-    ///
-    /// An indexer that chooses the resume point itself already accounts for what it withheld, and
-    /// the cap below is inert against one. An indexer predating that reports the shard's high
-    /// watermark unconditionally — the newest version it holds, taken over the whole shard — which
-    /// on a pass that filled the limit sits above updates it did not send. A pass that filled the
-    /// limit is therefore never resumed above its own last delivered version.
-    fn resume_from(&self, watermark: StateVersion) -> StateVersion {
-        if self.filled_limit {
-            watermark.min(self.max_state_version)
-        } else {
-            watermark
         }
     }
 }
@@ -306,41 +273,6 @@ impl ShardCursor {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn pass(max_state_version: u64, filled_limit: bool) -> ShardPass {
-        ShardPass {
-            shard: Shard::from(1u32),
-            max_state_version: StateVersion::from(max_state_version),
-            filled_limit,
-        }
-    }
-
-    #[test]
-    fn a_pass_that_filled_the_limit_is_capped_at_its_last_delivered_version() {
-        // An indexer that reports the shard's high watermark regardless of what it withheld.
-        assert_eq!(
-            pass(100, true).resume_from(StateVersion::from(250)),
-            StateVersion::from(100)
-        );
-    }
-
-    #[test]
-    fn a_short_pass_takes_the_watermark_whole() {
-        // Nothing was withheld, so the watermark also carries the cursor past filtered-out versions.
-        assert_eq!(
-            pass(100, false).resume_from(StateVersion::from(250)),
-            StateVersion::from(250)
-        );
-    }
-
-    #[test]
-    fn the_cap_is_inert_when_the_indexer_chose_the_resume_point() {
-        // Such an indexer sends its last delivered version as the watermark on a truncated pass.
-        assert_eq!(
-            pass(100, true).resume_from(StateVersion::from(100)),
-            StateVersion::from(100)
-        );
-    }
 
     #[test]
     fn cursor_advances_monotonically() {

--- a/crates/wallet/ootle-rs/src/provider/utxo_watcher.rs
+++ b/crates/wallet/ootle-rs/src/provider/utxo_watcher.rs
@@ -50,8 +50,9 @@ impl StealthUtxoWatchRequest {
 /// A single decoded frame from the stealth UTXO update stream.
 ///
 /// Frames arrive grouped per shard: a `StartOfShard`, then zero or more `Unspent`/`Spent`/`Burnt`
-/// updates, terminated by an `EndOfShard` carrying the shard's high-watermark state version — use
-/// it to advance the resume cursor for that shard (see [`ShardCursor::observe`]).
+/// updates, terminated by an `EndOfShard`. `EndOfShard::max_state_version` is always a safe resume
+/// point for that shard — every update at or below it has been delivered — so advance the cursor
+/// from it via [`ShardCursor::observe`].
 #[derive(Debug, Clone)]
 pub enum StealthUtxoFrame {
     StartOfShard {
@@ -74,6 +75,9 @@ pub enum StealthUtxoFrame {
         id: UtxoId,
         version: u32,
     },
+    /// Terminates a shard's updates. `max_state_version` is the resume point for the shard: the
+    /// last delivered version while the shard still has updates to drain, and the shard's high
+    /// watermark once it is drained.
     EndOfShard {
         shard: Shard,
         max_state_version: StateVersion,
@@ -120,6 +124,7 @@ impl StealthUtxoStream {
                 },
             };
 
+            let per_shard_limit = self.request.per_shard_limit;
             let mut stream = match client.stream_utxo_updates_protobuf(self.request.into_request()).await {
                 Ok(stream) => stream,
                 Err(err) => {
@@ -129,19 +134,25 @@ impl StealthUtxoStream {
                 },
             };
 
-            // `EndOfShard` on the wire does not carry the shard number; stamp it from the preceding
-            // `StartOfShard` so each frame is self-describing.
-            let mut current_shard: Option<Shard> = None;
+            // `EndOfShard` on the wire carries neither the shard number nor any notion of how much
+            // of the shard was delivered; both come from the preceding `StartOfShard`, so each pass
+            // is remembered until its `EndOfShard` arrives.
+            let mut current_batch: Option<ShardBatch> = None;
             loop {
                 match stream.next().await {
                     Some(Ok(payload)) => {
                         let UtxoUpdatePayload { sos, update, eos } = payload;
                         if let Some(sos) = sos {
                             let shard = Shard::from(sos.shard);
-                            current_shard = Some(shard);
+                            let max_state_version = StateVersion::from(sos.max_state_version);
+                            current_batch = Some(ShardBatch {
+                                shard,
+                                max_state_version,
+                                is_truncated: sos.num_updates >= per_shard_limit,
+                            });
                             yield Ok(StealthUtxoFrame::StartOfShard {
                                 shard,
-                                max_state_version: StateVersion::from(sos.max_state_version),
+                                max_state_version,
                                 num_updates: sos.num_updates,
                             });
                         }
@@ -155,18 +166,21 @@ impl StealthUtxoStream {
                             }
                         }
                         if let Some(eos) = eos {
-                            // Take the shard so a following `EndOfShard` (or any frame) that is not
+                            // Take the batch so a following `EndOfShard` (or any frame) that is not
                             // preceded by a fresh `StartOfShard` errors out rather than being
                             // misattributed to this shard and corrupting its cursor.
-                            let Some(shard) = current_shard.take() else {
+                            let Some(batch) = current_batch.take() else {
                                 yield Err(UtxoWatcherError::DecodeError(
                                     "EndOfShard received before any StartOfShard".to_string(),
                                 ));
                                 return;
                             };
+                            let shard = batch.shard;
+                            let max_state_version =
+                                resume_watermark(&batch, StateVersion::from(eos.max_state_version));
                             yield Ok(StealthUtxoFrame::EndOfShard {
                                 shard,
-                                max_state_version: StateVersion::from(eos.max_state_version),
+                                max_state_version,
                             });
                         }
                     },
@@ -179,6 +193,33 @@ impl StealthUtxoStream {
                 }
             }
         }
+    }
+}
+
+/// What one pass over a single shard delivered, carried from its `StartOfShard` to its
+/// `EndOfShard`.
+struct ShardBatch {
+    shard: Shard,
+    /// The highest state version actually delivered in the pass.
+    max_state_version: StateVersion,
+    /// The pass filled `per_shard_limit`, so the shard holds further updates above
+    /// `max_state_version`.
+    is_truncated: bool,
+}
+
+/// The state version a shard's cursor may resume from after a pass.
+///
+/// `high_watermark` is the newest state version the indexer holds for the shard, taken over the
+/// whole shard rather than over what the pass returned. It therefore sits above the updates a
+/// truncated pass left undelivered, and resuming from it would step over them for good. Such a pass
+/// resumes from its last delivered version instead; only a pass that drained the shard may take the
+/// high watermark, which additionally carries the cursor past updates the request's own filters
+/// excluded.
+fn resume_watermark(batch: &ShardBatch, high_watermark: StateVersion) -> StateVersion {
+    if batch.is_truncated {
+        batch.max_state_version
+    } else {
+        high_watermark
     }
 }
 
@@ -257,5 +298,48 @@ impl ShardCursor {
         if max_state_version > *entry {
             *entry = max_state_version;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn batch(max_state_version: u64, is_truncated: bool) -> ShardBatch {
+        ShardBatch {
+            shard: Shard::from(1u32),
+            max_state_version: StateVersion::from(max_state_version),
+            is_truncated,
+        }
+    }
+
+    #[test]
+    fn drained_shard_resumes_from_the_high_watermark() {
+        // Carries the cursor past updates the request's filters excluded, so they are not re-read.
+        let watermark = resume_watermark(&batch(100, false), StateVersion::from(250));
+        assert_eq!(watermark, StateVersion::from(250));
+    }
+
+    #[test]
+    fn truncated_pass_resumes_from_the_last_delivered_version() {
+        let watermark = resume_watermark(&batch(100, true), StateVersion::from(250));
+        assert_eq!(watermark, StateVersion::from(100));
+    }
+
+    #[test]
+    fn a_truncated_pass_leaves_every_undelivered_update_above_the_cursor() {
+        let watermark = resume_watermark(&batch(100, true), StateVersion::from(250));
+        for undelivered in [101u64, 175, 250] {
+            assert!(StateVersion::from(undelivered) > watermark);
+        }
+    }
+
+    #[test]
+    fn cursor_advances_monotonically() {
+        let mut cursor = ShardCursor::default();
+        let shard = Shard::from(1u32);
+        cursor.observe(shard, StateVersion::from(250));
+        cursor.observe(shard, StateVersion::from(100));
+        assert_eq!(cursor.get(shard), StateVersion::from(250));
     }
 }

--- a/crates/wallet/sdk/Cargo.toml
+++ b/crates/wallet/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_wallet_sdk"
 description = "The Tari wallet library"
-version = "0.42.0"
+version = "0.43.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/wallet/sdk/src/models/utxo_update.rs
+++ b/crates/wallet/sdk/src/models/utxo_update.rs
@@ -22,6 +22,7 @@ pub struct UtxoUpdatePayload {
 pub struct StartOfShard {
     pub shard: Shard,
     pub max_state_version: StateVersion,
+    /// The shard holds updates beyond this pass, as reported by the indexer.
     pub has_more: bool,
 }
 

--- a/crates/wallet/sdk_services/src/indexer_rest_api.rs
+++ b/crates/wallet/sdk_services/src/indexer_rest_api.rs
@@ -232,7 +232,7 @@ impl WalletNetworkInterface for IndexerRestApiNetworkInterface {
                 let sos = res.sos.map(|sos| StartOfShard {
                     shard: Shard::from(sos.shard),
                     max_state_version: StateVersion::from(sos.max_state_version),
-                    has_more: sos.num_updates >= 1000,
+                    has_more: sos.has_more,
                 });
                 let update = res
                     .update

--- a/crates/wallet/storage_sqlite/Cargo.toml
+++ b/crates/wallet/storage_sqlite/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_wallet_storage_sqlite"
 description = "The Tari wallet SQLite storage library"
-version = "0.42.0"
+version = "0.43.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## Description

A wallet scanning stealth UTXOs could silently skip outputs — no error, no gap in the frame sequence, and nothing to notice after the fact. Two independent causes, both in the `/utxos/stream` resume protocol.

### 1. A read could stop in the middle of a state version

`state_version` is stamped per *sync batch* (`network_state_sync/worker.rs:638`) and applied to every update in it, so every UTXO a block touches on a shard shares one version. It is not a unique key, and a client's cursor can only say "everything after version V" — it cannot address a row within a version.

`utxos_get_updates` ordered by `state_version` and cut at `LIMIT n` wherever that fell. When the cut landed inside a version group, the reported `max_state_version` was that group's version `V`, and the next request's `> V` filter dropped the rest of the group. One busy block on a shard was enough.

### 2. `EndOfShard` reported a watermark above what was delivered

`EndOfShard.max_state_version` came from `utxos_get_max_state_version` — `MAX(state_version)` over the whole shard, ignoring `from_epoch`, `unspent_only` and the `per_shard_limit` truncation. `ootle-rs`'s `ShardCursor::observe` advanced from it unconditionally, exactly as the frame's doc instructed, so a truncated pass jumped its cursor past its own undelivered remainder.

## Fix

**Reads end on a version boundary** (`storage_sqlite/reader.rs`). The query takes one row beyond the limit to find where the boundary falls and holds back a trailing partial group. Note the `limit + 1` read is only a *probe*: when the whole probe sits at one version that group may be far larger, so a second unbounded read fetches it in full. A version group wider than the limit has no complete predecessor to stop at, so it is served whole and the limit gives way — returning nothing would leave the cursor unable to advance past the shard.

**Truncation is the server's answer, not each client's inference.** `UtxoStateUpdateSet` and protobuf `StartOfShard` carry `has_more` (new field tag 4, additive and wire-compatible), and `EndOfShard.max_state_version` is the resume point the indexer chose: the last delivered version while the shard has more to give, the shard's high watermark once drained. The high watermark still does its job on a drained pass — it carries the cursor past versions the request's own filters excluded.

Both consumers drop their `num_updates >= per_shard_limit` heuristic, which group-trimming makes actively wrong: a short batch would read as a drained shard. `ootle-rs` resumes from `EndOfShard`; `sdk_services`' scanner resumes from `StartOfShard.max_state_version` (now always a complete version) and loops on the authoritative `has_more`.

`per_shard_limit == 0` is now rejected: updates are served in whole state versions, so a zero limit would return one version rather than the empty response it asks for.

## Also in this PR

- **`X-Accel-Buffering: no`** on the three streaming endpoints (`/events`, `/transactions/events/stream`, `/utxos/stream`) via a shared helper. nginx and the proxies following its conventions buffer upstream responses by default, holding a stream's frames until the buffer fills or the response ends — on a long-lived SSE stream, indefinitely.
- **`/utxos/stream` declares its negotiated content type** instead of always answering `application/octet-stream`: `application/x-protobuf` for the length-delimited protobuf framing, `application/x-ndjson` for the newline-delimited JSON one. `Accept` gains `application/x-ndjson` alongside the existing `application/json`. Neither client validated the old header, so this is safe.

Both came out of checking whether the indexer can be horizontally scaled behind a load balancer. Worth recording from that review: the UTXO stream cursor is a network-global `(shard, state_version)` pair and each indexer's `utxos` table is contiguous per shard, so UTXO scanning is safe to round-robin across instances. The bugs above are orthogonal to that and bite a single indexer just as hard.

## Versions

Per `scripts/crate_versioning.py impact tari_indexer_client --breaking` — adding a public field is a minor bump:

| crate | version |
| --- | --- |
| `tari_indexer_client` | 0.41.0 → 0.42.0 |
| `ootle-rs` | 0.22.0 → 0.23.0 |
| `tari_ootle_wallet_sdk` | 0.42.0 → 0.43.0 |
| `tari_ootle_wallet_storage_sqlite` | 0.42.0 → 0.43.0 |
| `tari_ootle_walletd_client` | 0.42.0 → 0.43.0 |

Plus the workspace pins, and `bindings/src/types/UtxoStateUpdateSet.ts` hand-updated for the new field.

## Test plan

- [x] Four store tests in `storage_sqlite/store_factory.rs`: mid-group cut, lossless paged resume (drains a shard and asserts every row is seen), oversized group served whole, drained read reports no more
- [x] `ootle-rs` cursor tests in `utxo_watcher.rs`: monotonic advance, genesis covers every shard at zero
- [x] 36 `tari_indexer` storage tests and 34 `ootle-rs` lib tests pass
- [x] `cargo clippy --all-targets` clean on the touched crates
- [x] `cargo +nightly-2025-12-05 fmt --all`