### PR TITLE
test(integration): cover an epoch change that splits the committee

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5396,6 +5396,7 @@ dependencies = [
  "tari_validator_rollback",
  "time",
  "tokio",
+ "toml 0.9.11+spec-1.1.0",
  "tonic 0.13.1",
  "yaml_serde",
 ]
@@ -11972,6 +11973,7 @@ dependencies = [
  "tari_ootle_transaction",
  "tari_template_lib",
  "tari_transaction_components",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "toml 0.9.11+spec-1.1.0",

--- a/applications/tari_indexer/Cargo.toml
+++ b/applications/tari_indexer/Cargo.toml
@@ -32,7 +32,7 @@ tari_indexer_client = { workspace = true, default-features = false, features = [
 tari_indexer_lib = { workspace = true }
 tari_ootle_template_metadata = { workspace = true }
 tari_networking = { workspace = true }
-tari_ootle_app_utilities = { workspace = true, features = ["epoch_oracle", "p2p"] }
+tari_ootle_app_utilities = { workspace = true, features = ["consensus_constants", "epoch_oracle", "p2p"] }
 tari_ootle_common_types = { workspace = true }
 tari_ootle_p2p = { workspace = true }
 tari_ootle_storage = { workspace = true }

--- a/applications/tari_indexer/src/bootstrap.rs
+++ b/applications/tari_indexer/src/bootstrap.rs
@@ -415,6 +415,7 @@ pub async fn spawn_services(
     save_identities(config, &keypair)?;
     Ok(Services {
         network: config.network,
+        consensus_constants: consensus_constants.clone(),
         published_config: PublishedIndexerConfig::from(&config.indexer),
         keypair,
         networking,
@@ -435,6 +436,7 @@ pub async fn spawn_services(
 
 pub struct Services {
     pub network: Network,
+    pub consensus_constants: ConsensusConstants,
     pub published_config: PublishedIndexerConfig,
     pub keypair: RistrettoKeypair,
     pub networking: NetworkingHandle<TariMessagingSpec>,

--- a/applications/tari_indexer/src/config.rs
+++ b/applications/tari_indexer/src/config.rs
@@ -82,12 +82,19 @@ impl ApplicationConfig {
         self.to_data_dir().join("state.db")
     }
 
-    pub fn consensus_constants_path(&self) -> PathBuf {
-        if self.indexer.consensus_constants_file.is_absolute() {
-            return self.indexer.consensus_constants_file.clone();
+    /// The configured consensus constants file, resolved against the data directory.
+    pub fn localnet_consensus_constants_path(&self) -> Option<PathBuf> {
+        let path = self.indexer.localnet_consensus_constants_file.as_ref()?;
+        if path.is_absolute() {
+            return Some(path.clone());
         }
 
-        self.to_data_dir().join(&self.indexer.consensus_constants_file)
+        Some(self.to_data_dir().join(path))
+    }
+
+    /// Where a consensus constants file is picked up from when none is configured.
+    pub fn default_localnet_consensus_constants_path(&self) -> PathBuf {
+        self.to_data_dir().join("consensus_constants.toml")
     }
 
     pub fn global_db_path(&self) -> PathBuf {
@@ -104,11 +111,12 @@ pub struct IndexerConfig {
     pub identity_file: PathBuf,
     /// The relative path to store persistent data
     pub data_dir: PathBuf,
-    /// An absolute or relative (to data_dir) path to a file of consensus constant overrides. Read
-    /// once at startup, and only on LocalNet: every other network's constants are part of what its
-    /// nodes agree on. Absent file means the network's own constants.
-    #[serde(default = "default_consensus_constants_file")]
-    pub consensus_constants_file: PathBuf,
+    /// An absolute or relative (to data_dir) path to a file of consensus constant overrides, read
+    /// once at startup and only on LocalNet. Setting it says the file is expected, so an indexer that
+    /// cannot find it refuses to start. Leave it unset to pick up
+    /// `<data_dir>/consensus_constants.toml` if it happens to be there.
+    #[serde(default)]
+    pub localnet_consensus_constants_file: Option<PathBuf>,
     /// The p2p configuration settings
     pub p2p: P2pConfig,
     /// Listening address for the indexer API server
@@ -261,10 +269,6 @@ impl From<&IndexerConfig> for PublishedIndexerConfig {
     }
 }
 
-fn default_consensus_constants_file() -> PathBuf {
-    PathBuf::from("consensus_constants.toml")
-}
-
 fn default_transaction_retention_epochs() -> Option<u64> {
     Some(50)
 }
@@ -365,7 +369,7 @@ impl Default for IndexerConfig {
             override_from: None,
             identity_file: PathBuf::from("indexer_id.json"),
             data_dir: PathBuf::from("data/indexer"),
-            consensus_constants_file: default_consensus_constants_file(),
+            localnet_consensus_constants_file: None,
             p2p: P2pConfig::default(),
             api_listen_address: Some("127.0.0.1:18300".parse().unwrap()),
             metrics_listen_address: Some("127.0.0.1:18302".parse().unwrap()),

--- a/applications/tari_indexer/src/config.rs
+++ b/applications/tari_indexer/src/config.rs
@@ -82,6 +82,14 @@ impl ApplicationConfig {
         self.to_data_dir().join("state.db")
     }
 
+    pub fn consensus_constants_path(&self) -> PathBuf {
+        if self.indexer.consensus_constants_file.is_absolute() {
+            return self.indexer.consensus_constants_file.clone();
+        }
+
+        self.to_data_dir().join(&self.indexer.consensus_constants_file)
+    }
+
     pub fn global_db_path(&self) -> PathBuf {
         self.to_data_dir().join("global_storage.sqlite")
     }
@@ -96,6 +104,11 @@ pub struct IndexerConfig {
     pub identity_file: PathBuf,
     /// The relative path to store persistent data
     pub data_dir: PathBuf,
+    /// An absolute or relative (to data_dir) path to a file of consensus constant overrides. Read
+    /// once at startup, and only on LocalNet: every other network's constants are part of what its
+    /// nodes agree on. Absent file means the network's own constants.
+    #[serde(default = "default_consensus_constants_file")]
+    pub consensus_constants_file: PathBuf,
     /// The p2p configuration settings
     pub p2p: P2pConfig,
     /// Listening address for the indexer API server
@@ -248,6 +261,10 @@ impl From<&IndexerConfig> for PublishedIndexerConfig {
     }
 }
 
+fn default_consensus_constants_file() -> PathBuf {
+    PathBuf::from("consensus_constants.toml")
+}
+
 fn default_transaction_retention_epochs() -> Option<u64> {
     Some(50)
 }
@@ -348,6 +365,7 @@ impl Default for IndexerConfig {
             override_from: None,
             identity_file: PathBuf::from("indexer_id.json"),
             data_dir: PathBuf::from("data/indexer"),
+            consensus_constants_file: default_consensus_constants_file(),
             p2p: P2pConfig::default(),
             api_listen_address: Some("127.0.0.1:18300".parse().unwrap()),
             metrics_listen_address: Some("127.0.0.1:18302".parse().unwrap()),

--- a/applications/tari_indexer/src/lib.rs
+++ b/applications/tari_indexer/src/lib.rs
@@ -106,7 +106,11 @@ where
     #[cfg(feature = "metrics")]
     let mut registry = create_metrics_registry(keypair.public_key());
 
-    let consensus_constants = load_consensus_constants(config.network, &config.consensus_constants_path())?;
+    let consensus_constants = load_consensus_constants(
+        config.network,
+        config.localnet_consensus_constants_path().as_deref(),
+        &config.default_localnet_consensus_constants_path(),
+    )?;
     let services = spawn_services(
         &config,
         shutdown_signal.clone(),

--- a/applications/tari_indexer/src/lib.rs
+++ b/applications/tari_indexer/src/lib.rs
@@ -57,7 +57,6 @@ use log::*;
 pub use rest_api::ApiDoc;
 use serde::Serialize;
 use tari_common::exit_codes::{ExitCode, ExitError};
-use tari_consensus::consensus_constants::ConsensusConstants;
 use tari_epoch_manager::{
     EpochManagerEvent,
     EpochManagerReader,
@@ -65,7 +64,7 @@ use tari_epoch_manager::{
 };
 use tari_epoch_oracles::EpochOracle;
 use tari_networking::NetworkingService;
-use tari_ootle_app_utilities::keypair::setup_keypair_prompt;
+use tari_ootle_app_utilities::{consensus_constants_file::load_consensus_constants, keypair::setup_keypair_prompt};
 use tari_ootle_common_types::layer_one_transaction::LayerOneTransactionDef;
 use tari_ootle_p2p::PeerAddress;
 use tari_ootle_storage::global::{DbFactory, GlobalDb};
@@ -107,7 +106,7 @@ where
     #[cfg(feature = "metrics")]
     let mut registry = create_metrics_registry(keypair.public_key());
 
-    let consensus_constants = ConsensusConstants::from(config.network);
+    let consensus_constants = load_consensus_constants(config.network, &config.consensus_constants_path())?;
     let services = spawn_services(
         &config,
         shutdown_signal.clone(),

--- a/applications/tari_indexer/src/rest_api/context.rs
+++ b/applications/tari_indexer/src/rest_api/context.rs
@@ -8,6 +8,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use ootle_byte_type::ToByteType;
+use tari_consensus::consensus_constants::ConsensusConstants;
 use tari_epoch_manager::service::EpochManagerHandle;
 use tari_indexer_client::event::{IndexerEvent, TransactionEvent};
 use tari_networking::NetworkingHandle;
@@ -44,6 +45,7 @@ impl HandlerContext {
             inner: Arc::new(InnerContext {
                 cache_control_enabled: true,
                 network: services.network,
+                consensus_constants: services.consensus_constants.clone(),
                 published_config: services.published_config.clone(),
                 read_only_store: ReadOnlyStore::new(services.store.clone()),
                 global_db: services.global_db.clone(),
@@ -64,6 +66,12 @@ impl HandlerContext {
 
     pub fn global_db(&self) -> &GlobalDb<SqliteGlobalDbAdapter<PeerAddress>> {
         &self.inner.global_db
+    }
+
+    /// The constants this indexer started with, which on a LocalNet may differ from the network's
+    /// built-in values.
+    pub fn consensus_constants(&self) -> &ConsensusConstants {
+        &self.inner.consensus_constants
     }
 
     pub fn network(&self) -> Network {
@@ -146,6 +154,7 @@ impl HandlerContext {
 struct InnerContext {
     cache_control_enabled: bool,
     network: Network,
+    consensus_constants: ConsensusConstants,
     published_config: PublishedIndexerConfig,
     global_db: GlobalDb<SqliteGlobalDbAdapter<PeerAddress>>,
     epoch_manager: EpochManagerHandle<PeerAddress>,

--- a/applications/tari_indexer/src/rest_api/handlers/network.rs
+++ b/applications/tari_indexer/src/rest_api/handlers/network.rs
@@ -4,7 +4,7 @@
 use std::{ops::Deref, time::UNIX_EPOCH};
 
 use axum::{Extension, Json, response::Response};
-use tari_consensus::{consensus_constants::ConsensusConstants, hotstuff::ConsensusCurrentState};
+use tari_consensus::hotstuff::ConsensusCurrentState;
 use tari_indexer_client::{
     types,
     types::{
@@ -54,9 +54,7 @@ pub async fn get_economics(Extension(context): Extension<HandlerContext>) -> Han
         .await
         .map_err(ErrorResponse::anyhow)?;
 
-    let target_burn_rate_bps = ConsensusConstants::from(context.network())
-        .exhaust_burn_rate(current_epoch)
-        .as_bps();
+    let target_burn_rate_bps = context.consensus_constants().exhaust_burn_rate(current_epoch).as_bps();
     // Supply nets the receipt-sourced burn against claimed (both advance on the state-sync frontier), matching
     // `get_xtr_total_supply`; `total_exhaust_burned` (header) is reported alongside as a cross-check.
     let total_supply = econ

--- a/applications/tari_ootle_app_utilities/Cargo.toml
+++ b/applications/tari_ootle_app_utilities/Cargo.toml
@@ -43,9 +43,13 @@ tokio = { workspace = true, features = ["default", "macros", "time", "sync", "rt
 url = { workspace = true, features = ["serde"] }
 toml = { workspace = true }
 config = { workspace = true }
+# Only the consensus constants file needs the consensus engine, so it is behind a feature: nothing
+# that merely prices a transaction has to carry it.
+tari_consensus = { workspace = true, optional = true }
 
 [dev-dependencies]
 bounded-vec = { workspace = true }
+tempfile = { workspace = true }
 # Test-only, so nothing that prices a transaction has to carry the consensus engine: lets the
 # restated burn rate be pinned to the consensus constant rather than drifting from it.
 tari_consensus = { workspace = true }
@@ -53,3 +57,4 @@ tari_consensus = { workspace = true }
 [features]
 p2p = ["tari_networking", "tari_ootle_p2p", "libp2p-identity", "multiaddr"]
 epoch_oracle = ["tari_epoch_oracles"]
+consensus_constants = ["tari_consensus"]

--- a/applications/tari_ootle_app_utilities/src/consensus_constants_file.rs
+++ b/applications/tari_ootle_app_utilities/src/consensus_constants_file.rs
@@ -70,6 +70,10 @@ impl ConsensusConstantsFile {
             constants.pacemaker_block_time = Duration::from_secs(secs);
         }
 
+        if constants.committee_size_per_shard_group == 0 {
+            return Err(ConsensusConstantsFileError::CommitteeSizeIsZero);
+        }
+
         if let Some(bps) = self.exhaust_burn_rate_bps {
             if bps > MAX_EXHAUST_BURN_RATE_BPS {
                 return Err(ConsensusConstantsFileError::ExhaustBurnRateTooHigh {
@@ -135,6 +139,8 @@ pub enum ConsensusConstantsFileError {
     Read { path: PathBuf, source: std::io::Error },
     #[error("Failed to parse consensus constants file {path}: {source}")]
     Parse { path: PathBuf, source: toml::de::Error },
+    #[error("Committee size must be greater than zero")]
+    CommitteeSizeIsZero,
     #[error("Exhaust burn rate {bps}bps is above the maximum of {max}bps")]
     ExhaustBurnRateTooHigh { bps: u16, max: u16 },
 }
@@ -171,6 +177,19 @@ mod tests {
         assert_eq!(constants.committee_size_per_shard_group, 3);
         assert_eq!(constants.max_block_weight, defaults.max_block_weight);
         assert_eq!(constants.num_preshards, defaults.num_preshards);
+    }
+
+    #[test]
+    fn a_committee_size_of_zero_is_refused() {
+        let mut constants = ConsensusConstants::from(Network::LocalNet);
+        let overrides = ConsensusConstantsFile {
+            committee_size_per_shard_group: Some(0),
+            ..Default::default()
+        };
+        assert!(matches!(
+            overrides.apply_to(&mut constants),
+            Err(ConsensusConstantsFileError::CommitteeSizeIsZero)
+        ));
     }
 
     #[test]

--- a/applications/tari_ootle_app_utilities/src/consensus_constants_file.rs
+++ b/applications/tari_ootle_app_utilities/src/consensus_constants_file.rs
@@ -84,19 +84,35 @@ impl ConsensusConstantsFile {
     }
 }
 
-/// Loads the consensus constants for `network`, applying the overrides in `path` if that file exists.
+/// Loads the consensus constants for `network`.
 ///
-/// Only a LocalNet reads the file at all. Every other network's constants are part of what its nodes
+/// Only a LocalNet reads a file at all. Every other network's constants are part of what its nodes
 /// agree on, so there is nothing a local file could say about them that would be safe to act on, and
 /// a file left behind by a devnet cannot reach a node that is not on one.
+///
+/// A `configured` path is one an operator named, so its absence is a misconfiguration and is
+/// reported. `default_path` is a convenience - a file may be dropped there to take effect, and its
+/// absence is the ordinary case.
 pub fn load_consensus_constants(
     network: Network,
-    path: &Path,
+    configured: Option<&Path>,
+    default_path: &Path,
 ) -> Result<ConsensusConstants, ConsensusConstantsFileError> {
     let mut constants = ConsensusConstants::from(network);
-    if !matches!(network, Network::LocalNet) || !path.exists() {
+    if !matches!(network, Network::LocalNet) {
         return Ok(constants);
     }
+
+    let path = match configured {
+        Some(path) if !path.exists() => {
+            return Err(ConsensusConstantsFileError::ConfiguredFileNotFound {
+                path: path.to_path_buf(),
+            });
+        },
+        Some(path) => path,
+        None if default_path.exists() => default_path,
+        None => return Ok(constants),
+    };
 
     let contents = fs::read_to_string(path).map_err(|source| ConsensusConstantsFileError::Read {
         path: path.to_path_buf(),
@@ -113,6 +129,8 @@ pub fn load_consensus_constants(
 
 #[derive(Debug, thiserror::Error)]
 pub enum ConsensusConstantsFileError {
+    #[error("Consensus constants file {path} is configured but does not exist")]
+    ConfiguredFileNotFound { path: PathBuf },
     #[error("Failed to read consensus constants file {path}: {source}")]
     Read { path: PathBuf, source: std::io::Error },
     #[error("Failed to parse consensus constants file {path}: {source}")]
@@ -168,14 +186,19 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn a_network_that_is_not_local_does_not_read_the_file() {
-        let dir = tempfile::tempdir().unwrap();
+    fn write_constants_file(dir: &tempfile::TempDir) -> PathBuf {
         let path = dir.path().join("consensus_constants.toml");
         fs::write(&path, "committee_size_per_shard_group = 3").unwrap();
+        path
+    }
+
+    #[test]
+    fn a_network_that_is_not_local_reads_no_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_constants_file(&dir);
 
         for network in [Network::MainNet, Network::Esmeralda, Network::StageNet] {
-            let constants = load_consensus_constants(network, &path).unwrap();
+            let constants = load_consensus_constants(network, Some(&path), &path).unwrap();
             assert_eq!(
                 constants.committee_size_per_shard_group,
                 ConsensusConstants::from(network).committee_size_per_shard_group
@@ -184,13 +207,35 @@ mod tests {
     }
 
     #[test]
-    fn a_local_network_reads_the_file() {
+    fn a_file_at_the_default_location_is_read() {
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("consensus_constants.toml");
-        fs::write(&path, "committee_size_per_shard_group = 3").unwrap();
+        let path = write_constants_file(&dir);
 
-        let constants = load_consensus_constants(Network::LocalNet, &path).unwrap();
+        let constants = load_consensus_constants(Network::LocalNet, None, &path).unwrap();
         assert_eq!(constants.committee_size_per_shard_group, 3);
+    }
+
+    #[test]
+    fn nothing_at_the_default_location_is_the_ordinary_case() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("consensus_constants.toml");
+
+        let constants = load_consensus_constants(Network::LocalNet, None, &missing).unwrap();
+        assert_eq!(
+            constants.committee_size_per_shard_group,
+            ConsensusConstants::DEFAULT_DEVNET_COMMITTEE_SIZE
+        );
+    }
+
+    #[test]
+    fn a_configured_file_that_is_not_there_is_a_misconfiguration() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("elsewhere.toml");
+
+        assert!(matches!(
+            load_consensus_constants(Network::LocalNet, Some(&missing), &missing),
+            Err(ConsensusConstantsFileError::ConfiguredFileNotFound { .. })
+        ));
     }
 
     #[test]

--- a/applications/tari_ootle_app_utilities/src/consensus_constants_file.rs
+++ b/applications/tari_ootle_app_utilities/src/consensus_constants_file.rs
@@ -1,0 +1,201 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
+use serde::{Deserialize, Serialize};
+use tari_consensus::consensus_constants::ConsensusConstants;
+use tari_engine_types::fees::{ExhaustBurnRate, MAX_EXHAUST_BURN_RATE_BPS};
+use tari_ootle_transaction::Network;
+
+/// Overrides for a LocalNet's consensus constants, applied over the network's built-in values.
+///
+/// Consensus constants have to agree across a network, so this is authored once and handed to every
+/// node on a devnet rather than set per node. Every field is optional: an absent field keeps the
+/// network's value, and an absent file leaves the network untouched.
+///
+/// `num_preshards` is deliberately not settable. Shard identity is derived from it everywhere, so
+/// nodes that disagree on it do not form a misconfigured network, they form no network at all.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct ConsensusConstantsFile {
+    pub base_layer_confirmations: Option<u64>,
+    pub committee_size_per_shard_group: Option<u32>,
+    pub pacemaker_block_time_secs: Option<u64>,
+    pub missed_proposal_suspend_threshold: Option<u64>,
+    pub missed_proposal_evict_threshold: Option<u64>,
+    pub missed_proposal_recovery_threshold: Option<u64>,
+    pub max_block_weight: Option<u64>,
+    pub max_commands_in_block: Option<usize>,
+    pub max_block_validation_weight: Option<u64>,
+    pub max_transaction_weight: Option<u64>,
+    pub max_block_execution_points: Option<u64>,
+    pub max_block_validation_execution_points: Option<u64>,
+    pub exhaust_burn_rate_bps: Option<u16>,
+    pub max_transaction_validity_epochs: Option<u64>,
+    pub epoch_end_spread_blocks: Option<u64>,
+}
+
+impl ConsensusConstantsFile {
+    pub fn apply_to(self, constants: &mut ConsensusConstants) -> Result<(), ConsensusConstantsFileError> {
+        macro_rules! set {
+            ($($field:ident),+ $(,)?) => {
+                $(if let Some(value) = self.$field {
+                    constants.$field = value;
+                })+
+            };
+        }
+
+        set!(
+            base_layer_confirmations,
+            committee_size_per_shard_group,
+            missed_proposal_suspend_threshold,
+            missed_proposal_evict_threshold,
+            missed_proposal_recovery_threshold,
+            max_block_weight,
+            max_commands_in_block,
+            max_block_validation_weight,
+            max_transaction_weight,
+            max_block_execution_points,
+            max_block_validation_execution_points,
+            max_transaction_validity_epochs,
+            epoch_end_spread_blocks,
+        );
+
+        if let Some(secs) = self.pacemaker_block_time_secs {
+            constants.pacemaker_block_time = Duration::from_secs(secs);
+        }
+
+        if let Some(bps) = self.exhaust_burn_rate_bps {
+            if bps > MAX_EXHAUST_BURN_RATE_BPS {
+                return Err(ConsensusConstantsFileError::ExhaustBurnRateTooHigh {
+                    bps,
+                    max: MAX_EXHAUST_BURN_RATE_BPS,
+                });
+            }
+            constants.exhaust_burn_rate = ExhaustBurnRate::new(bps);
+        }
+
+        Ok(())
+    }
+}
+
+/// Loads the consensus constants for `network`, applying the overrides in `path` if that file exists.
+///
+/// Only a LocalNet reads the file at all. Every other network's constants are part of what its nodes
+/// agree on, so there is nothing a local file could say about them that would be safe to act on, and
+/// a file left behind by a devnet cannot reach a node that is not on one.
+pub fn load_consensus_constants(
+    network: Network,
+    path: &Path,
+) -> Result<ConsensusConstants, ConsensusConstantsFileError> {
+    let mut constants = ConsensusConstants::from(network);
+    if !matches!(network, Network::LocalNet) || !path.exists() {
+        return Ok(constants);
+    }
+
+    let contents = fs::read_to_string(path).map_err(|source| ConsensusConstantsFileError::Read {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let overrides: ConsensusConstantsFile =
+        toml::from_str(&contents).map_err(|source| ConsensusConstantsFileError::Parse {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    overrides.apply_to(&mut constants)?;
+    Ok(constants)
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ConsensusConstantsFileError {
+    #[error("Failed to read consensus constants file {path}: {source}")]
+    Read { path: PathBuf, source: std::io::Error },
+    #[error("Failed to parse consensus constants file {path}: {source}")]
+    Parse { path: PathBuf, source: toml::de::Error },
+    #[error("Exhaust burn rate {bps}bps is above the maximum of {max}bps")]
+    ExhaustBurnRateTooHigh { bps: u16, max: u16 },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(toml_str: &str) -> ConsensusConstants {
+        let mut constants = ConsensusConstants::from(Network::LocalNet);
+        toml::from_str::<ConsensusConstantsFile>(toml_str)
+            .unwrap()
+            .apply_to(&mut constants)
+            .unwrap();
+        constants
+    }
+
+    #[test]
+    fn an_empty_file_keeps_every_network_value() {
+        let defaults = ConsensusConstants::from(Network::LocalNet);
+        let constants = parse("");
+        assert_eq!(
+            constants.committee_size_per_shard_group,
+            defaults.committee_size_per_shard_group
+        );
+        assert_eq!(constants.pacemaker_block_time, defaults.pacemaker_block_time);
+        assert_eq!(constants.max_block_weight, defaults.max_block_weight);
+    }
+
+    #[test]
+    fn a_field_that_is_set_replaces_only_itself() {
+        let defaults = ConsensusConstants::from(Network::LocalNet);
+        let constants = parse("committee_size_per_shard_group = 3");
+        assert_eq!(constants.committee_size_per_shard_group, 3);
+        assert_eq!(constants.max_block_weight, defaults.max_block_weight);
+        assert_eq!(constants.num_preshards, defaults.num_preshards);
+    }
+
+    #[test]
+    fn a_burn_rate_above_the_maximum_is_refused() {
+        let mut constants = ConsensusConstants::from(Network::LocalNet);
+        let overrides = ConsensusConstantsFile {
+            exhaust_burn_rate_bps: Some(MAX_EXHAUST_BURN_RATE_BPS + 1),
+            ..Default::default()
+        };
+        assert!(matches!(
+            overrides.apply_to(&mut constants),
+            Err(ConsensusConstantsFileError::ExhaustBurnRateTooHigh { .. })
+        ));
+    }
+
+    #[test]
+    fn a_network_that_is_not_local_does_not_read_the_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("consensus_constants.toml");
+        fs::write(&path, "committee_size_per_shard_group = 3").unwrap();
+
+        for network in [Network::MainNet, Network::Esmeralda, Network::StageNet] {
+            let constants = load_consensus_constants(network, &path).unwrap();
+            assert_eq!(
+                constants.committee_size_per_shard_group,
+                ConsensusConstants::from(network).committee_size_per_shard_group
+            );
+        }
+    }
+
+    #[test]
+    fn a_local_network_reads_the_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("consensus_constants.toml");
+        fs::write(&path, "committee_size_per_shard_group = 3").unwrap();
+
+        let constants = load_consensus_constants(Network::LocalNet, &path).unwrap();
+        assert_eq!(constants.committee_size_per_shard_group, 3);
+    }
+
+    #[test]
+    fn a_field_the_network_must_agree_on_by_construction_is_not_settable() {
+        let err = toml::from_str::<ConsensusConstantsFile>("num_preshards = 4").unwrap_err();
+        assert!(err.to_string().contains("num_preshards"), "{err}");
+    }
+}

--- a/applications/tari_ootle_app_utilities/src/lib.rs
+++ b/applications/tari_ootle_app_utilities/src/lib.rs
@@ -23,6 +23,8 @@
 pub mod claim_burn_proof_verifier;
 pub mod common_cli_args;
 pub mod configuration;
+#[cfg(feature = "consensus_constants")]
+pub mod consensus_constants_file;
 #[cfg(feature = "epoch_oracle")]
 pub mod epoch_oracle_config;
 pub mod fee_tables;

--- a/applications/tari_swarm_daemon/Cargo.toml
+++ b/applications/tari_swarm_daemon/Cargo.toml
@@ -21,7 +21,7 @@ minotari_wallet_grpc_client = { workspace = true }
 tari_validator_node_client = { workspace = true }
 tari_ootle_walletd_client = { workspace = true }
 tari_template_lib_types = { workspace = true }
-tari_ootle_app_utilities = { workspace = true }
+tari_ootle_app_utilities = { workspace = true, features = ["consensus_constants"] }
 tari_ootle_wallet_sdk = { workspace = true }
 
 anyhow = { workspace = true }

--- a/applications/tari_swarm_daemon/src/process_definitions/context.rs
+++ b/applications/tari_swarm_daemon/src/process_definitions/context.rs
@@ -1,7 +1,11 @@
 //   Copyright 2024 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::{collections::HashMap, net::IpAddr, path::PathBuf};
+use std::{
+    collections::HashMap,
+    net::IpAddr,
+    path::{Path, PathBuf},
+};
 
 use tari_ootle_wallet_sdk::Network;
 use url::Url;
@@ -15,6 +19,10 @@ use crate::process_manager::{
     MinoTariWalletProcess,
     ValidatorNodeProcess,
 };
+
+/// Name of the swarm-wide consensus constants file. It is written on start-up so that it can simply
+/// be edited, and every node the swarm forks is pointed at it.
+pub const CONSENSUS_CONSTANTS_FILE_NAME: &str = "consensus_constants.toml";
 
 pub struct ProcessContext<'a> {
     instance_id: InstanceId,
@@ -70,6 +78,19 @@ impl<'a> ProcessContext<'a> {
 
     pub fn processes_path(&self) -> &PathBuf {
         &self.processes_path
+    }
+
+    /// The swarm's own directory, which holds the files shared by every instance in it.
+    pub fn swarm_path(&self) -> &Path {
+        self.processes_path
+            .parent()
+            .expect("INVARIANT: the processes directory is always inside the swarm directory")
+    }
+
+    /// The consensus constants every node in this swarm reads. Constants have to agree across a
+    /// network, so this is one file for the swarm rather than one per instance.
+    pub fn consensus_constants_file(&self) -> PathBuf {
+        self.swarm_path().join(CONSENSUS_CONSTANTS_FILE_NAME)
     }
 
     pub fn network(&self) -> Network {

--- a/applications/tari_swarm_daemon/src/process_definitions/context.rs
+++ b/applications/tari_swarm_daemon/src/process_definitions/context.rs
@@ -30,6 +30,7 @@ pub struct ProcessContext<'a> {
     envs: &'a [(String, String)],
     base_path: PathBuf,
     processes_path: PathBuf,
+    swarm_path: PathBuf,
     network: Network,
     listen_ip: IpAddr,
     port_allocator: &'a mut AllocatedPorts,
@@ -44,6 +45,7 @@ impl<'a> ProcessContext<'a> {
         envs: &'a [(String, String)],
         base_path: PathBuf,
         processes_path: PathBuf,
+        swarm_path: PathBuf,
         network: Network,
         listen_ip: IpAddr,
         port_allocator: &'a mut AllocatedPorts,
@@ -56,6 +58,7 @@ impl<'a> ProcessContext<'a> {
             envs,
             base_path,
             processes_path,
+            swarm_path,
             network,
             listen_ip,
             port_allocator,
@@ -82,9 +85,7 @@ impl<'a> ProcessContext<'a> {
 
     /// The swarm's own directory, which holds the files shared by every instance in it.
     pub fn swarm_path(&self) -> &Path {
-        self.processes_path
-            .parent()
-            .expect("INVARIANT: the processes directory is always inside the swarm directory")
+        &self.swarm_path
     }
 
     /// The consensus constants every node in this swarm reads. Constants have to agree across a

--- a/applications/tari_swarm_daemon/src/process_definitions/indexer.rs
+++ b/applications/tari_swarm_daemon/src/process_definitions/indexer.rs
@@ -66,6 +66,10 @@ impl ProcessDefinition for Indexer {
             .arg(format!("-pindexer.web_ui_public_graphql_url={graphql_public_url}"))
             .arg("-pepoch_oracle.base_layer.scanning_interval=1")
             .arg(format!("-pindexer.rate_limits.enabled={rate_limit}"))
+            .arg(format!(
+                "-pindexer.localnet_consensus_constants_file={}",
+                context.consensus_constants_file().display()
+            ))
             .env("API_DEBUG", "1"); // Enable detailed API error messages
 
         // mDNS is not guaranteed to work, so we'll explicitly set the seed peers for the indexer.

--- a/applications/tari_swarm_daemon/src/process_definitions/validator_node.rs
+++ b/applications/tari_swarm_daemon/src/process_definitions/validator_node.rs
@@ -66,7 +66,11 @@ impl ProcessDefinition for ValidatorNode {
             ))
             .arg(format!("-pvalidator_node.p2p.listener_port={p2p_port}"))
             .arg(format!("-pvalidator_node.json_rpc_listener_address={json_rpc_address}"))
-            .arg(format!("-pvalidator_node.web_ui_listener_address={web_ui_address}"));
+            .arg(format!("-pvalidator_node.web_ui_listener_address={web_ui_address}"))
+            .arg(format!(
+                "-pvalidator_node.localnet_consensus_constants_file={}",
+                context.consensus_constants_file().display()
+            ));
         // .arg("-pepoch_oracle.base_layer.scanning_interval=1");
 
         if let Some(console_port) = context.get_setting("tokio_console_port") {

--- a/applications/tari_swarm_daemon/src/process_manager/instances/manager.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/instances/manager.rs
@@ -24,9 +24,29 @@ use tokio::{
 };
 
 use super::InstanceId;
+
+/// Written to the swarm directory when there is no constants file there. Everything is commented
+/// out, so it changes nothing until a line is uncommented, and it lists what may be changed without
+/// having to go and look.
+const CONSENSUS_CONSTANTS_TEMPLATE: &str = r#"# Consensus constants for this swarm, read once at
+# start-up by every node in it. Only LocalNet reads this file at all. Uncomment a line to change it
+# and restart the swarm; anything left commented keeps the network's own value.
+#
+# The number of committees is the registered validator count divided by the committee size, so a
+# smaller committee splits the shard space across fewer nodes.
+# committee_size_per_shard_group = 3
+
+# pacemaker_block_time_secs = 10
+# base_layer_confirmations = 3
+# missed_proposal_suspend_threshold = 5
+# missed_proposal_evict_threshold = 10
+# missed_proposal_recovery_threshold = 5
+# max_transaction_validity_epochs = 10
+# epoch_end_spread_blocks = 0
+"#;
 use crate::{
     config::{InstanceConfig, InstanceType},
-    process_definitions::{ProcessContext, get_definition},
+    process_definitions::{CONSENSUS_CONSTANTS_FILE_NAME, ProcessContext, get_definition},
     process_manager::{
         AllocatedPorts,
         IndexerProcess,
@@ -79,6 +99,7 @@ impl InstanceManager {
 
     /// Fork all defined processes in order
     pub async fn fork_all(&mut self, executables: Executables<'_>) -> anyhow::Result<()> {
+        self.write_consensus_constants_template().await?;
         for mut instance in self.config.clone() {
             let executable = executables.get(instance.execution_instance_type()).ok_or_else(|| {
                 anyhow!(
@@ -101,6 +122,25 @@ impl InstanceManager {
                 .await?;
             }
         }
+        Ok(())
+    }
+
+    /// Writes a commented consensus constants file into the swarm directory if there is not one
+    /// already. Every node forked here is pointed at it, so a devnet is retuned by uncommenting a
+    /// line and restarting rather than by finding out where the setting lives.
+    async fn write_consensus_constants_template(&self) -> anyhow::Result<()> {
+        let path = self.base_path.join(CONSENSUS_CONSTANTS_FILE_NAME);
+        if fs::try_exists(&path).await.unwrap_or(false) {
+            return Ok(());
+        }
+
+        fs::create_dir_all(&self.base_path)
+            .await
+            .context("create_dir_all for the consensus constants file")?;
+        fs::write(&path, CONSENSUS_CONSTANTS_TEMPLATE)
+            .await
+            .context("write the consensus constants file")?;
+        log::info!("📝 Wrote consensus constants file {}", path.display());
         Ok(())
     }
 

--- a/applications/tari_swarm_daemon/src/process_manager/instances/manager.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/instances/manager.rs
@@ -32,17 +32,18 @@ const CONSENSUS_CONSTANTS_TEMPLATE: &str = r#"# Consensus constants for this swa
 # start-up by every node in it. Only LocalNet reads this file at all. Uncomment a line to change it
 # and restart the swarm; anything left commented keeps the network's own value.
 #
-# The number of committees is the registered validator count divided by the committee size, so a
-# smaller committee splits the shard space across fewer nodes.
-# committee_size_per_shard_group = 3
+# Every value below is the one this network already uses, so uncommenting a line as it stands changes
+# nothing. The number of committees is the registered validator count divided by the committee size,
+# so a smaller committee splits the shard space across fewer nodes.
+# committee_size_per_shard_group = 7
 
 # pacemaker_block_time_secs = 10
 # base_layer_confirmations = 3
 # missed_proposal_suspend_threshold = 5
 # missed_proposal_evict_threshold = 10
 # missed_proposal_recovery_threshold = 5
-# max_transaction_validity_epochs = 10
-# epoch_end_spread_blocks = 0
+# max_transaction_validity_epochs = 2160
+# epoch_end_spread_blocks = 1
 "#;
 use crate::{
     config::{InstanceConfig, InstanceType},
@@ -236,6 +237,7 @@ impl InstanceManager {
             &instance_envs,
             base_path.clone(),
             processes_path,
+            self.base_path.clone(),
             self.network,
             listen_ip,
             &mut allocated_ports,

--- a/applications/tari_swarm_daemon/src/process_manager/manager.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/manager.rs
@@ -13,7 +13,10 @@ use futures::future::Either;
 use log::{debug, info};
 use minotari_wallet_grpc_client::grpc;
 use tari_consensus::consensus_constants::ConsensusConstants;
-use tari_ootle_app_utilities::configuration::convert_network_to_l1_network;
+use tari_ootle_app_utilities::{
+    configuration::convert_network_to_l1_network,
+    consensus_constants_file::load_consensus_constants,
+};
 use tari_ootle_wallet_sdk::Network;
 use tari_shutdown::ShutdownSignal;
 use tari_transaction_components::consensus::NetworkConsensus;
@@ -23,6 +26,7 @@ use tokio::{sync::mpsc, time, time::sleep};
 use crate::{
     config::{Config, InstanceType},
     layer_one_transactions::LayerOneTransactionService,
+    process_definitions::CONSENSUS_CONSTANTS_FILE_NAME,
     process_manager::{
         InstanceId,
         MinoTariWalletProcess,
@@ -47,6 +51,7 @@ pub struct ProcessManager {
     skip_registration: bool,
     enable_manual_connect: bool,
     network: Network,
+    base_dir: PathBuf,
     config_path: PathBuf,
     config_last_modified: Option<SystemTime>,
 }
@@ -79,10 +84,19 @@ impl ProcessManager {
             shutdown_signal,
             enable_manual_connect: config.enable_manual_validator_connect,
             network: config.network,
+            base_dir: config.base_dir.clone(),
             config_path,
             config_last_modified,
         };
         (this, ProcessManagerHandle::new(tx_request))
+    }
+
+    /// The constants every node in this swarm was started with, read from the file the swarm wrote and
+    /// pointed them at.
+    fn consensus_constants(&self) -> anyhow::Result<ConsensusConstants> {
+        let path = self.base_dir.join(CONSENSUS_CONSTANTS_FILE_NAME);
+        let constants = load_consensus_constants(self.network, Some(&path), &path)?;
+        Ok(constants)
     }
 
     async fn start_up(&mut self) -> anyhow::Result<()> {
@@ -737,8 +751,9 @@ impl ProcessManager {
             .pop()
             .ok_or_else(|| anyhow!("No layer one consensus constants for network {}", self.network))?
             .epoch_length();
-        // Must match the validator's oracle lag (`height_lag`), which is set from this constant.
-        let confirmations = ConsensusConstants::from(self.network).base_layer_confirmations;
+        // Must match the validator's oracle lag (`height_lag`), which is set from this constant - and
+        // so from the same file the validators are pointed at.
+        let confirmations = self.consensus_constants()?.base_layer_confirmations;
 
         let tip = self.get_base_layer_tip_height().await?;
         // The registrations are broadcast and confirm in the next block mined.

--- a/applications/tari_validator_node/Cargo.toml
+++ b/applications/tari_validator_node/Cargo.toml
@@ -21,7 +21,7 @@ tari_transaction_components = { workspace = true }
 tari_crypto = { workspace = true }
 tari_epoch_oracles = { workspace = true, features = ["base_layer"] }
 tari_validator_node_rpc = { workspace = true }
-tari_ootle_app_utilities = { workspace = true, features = ["epoch_oracle", "p2p"] }
+tari_ootle_app_utilities = { workspace = true, features = ["consensus_constants", "epoch_oracle", "p2p"] }
 tari_ootle_common_types = { workspace = true }
 tari_ootle_p2p = { workspace = true }
 tari_engine = { workspace = true, features = ["wasm-cache"] }

--- a/applications/tari_validator_node/src/config.rs
+++ b/applications/tari_validator_node/src/config.rs
@@ -80,6 +80,11 @@ pub struct ValidatorNodeConfig {
     pub data_dir: PathBuf,
     /// An absolute or relative (to data_dir) path to the state database
     pub state_db_path: PathBuf,
+    /// An absolute or relative (to data_dir) path to a file of consensus constant overrides. Read
+    /// once at startup, and only on LocalNet: every other network's constants are part of what its
+    /// nodes agree on. Absent file means the network's own constants.
+    #[serde(default = "default_consensus_constants_file")]
+    pub consensus_constants_file: PathBuf,
     /// Database config
     // pub database: tari_any_state_store::Config,
     /// The p2p configuration settings
@@ -150,6 +155,10 @@ fn default_max_consensus_messaging_queue_bytes() -> usize {
     128 * 1024 * 1024
 }
 
+fn default_consensus_constants_file() -> PathBuf {
+    PathBuf::from("consensus_constants.toml")
+}
+
 impl ValidatorNodeConfig {
     pub fn set_base_path<P: AsRef<Path>>(&mut self, base_path: P) {
         if !self.shard_key_file.is_absolute() {
@@ -163,6 +172,9 @@ impl ValidatorNodeConfig {
         }
         if !self.state_db_path.is_absolute() {
             self.state_db_path = self.data_dir.join(&self.state_db_path);
+        }
+        if !self.consensus_constants_file.is_absolute() {
+            self.consensus_constants_file = self.data_dir.join(&self.consensus_constants_file);
         }
         // if !self.database.rocks_db.path.is_absolute() {
         //     self.database.rocks_db.path = self.data_dir.as_ref().join(&self.database.rocks_db.path);
@@ -185,6 +197,7 @@ impl Default for ValidatorNodeConfig {
             identity_file: PathBuf::from("validator_node_id.json"),
             data_dir: PathBuf::from("data/validator_node"),
             state_db_path: PathBuf::from("rocksdb"),
+            consensus_constants_file: default_consensus_constants_file(),
             // database: tari_any_state_store::Config {
             //     database_type: AnyDatabaseType::Sqlite,
             //     rocks_db: RocksConfig { path: "rocksdb".into() },

--- a/applications/tari_validator_node/src/config.rs
+++ b/applications/tari_validator_node/src/config.rs
@@ -80,11 +80,12 @@ pub struct ValidatorNodeConfig {
     pub data_dir: PathBuf,
     /// An absolute or relative (to data_dir) path to the state database
     pub state_db_path: PathBuf,
-    /// An absolute or relative (to data_dir) path to a file of consensus constant overrides. Read
-    /// once at startup, and only on LocalNet: every other network's constants are part of what its
-    /// nodes agree on. Absent file means the network's own constants.
-    #[serde(default = "default_consensus_constants_file")]
-    pub consensus_constants_file: PathBuf,
+    /// An absolute or relative (to data_dir) path to a file of consensus constant overrides, read
+    /// once at startup and only on LocalNet. Setting it says the file is expected, so a node that
+    /// cannot find it refuses to start. Leave it unset to pick up
+    /// `<data_dir>/consensus_constants.toml` if it happens to be there.
+    #[serde(default)]
+    pub localnet_consensus_constants_file: Option<PathBuf>,
     /// Database config
     // pub database: tari_any_state_store::Config,
     /// The p2p configuration settings
@@ -155,10 +156,6 @@ fn default_max_consensus_messaging_queue_bytes() -> usize {
     128 * 1024 * 1024
 }
 
-fn default_consensus_constants_file() -> PathBuf {
-    PathBuf::from("consensus_constants.toml")
-}
-
 impl ValidatorNodeConfig {
     pub fn set_base_path<P: AsRef<Path>>(&mut self, base_path: P) {
         if !self.shard_key_file.is_absolute() {
@@ -173,8 +170,12 @@ impl ValidatorNodeConfig {
         if !self.state_db_path.is_absolute() {
             self.state_db_path = self.data_dir.join(&self.state_db_path);
         }
-        if !self.consensus_constants_file.is_absolute() {
-            self.consensus_constants_file = self.data_dir.join(&self.consensus_constants_file);
+        if let Some(path) = self
+            .localnet_consensus_constants_file
+            .as_ref()
+            .filter(|p| !p.is_absolute())
+        {
+            self.localnet_consensus_constants_file = Some(self.data_dir.join(path));
         }
         // if !self.database.rocks_db.path.is_absolute() {
         //     self.database.rocks_db.path = self.data_dir.as_ref().join(&self.database.rocks_db.path);
@@ -182,6 +183,11 @@ impl ValidatorNodeConfig {
         // if !self.database.sqlite.path.is_absolute() {
         //     self.database.sqlite.path = self.data_dir.as_ref().join(&self.database.sqlite.path);
         // }
+    }
+
+    /// Where a consensus constants file is picked up from when none is configured.
+    pub fn default_localnet_consensus_constants_file(&self) -> PathBuf {
+        self.data_dir.join("consensus_constants.toml")
     }
 
     pub fn get_global_db_path(&self) -> PathBuf {
@@ -197,7 +203,7 @@ impl Default for ValidatorNodeConfig {
             identity_file: PathBuf::from("validator_node_id.json"),
             data_dir: PathBuf::from("data/validator_node"),
             state_db_path: PathBuf::from("rocksdb"),
-            consensus_constants_file: default_consensus_constants_file(),
+            localnet_consensus_constants_file: None,
             // database: tari_any_state_store::Config {
             //     database_type: AnyDatabaseType::Sqlite,
             //     rocks_db: RocksConfig { path: "rocksdb".into() },

--- a/applications/tari_validator_node/src/lib.rs
+++ b/applications/tari_validator_node/src/lib.rs
@@ -130,8 +130,11 @@ pub async fn run_validator_node(
     #[cfg(feature = "metrics")]
     let metrics_registry = create_metrics_registry(keypair.public_key(), &mut base_registry);
 
-    let consensus_constants =
-        load_consensus_constants(config.network, &config.validator_node.consensus_constants_file)?;
+    let consensus_constants = load_consensus_constants(
+        config.network,
+        config.validator_node.localnet_consensus_constants_file.as_deref(),
+        &config.validator_node.default_localnet_consensus_constants_file(),
+    )?;
     let mut services = spawn_services(
         config.clone(),
         shutdown.to_signal(),

--- a/applications/tari_validator_node/src/lib.rs
+++ b/applications/tari_validator_node/src/lib.rs
@@ -45,11 +45,14 @@ use std::{fs, io, iter, process, time::Instant};
 use log::*;
 use serde::{Deserialize, Serialize};
 use tari_common::exit_codes::{ExitCode, ExitError};
-use tari_consensus::consensus_constants::ConsensusConstants;
 use tari_engine_types::crypto::{MAX_LAZY_BP_AGG_FACTORS, get_commitment_factory, get_static_range_proof_service};
 use tari_epoch_manager::traits::EpochManagerSpec;
 use tari_epoch_oracles::EpochOracle;
-use tari_ootle_app_utilities::{keypair::RistrettoKeypair, protocol_activation::check_and_record_activation_schedule};
+use tari_ootle_app_utilities::{
+    consensus_constants_file::load_consensus_constants,
+    keypair::RistrettoKeypair,
+    protocol_activation::check_and_record_activation_schedule,
+};
 use tari_ootle_common_types::SubstateAddress;
 use tari_ootle_p2p::PeerAddress;
 use tari_ootle_storage::global::{DbFactory, GlobalDb};
@@ -127,7 +130,8 @@ pub async fn run_validator_node(
     #[cfg(feature = "metrics")]
     let metrics_registry = create_metrics_registry(keypair.public_key(), &mut base_registry);
 
-    let consensus_constants = ConsensusConstants::from(config.network);
+    let consensus_constants =
+        load_consensus_constants(config.network, &config.validator_node.consensus_constants_file)?;
     let mut services = spawn_services(
         config.clone(),
         shutdown.to_signal(),

--- a/crates/consensus/src/consensus_constants.rs
+++ b/crates/consensus/src/consensus_constants.rs
@@ -20,7 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{env, time::Duration};
+use std::time::Duration;
 
 use tari_engine_types::fees::ExhaustBurnRate;
 use tari_ootle_common_types::{Epoch, NumPreshards};
@@ -118,8 +118,8 @@ pub struct ConsensusConstants {
 }
 
 impl ConsensusConstants {
-    /// Committee size used when `TARI_DEVNET_COMMITTEE_SIZE` is unset, and the size [`Self::DEVNET`]
-    /// is built at.
+    /// The committee size [`Self::DEVNET`] is built at. A devnet that wants another size sets it in a
+    /// consensus constants file, which every node on that network is handed.
     pub const DEFAULT_DEVNET_COMMITTEE_SIZE: u32 = 7;
     /// Devnet at the default committee size.
     pub const DEVNET: Self = Self::devnet(Self::DEFAULT_DEVNET_COMMITTEE_SIZE);
@@ -320,11 +320,7 @@ impl From<Network> for ConsensusConstants {
     fn from(network: Network) -> Self {
         match network {
             Network::MainNet => Self::mainnet(),
-            // Allow committee size to be overridden for LocalNet
-            Network::LocalNet => env::var("TARI_DEVNET_COMMITTEE_SIZE")
-                .ok()
-                .and_then(|s| s.parse().ok())
-                .map_or(Self::DEVNET, Self::devnet),
+            Network::LocalNet => Self::DEVNET,
             Network::Esmeralda => Self::esmeralda(),
             Network::StageNet | Network::NextNet | Network::Igor => Self::testnet(),
         }

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -31,7 +31,7 @@ tari_shutdown = { workspace = true }
 tari_sidechain = { workspace = true }
 
 tari_crypto = { workspace = true }
-tari_ootle_app_utilities = { workspace = true, features = ["epoch_oracle", "p2p"] }
+tari_ootle_app_utilities = { workspace = true, features = ["consensus_constants", "epoch_oracle", "p2p"] }
 tari_ootle_common_types = { workspace = true }
 tari_engine = { workspace = true }
 tari_engine_types = { workspace = true }
@@ -76,6 +76,7 @@ rand = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true, features = ["default", "derive"] }
 serde_json = { workspace = true }
+toml = { workspace = true }
 time = { workspace = true }
 yaml_serde = "0.10"
 tokio = { workspace = true, features = [

--- a/integration_tests/src/indexer.rs
+++ b/integration_tests/src/indexer.rs
@@ -173,6 +173,7 @@ pub async fn spawn_indexer(world: &mut TariWorld, indexer_name: String, base_nod
     let db_path = base_dir.to_path_buf().join("state.db");
 
     let (ipc_sender, ipc_receiver) = tokio::sync::mpsc::unbounded_channel();
+    let consensus_constants_file = world.consensus_constants_file.clone();
 
     let handle = task::spawn(async move {
         let mut config = ApplicationConfig {
@@ -188,6 +189,9 @@ pub async fn spawn_indexer(world: &mut TariWorld, indexer_name: String, base_nod
         config.common.base_path = base_dir.to_path_buf();
         config.indexer.data_dir = base_dir.to_path_buf();
         config.indexer.identity_file = base_dir.join("indexer_id.json");
+        if let Some(path) = consensus_constants_file {
+            config.indexer.consensus_constants_file = path;
+        }
         config.epoch_oracle.base_layer.base_node_grpc_url =
             Some(format!("http://127.0.0.1:{}", base_node_grpc_port).parse().unwrap());
         config.indexer.block_scanning_interval = Duration::from_secs(5);

--- a/integration_tests/src/indexer.rs
+++ b/integration_tests/src/indexer.rs
@@ -173,7 +173,7 @@ pub async fn spawn_indexer(world: &mut TariWorld, indexer_name: String, base_nod
     let db_path = base_dir.to_path_buf().join("state.db");
 
     let (ipc_sender, ipc_receiver) = tokio::sync::mpsc::unbounded_channel();
-    let consensus_constants_file = world.consensus_constants_file.clone();
+    let localnet_consensus_constants_file = world.consensus_constants_file.clone();
 
     let handle = task::spawn(async move {
         let mut config = ApplicationConfig {
@@ -189,9 +189,7 @@ pub async fn spawn_indexer(world: &mut TariWorld, indexer_name: String, base_nod
         config.common.base_path = base_dir.to_path_buf();
         config.indexer.data_dir = base_dir.to_path_buf();
         config.indexer.identity_file = base_dir.join("indexer_id.json");
-        if let Some(path) = consensus_constants_file {
-            config.indexer.consensus_constants_file = path;
-        }
+        config.indexer.localnet_consensus_constants_file = localnet_consensus_constants_file;
         config.epoch_oracle.base_layer.base_node_grpc_url =
             Some(format!("http://127.0.0.1:{}", base_node_grpc_port).parse().unwrap());
         config.indexer.block_scanning_interval = Duration::from_secs(5);

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -42,6 +42,7 @@ use tari_consensus::consensus_constants::ConsensusConstants;
 use tari_crypto::keys::SecretKey;
 use tari_engine_types::substate::SubstateId;
 use tari_ootle_common_types::SubstateRequirement;
+use tari_ootle_transaction::Network;
 use tari_ootle_wallet_sdk::models::AccountWithAddress;
 use tari_sidechain::EvictionProof;
 use tari_transaction_components::{
@@ -109,7 +110,7 @@ impl TariWorld {
         )
         .unwrap();
         Self {
-            consensus_constants: ConsensusConstants::devnet(7),
+            consensus_constants: ConsensusConstants::from(Network::LocalNet),
             base_nodes: IndexMap::new(),
             wallets: IndexMap::new(),
             validator_nodes: IndexMap::new(),

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -184,8 +184,8 @@ impl TariWorld {
         )
         .expect("Failed to write consensus constants file");
 
-        self.consensus_constants =
-            load_consensus_constants(Network::LocalNet, &path).expect("Failed to load consensus constants");
+        self.consensus_constants = load_consensus_constants(Network::LocalNet, Some(&path), &path)
+            .expect("Failed to load consensus constants");
         self.consensus_constants_file = Some(path);
     }
 

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -24,6 +24,7 @@ use std::{
     collections::HashMap,
     fmt::{Debug, Formatter},
     fs,
+    path::PathBuf,
     time::{Duration, Instant},
 };
 
@@ -41,6 +42,7 @@ use tari_common_types::{
 use tari_consensus::consensus_constants::ConsensusConstants;
 use tari_crypto::keys::SecretKey;
 use tari_engine_types::substate::SubstateId;
+use tari_ootle_app_utilities::consensus_constants_file::{ConsensusConstantsFile, load_consensus_constants};
 use tari_ootle_common_types::SubstateRequirement;
 use tari_ootle_transaction::Network;
 use tari_ootle_wallet_sdk::models::AccountWithAddress;
@@ -54,7 +56,10 @@ use validator_node::ValidatorNodeProcess;
 use wallet::WalletProcess;
 use wallet_daemon::TariWalletDaemonProcess;
 
-use crate::{claim_proof::CucumberClaimProof, logging::get_base_dir};
+use crate::{
+    claim_proof::CucumberClaimProof,
+    logging::{get_base_dir, get_base_dir_for_scenario},
+};
 
 pub mod base_node;
 pub mod claim_proof;
@@ -86,6 +91,10 @@ pub struct TariWorld {
     pub http_server: Option<MockHttpServer>,
     pub template_mock_server_port: Option<u16>,
     pub current_scenario_name: Option<String>,
+    /// The consensus constants file every node in this scenario is pointed at. Consensus constants
+    /// have to agree across a network, so a scenario authors one file and hands it to each node it
+    /// spawns rather than configuring them one by one.
+    pub consensus_constants_file: Option<PathBuf>,
     pub claim_proofs: HashMap<String, CucumberClaimProof>,
     pub substate_ids: IndexMap<String, SubstateId>,
     pub num_databases_saved: usize,
@@ -122,6 +131,7 @@ impl TariWorld {
             http_server: None,
             template_mock_server_port: None,
             current_scenario_name: None,
+            consensus_constants_file: None,
             claim_proofs: HashMap::new(),
             substate_ids: IndexMap::new(),
             num_databases_saved: 0,
@@ -160,6 +170,23 @@ impl TariWorld {
         write_point("wallet.log", point_name);
         write_point("network.log", point_name);
         write_point("wallet_daemon.log", point_name);
+    }
+
+    /// Writes `overrides` to a file shared by every node this scenario spawns, and adopts the
+    /// resulting constants as the world's own so that assertions and nodes cannot disagree.
+    pub fn set_consensus_constants(&mut self, overrides: &ConsensusConstantsFile) {
+        let dir = get_base_dir_for_scenario("network", self.get_current_scenario_name(), "consensus_constants");
+        fs::create_dir_all(&dir).expect("Failed to create consensus constants directory");
+        let path = dir.join("consensus_constants.toml");
+        fs::write(
+            &path,
+            toml::to_string(overrides).expect("Failed to serialize consensus constants"),
+        )
+        .expect("Failed to write consensus constants file");
+
+        self.consensus_constants =
+            load_consensus_constants(Network::LocalNet, &path).expect("Failed to load consensus constants");
+        self.consensus_constants_file = Some(path);
     }
 
     pub fn get_current_scenario_name(&self) -> &str {

--- a/integration_tests/src/validator_node.rs
+++ b/integration_tests/src/validator_node.rs
@@ -149,7 +149,7 @@ pub async fn spawn_validator_node(
         base_node_grpc_port,
         fee_claim_public_key,
         peer_seeds,
-        consensus_constants_file: world.consensus_constants_file.clone(),
+        localnet_consensus_constants_file: world.consensus_constants_file.clone(),
     })
     .await
 }
@@ -180,7 +180,7 @@ pub async fn respawn_validator_node(world: &mut TariWorld, validator_node_name: 
         base_node_grpc_port: old.base_node_grpc_port,
         fee_claim_public_key,
         peer_seeds,
-        consensus_constants_file: world.consensus_constants_file.clone(),
+        localnet_consensus_constants_file: world.consensus_constants_file.clone(),
     })
     .await
 }
@@ -199,7 +199,7 @@ struct ValidatorSpawn {
     base_node_grpc_port: u16,
     fee_claim_public_key: RistrettoPublicKey,
     peer_seeds: Vec<String>,
-    consensus_constants_file: Option<PathBuf>,
+    localnet_consensus_constants_file: Option<PathBuf>,
 }
 
 async fn spawn_validator_node_process(spawn: ValidatorSpawn) -> ValidatorNodeProcess {
@@ -209,7 +209,7 @@ async fn spawn_validator_node_process(spawn: ValidatorSpawn) -> ValidatorNodePro
         base_node_grpc_port,
         fee_claim_public_key,
         peer_seeds,
-        consensus_constants_file,
+        localnet_consensus_constants_file,
     } = spawn;
     let (port, json_rpc_port) = get_os_assigned_ports();
     let web_ui_port = get_os_assigned_port();
@@ -239,9 +239,7 @@ async fn spawn_validator_node_process(spawn: ValidatorSpawn) -> ValidatorNodePro
             config.validator_node.web_ui_listener_address = Some(format!("127.0.0.1:{}", web_ui_port).parse().unwrap());
             config.validator_node.p2p.listener_port = port;
             config.validator_node.fee_claim_public_key = fee_claim_public_key;
-            if let Some(path) = consensus_constants_file {
-                config.validator_node.consensus_constants_file = path;
-            }
+            config.validator_node.localnet_consensus_constants_file = localnet_consensus_constants_file;
             config.peer_seeds.peer_seeds = StringList::from(peer_seeds);
 
             // Load-if-exists: fresh dirs get a random identity + save; restarts reuse

--- a/integration_tests/src/validator_node.rs
+++ b/integration_tests/src/validator_node.rs
@@ -149,6 +149,7 @@ pub async fn spawn_validator_node(
         base_node_grpc_port,
         fee_claim_public_key,
         peer_seeds,
+        consensus_constants_file: world.consensus_constants_file.clone(),
     })
     .await
 }
@@ -179,6 +180,7 @@ pub async fn respawn_validator_node(world: &mut TariWorld, validator_node_name: 
         base_node_grpc_port: old.base_node_grpc_port,
         fee_claim_public_key,
         peer_seeds,
+        consensus_constants_file: world.consensus_constants_file.clone(),
     })
     .await
 }
@@ -197,6 +199,7 @@ struct ValidatorSpawn {
     base_node_grpc_port: u16,
     fee_claim_public_key: RistrettoPublicKey,
     peer_seeds: Vec<String>,
+    consensus_constants_file: Option<PathBuf>,
 }
 
 async fn spawn_validator_node_process(spawn: ValidatorSpawn) -> ValidatorNodeProcess {
@@ -206,6 +209,7 @@ async fn spawn_validator_node_process(spawn: ValidatorSpawn) -> ValidatorNodePro
         base_node_grpc_port,
         fee_claim_public_key,
         peer_seeds,
+        consensus_constants_file,
     } = spawn;
     let (port, json_rpc_port) = get_os_assigned_ports();
     let web_ui_port = get_os_assigned_port();
@@ -235,6 +239,9 @@ async fn spawn_validator_node_process(spawn: ValidatorSpawn) -> ValidatorNodePro
             config.validator_node.web_ui_listener_address = Some(format!("127.0.0.1:{}", web_ui_port).parse().unwrap());
             config.validator_node.p2p.listener_port = port;
             config.validator_node.fee_claim_public_key = fee_claim_public_key;
+            if let Some(path) = consensus_constants_file {
+                config.validator_node.consensus_constants_file = path;
+            }
             config.peer_seeds.peer_seeds = StringList::from(peer_seeds);
 
             // Load-if-exists: fresh dirs get a random identity + save; restarts reuse

--- a/integration_tests/tests/cucumber.rs
+++ b/integration_tests/tests/cucumber.rs
@@ -21,7 +21,7 @@
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 mod steps;
-use std::{fs, future, io, panic, str::FromStr, time::Duration};
+use std::{env, fs, future, io, panic, str::FromStr, time::Duration};
 
 use anyhow::bail;
 use cucumber::{ScenarioType, World, WriterExt, gherkin::Step, given, then, when, writer, writer::Verbosity};
@@ -52,8 +52,28 @@ use tari_validator_node_client::types::AddPeerRequest;
 
 const LOG_TARGET: &str = "cucumber";
 
-#[tokio::main]
-async fn main() {
+fn main() {
+    // Validators and indexers run in-process here, and each derives its consensus constants from the
+    // network, so the committee size that decides how many shard groups the network splits into is
+    // shared by every node in the run. A smaller committee than the devnet default lets a scenario
+    // reach a second shard group with a handful of nodes rather than fourteen, and leaves every
+    // scenario that registers five or fewer validators on a single committee as before.
+    // SAFETY: nothing has been spawned yet, so no other thread can be reading the environment.
+    if env::var(COMMITTEE_SIZE_VAR).is_err() {
+        unsafe { env::set_var(COMMITTEE_SIZE_VAR, "3") };
+    }
+
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("Failed to build tokio runtime")
+        .block_on(run());
+}
+
+/// Overrides `committee_size_per_shard_group` for `LocalNet`, read by `ConsensusConstants::from`.
+const COMMITTEE_SIZE_VAR: &str = "TARI_DEVNET_COMMITTEE_SIZE";
+
+async fn run() {
     let log_path = create_log_config_file();
     let base_path = get_base_dir();
     initialize_logging(log_path.as_path(), &base_path, include_str!("./log4rs/cucumber.yml")).unwrap();

--- a/integration_tests/tests/cucumber.rs
+++ b/integration_tests/tests/cucumber.rs
@@ -21,7 +21,7 @@
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 mod steps;
-use std::{env, fs, future, io, panic, str::FromStr, time::Duration};
+use std::{fs, future, io, panic, str::FromStr, time::Duration};
 
 use anyhow::bail;
 use cucumber::{ScenarioType, World, WriterExt, gherkin::Step, given, then, when, writer, writer::Verbosity};
@@ -52,28 +52,8 @@ use tari_validator_node_client::types::AddPeerRequest;
 
 const LOG_TARGET: &str = "cucumber";
 
-fn main() {
-    // Validators and indexers run in-process here, and each derives its consensus constants from the
-    // network, so the committee size that decides how many shard groups the network splits into is
-    // shared by every node in the run. A smaller committee than the devnet default lets a scenario
-    // reach a second shard group with a handful of nodes rather than fourteen, and leaves every
-    // scenario that registers five or fewer validators on a single committee as before.
-    // SAFETY: nothing has been spawned yet, so no other thread can be reading the environment.
-    if env::var(COMMITTEE_SIZE_VAR).is_err() {
-        unsafe { env::set_var(COMMITTEE_SIZE_VAR, "3") };
-    }
-
-    tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .expect("Failed to build tokio runtime")
-        .block_on(run());
-}
-
-/// Overrides `committee_size_per_shard_group` for `LocalNet`, read by `ConsensusConstants::from`.
-const COMMITTEE_SIZE_VAR: &str = "TARI_DEVNET_COMMITTEE_SIZE";
-
-async fn run() {
+#[tokio::main]
+async fn main() {
     let log_path = create_log_config_file();
     let base_path = get_base_dir();
     initialize_logging(log_path.as_path(), &base_path, include_str!("./log4rs/cucumber.yml")).unwrap();

--- a/integration_tests/tests/features/committee_split.feature
+++ b/integration_tests/tests/features/committee_split.feature
@@ -8,6 +8,10 @@ Feature: Committee split
   Scenario: Indexer keeps serving when an epoch change splits the committee
     Given a network with spec
     """
+    consensus_constants:
+      # One committee per three validators, so a sixth registration splits the network rather than
+      # needing the fourteen the devnet default would ask for.
+      committee_size_per_shard_group: 3
     validators:
       - name: VN1
       - name: VN2

--- a/integration_tests/tests/features/committee_split.feature
+++ b/integration_tests/tests/features/committee_split.feature
@@ -1,0 +1,41 @@
+# Copyright 2026 The Tari Project
+# SPDX-License-Identifier: BSD-3-Clause
+
+@serial
+@committee_split
+Feature: Committee split
+
+  Scenario: Indexer keeps serving when an epoch change splits the committee
+    Given a network with spec
+    """
+    validators:
+      - name: VN1
+      - name: VN2
+      - name: VN3
+      - name: VN4
+      - name: VN5
+    walletds:
+      - name: WALLET_D
+    """
+
+    Then the network has 1 shard group according to indexer INDEXER
+
+    When I create an account ACC1 via the wallet daemon WALLET_D with 10000 XTR
+    Then I wait for the indexer INDEXER to sync with the network
+
+    # A sixth registration takes the validator count past the committee size, so the next epoch splits
+    # the shard space in two and every validator stops storing half of what it stored before.
+    Given a validator node VN6 connected to base node BASE_NODE
+    Given validator VN6 nodes connect to all other validators
+    When indexer INDEXER connects to all other validators
+    When validator node VN6 sends a registration transaction to base wallet MINOTARI_WALLET
+    Then miner MINER mines to the next epoch
+    Then the validator node VN6 is listed as registered
+    When all validator nodes have started epoch 4
+    Then the network has 2 shard groups according to indexer INDEXER
+
+    # Reads have to survive the split. Each validator now answers for half the shard space, so an
+    # indexer still asking one of them for the whole of it is refused, and must re-plan onto the new
+    # shard groups rather than treating the refusal as an empty round.
+    When I create an account ACC2 via the wallet daemon WALLET_D with 10000 XTR
+    Then I wait for the indexer INDEXER to sync with the network

--- a/integration_tests/tests/steps/indexer.rs
+++ b/integration_tests/tests/steps/indexer.rs
@@ -13,7 +13,7 @@ use integration_tests::{
     indexer::{IndexerProcess, spawn_indexer},
 };
 use libp2p::Multiaddr;
-use tari_ootle_common_types::{Epoch, displayable::Displayable, optional::Optional, shard::Shard};
+use tari_ootle_common_types::{Epoch, StateVersion, displayable::Displayable, optional::Optional, shard::Shard};
 
 #[when(expr = "indexer {word} connects to all other validators")]
 async fn given_validator_connects_to_other_vns(world: &mut TariWorld, name: String) {
@@ -432,32 +432,43 @@ async fn assert_catalogue_entry_not_found(world: &mut TariWorld, indexer_name: S
 
 #[then(expr = "I wait for the indexer {word} to sync with the network")]
 async fn i_wait_for_the_indexer_to_sync_with_the_network(world: &mut TariWorld, indexer_name: String) {
-    let vn = world
+    // A validator reports state versions for its own shard group only, so the target is the union
+    // over every running validator: on a network of more than one committee, a single validator
+    // describes half the shard space and says nothing about the half another committee holds.
+    let mut epoch = None;
+    let mut state_versions: HashMap<Shard, StateVersion> = HashMap::new();
+    for vn in world
         .validator_nodes
         .values()
         .chain(world.vn_seeds.values())
-        .find(|vn| !vn.shutdown.is_triggered())
-        .expect(
-            "No running validator nodes found. An indexer must be connected to a running validator node to sync with \
-             the network",
-        );
-    let consensus_stats = vn
-        .get_client()
-        .get_consensus_status()
-        .await
-        .expect("Failed to get epoch stats from VN");
-    if consensus_stats.state != "Running" {
-        panic!(
-            "Validator node {} is not running. An indexer must be connected to a running validator node to sync with \
-             the network",
-            vn.name
-        );
+        .filter(|vn| !vn.shutdown.is_triggered())
+    {
+        let consensus_stats = vn
+            .get_client()
+            .get_consensus_status()
+            .await
+            .expect("Failed to get epoch stats from VN");
+        if consensus_stats.state != "Running" {
+            continue;
+        }
+        epoch = Some(consensus_stats.epoch);
+        for (shard, version) in consensus_stats.state_versions.unwrap_or_default() {
+            state_versions
+                .entry(shard)
+                .and_modify(|v| *v = (*v).max(version))
+                .or_insert(version);
+        }
     }
-    let epoch = consensus_stats.epoch;
+
+    let epoch = epoch.expect(
+        "No running validator nodes found. An indexer must be connected to a running validator node to sync with the \
+         network",
+    );
     let prev_epoch = epoch.checked_sub(Epoch(1)).expect("Epoch is zero");
-    let state_versions = consensus_stats
-        .state_versions
-        .unwrap_or_else(|| panic!("No state versions found in consensus stats for running VN {}", vn.name));
+    assert!(
+        !state_versions.is_empty(),
+        "No state versions found in consensus stats for any running validator"
+    );
 
     let indexer = world.get_indexer(&indexer_name);
     assert!(!indexer.handle.is_finished(), "Indexer {} is not running", indexer_name);

--- a/integration_tests/tests/steps/indexer.rs
+++ b/integration_tests/tests/steps/indexer.rs
@@ -33,6 +33,39 @@ async fn given_validator_connects_to_other_vns(world: &mut TariWorld, name: Stri
     }
 }
 
+/// The number of shard groups follows the registered validator count divided by the committee size,
+/// so this is how a scenario states the shape of the network it has built - and waits for a
+/// registration to take effect at an epoch boundary.
+#[then(expr = "the network has {int} shard group(s) according to indexer {word}")]
+async fn network_has_shard_groups(world: &mut TariWorld, step: &Step, num_shard_groups: usize, name: String) {
+    cucumber_log!("=== Step:{}", step.value);
+    let client = world.get_indexer(&name).get_indexer_client();
+    let mut remaining = 20;
+    loop {
+        let state = client
+            .get_network_sync_state()
+            .await
+            .expect("Failed to get network sync state");
+        let shard_groups = &state.network_desc.shard_groups;
+        if shard_groups.len() == num_shard_groups {
+            return;
+        }
+
+        if remaining == 0 {
+            panic!(
+                "Indexer {} sees {} shard group(s) at epoch {}, expected {}: {:?}",
+                name,
+                shard_groups.len(),
+                state.network_desc.epoch,
+                num_shard_groups,
+                shard_groups
+            );
+        }
+        remaining -= 1;
+        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+    }
+}
+
 #[then(expr = "indexer {word} has scanned to at least height {int}")]
 pub async fn indexer_has_scanned_to_at_least_height(
     world: &mut TariWorld,

--- a/integration_tests/tests/steps/network/spec.rs
+++ b/integration_tests/tests/steps/network/spec.rs
@@ -1,6 +1,8 @@
 //   Copyright 2025 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+use tari_ootle_app_utilities::consensus_constants_file::ConsensusConstantsFile;
+
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct NetworkSpec {
@@ -16,6 +18,10 @@ pub struct NetworkSpec {
     pub walletds: Vec<WalletdSpec>,
     #[serde(default = "default_indexer")]
     pub indexer: NodeSpec,
+    /// Consensus constants for this network, applied over the LocalNet defaults. Written to one file
+    /// that every node in the scenario is pointed at, since constants have to agree across a network.
+    #[serde(default)]
+    pub consensus_constants: ConsensusConstantsFile,
 }
 
 impl Default for NetworkSpec {
@@ -27,6 +33,7 @@ impl Default for NetworkSpec {
             validators: default_validator(),
             walletds: default_walletd(),
             indexer: default_indexer(),
+            consensus_constants: ConsensusConstantsFile::default(),
         }
     }
 }

--- a/integration_tests/tests/steps/network/step.rs
+++ b/integration_tests/tests/steps/network/step.rs
@@ -21,6 +21,9 @@ use crate::{
 };
 
 async fn create_network(world: &mut TariWorld, step: &Step, spec: NetworkSpec) {
+    // Before anything is spawned: every node in the scenario reads the same constants file, and the
+    // world's own copy comes from it too.
+    world.set_consensus_constants(&spec.consensus_constants);
     spawn_base_node(world, spec.base_node.name.clone()).await;
     spawn_minotari_wallet(world, spec.minotari_wallet.name.clone(), spec.base_node.name.clone()).await;
     register_miner_process(


### PR DESCRIPTION
## Description

Every integration scenario runs on a single committee, so nothing exercises the case #2511 was written for: a validator that stops storing shards it used to store. The rejection, the indexer's per-shard-group recovery, and the re-authorisation of a tip claim at an epoch boundary all need a network whose committee membership actually changes.

**Why that was out of reach.** `calculate_num_committees` is `max(1, num_vns / committee_size)` and `integration_tests` ran at the devnet default of 7, so a second shard group needed 14 validators. This is also why the repo's own `Leader failure with multiple committees` scenario is `@ignore`d — at ten validators it stopped producing more than one committee and became a misnomer.

## Changes

### A consensus constants file for LocalNet

Committee size is a consensus constant — a network's nodes have to agree on it — and the only way to change it was `TARI_DEVNET_COMMITTEE_SIZE`, read at startup. That is a per-process setting for a network-wide fact, and no use of it lets one scenario differ from the rest of a test run.

A LocalNet now reads its constants from a file named by `consensus_constants_file` on the validator node and indexer configs, defaulting to `consensus_constants.toml` in the data directory:

```toml
committee_size_per_shard_group = 3
pacemaker_block_time_secs = 5
```

* Every field is optional and applied over the network's own values, so an absent file — or an absent field — changes nothing. Point several nodes at one path and a devnet is configured from a single authored source.
* Read **once at startup**, where `ConsensusConstants::from(network)` was called before. Changing constants means restarting, which is right for something the network has to agree on.
* Read **only on LocalNet**. Every other network's constants are part of what its nodes agree on, so nothing a local file says about them is safe to act on, and a file left behind by a devnet cannot reach a node that is not on one.
* `num_preshards` is not settable. Shard identity is derived from it everywhere, so nodes that disagree on it do not form a misconfigured network, they form no network at all. `deny_unknown_fields` makes an attempt to set it — or a typo — a startup error rather than a silent no-op.
* It sits behind a feature on `tari_ootle_app_utilities`, honouring the existing intent that nothing which merely prices a transaction has to carry the consensus engine. `TARI_DEVNET_COMMITTEE_SIZE` gives way to it.

**What this does not do:** it does not stop nodes being handed *different* files. Nothing today commits to the constants — `epoch_hash` is base-layer-derived or a static function of the epoch — so a mismatch still forks quietly. Attesting the constants in something peers already exchange is the fix for that, and is worth doing independently of where the values are read from.

### The test the file enables

* The harness authors one file per scenario from a `consensus_constants` block on the network spec, hands it to every node it spawns, and takes its own constants from the same file so that assertions and nodes cannot disagree.
* A new step, `the network has {int} shard group(s) according to indexer {word}`, polls the indexer's `network/stats`. It is how a scenario states the shape of the network it built, and how it waits for a registration to take effect at an epoch boundary.
* `committee_split.feature`: a five-validator network at committee size 3, a sixth validator registered mid-scenario, an assertion that the following epoch has two shard groups, and reads that must keep working across the split.

## Motivation and Context

Follow-up to #2511, which made a `sync_state` responder refuse an unbounded request for shards it no longer stores, and made the indexer confine that refusal to the shard group it came from. That merged on unit tests and review because no integration scenario could produce a committee change: `calculate_num_committees` is `num_vns / committee_size`, so at the devnet default of 7 a second shard group needed fourteen validators. It is also why the repo's own `Leader failure with multiple committees` scenario is `@ignore`d — at ten validators it stopped producing more than one committee.

## How Has This Been Tested?

Six unit tests on the constants file: an empty file keeps every network value, a set field replaces only itself, a burn rate above the maximum is refused, a network that is not local does not read the file, a local one does, and `num_preshards` is not accepted.

`cargo check --workspace --all-targets` and clippy are clean across the touched crates.

The scenario itself passes, run locally on top of #2516:

```
CUC_DEBUG=1 cargo test -p integration_tests --test cucumber --release -- --tags "@committee_split"
```

**It requires #2516.** On `development` as it stands the scenario fails at `all validator nodes have started epoch 4`: the committee split leaves every validator looping between `Running` and `CheckSync`, because the epoch checkpoint is rolled back by the very error that asks for a sync and `check_sync` cannot see that a shard group moved. This scenario is what found that, and it is the test for it — merge #2516 first.

## What process can a PR reviewer use to test or verify this change?

`cargo test -p integration_tests --test cucumber -- --tags '@committee_split'`.

To see it fail without #2511's responder change, revert `ensure_all_stored` in `sync_state`: the indexer goes on treating a non-member's silence as a completed round, and its sync progress for the shards that moved stops advancing. That comparison only holds because `I wait for the indexer to sync with the network` now takes its target as the union of state versions across every running validator — a single validator reports its own shard group only, which after the split is the half it kept rather than the half that moved.

## Breaking Changes

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify
