### PR TITLE
fix(consensus): let a validator whose shard group changes actually sync

### DIFF
--- a/crates/consensus/src/hotstuff/on_receive_local_proposal.rs
+++ b/crates/consensus/src/hotstuff/on_receive_local_proposal.rs
@@ -569,6 +569,13 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveLocalProposalHandler<TConsensusSpec
         let store = self.store.clone();
         let network = self.config.network;
         let sidechain_id = self.config.sidechain_id;
+        // A validator whose shard group changes at this boundary holds no state for the shards it is
+        // about to serve, so it cannot open the next epoch from what it has: it state-syncs the new
+        // group first. The checkpoint is written either way, because it is what the committee taking
+        // these shards over syncs against - this node is one of the few sources of it - and what this
+        // node's own recovery reads to know the sync is worth attempting.
+        let eoe_shard_group = eoe_block.shard_group();
+        let shard_group_changed = next_shard_group.is_some_and(|sg| sg != eoe_shard_group);
         task::spawn_blocking(move || {
             store.with_write_tx(|tx| {
                 // Generate checkpoint
@@ -589,19 +596,7 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveLocalProposalHandler<TConsensusSpec
                 }
                 checkpoint.save(tx)?;
 
-                if let Some(next_shard_group) = next_shard_group {
-                    // If this shard group remains the same, we can just continue. However, if shard groups change and
-                    // we now manage a shard we have not synced, we should to kick into sync.
-                    if next_shard_group != eoe_block.shard_group() {
-                        return Err(HotStuffError::NeedsSync {
-                            reason: format!(
-                                "Shard group changed from {} to {}. We need to sync the new shard group.",
-                                eoe_block.shard_group(),
-                                next_shard_group
-                            ),
-                        });
-                    }
-
+                if let Some(next_shard_group) = next_shard_group.filter(|_| !shard_group_changed) {
                     // Create the next genesis
                     let mut genesis = Block::genesis(
                         network,
@@ -628,6 +623,15 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveLocalProposalHandler<TConsensusSpec
             })
         })
         .await??;
+
+        if let Some(next_shard_group) = next_shard_group.filter(|_| shard_group_changed) {
+            return Err(HotStuffError::NeedsSync {
+                reason: format!(
+                    "Shard group changed from {eoe_shard_group} to {next_shard_group} at {next_epoch}. We need to \
+                     sync the new shard group.",
+                ),
+            });
+        }
 
         self.pacemaker.set_epoch(next_epoch).await?;
         self.publish_event(HotstuffEvent::EpochChanged {

--- a/crates/rpc_state_sync/src/state_sync.rs
+++ b/crates/rpc_state_sync/src/state_sync.rs
@@ -749,6 +749,23 @@ enum ProbeOutcome {
 impl<TConsensusSpec> RpcStateSyncClientProtocol<TConsensusSpec>
 where TConsensusSpec: ConsensusSpec<Addr = PeerAddress> + Send + Sync + 'static
 {
+    /// The shard group this node serves at `epoch`, when a committee change has moved it off the one
+    /// `leaf` was committed under.
+    ///
+    /// A node in that position holds none of the state for the shards it has been handed, which no
+    /// agreement with the committee it is leaving can tell it: that committee is level with it on the
+    /// shards they shared, and silent about the rest.
+    async fn shard_group_moved_since(
+        &self,
+        epoch: Epoch,
+        leaf: &LeafBlock,
+    ) -> Result<Option<ShardGroup>, RpcStateSyncError> {
+        let info = self.epoch_manager.get_local_committee_info(epoch).await.optional()?;
+        Ok(info
+            .map(|info| info.shard_group())
+            .filter(|shard_group| *shard_group != leaf.shard_group()))
+    }
+
     /// Probe committee members for their highest QCs and classify the result. See `ProbeOutcome`.
     #[expect(clippy::too_many_lines)]
     async fn probe_high_qcs_at_leaf(
@@ -965,6 +982,11 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress> + Send + Sync + 'static
         // Fast path: oracle hasn't advanced past our leaf — nothing to do.
         if oracle_epoch <= leaf.epoch() {
             return Ok(SyncStatus::UpToDate);
+        }
+
+        if let Some(shard_group) = self.shard_group_moved_since(oracle_epoch, &leaf).await? {
+            info!(target: LOG_TARGET, "🛜 Our shard group changed from {} to {shard_group} at {oracle_epoch}; will state-sync the new group.", leaf.shard_group());
+            return Ok(SyncStatus::Behind { target_epoch: None });
         }
 
         // Fast path: we have a finalised epoch checkpoint at our leaf's epoch. The committee


### PR DESCRIPTION
## Description

An epoch boundary that changes the number of committees hands a validator shards it holds no state for. `process_end_of_epoch` correctly refuses to open the next epoch until those shards are synced — but the way it refuses leaves the network unable to recover.

**The checkpoint is rolled back.** The refusal is an `Err(HotStuffError::NeedsSync)` returned from inside the `with_write_tx` closure that has just called `checkpoint.save(tx)` (`on_receive_local_proposal.rs:590-602`). `with_write_tx` rolls back on `Err` (`state_store/mod.rs:96-106`), so the epoch checkpoint goes with it — on every member of the committee, on every attempt. Nothing on the network then holds a checkpoint for the epoch that just ended, which is exactly what a validator joining those shards syncs against. A node that registered into the new committee reports `Checkpoint for epoch Epoch(3) is not yet available from the previous committee` and drops to `Sleeping`.

**`check_sync` cannot see the problem.** It measures whether this node is behind its peers by height and epoch. A node whose shard group changed is behind by neither: it is level with the committee it is leaving, and that committee is silent about the shards it is joining. With no checkpoint at the leaf epoch (see above) it falls through to the stall-recovery probe, which answers `QuorumAtLeaf` — the old committee is stalled at our leaf, so join consensus directly — and returns `UpToDate`. That answer is right for the question the probe asks and wrong here.

The two compose into a hot loop. Consensus re-enters `Running`, re-processes the end-of-epoch block, raises `NeedsSync`, `CheckSync` says it is up to date, and round it goes:

```
Running --- Behind peers ---> CheckSync      10242
CheckSync --- Ready ---> Running             10241
```

That is sixty seconds of a six-validator swarm splitting into two committees. The epoch never advances, no genesis for the new epoch is ever created, and the validator waiting to join the new committee never gets its checkpoint.

## Changes

* The epoch checkpoint is committed before the shard-group change is signalled. The `NeedsSync` is raised after the write transaction closes, so the checkpoint survives: the committee taking these shards over syncs against it, and this node's own recovery reads it to know the sync is worth attempting.
* `check_sync` reports a node whose shard group has moved since its leaf as `Behind`, ahead of the checkpoint and probe paths. It then state-syncs the shards it has been handed instead of rejoining consensus without them.

Both are needed. The first alone would let `check_sync` reach its checkpoint fast path in this particular case, but leaves the probe answering `UpToDate` for any node that reaches the boundary without a local checkpoint — a crash before the commit, say. The second alone leaves the network with no checkpoint to sync against.

## Motivation and Context

Nothing has exercised a committee change: `calculate_num_committees` is `num_vns / committee_size`, so at the devnet default of 7 a second shard group needs fourteen validators, and the repo's own `Leader failure with multiple committees` scenario is `@ignore`d — at ten validators it stopped producing more than one committee some time ago.

#2515 adds a scenario that reaches two committees with six validators, and it fails on this. This PR is what it needs to pass.

## How Has This Been Tested?

`cargo lints clippy -p tari_consensus -p tari_rpc_state_sync --all-targets` is clean.

End to end against the committee-split scenario from #2515, which is the only test that reaches this path. Merged onto this branch and run locally:

```
git merge origin/test/split-committee-state-sync
CUC_DEBUG=1 cargo test -p integration_tests --test cucumber --release -- --tags "@committee_split"
```

It passes with this change and fails without it, at `all validator nodes have started epoch 4`, with the loop above in the logs. One run each way, on one machine — enough to show the mechanism, not enough to speak to flakiness.

## What process can a PR reviewer use to test or verify this change?

Beyond the scenario: the diagnosis is legible in a failing run's `ootle.log` — every `Behind peers, starting sync` line carries `Shard group changed from ShardGroup(1-256) to ShardGroup(1-128)`, and `EpochCheckpoint::get_by_shard_group` finds nothing at the leaf epoch on any node.

## Breaking Changes

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify
