### PR TITLE
feat(indexer): follow each shard group's tip on a held-open sync_state stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11745,6 +11745,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-stream",
+ "tokio-util 0.7.18",
  "toml 0.9.11+spec-1.1.0",
  "tower-http",
  "tracing",

--- a/applications/tari_indexer/Cargo.toml
+++ b/applications/tari_indexer/Cargo.toml
@@ -91,6 +91,7 @@ tokio = { workspace = true, features = [
     "rt-multi-thread",
 ] }
 tokio-stream = { workspace = true }
+tokio-util = { workspace = true }
 tower-http = { workspace = true, features = ["default", "cors", "limit", "trace"] }
 url = { workspace = true, features = ["serde"] }
 prometheus-client = { workspace = true, optional = true }

--- a/applications/tari_indexer/docs/configuration.md
+++ b/applications/tari_indexer/docs/configuration.md
@@ -62,8 +62,20 @@ Main indexer application settings.
 # Block scanning interval in seconds (default: 10)
 #block_scanning_interval = 10
 
-# State scanning interval in seconds (default: 60)
+# How long, in seconds, a shard group waits before reopening its state sync stream after it fails,
+# or after a validator that does not follow its tip closes it (default: 60)
 #state_scanning_interval = 60
+
+# The longest, in seconds, a validator holds a state sync stream open with no transition to send. The
+# stream follows the validator's tip and is reopened once this passes, one completion marker per
+# shard. The substate cache serves a quiet shard only while its last marker arrived within
+# substate_cache_max_serve_lag, so keep this comfortably shorter than that (default: 120)
+#state_sync_stream_deadline = 120
+
+# How often, in seconds, a validator is asked to show it is still there while the state sync stream
+# has nothing to send. Must be well under state_sync_stream_deadline; validators serve no shorter
+# than their own minimum (5s by default) (default: 10)
+#state_sync_keepalive_interval = 10
 
 # How many epochs past its terminal epoch a transaction submitted through this indexer is retained.
 # A transaction's terminal epoch is the epoch it committed in once its receipt has been indexed, and

--- a/applications/tari_indexer/src/bootstrap.rs
+++ b/applications/tari_indexer/src/bootstrap.rs
@@ -274,6 +274,8 @@ pub async fn spawn_services(
         NetworkWideStateSyncConfig {
             event_filters: Arc::from(config.indexer.event_filters.clone()),
             work_interval: config.indexer.state_scanning_interval,
+            stream_deadline: config.indexer.state_sync_stream_deadline,
+            keepalive_interval: config.indexer.state_sync_keepalive_interval,
             watched_templates: watched_templates.clone(),
         },
         event_notifier.clone(),

--- a/applications/tari_indexer/src/config.rs
+++ b/applications/tari_indexer/src/config.rs
@@ -138,8 +138,28 @@ pub struct IndexerConfig {
     /// How often do we want to scan the second layer for new versions
     #[serde(with = "serializers::seconds")]
     pub block_scanning_interval: Duration,
+    /// How long a shard group waits before reopening its state sync stream after the stream fails,
+    /// or after a validator that does not follow its tip closes it. Also how often sync statistics
+    /// are reported.
     #[serde(with = "serializers::seconds")]
     pub state_scanning_interval: Duration,
+    /// The longest a validator holds a state sync stream open without a transition to send. The
+    /// stream stays open past the validator's tip, streaming transitions as they commit, and is
+    /// reopened once this passes - at the cost of one completion marker per shard - so it need not
+    /// be long.
+    ///
+    /// The substate cache serves a shard that has seen no transition only while its last completion
+    /// marker arrived within `substate_cache_max_serve_lag`, and a quiet shard's next marker is the
+    /// reopen, which follows up to a minute after this passes. This must therefore be comfortably
+    /// shorter than that lag.
+    #[serde(default = "default_state_sync_stream_deadline", with = "serializers::seconds")]
+    pub state_sync_stream_deadline: Duration,
+    /// How often a validator is asked to show it is still there while the state sync stream has
+    /// nothing to send. Must be well under `state_sync_stream_deadline`. A validator serves no
+    /// shorter an interval than its own minimum (5s by default), and the stream is given up after
+    /// several missed keepalives.
+    #[serde(default = "default_state_sync_keepalive_interval", with = "serializers::seconds")]
+    pub state_sync_keepalive_interval: Duration,
     /// The sidechain to listen on. Also identifies this chain for L1 burn-claim binding.
     pub sidechain_id: Option<RistrettoPublicKey>,
     /// Cache TTL for substates fetched during dry run transaction processing.
@@ -156,11 +176,13 @@ pub struct IndexerConfig {
     /// could supersede or destroy it has already reached this indexer through that shard's transition
     /// stream, which only holds while the stream is being kept up with.
     ///
-    /// It must comfortably exceed a full sync round - `state_scanning_interval` plus however long it
-    /// takes to sync every shard group - or the cache closes between rounds and every read costs a
-    /// validator round trip. It is also the only bound on a validator that has stopped serving
-    /// transitions: until it expires, values that the withheld transitions would have retracted are
-    /// still served. Ordinary staleness is bounded by the sync round, not by this.
+    /// A shard that sees no transition is confirmed only when its stream is reopened, so this must
+    /// comfortably exceed `state_sync_stream_deadline` plus the minute or so a reopen can take, or
+    /// the cache closes for quiet shards between reopens and every read costs a validator round
+    /// trip. It is also the only bound on a validator that has stopped serving transitions: until
+    /// it expires, values that the withheld transitions would have retracted are still served.
+    /// Ordinary staleness is bounded by how promptly the validator streams its commits, not by
+    /// this.
     #[serde(default = "default_substate_cache_max_serve_lag", with = "serializers::seconds")]
     pub substate_cache_max_serve_lag: Duration,
     /// Maximum substates held in the cache - one entry each, its head version. Beyond this the oldest
@@ -232,6 +254,14 @@ pub struct IndexerConfig {
 
 fn default_verify_substate_proofs() -> bool {
     true
+}
+
+fn default_state_sync_stream_deadline() -> Duration {
+    Duration::from_secs(120)
+}
+
+fn default_state_sync_keepalive_interval() -> Duration {
+    Duration::from_secs(10)
 }
 
 fn default_substate_cache_max_serve_lag() -> Duration {
@@ -379,6 +409,8 @@ impl Default for IndexerConfig {
             web_ui_public_graphql_url: None,
             block_scanning_interval: Duration::from_secs(10),
             state_scanning_interval: Duration::from_secs(60),
+            state_sync_stream_deadline: default_state_sync_stream_deadline(),
+            state_sync_keepalive_interval: default_state_sync_keepalive_interval(),
             sidechain_id: None,
             dry_run_cache_ttl: Duration::from_secs(10),
             allow_past_protocol_activation: false,

--- a/applications/tari_indexer/src/network_state_sync/config.rs
+++ b/applications/tari_indexer/src/network_state_sync/config.rs
@@ -9,7 +9,15 @@ use crate::network_state_sync::EventFilter;
 
 #[derive(Debug, Clone)]
 pub struct NetworkWideStateSyncConfig {
+    /// How long a shard group waits before reopening its stream after a failure or a final marker,
+    /// and how often sync statistics are reported.
     pub work_interval: Duration,
+    /// The deadline asked of a validator for a state sync stream. See
+    /// `IndexerConfig::state_sync_stream_deadline`.
+    pub stream_deadline: Duration,
+    /// The keepalive interval asked of a validator for a state sync stream. See
+    /// `IndexerConfig::state_sync_keepalive_interval`.
+    pub keepalive_interval: Duration,
     pub event_filters: Arc<[EventFilter]>,
     pub watched_templates: Arc<HashSet<TemplateAddress>>,
 }
@@ -18,6 +26,8 @@ impl Default for NetworkWideStateSyncConfig {
     fn default() -> Self {
         Self {
             work_interval: Duration::from_secs(30),
+            stream_deadline: Duration::from_secs(120),
+            keepalive_interval: Duration::from_secs(10),
             event_filters: Arc::new([]),
             watched_templates: Arc::new(HashSet::new()),
         }

--- a/applications/tari_indexer/src/network_state_sync/stats.rs
+++ b/applications/tari_indexer/src/network_state_sync/stats.rs
@@ -1,42 +1,52 @@
 //   Copyright 2025 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::fmt::Display;
+use std::{
+    fmt::Display,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
 
+/// Counters shared by every shard-group stream, reported and reset together.
 #[derive(Debug, Clone, Default)]
 pub struct SyncStats {
-    pub total_checkpoints: usize,
-    pub total_state_updates: usize,
-    pub total_events: usize,
+    inner: Arc<Counters>,
+}
+
+#[derive(Debug, Default)]
+struct Counters {
+    checkpoints: AtomicUsize,
+    state_updates: AtomicUsize,
+    events: AtomicUsize,
 }
 
 impl SyncStats {
     pub fn new() -> Self {
-        Self {
-            total_checkpoints: 0,
-            total_state_updates: 0,
-            total_events: 0,
-        }
+        Self::default()
     }
 
-    pub fn increment_checkpoints(&mut self) {
-        self.total_checkpoints += 1;
+    pub fn increment_checkpoints(&self) {
+        self.inner.checkpoints.fetch_add(1, Ordering::Relaxed);
     }
 
-    pub fn increase_state_updates(&mut self, by: usize) {
-        self.total_state_updates += by;
+    pub fn increase_state_updates(&self, by: usize) {
+        self.inner.state_updates.fetch_add(by, Ordering::Relaxed);
     }
 
-    pub fn increase_events(&mut self, by: usize) {
-        self.total_events += by;
+    pub fn increase_events(&self, by: usize) {
+        self.inner.events.fetch_add(by, Ordering::Relaxed);
     }
 
     pub fn log_stats(&self) {
         log::info!("{}", self);
     }
 
-    pub fn reset(&mut self) {
-        *self = Self::new();
+    pub fn reset(&self) {
+        self.inner.checkpoints.store(0, Ordering::Relaxed);
+        self.inner.state_updates.store(0, Ordering::Relaxed);
+        self.inner.events.store(0, Ordering::Relaxed);
     }
 }
 
@@ -45,7 +55,9 @@ impl Display for SyncStats {
         write!(
             f,
             "Sync Stats: {{ checkpoints: {}, state_updates: {}, events: {} }}",
-            self.total_checkpoints, self.total_state_updates, self.total_events
+            self.inner.checkpoints.load(Ordering::Relaxed),
+            self.inner.state_updates.load(Ordering::Relaxed),
+            self.inner.events.load(Ordering::Relaxed)
         )
     }
 }

--- a/applications/tari_indexer/src/network_state_sync/sync_plan.rs
+++ b/applications/tari_indexer/src/network_state_sync/sync_plan.rs
@@ -4,20 +4,22 @@
 use std::collections::HashMap;
 
 use tari_epoch_manager::service::NetworkDescription;
-use tari_ootle_common_types::{Epoch, ShardGroup, StateVersion, shard::Shard};
+use tari_ootle_common_types::ShardGroup;
 
-use crate::network_state_sync::{committee_client::ValidatorCommitteeRpcPool, sync_progress::SyncProgress};
+use crate::network_state_sync::{committee_client::ValidatorCommitteeRpcPool, sync_progress::SharedSyncProgress};
 
+/// What one epoch's worth of syncing is drawn against: the committees as they stand, a session pool
+/// for each, and the progress every stream advances.
 pub struct SyncPlan {
     network_description: NetworkDescription,
-    sync_progress: SyncProgress,
+    sync_progress: SharedSyncProgress,
     committee_pools: HashMap<ShardGroup, ValidatorCommitteeRpcPool>,
 }
 
 impl SyncPlan {
     pub fn new(
         network_description: NetworkDescription,
-        sync_progress: SyncProgress,
+        sync_progress: SharedSyncProgress,
         committee_pools: HashMap<ShardGroup, ValidatorCommitteeRpcPool>,
     ) -> Self {
         Self {
@@ -27,17 +29,7 @@ impl SyncPlan {
         }
     }
 
-    pub fn add_checkpoint_sync_progress(&mut self, shard_group: ShardGroup, epoch: Epoch) {
-        self.sync_progress.checkpoint_progress.insert(shard_group, epoch);
-    }
-
-    pub fn add_state_sync_progress(&mut self, shard: Shard, state_version: StateVersion, epoch: Epoch) {
-        self.sync_progress
-            .last_state_versions
-            .insert(shard, (state_version, epoch));
-    }
-
-    pub fn sync_progress(&self) -> &SyncProgress {
+    pub fn sync_progress(&self) -> &SharedSyncProgress {
         &self.sync_progress
     }
 

--- a/applications/tari_indexer/src/network_state_sync/sync_progress.rs
+++ b/applications/tari_indexer/src/network_state_sync/sync_progress.rs
@@ -1,10 +1,13 @@
 //   Copyright 2025 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+use std::sync::Arc;
+
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use serde_with::{Seq, serde_as};
 use tari_ootle_common_types::{Epoch, ShardGroup, StateVersion, shard::Shard};
+use tokio::sync::{Mutex, MutexGuard};
 
 #[serde_as]
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -15,4 +18,44 @@ pub struct SyncProgress {
     pub checkpoint_progress: IndexMap<ShardGroup, Epoch>,
     #[serde_as(as = "Seq<(_, _)>")]
     pub last_state_versions: IndexMap<Shard, (StateVersion, Epoch)>,
+}
+
+impl SyncProgress {
+    pub fn checkpoint_epoch(&self, shard_group: ShardGroup) -> Option<Epoch> {
+        self.checkpoint_progress.get(&shard_group).copied()
+    }
+
+    pub fn record_checkpoint(&mut self, shard_group: ShardGroup, epoch: Epoch) {
+        self.checkpoint_progress.insert(shard_group, epoch);
+    }
+
+    pub fn last_state_version(&self, shard: Shard) -> Option<StateVersion> {
+        self.last_state_versions.get(&shard).map(|(version, _)| *version)
+    }
+
+    pub fn record_state_version(&mut self, shard: Shard, state_version: StateVersion, epoch: Epoch) {
+        self.last_state_versions.insert(shard, (state_version, epoch));
+    }
+}
+
+/// The sync progress shared by every shard-group stream, each of which advances its own shards.
+///
+/// Progress is persisted as a single value, so a stream holds the lock from taking the snapshot it
+/// writes until that write returns: two snapshots taken in one order and written in the other would
+/// roll one group's cursor back.
+#[derive(Debug, Clone, Default)]
+pub struct SharedSyncProgress {
+    inner: Arc<Mutex<SyncProgress>>,
+}
+
+impl SharedSyncProgress {
+    pub fn new(progress: SyncProgress) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(progress)),
+        }
+    }
+
+    pub async fn lock(&self) -> MutexGuard<'_, SyncProgress> {
+        self.inner.lock().await
+    }
 }

--- a/applications/tari_indexer/src/network_state_sync/worker.rs
+++ b/applications/tari_indexer/src/network_state_sync/worker.rs
@@ -532,9 +532,6 @@ impl NetworkWideStateSync {
                 Ok(StreamEnd::Final) => {
                     wait("the validator closed the stream at its tip and does not follow").await;
                 },
-                Ok(StreamEnd::NothingToFollow) => {
-                    wait("no shard has a version to follow from").await;
-                },
                 Err(err) if err.is_peer_fault() => {
                     warn!(target: LOG_TARGET, "⚠️ State sync for shard group {} from {} failed: {}", shard_group, session.peer_address(), err);
                     wait("the peer failed").await;
@@ -549,9 +546,10 @@ impl NetworkWideStateSync {
     ///
     /// A shard that has never been synced wants only the current head state rather than its full
     /// history, which is expressed by the `UP_ONLY` filter. Filters apply to the whole request, so
-    /// such shards are streamed separately from the ones being caught up incrementally, and only the
-    /// incremental stream follows the tip: a shard leaves the from-scratch stream with a cursor and
-    /// joins the followed stream opened right after it.
+    /// such shards are streamed separately, on a stream that runs to its tip and closes. Every shard
+    /// then joins the followed stream: one the head fetch found nothing for follows from version one,
+    /// since its first transition is its head state, and it has to arrive while the stream is open
+    /// rather than on the reopen after the deadline.
     async fn sync_shard_group_state(
         &mut self,
         shards: impl Iterator<Item = Shard>,
@@ -567,7 +565,10 @@ impl NetworkWideStateSync {
             SubstateValueFilterFlags::TEMPLATE_METADATA;
 
         let shards = shards.collect::<Vec<_>>();
-        let (from_scratch, _) = partition_cursors(&shards, &*progress.lock().await);
+        let from_scratch = cursors_for(&shards, &*progress.lock().await)
+            .into_iter()
+            .filter(|cursor| cursor.start_state_version == 1)
+            .collect::<Vec<_>>();
         if !from_scratch.is_empty() {
             info!(
                 target: LOG_TARGET,
@@ -590,16 +591,12 @@ impl NetworkWideStateSync {
             }
         }
 
-        // A shard that had nothing to fetch from scratch is left for the next stream.
-        let (_, incremental) = partition_cursors(&shards, &*progress.lock().await);
-        if incremental.is_empty() {
-            return Ok(StreamEnd::NothingToFollow);
-        }
+        let cursors = cursors_for(&shards, &*progress.lock().await);
         // ALL_HASHES adds an id and a version for every substate outside the value filter, which is
         // what lets the substate cache tell a superseded or destroyed entry from a current one. It
         // is pointless on the from-scratch stream: those shards have no cached entries to retire.
         self.stream_shard_state(
-            incremental,
+            cursors,
             value_filters | SubstateValueFilterFlags::ALL_HASHES,
             true,
             progress,
@@ -919,30 +916,20 @@ enum StreamEnd {
     /// A followed stream was abandoned by the responder after it had nothing to send for the
     /// deadline.
     TimedOut,
-    /// No stream was opened to follow: every shard in the group is still at version zero.
-    NothingToFollow,
     /// The plan is being wound down.
     Cancelled,
 }
 
-/// Splits `shards` into cursors for those never synced, which want only the head state, and those
-/// with a version to resume from. Both lists keep the order of `shards`.
-fn partition_cursors(shards: &[Shard], progress: &SyncProgress) -> (Vec<rpc::ShardCursor>, Vec<rpc::ShardCursor>) {
-    let mut from_scratch = Vec::new();
-    let mut incremental = Vec::new();
-    for &shard in shards {
-        let prev_version = progress.last_state_version(shard).map_or(0, |v| v.as_u64());
-        let cursor = rpc::ShardCursor {
+/// A cursor per shard resuming after the version recorded for it, in the order of `shards`. A shard
+/// never synced resumes from version one.
+fn cursors_for(shards: &[Shard], progress: &SyncProgress) -> Vec<rpc::ShardCursor> {
+    shards
+        .iter()
+        .map(|&shard| rpc::ShardCursor {
             shard: shard.as_u32(),
-            start_state_version: prev_version + 1,
-        };
-        if prev_version == 0 {
-            from_scratch.push(cursor);
-        } else {
-            incremental.push(cursor);
-        }
-    }
-    (from_scratch, incremental)
+            start_state_version: progress.last_state_version(shard).map_or(0, |v| v.as_u64()) + 1,
+        })
+        .collect()
 }
 
 /// Enforces the ordering a `sync_state` stream promises across the shards it carries: a shard's

--- a/applications/tari_indexer/src/network_state_sync/worker.rs
+++ b/applications/tari_indexer/src/network_state_sync/worker.rs
@@ -7,7 +7,7 @@ use std::{
     sync::Arc,
 };
 
-use futures::StreamExt;
+use futures::{StreamExt, future, stream::FuturesUnordered};
 use log::*;
 use ootle_network::Network;
 #[cfg(feature = "metrics")]
@@ -33,7 +33,7 @@ use tari_ootle_storage::{
     },
 };
 use tari_ootle_transaction::TransactionId;
-use tari_rpc_framework::__macro_reexports::future::Either;
+use tari_rpc_framework::{__macro_reexports::future::Either, RpcRequestOptions};
 use tari_shutdown::ShutdownSignal;
 use tari_template_lib_types::{Amount, TemplateAddress, TransactionReceiptAddress};
 use tokio::{sync::broadcast, time};
@@ -48,7 +48,7 @@ use crate::{
         shard_watermarks::ShardWatermarks,
         stats::SyncStats,
         sync_plan::SyncPlan,
-        sync_progress::SyncProgress,
+        sync_progress::{SharedSyncProgress, SyncProgress},
         validator_status::ValidatorStatusMonitor,
     },
     notify::Notify,
@@ -154,35 +154,46 @@ impl NetworkWideStateSync {
         #[cfg(feature = "metrics")]
         self.update_metrics().await;
 
-        let mut interval = time::interval(self.config.work_interval);
-        interval.set_missed_tick_behavior(time::MissedTickBehavior::Delay);
+        let mut report_interval = time::interval(self.config.work_interval);
+        report_interval.set_missed_tick_behavior(time::MissedTickBehavior::Delay);
+        report_interval.reset();
 
         loop {
-            tokio::select! {
-                Ok(event) = epoch_events.recv() => {
-                    interval.reset();
-                    self.handle_epoch_event(event).await?;
-                },
-                _ = interval.tick() => {
-                    self.start_sync_round().await?;
+            let sync_plan = self.initialize_sync_plan().await?;
+            // A plan is drawn against the committees of one epoch: which shard group serves which
+            // shards, and who is in it. When the epoch moves, every stream is dropped and a new plan
+            // drawn; the cursors survive in the persisted progress, so nothing is re-streamed.
+            let mut sync = pin!(self.clone().sync_plan(sync_plan));
+            loop {
+                tokio::select! {
+                    event = epoch_events.recv() => {
+                        match event {
+                            Ok(event) => self.handle_epoch_event(event),
+                            Err(broadcast::error::RecvError::Lagged(n)) => {
+                                warn!(target: LOG_TARGET, "⚠️ Missed {n} epoch event(s). Re-planning the state sync");
+                            },
+                            Err(broadcast::error::RecvError::Closed) => {
+                                return Err(NetworkStateSyncError::InvariantError {
+                                    details: "Epoch manager stopped publishing events".to_string(),
+                                });
+                            },
+                        }
+                        break;
+                    },
+                    result = &mut sync => {
+                        result?;
+                        time::sleep(self.config.work_interval).await;
+                        break;
+                    },
+                    _ = report_interval.tick() => {
+                        self.stats.log_stats();
+                        self.stats.reset();
+                        #[cfg(feature = "metrics")]
+                        self.update_metrics().await;
+                    },
                 }
             }
         }
-    }
-
-    async fn start_sync_round(&mut self) -> Result<(), NetworkStateSyncError> {
-        info!(target: LOG_TARGET, "🌍️ Starting network-wide state sync round...");
-        let sync_plan = self.initialize_sync_plan().await?;
-        if sync_plan.network_description().epoch.is_zero() {
-            info!(target: LOG_TARGET, "🌍️ Current epoch is zero, nothing to sync.");
-            return Ok(());
-        }
-        self.start_sync(sync_plan).await?;
-        self.stats.log_stats();
-        self.stats.reset();
-        #[cfg(feature = "metrics")]
-        self.update_metrics().await;
-        Ok(())
     }
 
     /// Reads the persisted economic totals and publishes them to the Prometheus gauges. Metrics are
@@ -201,15 +212,13 @@ impl NetworkWideStateSync {
         }
     }
 
-    async fn handle_epoch_event(&mut self, event: EpochManagerEvent) -> Result<(), NetworkStateSyncError> {
+    fn handle_epoch_event(&self, event: EpochManagerEvent) {
         match event {
             EpochManagerEvent::EpochChanged { epoch, .. } => {
                 info!(target: LOG_TARGET, "🌍️ Epoch changed to {}.", epoch);
                 self.notify.notify(NewEpochEvent { epoch });
-                self.start_sync_round().await?;
             },
         }
-        Ok(())
     }
 
     async fn initialize_sync_plan(&self) -> Result<SyncPlan, NetworkStateSyncError> {
@@ -227,33 +236,42 @@ impl NetworkWideStateSync {
             committee_pools.insert(shard_group, pool);
         }
 
-        Ok(SyncPlan::new(network_desc, sync_progress, committee_pools))
+        Ok(SyncPlan::new(
+            network_desc,
+            SharedSyncProgress::new(sync_progress),
+            committee_pools,
+        ))
     }
 
-    async fn start_sync(&mut self, mut sync_plan: SyncPlan) -> Result<(), NetworkStateSyncError> {
-        self.sync_checkpoints(&mut sync_plan).await?;
-        self.sync_state(&mut sync_plan).await?;
-
-        Ok(())
+    /// Syncs the previous epoch's checkpoints, then follows every shard group's tip until the plan
+    /// is dropped. Returns only on an error that is not one shard group's alone.
+    async fn sync_plan(self, sync_plan: SyncPlan) -> Result<(), NetworkStateSyncError> {
+        if sync_plan.network_description().epoch.is_zero() {
+            info!(target: LOG_TARGET, "🌍️ Current epoch is zero, nothing to sync.");
+            return future::pending().await;
+        }
+        info!(target: LOG_TARGET, "🌍️ Starting network-wide state sync...");
+        self.sync_checkpoints(&sync_plan).await?;
+        self.follow_state(&sync_plan).await
     }
 
     #[expect(clippy::too_many_lines)]
-    async fn sync_checkpoints(&mut self, sync_plan_mut: &mut SyncPlan) -> Result<(), NetworkStateSyncError> {
-        let prev_epoch = sync_plan_mut
+    async fn sync_checkpoints(&self, sync_plan: &SyncPlan) -> Result<(), NetworkStateSyncError> {
+        let prev_epoch = sync_plan
             .network_description()
             .epoch()
             .checked_sub(Epoch(1))
             .ok_or_else(|| NetworkStateSyncError::InvariantError {
                 details: "current epoch is zero, there are no checkpoints to sync".to_string(),
             })?;
-        let committee_pools = sync_plan_mut.committee_pools().clone();
+        let committee_pools = sync_plan.committee_pools().clone();
 
         for (shard_group, mut pool) in committee_pools {
-            let from_epoch = sync_plan_mut
+            let from_epoch = sync_plan
                 .sync_progress()
-                .checkpoint_progress
-                .get(&shard_group)
-                .copied()
+                .lock()
+                .await
+                .checkpoint_epoch(shard_group)
                 .unwrap_or_else(Epoch::zero);
             if from_epoch >= prev_epoch {
                 info!(target: LOG_TARGET, "🌍️ No checkpoints to sync for shard group {shard_group} from epoch {from_epoch}");
@@ -303,8 +321,9 @@ impl NetworkWideStateSync {
 
             if checkpoints.is_empty() {
                 info!(target: LOG_TARGET, "🌍️ No checkpoints found for shard group {shard_group} from epoch {from_epoch} (prev_epoch {prev_epoch})");
-                sync_plan_mut.add_checkpoint_sync_progress(shard_group, prev_epoch);
-                let sync_progress_snapshot = sync_plan_mut.sync_progress().clone();
+                let mut progress = sync_plan.sync_progress().lock().await;
+                progress.record_checkpoint(shard_group, prev_epoch);
+                let sync_progress_snapshot = progress.clone();
                 self.store
                     .with_write_tx(move |tx| tx.key_value_set(Key::SyncProgress, sync_progress_snapshot))
                     .await?;
@@ -362,10 +381,11 @@ impl NetworkWideStateSync {
                 info!(target: LOG_TARGET, "🌍️ Inserting checkpoint for {}, shard group {}", checkpoint.epoch(), checkpoint_shard_group);
 
                 self.stats.increment_checkpoints();
-                sync_plan_mut.add_checkpoint_sync_progress(shard_group, checkpoint.epoch());
                 let xtr_exhausted = Amount::from(checkpoint.header().accumulated_data().total_exhaust_burn);
                 let checkpoint_epoch = checkpoint.epoch();
-                let sync_progress_snapshot = sync_plan_mut.sync_progress().clone();
+                let mut progress = sync_plan.sync_progress().lock().await;
+                progress.record_checkpoint(shard_group, checkpoint_epoch);
+                let sync_progress_snapshot = progress.clone();
                 self.store
                     .with_write_tx(move |tx| {
                         if !tx.epoch_checkpoint_exists(shard_group, checkpoint_epoch)? {
@@ -387,17 +407,49 @@ impl NetworkWideStateSync {
         Ok(())
     }
 
-    async fn sync_state(&mut self, sync_plan_mut: &mut SyncPlan) -> Result<(), NetworkStateSyncError> {
-        let committee_pools = sync_plan_mut.committee_pools().clone();
+    /// Follows every shard group's tip at once, each on its own stream, until dropped. Returns only
+    /// on an error that is not one shard group's alone; a group whose peer fails is retried on its
+    /// own without disturbing the others.
+    async fn follow_state(&self, sync_plan: &SyncPlan) -> Result<(), NetworkStateSyncError> {
+        let mut committee_pools = sync_plan.committee_pools().iter().collect::<Vec<_>>();
+        committee_pools.sort_by_key(|(shard_group, _)| **shard_group);
 
-        let mut has_synced_global_shard = false;
+        // Every committee holds the global shard, so it is claimed by exactly one group: the lowest.
+        let mut groups = committee_pools
+            .into_iter()
+            .enumerate()
+            .map(|(i, (shard_group, pool))| {
+                self.clone()
+                    .follow_shard_group(*shard_group, pool.clone(), i == 0, sync_plan.sync_progress().clone())
+            })
+            .collect::<FuturesUnordered<_>>();
 
-        for (shard_group, mut pool) in committee_pools {
-            // TODO: consider syncing shards in epoch chunks rather than one after another
+        while let Some(result) = groups.next().await {
+            result?;
+        }
+        Ok(())
+    }
+
+    /// Keeps one shard group synced: opens a stream from a committee member, follows it until it
+    /// ends, and opens another.
+    ///
+    /// A stream that ends because the validator had nothing to send for the deadline is reopened at
+    /// once - that is the ordinary end of a followed stream, and the reopen refreshes each shard's
+    /// watermark. One closed by a validator that does not follow, or failed by the peer, waits the
+    /// work interval first: the former is polling, the latter wants a different peer.
+    async fn follow_shard_group(
+        mut self,
+        shard_group: ShardGroup,
+        mut pool: ValidatorCommitteeRpcPool,
+        syncs_global_shard: bool,
+        progress: SharedSyncProgress,
+    ) -> Result<(), NetworkStateSyncError> {
+        loop {
             let mut session = match pool.new_session().await {
                 Ok(s) => s,
                 Err(e) => {
-                    warn!(target: LOG_TARGET, "⚠️ Failed to create session for shard group {}: {}. Continuing with others", shard_group, e);
+                    warn!(target: LOG_TARGET, "⚠️ Failed to create session for shard group {}: {}. Retrying in {:.0?}", shard_group, e, self.config.work_interval);
+                    time::sleep(self.config.work_interval).await;
                     continue;
                 },
             };
@@ -412,76 +464,64 @@ impl NetworkWideStateSync {
                 Ok(None) => {},
                 // probe only returns Err for an invalid (forged) commit proof.
                 Err(e) => {
-                    warn!(target: LOG_TARGET, "⚠️ Validator {} for shard group {} served an INVALID commit proof: {}. Skipping this round.", session.peer_address(), shard_group, e);
+                    warn!(target: LOG_TARGET, "⚠️ Validator {} for shard group {} served an INVALID commit proof: {}. Retrying in {:.0?}", session.peer_address(), shard_group, e, self.config.work_interval);
+                    time::sleep(self.config.work_interval).await;
                     continue;
                 },
             }
 
-            // Every committee holds the global shard, so it is synced once per round from whichever
-            // committee is reached first. Shard 0 sorts before every preshard, which keeps the cursor
-            // list ascending as the responder requires.
-            let shards = (!has_synced_global_shard)
+            // Shard 0 sorts before every preshard, which keeps the cursor list ascending as the
+            // responder requires.
+            let shards = syncs_global_shard
                 .then_some(Shard::global())
                 .into_iter()
                 .chain(shard_group.shard_iter());
 
             // A responder that cannot serve these shards - it left the committee, or the epoch this
-            // indexer resolved its committees at has moved on - costs this shard group the round and
-            // no more. The global shard stays unclaimed so that the next committee streams it.
-            if let Err(err) = self
-                .sync_shard_group_state(shards, sync_plan_mut, shard_group, &mut session)
+            // indexer resolved its committees at has moved on - costs this shard group a retry and
+            // no more.
+            match self
+                .sync_shard_group_state(shards, &progress, shard_group, &mut session)
                 .await
             {
-                if !err.is_peer_fault() {
-                    return Err(err);
-                }
-                warn!(target: LOG_TARGET, "⚠️ State sync for shard group {} from {} failed: {}. Continuing with others", shard_group, session.peer_address(), err);
-                continue;
+                Ok(StreamEnd::TimedOut) => {
+                    debug!(target: LOG_TARGET, "🌍️ State sync stream for shard group {shard_group} from {} had nothing to send for the deadline. Reopening", session.peer_address());
+                },
+                Ok(StreamEnd::Final) => {
+                    debug!(target: LOG_TARGET, "🌍️ Validator {} closed the state sync stream for shard group {shard_group} at its tip. Reopening in {:.0?}", session.peer_address(), self.config.work_interval);
+                    time::sleep(self.config.work_interval).await;
+                },
+                Err(err) if err.is_peer_fault() => {
+                    warn!(target: LOG_TARGET, "⚠️ State sync for shard group {} from {} failed: {}. Retrying in {:.0?}", shard_group, session.peer_address(), err, self.config.work_interval);
+                    time::sleep(self.config.work_interval).await;
+                },
+                Err(err) => return Err(err),
             }
-            has_synced_global_shard = true;
         }
-
-        Ok(())
     }
 
     /// Syncs every given shard from `session`, which serves them all over a single stream.
     ///
     /// A shard that has never been synced wants only the current head state rather than its full
     /// history, which is expressed by the `UP_ONLY` filter. Filters apply to the whole request, so
-    /// such shards are streamed separately from the ones being caught up incrementally: two streams
-    /// per shard group at most, and one in the steady state.
+    /// such shards are streamed separately from the ones being caught up incrementally, and only the
+    /// incremental stream follows the tip: a shard leaves the from-scratch stream with a cursor and
+    /// joins the followed stream opened right after it.
     async fn sync_shard_group_state(
         &mut self,
         shards: impl Iterator<Item = Shard>,
-        sync_plan_mut: &mut SyncPlan,
+        progress: &SharedSyncProgress,
         shard_group: ShardGroup,
         session: &mut ValidatorRpcSession,
-    ) -> Result<(), NetworkStateSyncError> {
+    ) -> Result<StreamEnd, NetworkStateSyncError> {
         let value_filters = SubstateValueFilterFlags::UTXO |
             SubstateValueFilterFlags::VALIDATOR_FEE_POOL |
             SubstateValueFilterFlags::CLAIMED_OUTPUT_TOMBSTONE |
             SubstateValueFilterFlags::TRANSACTION_RECEIPT |
             SubstateValueFilterFlags::TEMPLATE_METADATA;
 
-        let mut from_scratch = Vec::new();
-        let mut incremental = Vec::new();
-        for shard in shards {
-            let prev_version = sync_plan_mut
-                .sync_progress()
-                .last_state_versions
-                .get(&shard)
-                .map_or(0, |(v, _)| v.as_u64());
-            let cursor = rpc::ShardCursor {
-                shard: shard.as_u32(),
-                start_state_version: prev_version + 1,
-            };
-            if prev_version == 0 {
-                from_scratch.push(cursor);
-            } else {
-                incremental.push(cursor);
-            }
-        }
-
+        let shards = shards.collect::<Vec<_>>();
+        let (from_scratch, _) = partition_cursors(&shards, &*progress.lock().await);
         if !from_scratch.is_empty() {
             info!(
                 target: LOG_TARGET,
@@ -491,28 +531,31 @@ impl NetworkWideStateSync {
             self.stream_shard_state(
                 from_scratch,
                 value_filters | SubstateValueFilterFlags::UP_ONLY,
-                sync_plan_mut,
+                false,
+                progress,
                 shard_group,
                 session,
             )
             .await?;
         }
 
-        if !incremental.is_empty() {
-            // ALL_HASHES adds an id and a version for every substate outside the value filter, which is
-            // what lets the substate cache tell a superseded or destroyed entry from a current one. It
-            // is pointless on the from-scratch stream: those shards have no cached entries to retire.
-            self.stream_shard_state(
-                incremental,
-                value_filters | SubstateValueFilterFlags::ALL_HASHES,
-                sync_plan_mut,
-                shard_group,
-                session,
-            )
-            .await?;
+        // A shard that had nothing to fetch from scratch is left for the next stream.
+        let (_, incremental) = partition_cursors(&shards, &*progress.lock().await);
+        if incremental.is_empty() {
+            return Ok(StreamEnd::Final);
         }
-
-        Ok(())
+        // ALL_HASHES adds an id and a version for every substate outside the value filter, which is
+        // what lets the substate cache tell a superseded or destroyed entry from a current one. It
+        // is pointless on the from-scratch stream: those shards have no cached entries to retire.
+        self.stream_shard_state(
+            incremental,
+            value_filters | SubstateValueFilterFlags::ALL_HASHES,
+            true,
+            progress,
+            shard_group,
+            session,
+        )
+        .await
     }
 
     /// Records a committee-validated tip into the verified-root store, after a fail-open epoch
@@ -543,36 +586,48 @@ impl NetworkWideStateSync {
         Ok(())
     }
 
-    /// Consumes a single `sync_state` stream covering `cursors`.
+    /// Consumes a single `sync_state` stream covering `cursors`, following the responder's tip if
+    /// `follow` is set.
     ///
     /// The responder streams each shard's updates contiguously and closes it off with a completion
     /// marker, so progress is recorded per shard as the stream advances - an interrupted stream keeps
-    /// everything already committed and simply resumes from the recorded cursors next round.
+    /// everything already committed and simply resumes from the recorded cursors when reopened. A
+    /// followed stream keeps going past the tip, closing off each burst of a shard's new versions
+    /// with a further marker; it ends when the responder has had nothing to send for the deadline,
+    /// or can no longer serve it.
     #[expect(clippy::too_many_lines)]
     async fn stream_shard_state(
         &mut self,
         cursors: Vec<rpc::ShardCursor>,
         value_filters: SubstateValueFilterFlags,
-        sync_plan_mut: &mut SyncPlan,
+        follow: bool,
+        progress: &SharedSyncProgress,
         shard_group: ShardGroup,
         session: &mut ValidatorRpcSession,
-    ) -> Result<(), NetworkStateSyncError> {
+    ) -> Result<StreamEnd, NetworkStateSyncError> {
         let mut order = StreamOrder::new(&cursors);
 
         info!(
             target: LOG_TARGET,
-            "🌍️ Starting state sync for {} shard(s) in shard group {shard_group} from peer {}",
+            "🌍️ Starting state sync for {} shard(s) in shard group {shard_group} from peer {} (follow: {follow})",
             cursors.len(),
             session.peer_address()
         );
 
+        let options = RpcRequestOptions::new()
+            .with_deadline(self.config.stream_deadline)
+            .with_keepalive_interval(self.config.keepalive_interval);
         let mut stream = session
-            .sync_state(rpc::SyncStateRequest {
-                cursors,
-                // Sync to latest epoch
-                until_epoch: None,
-                value_filters: value_filters.bits(),
-            })
+            .sync_state_with_options(
+                rpc::SyncStateRequest {
+                    cursors,
+                    // Sync to latest epoch
+                    until_epoch: None,
+                    value_filters: value_filters.bits(),
+                    follow,
+                },
+                options,
+            )
             .await?;
 
         // Buffers accumulate a single (shard, state version) at a time: the responder splits an
@@ -587,9 +642,17 @@ impl NetworkWideStateSync {
         let mut xtr_fees = Amount::zero();
         let mut xtr_receipt_burn = Amount::zero();
 
-        let mut saw_final = false;
         while let Some(result) = stream.next().await {
-            let msg = result?;
+            let msg = match result {
+                Ok(msg) => msg,
+                // A followed stream with nothing to send for the deadline is simply abandoned by the
+                // responder, which the client reports as a timeout.
+                Err(status) if follow && status.as_status_code().is_timeout() => {
+                    debug!(target: LOG_TARGET, "🌍️ State sync stream for shard group {shard_group} timed out: {status}");
+                    return Ok(StreamEnd::TimedOut);
+                },
+                Err(status) => return Err(status.into()),
+            };
             let batch = match msg.response {
                 Some(rpc::sync_state_response::Response::Batch(batch)) => batch,
                 Some(rpc::sync_state_response::Response::Complete(complete)) => {
@@ -611,20 +674,18 @@ impl NetworkWideStateSync {
                                 details: "Received sync completion without epoch".to_string(),
                             })?;
                     // Only persist when the watermark advances - a caught-up shard re-sends the same
-                    // version every round, and we must not write on every empty round.
-                    let already_synced = sync_plan_mut
-                        .sync_progress()
-                        .last_state_versions
-                        .get(&shard)
-                        .is_some_and(|(v, _)| synced_to <= *v);
+                    // version on every reopen, and we must not write on every empty one.
+                    let mut progress = progress.lock().await;
+                    let already_synced = progress.last_state_version(shard).is_some_and(|v| synced_to <= v);
                     if !already_synced {
-                        sync_plan_mut.add_state_sync_progress(shard, synced_to, msg_epoch);
-                        let sync_progress_snapshot = sync_plan_mut.sync_progress().clone();
+                        progress.record_state_version(shard, synced_to, msg_epoch);
+                        let sync_progress_snapshot = progress.clone();
                         self.store
                             .clone()
                             .with_write_tx(move |tx| tx.key_value_set(Key::SyncProgress, sync_progress_snapshot))
                             .await?;
                     }
+                    drop(progress);
                     // The completion marker is the only point at which this shard is known to be
                     // level with the committee, which is what the substate cache needs: mid-stream
                     // the indexer holds every transition up to some version while the chain is
@@ -633,8 +694,7 @@ impl NetworkWideStateSync {
                     self.shard_watermarks.confirm(shard, synced_to);
                     debug!(target: LOG_TARGET, "🌍️ Completed state sync for shard {shard} in shard group {shard_group} to epoch {msg_epoch} and state version {synced_to}");
                     if complete.is_final {
-                        saw_final = true;
-                        break;
+                        return Ok(StreamEnd::Final);
                     }
                     continue;
                 },
@@ -704,8 +764,9 @@ impl NetworkWideStateSync {
             let event_count: usize = transactions.iter().map(|(_, t)| t.events.len()).sum();
             self.stats.increase_events(event_count);
 
-            sync_plan_mut.add_state_sync_progress(shard, state_version, msg_epoch);
-            let sync_progress_snapshot = sync_plan_mut.sync_progress().clone();
+            let mut progress = progress.lock().await;
+            progress.record_state_version(shard, state_version, msg_epoch);
+            let sync_progress_snapshot = progress.clone();
 
             let network = self.network;
             let event_filters = self.config.event_filters.clone();
@@ -756,6 +817,7 @@ impl NetworkWideStateSync {
                     Ok(inserted)
                 })
                 .await?;
+            drop(progress);
 
             // The stream flushes (has_more == false) once per state version, so each commit must fold only
             // that version's delta. Reset the running totals here, mirroring the buffer drains above.
@@ -772,30 +834,62 @@ impl NetworkWideStateSync {
             }
         }
 
-        if !saw_final {
-            return Err(NetworkStateSyncError::InvalidStateUpdate {
-                details: format!(
-                    "State sync stream for shard group {shard_group} ended without a final completion marker"
-                ),
-            });
-        }
-
-        Ok(())
+        // A followed stream is only ever ended by the responder for want of its warrant, which it
+        // reports, or of consensus. Ending silently is the peer's failing either way.
+        Err(NetworkStateSyncError::InvalidStateUpdate {
+            details: if follow {
+                format!("Followed state sync stream for shard group {shard_group} was closed by the responder")
+            } else {
+                format!("State sync stream for shard group {shard_group} ended without a final completion marker")
+            },
+        })
     }
 }
 
-/// Enforces the ordering a `sync_state` stream promises across the shards it carries: each shard is
-/// streamed contiguously, its versions strictly advance, and nothing for it follows its completion
-/// marker.
+/// How a `sync_state` stream ended without failing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StreamEnd {
+    /// The responder closed it with a final completion marker: it streamed to its tip and does not
+    /// follow.
+    Final,
+    /// A followed stream was abandoned by the responder after it had nothing to send for the
+    /// deadline.
+    TimedOut,
+}
+
+/// Splits `shards` into cursors for those never synced, which want only the head state, and those
+/// with a version to resume from. Both lists keep the order of `shards`.
+fn partition_cursors(shards: &[Shard], progress: &SyncProgress) -> (Vec<rpc::ShardCursor>, Vec<rpc::ShardCursor>) {
+    let mut from_scratch = Vec::new();
+    let mut incremental = Vec::new();
+    for &shard in shards {
+        let prev_version = progress.last_state_version(shard).map_or(0, |v| v.as_u64());
+        let cursor = rpc::ShardCursor {
+            shard: shard.as_u32(),
+            start_state_version: prev_version + 1,
+        };
+        if prev_version == 0 {
+            from_scratch.push(cursor);
+        } else {
+            incremental.push(cursor);
+        }
+    }
+    (from_scratch, incremental)
+}
+
+/// Enforces the ordering a `sync_state` stream promises across the shards it carries: a shard's
+/// versions strictly advance, and a version split across chunks is delivered whole before anything
+/// else.
 ///
-/// The consumer relies on all three. Its buffers hold one `(shard, state version)` at a time, so an
-/// interleaved shard would mix two shards' updates into one commit; and because the running economic
-/// totals are read-modify-write, re-applying a version already committed would double-count it.
+/// The consumer relies on both. Its buffers hold one `(shard, state version)` at a time, so a shard
+/// interleaved mid-version would mix two shards' updates into one commit; and because the running
+/// economic totals are read-modify-write, re-applying a version already committed would double-count
+/// it. A completion marker closes off what was streamed so far for a shard and a followed stream
+/// carries more for it after, so a marker does not end a shard.
 struct StreamOrder {
     /// Highest version committed per requested shard, seeded from the cursor so a responder cannot
     /// replay versions the caller already holds.
     committed_versions: HashMap<Shard, StateVersion>,
-    completed: HashSet<Shard>,
     /// Set while a version is split across chunks, until the chunk that flushes it.
     pending_chunk: Option<(Shard, StateVersion)>,
 }
@@ -812,7 +906,6 @@ impl StreamOrder {
                     )
                 })
                 .collect(),
-            completed: HashSet::new(),
             pending_chunk: None,
         }
     }
@@ -821,9 +914,6 @@ impl StreamOrder {
         let Some(committed_version) = self.committed_versions.get(&shard).copied() else {
             return Err(format!("Received batch for unrequested shard {shard}"));
         };
-        if self.completed.contains(&shard) {
-            return Err(format!("Received batch for shard {shard} after its completion marker"));
-        }
         if state_version <= committed_version {
             return Err(format!(
                 "Received v{state_version} for shard {shard}, which is not ahead of the committed v{committed_version}"
@@ -856,9 +946,6 @@ impl StreamOrder {
                 "Received completion marker for shard {shard} while v{pending_version} of shard {pending_shard} is \
                  still incomplete"
             ));
-        }
-        if !self.completed.insert(shard) {
-            return Err(format!("Received a second completion marker for shard {shard}"));
         }
         Ok(())
     }
@@ -1122,9 +1209,14 @@ mod tests {
         }
 
         #[test]
-        fn it_rejects_a_batch_after_the_shards_marker() {
-            let mut o = order(&[(1, 1)]);
+        fn it_accepts_a_followed_shard_streamed_again_after_its_marker() {
+            let mut o = order(&[(1, 1), (2, 1)]);
             o.accept_batch(S1, v(2), false).unwrap();
+            o.accept_marker(S1).unwrap();
+            o.accept_marker(S2).unwrap();
+            o.accept_batch(S1, v(3), false).unwrap();
+            o.accept_marker(S1).unwrap();
+            // A forced marker on an epoch change closes off nothing new.
             o.accept_marker(S1).unwrap();
             assert!(o.accept_batch(S1, v(3), false).is_err());
         }
@@ -1140,13 +1232,6 @@ mod tests {
         fn it_rejects_a_marker_while_a_version_is_incomplete() {
             let mut o = order(&[(1, 1)]);
             o.accept_batch(S1, v(3), true).unwrap();
-            assert!(o.accept_marker(S1).is_err());
-        }
-
-        #[test]
-        fn it_rejects_a_second_marker_for_a_shard() {
-            let mut o = order(&[(1, 1)]);
-            o.accept_marker(S1).unwrap();
             assert!(o.accept_marker(S1).is_err());
         }
 

--- a/applications/tari_indexer/src/network_state_sync/worker.rs
+++ b/applications/tari_indexer/src/network_state_sync/worker.rs
@@ -7,7 +7,7 @@ use std::{
     sync::Arc,
 };
 
-use futures::{StreamExt, future, stream::FuturesUnordered};
+use futures::{StreamExt, future::Either, stream::FuturesUnordered};
 use log::*;
 use ootle_network::Network;
 #[cfg(feature = "metrics")]
@@ -33,10 +33,11 @@ use tari_ootle_storage::{
     },
 };
 use tari_ootle_transaction::TransactionId;
-use tari_rpc_framework::{__macro_reexports::future::Either, RpcRequestOptions};
+use tari_rpc_framework::RpcRequestOptions;
 use tari_shutdown::ShutdownSignal;
 use tari_template_lib_types::{Amount, TemplateAddress, TransactionReceiptAddress};
 use tokio::{sync::broadcast, time};
+use tokio_util::sync::CancellationToken;
 
 #[cfg(feature = "metrics")]
 use crate::{network_state_sync::NetworkStateMetrics, store::ReadOnlyStore};
@@ -161,9 +162,17 @@ impl NetworkWideStateSync {
         loop {
             let sync_plan = self.initialize_sync_plan().await?;
             // A plan is drawn against the committees of one epoch: which shard group serves which
-            // shards, and who is in it. When the epoch moves, every stream is dropped and a new plan
-            // drawn; the cursors survive in the persisted progress, so nothing is re-streamed.
-            let mut sync = pin!(self.clone().sync_plan(sync_plan));
+            // shards, and who is in it. When the epoch moves, every stream is wound down and a new
+            // plan drawn; the cursors survive in the persisted progress, so nothing is re-streamed.
+            //
+            // Wound down, not dropped: a write transaction runs to its commit on a blocking thread
+            // whether or not the future awaiting it survives, and a plan drawn from progress read
+            // before that commit would carry a cursor the commit has moved past. Once persisted
+            // over the committed one, that cursor re-streams a version whose economic totals were
+            // already folded in. So every stream is told to stop, and the plan is awaited to the
+            // end before the next is read.
+            let cancel = CancellationToken::new();
+            let mut sync = pin!(self.clone().sync_plan(sync_plan, cancel.clone()));
             loop {
                 tokio::select! {
                     event = epoch_events.recv() => {
@@ -178,6 +187,8 @@ impl NetworkWideStateSync {
                                 });
                             },
                         }
+                        cancel.cancel();
+                        sync.await?;
                         break;
                     },
                     result = &mut sync => {
@@ -243,20 +254,26 @@ impl NetworkWideStateSync {
         ))
     }
 
-    /// Syncs the previous epoch's checkpoints, then follows every shard group's tip until the plan
-    /// is dropped. Returns only on an error that is not one shard group's alone.
-    async fn sync_plan(self, sync_plan: SyncPlan) -> Result<(), NetworkStateSyncError> {
+    /// Syncs the previous epoch's checkpoints, then follows every shard group's tip until `cancel`
+    /// is triggered, at which point it returns once every stream has stopped between messages.
+    /// Returns early only on an error that is not one shard group's alone.
+    async fn sync_plan(self, sync_plan: SyncPlan, cancel: CancellationToken) -> Result<(), NetworkStateSyncError> {
         if sync_plan.network_description().epoch.is_zero() {
             info!(target: LOG_TARGET, "🌍️ Current epoch is zero, nothing to sync.");
-            return future::pending().await;
+            cancel.cancelled().await;
+            return Ok(());
         }
         info!(target: LOG_TARGET, "🌍️ Starting network-wide state sync...");
-        self.sync_checkpoints(&sync_plan).await?;
-        self.follow_state(&sync_plan).await
+        self.sync_checkpoints(&sync_plan, &cancel).await?;
+        self.follow_state(&sync_plan, &cancel).await
     }
 
     #[expect(clippy::too_many_lines)]
-    async fn sync_checkpoints(&self, sync_plan: &SyncPlan) -> Result<(), NetworkStateSyncError> {
+    async fn sync_checkpoints(
+        &self,
+        sync_plan: &SyncPlan,
+        cancel: &CancellationToken,
+    ) -> Result<(), NetworkStateSyncError> {
         let prev_epoch = sync_plan
             .network_description()
             .epoch()
@@ -267,6 +284,9 @@ impl NetworkWideStateSync {
         let committee_pools = sync_plan.committee_pools().clone();
 
         for (shard_group, mut pool) in committee_pools {
+            if cancel.is_cancelled() {
+                return Ok(());
+            }
             let from_epoch = sync_plan
                 .sync_progress()
                 .lock()
@@ -407,10 +427,14 @@ impl NetworkWideStateSync {
         Ok(())
     }
 
-    /// Follows every shard group's tip at once, each on its own stream, until dropped. Returns only
-    /// on an error that is not one shard group's alone; a group whose peer fails is retried on its
-    /// own without disturbing the others.
-    async fn follow_state(&self, sync_plan: &SyncPlan) -> Result<(), NetworkStateSyncError> {
+    /// Follows every shard group's tip at once, each on its own stream, until cancelled. Returns
+    /// early only on an error that is not one shard group's alone; a group whose peer fails is
+    /// retried on its own without disturbing the others.
+    async fn follow_state(
+        &self,
+        sync_plan: &SyncPlan,
+        cancel: &CancellationToken,
+    ) -> Result<(), NetworkStateSyncError> {
         let mut committee_pools = sync_plan.committee_pools().iter().collect::<Vec<_>>();
         committee_pools.sort_by_key(|(shard_group, _)| **shard_group);
 
@@ -419,8 +443,13 @@ impl NetworkWideStateSync {
             .into_iter()
             .enumerate()
             .map(|(i, (shard_group, pool))| {
-                self.clone()
-                    .follow_shard_group(*shard_group, pool.clone(), i == 0, sync_plan.sync_progress().clone())
+                self.clone().follow_shard_group(
+                    *shard_group,
+                    pool.clone(),
+                    i == 0,
+                    sync_plan.sync_progress().clone(),
+                    cancel.clone(),
+                )
             })
             .collect::<FuturesUnordered<_>>();
 
@@ -431,7 +460,7 @@ impl NetworkWideStateSync {
     }
 
     /// Keeps one shard group synced: opens a stream from a committee member, follows it until it
-    /// ends, and opens another.
+    /// ends, and opens another, until cancelled.
     ///
     /// A stream that ends because the validator had nothing to send for the deadline is reopened at
     /// once - that is the ordinary end of a followed stream, and the reopen refreshes each shard's
@@ -443,13 +472,25 @@ impl NetworkWideStateSync {
         mut pool: ValidatorCommitteeRpcPool,
         syncs_global_shard: bool,
         progress: SharedSyncProgress,
+        cancel: CancellationToken,
     ) -> Result<(), NetworkStateSyncError> {
-        loop {
+        let interval = self.config.work_interval;
+        let wait = |reason: &'static str| {
+            let cancel = cancel.clone();
+            async move {
+                debug!(target: LOG_TARGET, "🌍️ Shard group {shard_group}: {reason}. Retrying in {interval:.0?}");
+                tokio::select! {
+                    _ = cancel.cancelled() => {},
+                    _ = time::sleep(interval) => {},
+                }
+            }
+        };
+        while !cancel.is_cancelled() {
             let mut session = match pool.new_session().await {
                 Ok(s) => s,
                 Err(e) => {
-                    warn!(target: LOG_TARGET, "⚠️ Failed to create session for shard group {}: {}. Retrying in {:.0?}", shard_group, e, self.config.work_interval);
-                    time::sleep(self.config.work_interval).await;
+                    warn!(target: LOG_TARGET, "⚠️ Failed to create session for shard group {}: {}", shard_group, e);
+                    wait("no session").await;
                     continue;
                 },
             };
@@ -464,8 +505,8 @@ impl NetworkWideStateSync {
                 Ok(None) => {},
                 // probe only returns Err for an invalid (forged) commit proof.
                 Err(e) => {
-                    warn!(target: LOG_TARGET, "⚠️ Validator {} for shard group {} served an INVALID commit proof: {}. Retrying in {:.0?}", session.peer_address(), shard_group, e, self.config.work_interval);
-                    time::sleep(self.config.work_interval).await;
+                    warn!(target: LOG_TARGET, "⚠️ Validator {} for shard group {} served an INVALID commit proof: {}", session.peer_address(), shard_group, e);
+                    wait("invalid commit proof").await;
                     continue;
                 },
             }
@@ -481,23 +522,27 @@ impl NetworkWideStateSync {
             // indexer resolved its committees at has moved on - costs this shard group a retry and
             // no more.
             match self
-                .sync_shard_group_state(shards, &progress, shard_group, &mut session)
+                .sync_shard_group_state(shards, &progress, shard_group, &mut session, &cancel)
                 .await
             {
+                Ok(StreamEnd::Cancelled) => return Ok(()),
                 Ok(StreamEnd::TimedOut) => {
                     debug!(target: LOG_TARGET, "🌍️ State sync stream for shard group {shard_group} from {} had nothing to send for the deadline. Reopening", session.peer_address());
                 },
                 Ok(StreamEnd::Final) => {
-                    debug!(target: LOG_TARGET, "🌍️ Validator {} closed the state sync stream for shard group {shard_group} at its tip. Reopening in {:.0?}", session.peer_address(), self.config.work_interval);
-                    time::sleep(self.config.work_interval).await;
+                    wait("the validator closed the stream at its tip and does not follow").await;
+                },
+                Ok(StreamEnd::NothingToFollow) => {
+                    wait("no shard has a version to follow from").await;
                 },
                 Err(err) if err.is_peer_fault() => {
-                    warn!(target: LOG_TARGET, "⚠️ State sync for shard group {} from {} failed: {}. Retrying in {:.0?}", shard_group, session.peer_address(), err, self.config.work_interval);
-                    time::sleep(self.config.work_interval).await;
+                    warn!(target: LOG_TARGET, "⚠️ State sync for shard group {} from {} failed: {}", shard_group, session.peer_address(), err);
+                    wait("the peer failed").await;
                 },
                 Err(err) => return Err(err),
             }
         }
+        Ok(())
     }
 
     /// Syncs every given shard from `session`, which serves them all over a single stream.
@@ -513,6 +558,7 @@ impl NetworkWideStateSync {
         progress: &SharedSyncProgress,
         shard_group: ShardGroup,
         session: &mut ValidatorRpcSession,
+        cancel: &CancellationToken,
     ) -> Result<StreamEnd, NetworkStateSyncError> {
         let value_filters = SubstateValueFilterFlags::UTXO |
             SubstateValueFilterFlags::VALIDATOR_FEE_POOL |
@@ -528,21 +574,26 @@ impl NetworkWideStateSync {
                 "🌍️ Syncing {} shard(s) in shard group {shard_group} from scratch. Only fetching the head state.",
                 from_scratch.len()
             );
-            self.stream_shard_state(
-                from_scratch,
-                value_filters | SubstateValueFilterFlags::UP_ONLY,
-                false,
-                progress,
-                shard_group,
-                session,
-            )
-            .await?;
+            let end = self
+                .stream_shard_state(
+                    from_scratch,
+                    value_filters | SubstateValueFilterFlags::UP_ONLY,
+                    false,
+                    progress,
+                    shard_group,
+                    session,
+                    cancel,
+                )
+                .await?;
+            if end == StreamEnd::Cancelled {
+                return Ok(end);
+            }
         }
 
         // A shard that had nothing to fetch from scratch is left for the next stream.
         let (_, incremental) = partition_cursors(&shards, &*progress.lock().await);
         if incremental.is_empty() {
-            return Ok(StreamEnd::Final);
+            return Ok(StreamEnd::NothingToFollow);
         }
         // ALL_HASHES adds an id and a version for every substate outside the value filter, which is
         // what lets the substate cache tell a superseded or destroyed entry from a current one. It
@@ -554,6 +605,7 @@ impl NetworkWideStateSync {
             progress,
             shard_group,
             session,
+            cancel,
         )
         .await
     }
@@ -595,7 +647,10 @@ impl NetworkWideStateSync {
     /// followed stream keeps going past the tip, closing off each burst of a shard's new versions
     /// with a further marker; it ends when the responder has had nothing to send for the deadline,
     /// or can no longer serve it.
-    #[expect(clippy::too_many_lines)]
+    ///
+    /// Cancellation is honoured between messages, so a version being committed when it arrives is
+    /// committed in full and the recorded progress reflects it.
+    #[expect(clippy::too_many_lines, clippy::too_many_arguments)]
     async fn stream_shard_state(
         &mut self,
         cursors: Vec<rpc::ShardCursor>,
@@ -604,6 +659,7 @@ impl NetworkWideStateSync {
         progress: &SharedSyncProgress,
         shard_group: ShardGroup,
         session: &mut ValidatorRpcSession,
+        cancel: &CancellationToken,
     ) -> Result<StreamEnd, NetworkStateSyncError> {
         let mut order = StreamOrder::new(&cursors);
 
@@ -642,7 +698,15 @@ impl NetworkWideStateSync {
         let mut xtr_fees = Amount::zero();
         let mut xtr_receipt_burn = Amount::zero();
 
-        while let Some(result) = stream.next().await {
+        loop {
+            let result = tokio::select! {
+                biased;
+                _ = cancel.cancelled() => return Ok(StreamEnd::Cancelled),
+                next = stream.next() => match next {
+                    Some(result) => result,
+                    None => break,
+                },
+            };
             let msg = match result {
                 Ok(msg) => msg,
                 // A followed stream with nothing to send for the deadline is simply abandoned by the
@@ -855,6 +919,10 @@ enum StreamEnd {
     /// A followed stream was abandoned by the responder after it had nothing to send for the
     /// deadline.
     TimedOut,
+    /// No stream was opened to follow: every shard in the group is still at version zero.
+    NothingToFollow,
+    /// The plan is being wound down.
+    Cancelled,
 }
 
 /// Splits `shards` into cursors for those never synced, which want only the head state, and those

--- a/applications/tari_ootle_app_utilities/config_presets/d_indexer.toml
+++ b/applications/tari_ootle_app_utilities/config_presets/d_indexer.toml
@@ -31,7 +31,20 @@
 
 # How often do we want to scan for changes. (default = 10)
 #block_scanning_interval=10
+# How long a shard group waits before reopening its state sync stream after it fails, or after a
+# validator that does not follow its tip closes it. (default = 60)
 #state_scanning_interval=60
+
+# The longest, in seconds, a validator holds a state sync stream open with no transition to send. The
+# stream follows the validator's tip and is reopened once this passes, one completion marker per
+# shard. The substate cache serves a quiet shard only while its last marker arrived within
+# substate_cache_max_serve_lag, so keep this comfortably shorter than that. (default = 120)
+#state_sync_stream_deadline = 120
+
+# How often, in seconds, a validator is asked to show it is still there while the state sync stream
+# has nothing to send. Must be well under state_sync_stream_deadline; validators serve no shorter
+# than their own minimum (5s by default). (default = 10)
+#state_sync_keepalive_interval = 10
 
 # How many epochs past its terminal epoch a transaction submitted through this indexer is retained
 # before it is pruned. A transaction's terminal epoch is the epoch it committed in once its receipt has

--- a/applications/tari_validator_node/src/p2p/rpc/rpc_impl.rs
+++ b/applications/tari_validator_node/src/p2p/rpc/rpc_impl.rs
@@ -483,6 +483,13 @@ impl<TStateStore: StateStore + Clone + Send + Sync + 'static> ValidatorNodeRpcSe
 
         let end_epoch = req.until_epoch.map(Epoch::from);
 
+        // A bounded stream is answered out of history, which has no tip to follow.
+        if req.follow && end_epoch.is_some() {
+            return Err(RpcStatus::bad_request(
+                "A bounded (until_epoch) request cannot follow the tip",
+            ));
+        }
+
         // An unbounded request asks for this node's tip, which only a member of the committee that
         // currently stores those shards can answer: a non-member receives no further transitions for
         // them and streams silence, which the caller cannot tell apart from being caught up. A bounded
@@ -524,12 +531,13 @@ impl<TStateStore: StateStore + Clone + Send + Sync + 'static> ValidatorNodeRpcSe
 
         debug!(
             target: LOG_TARGET,
-            "🌍 peer initiated sync with this node for {} shard(s) ({} to {}) to {} (values: {:?})",
+            "🌍 peer initiated sync with this node for {} shard(s) ({} to {}) to {} (values: {:?}, follow: {})",
             cursors.len(),
             cursors.first().map(|c| c.shard).display(),
             cursors.last().map(|c| c.shard).display(),
             end_epoch.display(),
-            value_filter_flags
+            value_filter_flags,
+            req.follow,
         );
 
         task::spawn(
@@ -541,6 +549,7 @@ impl<TStateStore: StateStore + Clone + Send + Sync + 'static> ValidatorNodeRpcSe
                 self.consensus.clone(),
                 self.epoch_manager.clone(),
                 tip_authority,
+                req.follow,
                 STATE_SYNC_MAX_BATCH_SIZE
                     .try_into()
                     .expect("STATE_SYNC_MAX_BATCH_SIZE is not zero"),

--- a/applications/tari_validator_node/src/p2p/rpc/state_sync_task.rs
+++ b/applications/tari_validator_node/src/p2p/rpc/state_sync_task.rs
@@ -30,6 +30,17 @@ pub struct ShardCursor {
 }
 
 impl ShardCursor {
+    /// True if `tip` holds a version this cursor has yet to stream.
+    fn is_behind(&self, tip: Option<Version>) -> bool {
+        tip.is_some_and(|tip| tip >= self.start_state_version)
+    }
+
+    /// Moves the resume point past `synced_to_version`. A node behind the caller's cursor reports a
+    /// tip below it; the cursor only ever advances.
+    fn advance_past(&mut self, synced_to_version: Version) {
+        self.start_state_version = self.start_state_version.max(synced_to_version + 1);
+    }
+
     /// Validates a caller-supplied cursor list.
     ///
     /// Ascending order rules out duplicates and lets the responder stream each shard contiguously,
@@ -221,7 +232,15 @@ impl<TStateStore: StateStore> StateSyncTask<TStateStore> {
         events: &mut broadcast::Receiver<HotstuffEvent>,
     ) -> Result<(), ()> {
         loop {
-            let force_marker = match events.recv().await {
+            // The client going away is otherwise only noticed by the next send, a block time later.
+            let event = tokio::select! {
+                event = events.recv() => event,
+                _ = self.sender.closed() => {
+                    debug!(target: LOG_TARGET, "Peer stream closed by client. Ending followed stream");
+                    return Err(());
+                },
+            };
+            let force_marker = match event {
                 Ok(HotstuffEvent::BlockCommitted { .. }) => false,
                 Ok(HotstuffEvent::EpochChanged { .. }) => true,
                 Ok(_) => continue,
@@ -240,8 +259,7 @@ impl<TStateStore: StateStore> StateSyncTask<TStateStore> {
 
     async fn follow_shard(&mut self, cursor: &mut ShardCursor, force_marker: bool) -> Result<(), ()> {
         let tip_at_start = self.snapshot_tip(cursor.shard).await?;
-        let moved = tip_at_start.is_some_and(|tip| tip >= cursor.start_state_version);
-        if !moved && !force_marker {
+        if !cursor.is_behind(tip_at_start) && !force_marker {
             return Ok(());
         }
         self.stream_shard(cursor, tip_at_start, false).await
@@ -326,8 +344,7 @@ impl<TStateStore: StateStore> StateSyncTask<TStateStore> {
         let synced_to_version = self
             .send_complete(cursor, tip_at_start, last_sent_version, is_final)
             .await?;
-        // A node behind the caller's cursor reports a tip below it; the cursor only ever advances.
-        cursor.start_state_version = cursor.start_state_version.max(synced_to_version + 1);
+        cursor.advance_past(synced_to_version);
         Ok(())
     }
 
@@ -577,6 +594,33 @@ mod tests {
         let authority = TipAuthority::new(Epoch(1), committee_info(9, 16));
         assert!(!authority.is_stale_at(Epoch(1)));
         assert!(authority.is_stale_at(Epoch(2)));
+    }
+
+    #[test]
+    fn a_cursor_is_behind_a_tip_at_or_past_its_resume_point() {
+        let cursor = ShardCursor {
+            shard: Shard::from_u32(1),
+            start_state_version: 5,
+        };
+        assert!(cursor.is_behind(Some(5)));
+        assert!(cursor.is_behind(Some(9)));
+        assert!(!cursor.is_behind(Some(4)));
+        assert!(!cursor.is_behind(None));
+    }
+
+    #[test]
+    fn a_cursor_advances_past_a_marker_and_never_moves_back() {
+        let mut cursor = ShardCursor {
+            shard: Shard::from_u32(1),
+            start_state_version: 5,
+        };
+        cursor.advance_past(9);
+        assert_eq!(cursor.start_state_version, 10);
+        // A node behind the cursor reports a lower tip.
+        cursor.advance_past(3);
+        assert_eq!(cursor.start_state_version, 10);
+        assert!(!cursor.is_behind(Some(9)));
+        assert!(cursor.is_behind(Some(10)));
     }
 
     #[test]

--- a/applications/tari_validator_node/src/p2p/rpc/state_sync_task.rs
+++ b/applications/tari_validator_node/src/p2p/rpc/state_sync_task.rs
@@ -4,6 +4,7 @@
 use std::num::NonZeroUsize;
 
 use log::*;
+use tari_consensus::hotstuff::HotstuffEvent;
 use tari_epoch_manager::{EpochManagerReader, service::EpochManagerHandle};
 use tari_ootle_common_types::{Epoch, NumPreshards, committee::CommitteeInfo, optional::Optional, shard::Shard};
 use tari_ootle_p2p::{PeerAddress, proto::rpc};
@@ -15,7 +16,7 @@ use tari_ootle_storage::{
 };
 use tari_rpc_framework::RpcStatus;
 use tari_state_tree::Version;
-use tokio::sync::mpsc;
+use tokio::sync::{broadcast, mpsc};
 
 use crate::{consensus::ConsensusHandle, p2p::rpc::CONSENSUS_NOT_RUNNING};
 
@@ -134,6 +135,8 @@ pub struct StateSyncTask<TStateStore: StateStore> {
     /// This node's warrant to serve its tip, for a stream that claims to. `None` for a bounded stream,
     /// which makes no such claim.
     tip_authority: Option<TipAuthority>,
+    /// Whether to hold the stream open at the tip and keep streaming as this node commits.
+    follow: bool,
     batch_size: NonZeroUsize,
     value_filters: SubstateValueFilterFlags,
 }
@@ -147,6 +150,7 @@ impl<TStateStore: StateStore> StateSyncTask<TStateStore> {
         consensus: ConsensusHandle,
         epoch_manager: EpochManagerHandle<PeerAddress>,
         tip_authority: Option<TipAuthority>,
+        follow: bool,
         batch_size: NonZeroUsize,
         value_filters: SubstateValueFilterFlags,
     ) -> Self {
@@ -158,6 +162,7 @@ impl<TStateStore: StateStore> StateSyncTask<TStateStore> {
             consensus,
             epoch_manager,
             tip_authority,
+            follow,
             batch_size,
             value_filters,
         }
@@ -166,7 +171,7 @@ impl<TStateStore: StateStore> StateSyncTask<TStateStore> {
     pub async fn run(mut self) -> Result<(), ()> {
         // Each shard's updates are streamed contiguously, in the order the caller listed them, so a
         // consumer can finalise a shard the moment its completion marker arrives.
-        let cursors = std::mem::take(&mut self.cursors);
+        let mut cursors = std::mem::take(&mut self.cursors);
         let Some(last_index) = cursors.len().checked_sub(1) else {
             // Every stream must carry a final marker, so an empty request cannot be answered with an
             // empty stream. `ShardCursor::validate_all` rejects one before it reaches here.
@@ -174,24 +179,15 @@ impl<TStateStore: StateStore> StateSyncTask<TStateStore> {
                 .await?;
             return Err(());
         };
-        for (i, cursor) in cursors.into_iter().enumerate() {
-            self.run_for_shard(&cursor, i == last_index).await?;
-        }
-        Ok(())
-    }
 
-    async fn run_for_shard(&mut self, cursor: &ShardCursor, is_final: bool) -> Result<(), ()> {
-        let shard = cursor.shard;
-        // For an unbounded (sync-to-tip) request, snapshot the committed tree tip before scanning. The
-        // completion marker advances the client over trailing versions that stream no updates (all
-        // filtered out for its subscription). Snapshotting first ensures the marker never reports
-        // beyond what we streamed: anything committed after this point is left for the next round.
-        let tip_at_start = if self.end_epoch.is_none() {
-            match self.read_latest_tree_version(shard) {
-                Ok(version) => version,
+        // Subscribed before the catch-up so that a commit landing during it is not missed.
+        let mut events = if self.follow {
+            match self.consensus.subscribe_to_hotstuff_events() {
+                Ok(events) => Some(events),
                 Err(err) => {
-                    error!(target: LOG_TARGET, "🌍 Error reading latest tree version for {}: {}", shard, err);
-                    self.send(Err(RpcStatus::log_internal_error(LOG_TARGET)(err))).await?;
+                    error!(target: LOG_TARGET, "🌍 Failed to subscribe to consensus events: {}", err);
+                    self.send(Err(RpcStatus::general("Consensus events are unavailable")))
+                        .await?;
                     return Err(());
                 },
             }
@@ -199,6 +195,91 @@ impl<TStateStore: StateStore> StateSyncTask<TStateStore> {
             None
         };
 
+        for (i, cursor) in cursors.iter_mut().enumerate() {
+            let is_final = events.is_none() && i == last_index;
+            self.run_for_shard(cursor, is_final).await?;
+        }
+
+        match events.as_mut() {
+            Some(events) => self.follow_tip(&mut cursors, events).await,
+            None => Ok(()),
+        }
+    }
+
+    /// Keeps streaming past the tip: each commit is followed by a pass over every cursor, and a
+    /// shard that moved is streamed and closed off with a further marker.
+    ///
+    /// The commit event is published from inside the committing transaction, so a pass may run
+    /// before the transitions it announces are visible; the next commit's pass picks them up, and
+    /// the pacemaker commits on a timer so that pass is never far off. An epoch change forces a
+    /// marker for every shard whether or not it moved: the marker re-establishes this node's
+    /// warrant at the new epoch, which is what ends the stream promptly for a shard this node no
+    /// longer stores, and tells the caller the epoch it is now level as of.
+    async fn follow_tip(
+        &mut self,
+        cursors: &mut [ShardCursor],
+        events: &mut broadcast::Receiver<HotstuffEvent>,
+    ) -> Result<(), ()> {
+        loop {
+            let force_marker = match events.recv().await {
+                Ok(HotstuffEvent::BlockCommitted { .. }) => false,
+                Ok(HotstuffEvent::EpochChanged { .. }) => true,
+                Ok(_) => continue,
+                // Dropped events are only ever commits or an epoch change, both answered by a pass.
+                Err(broadcast::error::RecvError::Lagged(_)) => true,
+                Err(broadcast::error::RecvError::Closed) => {
+                    debug!(target: LOG_TARGET, "🌍 Consensus stopped. Ending followed stream");
+                    return Ok(());
+                },
+            };
+            for cursor in cursors.iter_mut() {
+                self.follow_shard(cursor, force_marker).await?;
+            }
+        }
+    }
+
+    async fn follow_shard(&mut self, cursor: &mut ShardCursor, force_marker: bool) -> Result<(), ()> {
+        let tip_at_start = self.snapshot_tip(cursor.shard).await?;
+        let moved = tip_at_start.is_some_and(|tip| tip >= cursor.start_state_version);
+        if !moved && !force_marker {
+            return Ok(());
+        }
+        self.stream_shard(cursor, tip_at_start, false).await
+    }
+
+    async fn run_for_shard(&mut self, cursor: &mut ShardCursor, is_final: bool) -> Result<(), ()> {
+        // For an unbounded (sync-to-tip) request, snapshot the committed tree tip before scanning. The
+        // completion marker advances the client over trailing versions that stream no updates (all
+        // filtered out for its subscription). Snapshotting first ensures the marker never reports
+        // beyond what we streamed: anything committed after this point is left for the next round.
+        let tip_at_start = if self.end_epoch.is_none() {
+            self.snapshot_tip(cursor.shard).await?
+        } else {
+            None
+        };
+        self.stream_shard(cursor, tip_at_start, is_final).await
+    }
+
+    async fn snapshot_tip(&mut self, shard: Shard) -> Result<Option<Version>, ()> {
+        match self.read_latest_tree_version(shard) {
+            Ok(version) => Ok(version),
+            Err(err) => {
+                error!(target: LOG_TARGET, "🌍 Error reading latest tree version for {}: {}", shard, err);
+                self.send(Err(RpcStatus::log_internal_error(LOG_TARGET)(err))).await?;
+                Err(())
+            },
+        }
+    }
+
+    /// Streams `cursor`'s shard from its resume point and closes it off with a marker, advancing the
+    /// cursor past the version the marker reports.
+    async fn stream_shard(
+        &mut self,
+        cursor: &mut ShardCursor,
+        tip_at_start: Option<Version>,
+        is_final: bool,
+    ) -> Result<(), ()> {
+        let shard = cursor.shard;
         let mut current_state_version = cursor.start_state_version;
         let mut counter = 0usize;
         let mut last_sent_version: Option<Version> = None;
@@ -242,15 +323,20 @@ impl<TStateStore: StateStore> StateSyncTask<TStateStore> {
             }
         }
 
-        self.send_complete(cursor, tip_at_start, last_sent_version, is_final)
-            .await
+        let synced_to_version = self
+            .send_complete(cursor, tip_at_start, last_sent_version, is_final)
+            .await?;
+        // A node behind the caller's cursor reports a tip below it; the cursor only ever advances.
+        cursor.start_state_version = cursor.start_state_version.max(synced_to_version + 1);
+        Ok(())
     }
 
     fn read_latest_tree_version(&self, shard: Shard) -> Result<Option<Version>, StorageError> {
         self.store.with_read_tx(|tx| tx.state_tree_versions_get_latest(shard))
     }
 
-    /// Closes off a shard with a `SyncComplete` stating the version the client is now synced to.
+    /// Closes off a shard with a `SyncComplete` stating the version the client is now synced to, and
+    /// returns that version.
     ///
     /// For an unbounded request this is the committed tree tip (capped to what we streamed), letting the
     /// client advance over trailing versions that streamed no updates - e.g. a shard whose latest
@@ -270,7 +356,7 @@ impl<TStateStore: StateStore> StateSyncTask<TStateStore> {
         tip_at_start: Option<Version>,
         last_sent_version: Option<Version>,
         is_final: bool,
-    ) -> Result<(), ()> {
+    ) -> Result<Version, ()> {
         let epoch = match self.authorise_tip(cursor.shard).await {
             Ok(epoch) => epoch,
             Err(status) => {
@@ -294,7 +380,8 @@ impl<TStateStore: StateStore> StateSyncTask<TStateStore> {
                 is_final,
             })),
         }))
-        .await
+        .await?;
+        Ok(synced_to_version)
     }
 
     /// Establishes this node's standing to tell the caller that it is level with the committee for

--- a/crates/p2p/proto/rpc.proto
+++ b/crates/p2p/proto/rpc.proto
@@ -271,6 +271,13 @@ message SyncStateRequest {
   // ordered by ascending shard - the responder streams them in this order and the caller relies on a
   // shard's updates being contiguous.
   repeated ShardCursor cursors = 5;
+  // Keep the stream open once every cursor has reached this node's tip, streaming each shard's new
+  // versions as they commit and closing each such burst with a further SyncComplete for that shard.
+  // No marker on a followed stream carries is_final; the stream ends only when the responder can no
+  // longer serve it (it left the committee, consensus stopped) or the request deadline passes with
+  // nothing to send. Only valid for an unbounded request. A responder that does not support following
+  // closes the stream at the tip as usual, final marker included.
+  bool follow = 6;
 }
 
 message SyncStateResponse {
@@ -293,6 +300,8 @@ message SubstateBatch {
 
 // Emitted once per requested cursor, after that shard's last batch, stating the version the shard is
 // now synced to. The message for the final cursor carries is_final = true and terminates the stream.
+// On a followed stream a shard is closed off again after each burst of new versions, and none of
+// its markers is final.
 // For an unbounded (sync-to-tip) request synced_to_version is the committed state-tree tip and is
 // authoritative for the client's cursor - it advances the client over trailing versions that streamed
 // no updates (filtered out, or tree-only bumps). For a bounded (checkpoint) request the client

--- a/crates/rpc_state_sync/src/state_sync.rs
+++ b/crates/rpc_state_sync/src/state_sync.rs
@@ -201,6 +201,7 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
                 }],
                 until_epoch: Some(checkpoint.epoch().into()),
                 value_filters: SubstateValueFilterFlags::all_substates().bits(),
+                follow: false,
             })
             .await?;
 


### PR DESCRIPTION
## Summary

The indexer's network state sync no longer polls. Each shard group holds a `sync_state` stream open past the validator's tip and receives transitions as they commit, with a per-request deadline and keepalive interval. This is the follow-mode half of phase 2 of the substate cache work (after #2498, #2499, #2511, #2512).

### Wire (`crates/p2p/proto/rpc.proto`)

`SyncStateRequest.follow`. A following responder keeps an unbounded stream open once every cursor has reached its tip, streams each shard's new versions as they commit and closes off each such burst with a further `SyncComplete`. No marker on a followed stream is final. Refused on a bounded request. An old responder ignores the flag and closes at the tip with a final marker, so a following client degrades to polling.

### Responder (`state_sync_task.rs`)

- Subscribes to hotstuff events before the catch-up, then passes over every cursor on each `BlockCommitted`, streaming a shard only if its tip moved past the cursor.
- `EpochChanged` forces a marker for every shard. The marker re-runs `authorise_tip` at the new epoch, so a shard this node no longer stores ends the stream promptly instead of leaving the caller to wait out the deadline on silence.
- The commit event fires inside the committing transaction, so a pass can run before its transitions are visible. The next commit's pass catches them up; the pacemaker commits on a timer.
- The cursor advances monotonically past each marker.

### Indexer (`worker.rs`)

- Each shard group runs its own loop (session, probe, stream, reopen) and the groups run concurrently under a `FuturesUnordered`. The global shard is claimed by the lowest group.
- `sync_state_with_options` with `state_sync_stream_deadline` (120s) and `state_sync_keepalive_interval` (10s) from config.
- Stream ends: timeout on a followed stream is the ordinary quiet end and reopens at once (the reopen refreshes each shard's watermark with a marker); a final marker means the responder does not follow, so the reopen waits the work interval; anything else is a peer fault and also waits.
- An epoch change tears every stream down and re-plans against the new committees. Cursors survive in the persisted progress. Per-group teardown (item 4 of the handoff) and the `num_committees` re-plan (item 5) are the follow-up PR.
- Progress is shared between group loops behind a tokio mutex held from snapshot to write, since it is persisted as one value.
- `StreamOrder` no longer treats a marker as ending a shard. Version monotonicity and chunk integrity are unchanged.
- `SyncStats` is shared counters, reported every work interval.

### Config

`state_sync_stream_deadline` must stay comfortably under `substate_cache_max_serve_lag`: a quiet shard is confirmed only when its stream is reopened, and the client notices a quiet stream ended up to a minute after the deadline (the RPC grace period). With defaults that is ~180s against a 300s lag. Threading keepalive liveness into `ShardWatermarks` (item 3) lifts that constraint later.

## Test plan

- [x] `cargo test -p tari_indexer --lib network_state_sync`
- [x] `cargo test -p tari_validator_node --lib state_sync_task`
- [x] clippy clean on `tari_indexer`, `tari_validator_node`, `tari_rpc_state_sync`
- [x] CI integration tests, including `committee_split.feature` from #2515
