### PR TITLE
fix(consensus_tests): wait for the extra transaction to be seen, not for a pool count

### DIFF
--- a/crates/consensus_tests/src/leader_failure.rs
+++ b/crates/consensus_tests/src/leader_failure.rs
@@ -50,8 +50,8 @@ async fn single_shard_node_goes_down() {
 
         if committed_height == NodeHeight(1) {
             // This allows a few more leader failures to occur
-            test.send_transaction_to_all(Decision::Commit, 1, 2, 1).await;
-            test.wait_for_pool_count(TestVnDestination::All, 1).await;
+            let (tx, _, _) = test.send_transaction_to_all(Decision::Commit, 1, 2, 1).await;
+            test.wait_for_transaction_seen(TestVnDestination::All, tx.id()).await;
         }
 
         if test.validators_iter().filter(|vn| vn.address != failure_node).all(|v| {
@@ -125,8 +125,8 @@ async fn single_shard_neighbour_nodes_go_down() {
 
         if committed_height == NodeHeight(1) {
             // This allows a few more leader failures to occur
-            test.send_transaction_to_all(Decision::Commit, 1, 2, 1).await;
-            test.wait_for_pool_count(TestVnDestination::All, 1).await;
+            let (tx, _, _) = test.send_transaction_to_all(Decision::Commit, 1, 2, 1).await;
+            test.wait_for_transaction_seen(TestVnDestination::All, tx.id()).await;
         }
 
         if test
@@ -328,8 +328,8 @@ async fn multi_shard_node_goes_down() {
         if committed_height == NodeHeight(1) && !sent_extra_tx {
             sent_extra_tx = true;
             // This allows a few more leader failures to occur
-            test.send_transaction_to_all(Decision::Commit, 1, 2, 1).await;
-            test.wait_for_pool_count(TestVnDestination::All, 1).await;
+            let (tx, _, _) = test.send_transaction_to_all(Decision::Commit, 1, 2, 1).await;
+            test.wait_for_transaction_seen(TestVnDestination::All, tx.id()).await;
         }
 
         if test.validators_iter().filter(|vn| vn.address != failure_node).all(|v| {
@@ -547,8 +547,8 @@ async fn single_shard_node_goes_down_and_catches_up() {
 
         if committed_height == NodeHeight(1) {
             // This allows a few more leader failures to occur
-            test.send_transaction_to_all(Decision::Commit, 1, 2, 1).await;
-            test.wait_for_pool_count(TestVnDestination::All, 1).await;
+            let (tx, _, _) = test.send_transaction_to_all(Decision::Commit, 1, 2, 1).await;
+            test.wait_for_transaction_seen(TestVnDestination::All, tx.id()).await;
         }
 
         if is_back_online &&

--- a/crates/consensus_tests/src/support/harness.rs
+++ b/crates/consensus_tests/src/support/harness.rs
@@ -511,6 +511,18 @@ impl Test {
         .await
     }
 
+    /// Waits until every validator in `dest` has received the transaction. Unlike waiting on a pool count,
+    /// this cannot be raced by the transaction being proposed and finalized between two polls.
+    pub async fn wait_for_transaction_seen(&self, dest: TestVnDestination, tx_id: &TransactionId) {
+        self.wait_all_for_predicate(format!("transaction {tx_id} seen"), |vn| {
+            if !dest.is_for_vn(vn) {
+                return true;
+            }
+            vn.has_seen_transaction(tx_id)
+        })
+        .await
+    }
+
     pub fn with_all_validators(&self, f: impl FnMut(&Validator)) {
         self.validators.values().for_each(f);
     }

--- a/crates/consensus_tests/src/support/validator/instance.rs
+++ b/crates/consensus_tests/src/support/validator/instance.rs
@@ -10,6 +10,7 @@ use tari_ootle_common_types::{NodeHeight, ShardGroup, SubstateAddress, Versioned
 use tari_ootle_storage::{
     StateStore,
     StateStoreReadTransaction,
+    StorageError,
     consensus_models::{BookkeepingModel, TransactionExecution, TransactionPool},
 };
 use tari_ootle_transaction::{Transaction, TransactionId};
@@ -104,6 +105,16 @@ impl Validator {
                 epoch,
                 shard_group: self.shard_group,
             })
+    }
+
+    /// Returns true once the transaction has been received by this validator: either it is still in the
+    /// transaction pool or it has already been finalized and removed from it.
+    pub fn has_seen_transaction(&self, tx_id: &TransactionId) -> bool {
+        self.state_store()
+            .with_read_tx(|tx| {
+                Ok::<_, StorageError>(tx.transaction_pool_exists(tx_id)? || tx.transactions_exists(tx_id)?)
+            })
+            .unwrap()
     }
 
     pub fn has_committed_substates(&self, tx_id: &TransactionId) -> bool {


### PR DESCRIPTION
## Summary

Fixes the flaky `leader_failure::single_shard_node_goes_down_and_catches_up` failure seen in https://github.com/tari-project/tari-ootle/actions/runs/33778778967/job/100764591055 (unrelated to #2520).

The four leader failure tests send one extra transaction once height 1 commits, then call `wait_for_pool_count(All, 1)`. That asserts a transient state: if a validator's pool was already drained and the new transaction gets proposed and finalized inside one 100ms poll interval, the count never reaches 1 and the wait times out after 10s with "4 of 5 validators passed".

## Root cause in the failing run

- The CI runner was starved: spawning the 5 validators took 137s (RocksDB open took 12–50s each), versus 31s for the whole test on a healthy run.
- Consensus workers start as soon as each validator is spawned, so node 1 accumulated several leader timeouts alone before the network started.
- When the network started, dummy blocks 1 and 2, block 3 (the 10 initial txs) and their commit all landed within ~70ms. The height 1 commit event fired at the same instant node 1 drained its pool.
- Nodes 2–5 were polled before they finalized block 3 and passed on the old 10 txs. Node 1 was polled after (0), and by the next poll the new tx had been committed in block 7. Pool count stayed 0 for 10s.

## Fix

Replace the pool count wait with `wait_for_transaction_seen`, which passes once a validator either has the transaction in its pool or already has a record of it. This still guards what the original wait was for (the asynchronously delivered transaction landing before the "pool is empty" exit check) without depending on it staying in the pool.