### PR TITLE
fix(consensus_tests): keep validators idle until the test starts the epoch

### DIFF
--- a/crates/consensus_tests/src/support/epoch_manager.rs
+++ b/crates/consensus_tests/src/support/epoch_manager.rs
@@ -122,6 +122,7 @@ impl TestEpochManager {
         {
             let mut lock = self.inner.lock().await;
             lock.current_epoch = current_epoch;
+            lock.epoch_started = true;
         }
 
         let _ = self.tx_epoch_events.send(EpochManagerEvent::EpochChanged {
@@ -232,6 +233,20 @@ impl EpochManagerReader for TestEpochManager {
 
     fn subscribe(&self) -> broadcast::Receiver<EpochManagerEvent> {
         self.tx_epoch_events.subscribe()
+    }
+
+    async fn is_this_validator_registered_for_epoch(&self, epoch: Epoch) -> Result<bool, EpochManagerError> {
+        if !self.state_lock().await.epoch_started {
+            return Ok(false);
+        }
+        if self.current_epoch().await? < epoch {
+            return Ok(false);
+        }
+        match self.get_local_committee_info(epoch).await {
+            Ok(_) => Ok(true),
+            Err(err) if err.is_not_registered_error() => Ok(false),
+            Err(err) => Err(err),
+        }
     }
 
     async fn get_committee_for_substate(
@@ -514,6 +529,9 @@ impl EpochManagerReader for TestEpochManager {
 #[derive(Debug, Clone)]
 pub struct TestEpochManagerState {
     pub current_epoch: Epoch,
+    /// Validators must not leave the idle state until the test calls `set_current_epoch`, otherwise a
+    /// validator spawned early runs its pacemaker against peers that do not exist yet.
+    pub epoch_started: bool,
     pub last_epoch_hash: FixedHash,
     #[allow(clippy::type_complexity)]
     pub validator_nodes: HashMap<TestAddress, (ValidatorNode<TestAddress>, ShardGroup)>,
@@ -526,6 +544,7 @@ impl Default for TestEpochManagerState {
     fn default() -> Self {
         Self {
             current_epoch: Epoch(1),
+            epoch_started: false,
             last_epoch_hash: FixedHash::default(),
             validator_nodes: HashMap::new(),
             committees: HashMap::new(),


### PR DESCRIPTION
## Summary

`TestEpochManager` reported the validator as registered for `Epoch(1)` from construction, so `Idle::check_registration` promoted every validator to `Running` the moment it was spawned, before its peers existed. `Test::start_epoch` fires the epoch event after all validators are spawned and is meant to be what starts the pacemaker, but it was a no-op for this purpose.

On a starved CI runner spawning eight validators takes minutes (35–55s per RocksDB open in [this run](https://github.com/tari-project/tari-ootle/actions/runs/33847912225/job/100943897429)), so early validators hit 20s leader timeouts at height 0 repeatedly and burned the 30-block budget before the last validator came up. Same flake seen on `development` in run 33621032582.

## Change

- `TestEpochManagerState` gains an `epoch_started` flag, set by `set_current_epoch`.
- `TestEpochManager` overrides `is_this_validator_registered_for_epoch` to return `false` until that flag is set; otherwise it matches the trait default.

`Idle` subscribes to epoch events before checking registration, so the `EpochChanged` event from `start_epoch` promotes the validator without a race. All tests that call `start()` also call `start_epoch`.

## Testing

Ran `consensus::multishard_publish_template`, `consensus::single_shard*`, `leader_failure::*`, `epoch_change::*` locally: all pass.