### PR TITLE
fix(swarm): quiet the swarm console to info level

### DIFF
--- a/applications/tari_swarm_daemon/src/logger.rs
+++ b/applications/tari_swarm_daemon/src/logger.rs
@@ -72,17 +72,22 @@ pub fn init_logger(log_to_file: Option<PathBuf>) -> Result<(), log::SetLoggerErr
                 log
             ))
         })
-        .level(log::LevelFilter::Debug)
-        .chain(std::io::stdout());
+        .chain(
+            fern::Dispatch::new()
+                .level(log::LevelFilter::Info)
+                .chain(std::io::stdout()),
+        );
     if let Some(log) = log_to_file {
         logger = logger.chain(
-            fs::OpenOptions::new()
-                .create(true)
-                .write(true)
-                // Files get massive, so we truncate on each start
-                .truncate(true)
-                .open(log.join("swarm.log"))
-                .expect("Failed to open log file"),
+            fern::Dispatch::new().level(log::LevelFilter::Debug).chain(
+                fs::OpenOptions::new()
+                    .create(true)
+                    .write(true)
+                    // Files get massive, so we truncate on each start
+                    .truncate(true)
+                    .open(log.join("swarm.log"))
+                    .expect("Failed to open log file"),
+            ),
         );
     }
     logger.apply()

--- a/applications/tari_swarm_daemon/src/main.rs
+++ b/applications/tari_swarm_daemon/src/main.rs
@@ -218,6 +218,13 @@ async fn start(cli: &Cli) -> anyhow::Result<()> {
 
     init_logger(config.log_to_file.then_some(config.base_dir.join("logs/")))?;
 
+    log::info!(
+        "🐝 Starting swarm on {} (base dir: {}, start port: {})",
+        config.network,
+        config.base_dir.display(),
+        config.start_port
+    );
+
     let mut shutdown = Shutdown::new();
     let signal = shutdown.to_signal().select(exit_signal().context("exit_signal")?);
     let (task_handle, pm_handle) = process_manager::spawn(&config, config_path.clone(), shutdown.to_signal());

--- a/applications/tari_swarm_daemon/src/process_manager/instances/manager.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/instances/manager.rs
@@ -420,6 +420,7 @@ impl InstanceManager {
             .find(|i| i.id() == id)
             .ok_or_else(|| anyhow!("Instance not found"))?;
 
+        info!("🛑 Stopping {} (id: {})", instance.instance_type(), instance.id());
         instance.terminate().await?;
         instance.check_running()?;
         Ok(())

--- a/applications/tari_swarm_daemon/src/process_manager/instances/manager.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/instances/manager.rs
@@ -12,7 +12,7 @@ use std::{
 
 use anyhow::{Context, anyhow};
 use indexmap::IndexMap;
-use log::info;
+use log::{debug, info};
 use slug::slugify;
 use tari_ootle_wallet_sdk::Network;
 use tokio::{
@@ -261,7 +261,7 @@ impl InstanceManager {
             .stderr(Stdio::piped())
             // Any attempt to use stdin will fail immediately
             .stdin(Stdio::null());
-        info!("Command: {:?}", command);
+        debug!("Command: {:?}", command);
         let mut child = command.spawn().with_context(|| format!("spawn {instance_type}"))?;
 
         self.port_allocator.register(instance_id, allocated_ports.clone());

--- a/applications/tari_swarm_daemon/src/process_manager/manager.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/manager.rs
@@ -160,6 +160,7 @@ impl ProcessManager {
         layer_one_transaction_service: Option<&mut LayerOneTransactionService>,
     ) -> anyhow::Result<()> {
         if self.skip_registration {
+            info!("⏭️ Skipping validator node and template registration");
             return Ok(());
         }
 
@@ -682,6 +683,8 @@ impl ProcessManager {
             .find(|vn| vn.instance().id() == instance_id)
             .ok_or_else(|| anyhow!("Validator node with ID '{}' not found", instance_id))?;
 
+        info!("🟡 Registering validator node {}", vn.instance().name());
+
         if !vn.instance().is_running() {
             log::error!(
                 "Skipping registration for validator node {}: {} since it is not running",
@@ -837,6 +840,7 @@ impl ProcessManager {
         if blocks == 0 {
             return Ok(());
         }
+        info!("⛏️ Mining {blocks} block(s)");
         let executable = self
             .executable_manager
             .get_executable(InstanceType::MinoTariMiner)


### PR DESCRIPTION
## Description

The swarm daemon dispatched every log record at `Debug` to both stdout and `swarm.log`. Since each line of forwarded child-process output is logged at debug, the console was dominated by validator node / base node / wallet chatter and the daemon's own progress messages were lost in it.

- `logger.rs`: split the single dispatch — the stdout chain filters at `Info`, the `swarm.log` chain keeps `Debug`. Forwarded process output still lands in `swarm.log` (and in each instance's own `stdout.log` / `stderr.log`), just not on the console.
- `instances/manager.rs`: the `Command: {:?}` spawn dump drops from `info!` to `debug!`, alongside the process output it belongs with.

## Motivation and Context

Swarm's console output was unusable for watching what the daemon was doing.

## How Has This Been Tested?

`cargo check -p tari_swarm_daemon`.

## What process can a PR reviewer use to test or verify this change?

Run `tari_swarm_daemon start` and confirm the console shows only the 🚀/🟢 lifecycle lines, while `swarm.log` still contains the full forwarded process output.

## Breaking Changes

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify
