### PR TITLE
fix(indexer): answer a spent version as not found, not a server error

### DIFF
--- a/applications/tari_indexer/src/rest_api/handlers/substates.rs
+++ b/applications/tari_indexer/src/rest_api/handlers/substates.rs
@@ -10,12 +10,27 @@ use axum::{
 };
 use tari_engine_types::substate::SubstateId;
 use tari_indexer_client::types::{GetSubstateRequest, GetSubstateResponse, GetSubstatesRequest, GetSubstatesResponse};
-use tari_ootle_common_types::SubstateRequirementRef;
+use tari_ootle_common_types::{SubstateRequirementRef, optional::IsNotFoundError};
 
 use crate::{
     rest_api::{context::HandlerContext, error::ErrorResponse, handlers::HandlerResult},
-    substate_manager::FetchedSubstate,
+    substate_manager::{FetchedSubstate, SubstateManagerError},
 };
+
+/// Maps a lookup failure to a status the caller can act on.
+///
+/// A substate that is not there, and a version that has since been spent, are both answers about the
+/// thing that was asked for rather than failures of the indexer. A caller has to be able to tell
+/// those from the indexer being unable to answer at all, which is the only case left as a server
+/// error.
+fn substate_lookup_error(e: SubstateManagerError) -> ErrorResponse {
+    // A down is never undone, so naming a spent version is permanent for that version: the caller
+    // has to resolve the substate again rather than retry what it asked for.
+    if matches!(e, SubstateManagerError::InputSubstateIsDown { .. }) || e.is_not_found_error() {
+        return ErrorResponse::not_found(e.to_string());
+    }
+    ErrorResponse::internal_error(format!("Error getting substate: {e}"))
+}
 
 #[utoipa::path(
     get,
@@ -28,7 +43,11 @@ use crate::{
     ),
     responses(
         (status = 200, description = "Substate details", body = GetSubstateResponse),
-        (status = 404, description = "Substate not found", body = ErrorResponse),
+        (
+            status = 404,
+            description = "No such substate, or the version asked for has been spent",
+            body = ErrorResponse
+        ),
         (status = SERVICE_UNAVAILABLE, description = "Indexer is still syncing", body = ErrorResponse),
         (status = INTERNAL_SERVER_ERROR, description = "Failed to fetch substate", body = ErrorResponse),
     )
@@ -63,13 +82,13 @@ pub async fn get_substate(
                         verified: false,
                     })
             })
-            .map_err(|e| ErrorResponse::internal_error(format!("Error getting substate: {}", e)))?
+            .map_err(substate_lookup_error)?
     } else {
         manager
             .get_substates(iter::once(requirement))
             .await
             .map(|a| a.into_iter().next().map(|(_, fetched)| fetched))
-            .map_err(|e| ErrorResponse::internal_error(format!("Error getting substate: {}", e)))?
+            .map_err(substate_lookup_error)?
     };
 
     match maybe_substate {
@@ -127,4 +146,48 @@ pub async fn fetch_substates(
         .map_err(|e| ErrorResponse::internal_error(format!("Error getting substates: {}", e)))?;
 
     Ok(Json(GetSubstatesResponse { substates }))
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::http::StatusCode;
+    use tari_ootle_storage::StorageError;
+
+    use super::*;
+
+    fn substate() -> SubstateId {
+        format!("component_{:064x}", 1).parse().unwrap()
+    }
+
+    /// Naming a version that has since been superseded says something about the substate, not about
+    /// the indexer, so the caller is told what it asked for is gone rather than that we broke.
+    #[test]
+    fn a_spent_version_is_not_found() {
+        let e = SubstateManagerError::InputSubstateIsDown {
+            substate_id: substate(),
+            version: 0,
+        };
+        let resp = substate_lookup_error(e);
+        assert_eq!(resp.status, StatusCode::NOT_FOUND);
+        // The version the caller named has to survive into the message for it to re-resolve.
+        assert!(resp.error.contains("v0"), "{}", resp.error);
+    }
+
+    #[test]
+    fn a_substate_that_does_not_exist_is_not_found() {
+        let resp = substate_lookup_error(SubstateManagerError::InputSubstateDoesNotExist {
+            substate_id: substate(),
+        });
+        assert_eq!(resp.status, StatusCode::NOT_FOUND);
+    }
+
+    /// Only the indexer being unable to answer is a server error, or a caller cannot tell the two
+    /// apart and retries something that will never succeed.
+    #[test]
+    fn a_failure_to_answer_stays_a_server_error() {
+        let resp = substate_lookup_error(SubstateManagerError::StorageError(StorageError::QueryError {
+            reason: "boom".to_string(),
+        }));
+        assert_eq!(resp.status, StatusCode::INTERNAL_SERVER_ERROR);
+    }
 }

--- a/docs/developer-docs/public/indexer/openapi.json
+++ b/docs/developer-docs/public/indexer/openapi.json
@@ -10,7 +10,7 @@
       "name": "BSD-3-Clause",
       "identifier": "BSD-3-Clause"
     },
-    "version": "0.40.0"
+    "version": "0.41.0"
   },
   "paths": {
     "/epoch-checkpoints": {
@@ -559,7 +559,7 @@
             }
           },
           "404": {
-            "description": "Substate not found",
+            "description": "No such substate, or the version asked for has been spent",
             "content": {
               "application/json": {
                 "schema": {


### PR DESCRIPTION
Reported against a running swarm:

```
GET /substates/component_ceee907c…4bf4?local_search_only=false&version=0
→ 500
```

The component exists; version 0 has since been superseded.

## Cause

`get_substate` mapped **every** lookup failure to `internal_error`, so the `not_found` branch below it was only reachable when the manager returned `Ok(None)`. Both `InputSubstateIsDown` and `InputSubstateDoesNotExist` came back as 500 — the indexer reporting that it had broken, when in fact it had answered.

## Fix

`substate_lookup_error` maps a lookup failure to a status the caller can act on:

- **spent version** → 404. A down is never undone, so this is permanent for the version asked for: the caller has to re-resolve the substate rather than retry. The version survives into the message so it can.
- **no such substate** → 404, via the `IsNotFoundError` classification `SubstateManagerError` already carries.
- **anything else** → 500, which is now only the case where the indexer genuinely could not answer.

Left `SubstateManagerError`'s `IsNotFoundError` impl alone rather than adding `InputSubstateIsDown` to it. A spent version is a different answer from a missing substate, and folding them together would make a future `.optional()` caller silently swallow it. The distinction lives in the API layer, where it is about status codes rather than about optionality.

## Scope

The batch endpoint (`POST /substates/fetch`) keeps its blanket mapping. Neither `get_cached_substates` nor `fetch_and_cache_substates` raises the spent-version error, and a single status for a request covering up to twenty substates would not say which one it referred to.

## Note on the diff

`openapi.json` is regenerated (`cargo run -p tari_indexer --bin indexer-gen-openapi`). Besides the 404 description, it picks up `0.40.0` → `0.41.0` — the committed file was stale against the current workspace version, and that line is what the generator now emits.

## Tests

Three cover the mapping in both directions: a spent version is 404 and keeps the version in its message, a missing substate is 404, and a storage failure stays 500 — so nothing that means "the indexer could not answer" starts looking like an answer. 99 pass in `tari_indexer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)