### PR TITLE
feat(indexer): log and count substate cache refusals, invalidations and evictions

### DIFF
--- a/applications/tari_indexer/src/bootstrap.rs
+++ b/applications/tari_indexer/src/bootstrap.rs
@@ -270,6 +270,8 @@ pub async fn spawn_services(
 
     #[cfg(feature = "metrics")]
     let network_state_metrics = network_state_sync::NetworkStateMetrics::register(metrics_registry);
+    #[cfg(feature = "metrics")]
+    let substate_cache_metrics = crate::substate_cache::SubstateCacheMetrics::register(metrics_registry);
 
     // Shared between the state sync (which confirms how far each shard is synced) and the substate
     // cache (which serves an entry only while its shard is being kept up with).
@@ -294,6 +296,8 @@ pub async fn spawn_services(
         #[cfg(feature = "metrics")]
         network_state_metrics,
         #[cfg(feature = "metrics")]
+        substate_cache_metrics.clone(),
+        #[cfg(feature = "metrics")]
         consensus_constants.clone(),
     )
     .spawn(shutdown.clone());
@@ -308,6 +312,8 @@ pub async fn spawn_services(
         DEFAULT_CACHE_TTL,
         config.indexer.substate_cache_max_entries,
     );
+    #[cfg(feature = "metrics")]
+    let substate_cache = substate_cache.with_metrics(substate_cache_metrics);
     substate_cache.spawn_pruner(SUBSTATE_CACHE_PRUNE_INTERVAL, shutdown.clone());
     let substate_manager = SubstateManager::new(
         config.network,

--- a/applications/tari_indexer/src/network_state_sync/shard_watermarks.rs
+++ b/applications/tari_indexer/src/network_state_sync/shard_watermarks.rs
@@ -69,6 +69,15 @@ impl ShardWatermarks {
         (watermark.confirmed_at.elapsed() <= max_lag).then_some(watermark.state_version)
     }
 
+    /// The watermark for `shard` and how long ago it was confirmed, or `None` if it never was in
+    /// this run. Read together so that a confirmation landing between the two cannot make them
+    /// disagree.
+    pub fn confirmed(&self, shard: Shard) -> Option<(StateVersion, Duration)> {
+        self.read()
+            .get(&shard)
+            .map(|watermark| (watermark.state_version, watermark.confirmed_at.elapsed()))
+    }
+
     // Poisoning is recovered from rather than propagated: the map holds no invariant a panic could
     // break.
 
@@ -115,6 +124,16 @@ mod tests {
         watermarks.confirm(SHARD, StateVersion::new(7));
         watermarks.refresh(SHARD);
         assert_eq!(watermarks.get(SHARD, MAX_LAG), Some(StateVersion::new(7)));
+    }
+
+    #[test]
+    fn a_confirmation_reports_its_version_and_age_together() {
+        let watermarks = ShardWatermarks::new();
+        assert!(watermarks.confirmed(SHARD).is_none());
+        watermarks.confirm(SHARD, StateVersion::new(7));
+        let (version, age) = watermarks.confirmed(SHARD).unwrap();
+        assert_eq!(version, StateVersion::new(7));
+        assert!(age < MAX_LAG);
     }
 
     #[test]

--- a/applications/tari_indexer/src/network_state_sync/worker.rs
+++ b/applications/tari_indexer/src/network_state_sync/worker.rs
@@ -47,7 +47,7 @@ use tokio::{
 use tokio_util::sync::CancellationToken;
 
 #[cfg(feature = "metrics")]
-use crate::{network_state_sync::NetworkStateMetrics, store::ReadOnlyStore};
+use crate::{network_state_sync::NetworkStateMetrics, store::ReadOnlyStore, substate_cache::SubstateCacheMetrics};
 use crate::{
     network_state_sync::{
         committee_client::{ValidatorCommitteeRpcPool, ValidatorRpcSession},
@@ -91,6 +91,8 @@ pub struct NetworkWideStateSync {
     #[cfg(feature = "metrics")]
     metrics: NetworkStateMetrics,
     #[cfg(feature = "metrics")]
+    substate_cache_metrics: SubstateCacheMetrics,
+    #[cfg(feature = "metrics")]
     consensus_constants: ConsensusConstants,
 }
 
@@ -106,6 +108,7 @@ impl NetworkWideStateSync {
         validator_status: ValidatorStatusMonitor,
         shard_watermarks: Arc<ShardWatermarks>,
         #[cfg(feature = "metrics")] metrics: NetworkStateMetrics,
+        #[cfg(feature = "metrics")] substate_cache_metrics: SubstateCacheMetrics,
         #[cfg(feature = "metrics")] consensus_constants: ConsensusConstants,
     ) -> Self {
         Self {
@@ -121,6 +124,8 @@ impl NetworkWideStateSync {
             shard_watermarks,
             #[cfg(feature = "metrics")]
             metrics,
+            #[cfg(feature = "metrics")]
+            substate_cache_metrics,
             #[cfg(feature = "metrics")]
             consensus_constants,
         }
@@ -925,17 +930,17 @@ impl NetworkWideStateSync {
             let xtr_fees_snapshot = xtr_fees;
             let xtr_receipt_burn_snapshot = xtr_receipt_burn;
 
-            let inserted_events = self
+            let (inserted_events, retired_cache_entries) = self
                 .store
                 .clone()
-                .with_write_tx(move |tx| -> Result<Vec<InsertedEvent>, StorageError> {
+                .with_write_tx(move |tx| -> Result<(Vec<InsertedEvent>, usize), StorageError> {
                     debug!(target: LOG_TARGET, "✅ Committing {} updates for shard {shard} (epoch: {msg_epoch}, state version: {state_version})", updates_len);
                     // TODO: this is not currently used. Consider removing.
                     tx.batch_insert_substate_transitions(network, shard, state_version, updates)?;
                     // Must commit with the watermark below: the substate cache serves an entry on the
                     // argument that it holds every transition up to that watermark, which a reader
                     // seeing one of the two without the other would break.
-                    tx.substate_cache_invalidate(invalidations, state_version)?;
+                    let retired_cache_entries = tx.substate_cache_invalidate(invalidations, state_version)?;
                     debug!(target: LOG_TARGET, "✅ Committing {} UTXOs for shard {shard} (epoch: {msg_epoch})", utxos_len);
                     tx.batch_insert_utxo_updates(msg_epoch, utxos)?;
                     for substate_data in validator_fee_pools {
@@ -964,10 +969,15 @@ impl NetworkWideStateSync {
                     let receipt_burn = tx.key_value_get_value(Key::TariAccumulatedReceiptExhaustBurn).optional()?;
                     let new_receipt_burn = receipt_burn.unwrap_or_else(Amount::zero) + xtr_receipt_burn_snapshot;
                     tx.key_value_set(Key::TariAccumulatedReceiptExhaustBurn, new_receipt_burn)?;
-                    Ok(inserted)
+                    Ok((inserted, retired_cache_entries))
                 })
                 .await?;
             drop(progress);
+            if retired_cache_entries > 0 {
+                debug!(target: LOG_TARGET, "Retired {retired_cache_entries} cached substates for shard {shard} at state version {state_version}");
+                #[cfg(feature = "metrics")]
+                self.substate_cache_metrics.add_invalidations(retired_cache_entries);
+            }
 
             // The stream flushes (has_more == false) once per state version, so each commit must fold only
             // that version's delta. Reset the running totals here, mirroring the buffer drains above.

--- a/applications/tari_indexer/src/storage_sqlite/writer.rs
+++ b/applications/tari_indexer/src/storage_sqlite/writer.rs
@@ -632,12 +632,13 @@ impl IndexerStoreWriteTransaction for SqliteStoreWriteTransaction<'_> {
         &mut self,
         invalidations: I,
         state_version: StateVersion,
-    ) -> Result<(), StorageError> {
+    ) -> Result<usize, StorageError> {
         let now = unix_timestamp();
+        let mut retired = 0;
         for invalidation in invalidations {
-            self.apply_substate_cache_invalidation(&invalidation, state_version, now)?;
+            retired += self.apply_substate_cache_invalidation(&invalidation, state_version, now)?;
         }
-        Ok(())
+        Ok(retired)
     }
 
     fn substate_cache_retire_ahead<I: IntoIterator<Item = (SubstateCacheInvalidation, StateVersion)>>(
@@ -651,7 +652,7 @@ impl IndexerStoreWriteTransaction for SqliteStoreWriteTransaction<'_> {
         Ok(())
     }
 
-    fn substate_cache_prune(&mut self, journal_retention: Duration, max_entries: usize) -> Result<(), StorageError> {
+    fn substate_cache_prune(&mut self, journal_retention: Duration, max_entries: usize) -> Result<usize, StorageError> {
         const OPERATION: &str = "substate_cache_prune";
         use crate::storage_sqlite::schema::{substate_cache, substate_cache_invalidations};
 
@@ -668,7 +669,7 @@ impl IndexerStoreWriteTransaction for SqliteStoreWriteTransaction<'_> {
             .map_err(|e| StorageError::general(OPERATION, e))?;
         let excess = count.saturating_sub(max_entries as i64);
         if excess <= 0 {
-            return Ok(());
+            return Ok(0);
         }
 
         // An evicted entry costs one committee round trip to restore, so oldest-written-first is a
@@ -680,9 +681,7 @@ impl IndexerStoreWriteTransaction for SqliteStoreWriteTransaction<'_> {
         )
         .bind::<diesel::sql_types::BigInt, _>(excess)
         .execute(self.connection())
-        .map_err(|e| StorageError::general(OPERATION, e))?;
-
-        Ok(())
+        .map_err(|e| StorageError::general(OPERATION, e))
     }
 
     fn upsert_verified_state_root(&mut self, root: &VerifiedStateRoot) -> Result<(), StorageError> {
@@ -774,14 +773,15 @@ impl SqliteStoreWriteTransaction<'_> {
         invalidation: &SubstateCacheInvalidation,
         state_version: StateVersion,
         now: i64,
-    ) -> Result<(), StorageError> {
+    ) -> Result<usize, StorageError> {
         const OPERATION: &str = "substate_cache_invalidate";
         use crate::storage_sqlite::schema::{substate_cache, substate_cache_invalidations};
 
         let id = invalidation.substate_id().to_string();
+        let mut retired = 0;
 
         if let Some(retires_up_to) = invalidation.retires_up_to() {
-            diesel::delete(
+            retired += diesel::delete(
                 substate_cache::table
                     .filter(substate_cache::substate_id.eq(&id))
                     .filter(substate_cache::version.le(retires_up_to as i32)),
@@ -791,7 +791,7 @@ impl SqliteStoreWriteTransaction<'_> {
         }
 
         if invalidation.retires_nonexistence() {
-            diesel::delete(
+            retired += diesel::delete(
                 substate_cache::table
                     .filter(substate_cache::substate_id.eq(&id))
                     .filter(substate_cache::version.is_null()),
@@ -815,6 +815,6 @@ impl SqliteStoreWriteTransaction<'_> {
             .execute(self.connection())
             .map_err(|e| StorageError::general(OPERATION, e))?;
 
-        Ok(())
+        Ok(retired)
     }
 }

--- a/applications/tari_indexer/src/store.rs
+++ b/applications/tari_indexer/src/store.rs
@@ -359,11 +359,13 @@ pub trait IndexerStoreWriteTransaction {
     /// Must be applied in the same transaction that advances the sync watermark `state_version`
     /// belongs to: an entry is served on the argument that the cache holds every transition up to
     /// that watermark, which a reader observing one without the other would break.
+    ///
+    /// Returns how many cached entries were retired.
     fn substate_cache_invalidate<I: IntoIterator<Item = SubstateCacheInvalidation>>(
         &mut self,
         invalidations: I,
         state_version: StateVersion,
-    ) -> Result<(), StorageError>;
+    ) -> Result<usize, StorageError>;
 
     /// Like [`substate_cache_invalidate`](Self::substate_cache_invalidate), but for transitions
     /// learnt of ahead of the stream - from a committee's finalized result - so the journalled
@@ -377,8 +379,8 @@ pub trait IndexerStoreWriteTransaction {
     ) -> Result<(), StorageError>;
 
     /// Drops journal entries older than `journal_retention` and evicts the oldest cache entries down
-    /// to `max_entries`.
-    fn substate_cache_prune(&mut self, journal_retention: Duration, max_entries: usize) -> Result<(), StorageError>;
+    /// to `max_entries`. Returns how many entries were evicted.
+    fn substate_cache_prune(&mut self, journal_retention: Duration, max_entries: usize) -> Result<usize, StorageError>;
 }
 
 /// The locally recorded rejection state of a transaction.

--- a/applications/tari_indexer/src/substate_cache/metrics.rs
+++ b/applications/tari_indexer/src/substate_cache/metrics.rs
@@ -1,0 +1,56 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use prometheus_client::{metrics::counter::Counter, registry::Registry};
+
+use crate::metrics::CollectorRegister;
+
+/// Counters for what the cache does that a hit/miss ratio alone cannot explain: entries retired by
+/// the transition stream, entries evicted at the size cap, and reads refused because the shard's
+/// stream has fallen behind. A miss rate that climbs alongside `refused_stale` is a sync problem,
+/// not a cache one.
+///
+/// The hit/miss pair itself is recorded by the manager that fronts the cache, under
+/// `substate_scanner_cache_hits` and `substate_scanner_cache_misses`.
+#[derive(Debug, Clone)]
+pub struct SubstateCacheMetrics {
+    invalidations: Counter,
+    evictions: Counter,
+    refused_stale: Counter,
+}
+
+impl SubstateCacheMetrics {
+    pub fn register(registry: &mut Registry) -> Self {
+        let registry = registry.sub_registry_with_prefix("substate_cache");
+        Self {
+            invalidations: Counter::default().register_at(
+                "invalidations",
+                "Number of cached substate entries retired by a transition from the state sync stream",
+                registry,
+            ),
+            evictions: Counter::default().register_at(
+                "evictions",
+                "Number of cached substate entries evicted to stay within substate_cache_max_entries",
+                registry,
+            ),
+            refused_stale: Counter::default().register_at(
+                "refused_stale",
+                "Number of cache reads refused because the substate's shard was not confirmed level with its \
+                 committee recently enough to serve from",
+                registry,
+            ),
+        }
+    }
+
+    pub fn add_invalidations(&self, n: usize) {
+        self.invalidations.inc_by(n as u64);
+    }
+
+    pub fn add_evictions(&self, n: usize) {
+        self.evictions.inc_by(n as u64);
+    }
+
+    pub fn inc_refused_stale(&self) {
+        self.refused_stale.inc();
+    }
+}

--- a/applications/tari_indexer/src/substate_cache/mod.rs
+++ b/applications/tari_indexer/src/substate_cache/mod.rs
@@ -27,6 +27,11 @@ use crate::{
     store::{IndexerStore, IndexerStoreReadTransaction, IndexerStoreReader, IndexerStoreWriteTransaction},
 };
 
+#[cfg(feature = "metrics")]
+mod metrics;
+#[cfg(feature = "metrics")]
+pub use metrics::SubstateCacheMetrics;
+
 const LOG_TARGET: &str = "tari::indexer::substate_cache";
 
 fn now_unix_secs() -> Result<u64, SubstateCacheError> {
@@ -78,6 +83,8 @@ pub struct SqliteSubstateCache {
     /// correct, which is one recorded above the version the substate actually reached.
     head_ttl: Duration,
     max_entries: usize,
+    #[cfg(feature = "metrics")]
+    metrics: Option<SubstateCacheMetrics>,
 }
 
 impl std::fmt::Debug for SqliteSubstateCache {
@@ -109,7 +116,15 @@ impl SqliteSubstateCache {
             journal_retention,
             head_ttl,
             max_entries,
+            #[cfg(feature = "metrics")]
+            metrics: None,
         }
+    }
+
+    #[cfg(feature = "metrics")]
+    pub fn with_metrics(mut self, metrics: SubstateCacheMetrics) -> Self {
+        self.metrics = Some(metrics);
+        self
     }
 
     /// Periodically drops journal entries that can no longer veto a write and evicts the oldest
@@ -173,9 +188,39 @@ impl SqliteSubstateCache {
     async fn prune(&self) -> Result<(), StorageError> {
         let journal_retention = self.journal_retention;
         let max_entries = self.max_entries;
-        self.store
+        let evicted = self
+            .store
             .with_write_tx(move |tx| tx.substate_cache_prune(journal_retention, max_entries))
-            .await
+            .await?;
+        if evicted > 0 {
+            debug!(target: LOG_TARGET, "Evicted {evicted} substate cache entries to stay within {max_entries}");
+            #[cfg(feature = "metrics")]
+            self.metrics.as_ref().inspect(|m| m.add_evictions(evicted));
+        }
+        Ok(())
+    }
+
+    /// The watermark gate on serving `id`: `Some` while its shard was confirmed level with its
+    /// committee within `max_lag`. A refusal is what turns every read of the shard into a committee
+    /// round trip, so it is logged and counted rather than passed off as a miss.
+    fn serve_watermark(&self, id: &SubstateId, max_lag: Duration) -> Option<StateVersion> {
+        let shard = Self::shard_of(id);
+        match self.watermarks.confirmed(shard) {
+            Some((version, age)) if age <= max_lag => return Some(version),
+            Some((_, age)) => debug!(
+                target: LOG_TARGET,
+                "Refusing cached {id}: shard {shard} was last confirmed {}s ago, over the {}s serve lag",
+                age.as_secs(),
+                max_lag.as_secs(),
+            ),
+            None => debug!(
+                target: LOG_TARGET,
+                "Refusing cached {id}: shard {shard} has not been confirmed since startup"
+            ),
+        }
+        #[cfg(feature = "metrics")]
+        self.metrics.as_ref().inspect(|m| m.inc_refused_stale());
+        None
     }
 
     fn shard_of(id: &SubstateId) -> Shard {
@@ -216,11 +261,7 @@ impl SubstateCache for SqliteSubstateCache {
             if version.is_some() {
                 return Ok(None);
             }
-            if self
-                .watermarks
-                .get(Self::shard_of(id), self.negative_serve_lag)
-                .is_none()
-            {
+            if self.serve_watermark(id, self.negative_serve_lag).is_none() {
                 return Ok(None);
             }
             return Ok(Some(entry));
@@ -246,7 +287,7 @@ impl SubstateCache for SqliteSubstateCache {
 
         // Anything else is a claim about the substate's current state, which holds only while its
         // shard is being kept up with.
-        if self.watermarks.get(Self::shard_of(id), self.max_serve_lag).is_none() {
+        if self.serve_watermark(id, self.max_serve_lag).is_none() {
             return Ok(None);
         }
 


### PR DESCRIPTION
## Summary

A read refused because the shard's watermark was missing or stale came back as `Ok(None)`, indistinguishable from an empty cache and invisible in the logs, so an indexer whose every read had started costing a committee round trip gave no hint why (raised twice on #2498).

- `SqliteSubstateCache::read` now logs a refusal at debug with the shard, how long ago it was last confirmed (or that it never was since startup) and the serve lag it exceeded. `ShardWatermarks::age` supplies the age.
- Three counters join the hit/miss pair, registered under `substate_cache_`:
  - `invalidations` — entries retired by a transition from the state sync stream
  - `evictions` — entries dropped to stay within `substate_cache_max_entries`
  - `refused_stale` — reads refused on the watermark gate
- `substate_cache_invalidate` and `substate_cache_prune` return the affected row counts to feed them; the metrics struct is shared between the cache and the sync worker.

Phase 3 items 2 and 3 from the indexer cache plan.
