### PR TITLE
refactor(indexer)!: serve only the head from the substate cache

### DIFF
--- a/applications/tari_indexer/src/store.rs
+++ b/applications/tari_indexer/src/store.rs
@@ -260,7 +260,10 @@ pub trait IndexerStoreReadTransaction {
     // -------------------------------- Substate Cache -------------------------------- //
 
     /// The cached head version of `substate_id`. Says nothing about whether it is fresh enough to
-    /// serve, nor what it implies for lower versions - see [`crate::substate_cache::SqliteSubstateCache`].
+    /// serve - see [`crate::substate_cache::SqliteSubstateCache`] - nor what it implies for a
+    /// lookup at a particular version, which is
+    /// [`SubstateCacheEntry::answer_at`](tari_indexer_lib::substate_cache::SubstateCacheEntry::answer_at)'s
+    /// to decide.
     fn substate_cache_get(&mut self, substate_id: &SubstateId) -> Result<Option<SubstateCacheEntry>, StorageError>;
 }
 

--- a/applications/tari_indexer/src/substate_cache/mod.rs
+++ b/applications/tari_indexer/src/substate_cache/mod.rs
@@ -1,10 +1,7 @@
 //   Copyright 2026 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::{
-    sync::Arc,
-    time::{Duration, SystemTime, UNIX_EPOCH},
-};
+use std::{sync::Arc, time::Duration};
 
 use log::*;
 use tari_engine_types::substate::{SubstateDiff, SubstateId};
@@ -18,7 +15,6 @@ use tari_indexer_lib::substate_cache::{
 use tari_ootle_common_types::{NumPreshards, StateVersion, SubstateAddress, shard::Shard};
 use tari_ootle_storage::StorageError;
 use tari_shutdown::ShutdownSignal;
-use tari_validator_node_rpc::client::SubstateResult;
 use tokio::{task, time};
 
 use crate::{
@@ -34,13 +30,6 @@ pub use metrics::SubstateCacheMetrics;
 
 const LOG_TARGET: &str = "tari::indexer::substate_cache";
 
-fn now_unix_secs() -> Result<u64, SubstateCacheError> {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .map_err(|e| SubstateCacheError(e.to_string()))
-}
-
 /// Substate cache backed by the indexer's own database, so that an entry and the sync watermark it
 /// is justified by are written and read under one transaction.
 ///
@@ -49,26 +38,18 @@ fn now_unix_secs() -> Result<u64, SubstateCacheError> {
 /// until a timer expires - and that holds only for a shard whose stream this indexer is demonstrably
 /// keeping up with, which [`ShardWatermarks`] decides.
 ///
-/// A cached head also settles every version below it, without a validator and without a watermark.
-/// Versions are contiguous and upping a substate downs its predecessor, so a substate that ever
-/// reached version `L` has versions `0..L` down for good. Unlike a claim about the current state,
-/// that conclusion cannot go stale: a head this indexer holds is a lower bound on the real one, so a
-/// stale `L` only makes it more certainly true.
-///
-/// What can be wrong is `L` itself, if it was recorded above any version the substate reached. No
+/// What a lookup that names a version learns from the head is [`SubstateCacheEntry::answer_at`]'s
+/// to decide, not the cache's. What the cache guards is the head itself, which can be wrong only if
+/// it was recorded above any version the substate reached. No
 /// transition corrects that - every transition retires versions below the head, never above it - so
-/// `head_ttl` retires the head instead, and the next lookup replaces it.
+/// `head_ttl` lets a write displace such a head instead.
 ///
-/// An entry with no version settles nothing below it. Nonexistence says only that the substate has
-/// no live version now, and since a destroyed substate whose history has been pruned reports the
-/// same thing, it cannot be read as "never created": a versioned read goes to the committee.
-///
-/// It is also the one entry that needs the stream to be current, rather than merely recent, which is
-/// why `negative_serve_lag` is tighter than `max_serve_lag`. A head that is behind is still a lower
-/// bound on the real one, so age only makes it more certainly true; nonexistence is correct at the
-/// instant it is taken and false ever after if the substate has since been created. Every version
-/// the stream has not yet delivered is a version in which it may already be wrong, so it is served
-/// only while the stream is demonstrably alive.
+/// A record that the substate does not exist is the one entry that needs the stream to be current,
+/// rather than merely recent, which is why `negative_serve_lag` is tighter than `max_serve_lag`. A
+/// head that is behind is still a lower bound on the real one, so age only makes it more certainly
+/// true; nonexistence is correct at the instant it is taken and false ever after if the substate has
+/// since been created. Every version the stream has not yet delivered is a version in which it may
+/// already be wrong, so it is served only while the stream is demonstrably alive.
 #[derive(Clone)]
 pub struct SqliteSubstateCache {
     store: SqliteIndexerStore,
@@ -79,8 +60,9 @@ pub struct SqliteSubstateCache {
     negative_serve_lag: Duration,
     /// How long a substate stays journalled as recently changed. Only has to span a committee fetch.
     journal_retention: Duration,
-    /// How long a recorded head is treated as evidence. The backstop for a head no transition can
-    /// correct, which is one recorded above the version the substate actually reached.
+    /// How long a recorded head stands against a write that would lower it. The backstop for a head
+    /// no transition can correct, which is one recorded above the version the substate actually
+    /// reached.
     head_ttl: Duration,
     max_entries: usize,
     #[cfg(feature = "metrics")]
@@ -239,11 +221,7 @@ impl SubstateCache for SqliteSubstateCache {
             .map(|version| FetchWatermark::new(version.as_u64())))
     }
 
-    async fn read(
-        &self,
-        id: &SubstateId,
-        version: Option<u32>,
-    ) -> Result<Option<SubstateCacheEntry>, SubstateCacheError> {
+    async fn read(&self, id: &SubstateId) -> Result<Option<SubstateCacheEntry>, SubstateCacheError> {
         let stored_id = id.clone();
         let entry = self
             .store
@@ -254,46 +232,13 @@ impl SubstateCache for SqliteSubstateCache {
             return Ok(None);
         };
 
-        let Some(head) = entry.version else {
-            // Nonexistence is a claim about the substate's current state and nothing more. It says
-            // there is no live version, never what was true at some version below, so a versioned
-            // read has to go to the committee.
-            if version.is_some() {
-                return Ok(None);
-            }
-            if self.serve_watermark(id, self.negative_serve_lag).is_none() {
-                return Ok(None);
-            }
-            return Ok(Some(entry));
+        // Nonexistence needs the stream to be current, the head only recent: see the type docs.
+        let max_lag = if entry.version.is_some() {
+            self.max_serve_lag
+        } else {
+            self.negative_serve_lag
         };
-
-        if let Some(version) = version &&
-            version < head
-        {
-            // The conclusion does not age, but the head it rests on does: one recorded above the real
-            // version is retired by no transition, so it is aged out here instead.
-            if now_unix_secs()?.saturating_sub(entry.cached_at) > self.head_ttl.as_secs() {
-                return Ok(None);
-            }
-            return Ok(Some(SubstateCacheEntry {
-                version: Some(version),
-                substate_result: SubstateResult::Down { version },
-                // Derived now rather than when the head was fetched. The head only has to have been
-                // real at some point for this to hold, so the answer does not age.
-                cached_at: now_unix_secs()?,
-                verified: entry.verified,
-            }));
-        }
-
-        // Anything else is a claim about the substate's current state, which holds only while its
-        // shard is being kept up with.
-        if self.serve_watermark(id, self.max_serve_lag).is_none() {
-            return Ok(None);
-        }
-
-        // A version above the head is not something the cache knows anything about: this indexer is
-        // behind, or the substate never reached it.
-        if version.is_some_and(|version| version > head) {
+        if self.serve_watermark(id, max_lag).is_none() {
             return Ok(None);
         }
 
@@ -337,8 +282,19 @@ impl SubstateCache for SqliteSubstateCache {
 
 #[cfg(test)]
 mod tests {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use tari_validator_node_rpc::client::SubstateResult;
+
     use super::*;
     use crate::storage_sqlite::SqliteIndexerStore;
+
+    fn now_unix_secs() -> Result<u64, SubstateCacheError> {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .map_err(|e| SubstateCacheError(e.to_string()))
+    }
 
     const MAX_SERVE_LAG: Duration = Duration::from_secs(60);
     const NEGATIVE_SERVE_LAG: Duration = Duration::from_secs(30);
@@ -351,7 +307,6 @@ mod tests {
     async fn cache_with_head(
         version: u32,
         confirm_shard: bool,
-        head_age: Duration,
     ) -> (tempfile::TempDir, SqliteSubstateCache, SubstateId) {
         let dir = tempfile::tempdir().unwrap();
         let store = SqliteIndexerStore::try_create(dir.path().join("indexer.db")).unwrap();
@@ -369,7 +324,6 @@ mod tests {
             HEAD_TTL,
             1000,
         );
-        // Whether the head itself is up or down is irrelevant to what it settles about lower versions.
         let result = SubstateResult::Down { version };
         cache
             .write(
@@ -377,7 +331,7 @@ mod tests {
                 SubstateCacheEntryRef {
                     version: Some(version),
                     substate_result: &result,
-                    cached_at: now_unix_secs().unwrap() - head_age.as_secs(),
+                    cached_at: now_unix_secs().unwrap(),
                     verified: true,
                 },
                 FetchWatermark::new(100),
@@ -388,38 +342,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_version_below_the_head_is_reported_down_without_a_committee() {
-        let (_d, cache, id) = cache_with_head(6, true, Duration::ZERO).await;
-        let entry = cache.read(&id, Some(3)).await.unwrap().expect("no entry");
-        assert_eq!(entry.version, Some(3));
-        assert!(matches!(entry.substate_result, SubstateResult::Down { version: 3 }));
+    async fn a_head_is_served_while_its_shard_is_kept_up_with() {
+        let (_d, cache, id) = cache_with_head(6, true).await;
+        assert_eq!(cache.read(&id).await.unwrap().unwrap().version, Some(6));
     }
 
-    /// The head only has to have been real at some point: the real head is at or above it, so every
-    /// version below is down for good. Nothing about that can go stale, so a shard this indexer has
-    /// stopped keeping up with still answers.
+    /// A head is a claim about the substate's current state, which holds only while the shard that
+    /// would retire it is being kept up with.
     #[tokio::test]
-    async fn the_down_inference_needs_no_watermark() {
-        let (_d, cache, id) = cache_with_head(6, false, Duration::ZERO).await;
-        assert!(cache.read(&id, Some(3)).await.unwrap().is_some());
-        // A claim about the substate's current state still needs one.
-        assert!(cache.read(&id, None).await.unwrap().is_none());
-        assert!(cache.read(&id, Some(6)).await.unwrap().is_none());
-    }
-
-    #[tokio::test]
-    async fn the_head_answers_for_itself_and_for_an_unversioned_read() {
-        let (_d, cache, id) = cache_with_head(6, true, Duration::ZERO).await;
-        assert_eq!(cache.read(&id, None).await.unwrap().unwrap().version, Some(6));
-        assert_eq!(cache.read(&id, Some(6)).await.unwrap().unwrap().version, Some(6));
-    }
-
-    /// A head recorded above any version the substate reached is retired by no transition, so the
-    /// conclusions drawn from it have to age out even though the conclusions themselves cannot.
-    #[tokio::test]
-    async fn the_inference_stops_once_the_head_ages_out() {
-        let (_d, cache, id) = cache_with_head(6, true, HEAD_TTL + Duration::from_secs(1)).await;
-        assert!(cache.read(&id, Some(3)).await.unwrap().is_none());
+    async fn a_head_needs_a_watermark() {
+        let (_d, cache, id) = cache_with_head(6, false).await;
+        assert!(cache.read(&id).await.unwrap().is_none());
     }
 
     async fn cache_with_nonexistence(confirm_shard: bool) -> (tempfile::TempDir, SqliteSubstateCache, SubstateId) {
@@ -463,29 +396,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_cached_nonexistence_answers_an_unversioned_read() {
+    async fn a_cached_nonexistence_is_served_while_its_shard_is_current() {
         let (_d, cache, id) = cache_with_nonexistence(true).await;
-        let entry = cache.read(&id, None).await.unwrap().expect("no entry");
+        let entry = cache.read(&id).await.unwrap().expect("no entry");
         assert_eq!(entry.version, None);
         assert!(matches!(entry.substate_result, SubstateResult::DoesNotExist));
     }
 
-    /// Nonexistence says the substate has no live version now, never what was true at some version
-    /// below - and after a destroyed substate is pruned, a substate that did have those versions can
-    /// answer `DoesNotExist` too. The versioned read goes to the committee.
-    #[tokio::test]
-    async fn a_cached_nonexistence_does_not_answer_a_versioned_read() {
-        let (_d, cache, id) = cache_with_nonexistence(true).await;
-        assert!(cache.read(&id, Some(0)).await.unwrap().is_none());
-        assert!(cache.read(&id, Some(3)).await.unwrap().is_none());
-    }
-
-    /// Unlike the down inference, nonexistence is a claim about current state, so it holds only while
-    /// the shard that would retract it is being kept up with.
+    /// Nonexistence is a claim about current state, so it holds only while the shard that would
+    /// retract it is being kept up with.
     #[tokio::test]
     async fn a_cached_nonexistence_needs_a_watermark() {
         let (_d, cache, id) = cache_with_nonexistence(false).await;
-        assert!(cache.read(&id, None).await.unwrap().is_none());
+        assert!(cache.read(&id).await.unwrap().is_none());
     }
 
     /// The two gates are independent, and nonexistence gets the tighter one. A head that is behind
@@ -494,11 +417,11 @@ mod tests {
     #[tokio::test]
     async fn a_nonexistence_stops_being_served_before_a_head_does() {
         let (_d, cache, id) = cache_with_nonexistence_at(true, Duration::ZERO).await;
-        assert!(cache.read(&id, None).await.unwrap().is_none());
+        assert!(cache.read(&id).await.unwrap().is_none());
 
         // The same shard, at the same age, still answers for a head.
-        let (_d2, head_cache, head_id) = cache_with_head(6, true, Duration::ZERO).await;
-        assert!(head_cache.read(&head_id, None).await.unwrap().is_some());
+        let (_d2, head_cache, head_id) = cache_with_head(6, true).await;
+        assert!(head_cache.read(&head_id).await.unwrap().is_some());
     }
 
     async fn write_nonexistence(cache: &SqliteSubstateCache, id: &SubstateId, watermark: u64) {
@@ -534,15 +457,15 @@ mod tests {
             Substate::new(0, SubstateValue::NonFungible(NonFungibleContainer::no_data())),
         );
         cache.retire_committed(&diff).await.unwrap();
-        assert!(cache.read(&id, None).await.unwrap().is_none());
+        assert!(cache.read(&id).await.unwrap().is_none());
 
         // A fetch captured at the shard's watermark predates the commit, so its answer is refused.
         write_nonexistence(&cache, &id, 100).await;
-        assert!(cache.read(&id, None).await.unwrap().is_none());
+        assert!(cache.read(&id).await.unwrap().is_none());
 
         // One captured once the stream has moved past it is not.
         write_nonexistence(&cache, &id, 101).await;
-        assert!(cache.read(&id, None).await.unwrap().is_some());
+        assert!(cache.read(&id).await.unwrap().is_some());
     }
 
     /// The other half of the same race: a head the transaction replaced. The old head is retired,
@@ -554,7 +477,7 @@ mod tests {
             substate::{Substate, SubstateValue},
         };
 
-        let (_d, cache, id) = cache_with_head(6, true, Duration::ZERO).await;
+        let (_d, cache, id) = cache_with_head(6, true).await;
         let mut diff = SubstateDiff::new();
         diff.down(id.clone(), 6);
         diff.up(
@@ -562,7 +485,7 @@ mod tests {
             Substate::new(7, SubstateValue::NonFungible(NonFungibleContainer::no_data())),
         );
         cache.retire_committed(&diff).await.unwrap();
-        assert!(cache.read(&id, None).await.unwrap().is_none());
+        assert!(cache.read(&id).await.unwrap().is_none());
 
         let stale = SubstateResult::Down { version: 6 };
         let entry = SubstateCacheEntryRef {
@@ -572,16 +495,9 @@ mod tests {
             verified: true,
         };
         cache.write(&id, entry, FetchWatermark::new(100)).await.unwrap();
-        assert!(cache.read(&id, None).await.unwrap().is_none());
+        assert!(cache.read(&id).await.unwrap().is_none());
 
         cache.write(&id, entry, FetchWatermark::new(101)).await.unwrap();
-        assert_eq!(cache.read(&id, None).await.unwrap().unwrap().version, Some(6));
-    }
-
-    /// Above the head the cache knows nothing: this indexer is behind, or the substate never got there.
-    #[tokio::test]
-    async fn a_version_above_the_head_is_a_miss() {
-        let (_d, cache, id) = cache_with_head(6, true, Duration::ZERO).await;
-        assert!(cache.read(&id, Some(7)).await.unwrap().is_none());
+        assert_eq!(cache.read(&id).await.unwrap().unwrap().version, Some(6));
     }
 }

--- a/crates/indexer_lib/src/cached_substate_manager.rs
+++ b/crates/indexer_lib/src/cached_substate_manager.rs
@@ -192,7 +192,11 @@ where
         specific_version: Option<u32>,
     ) -> Result<SubstateLookupResult, IndexerError> {
         debug!(target: LOG_TARGET, "get_substate: {}v{}", substate_id, specific_version.display());
-        let cache_res = self.substate_cache.read(substate_id, specific_version).await?;
+        let cache_res = self
+            .substate_cache
+            .read(substate_id)
+            .await?
+            .and_then(|entry| entry.answer_at(specific_version));
         if let Some(entry) = cache_res {
             // Absence has nothing to prove against the state tree, so a cached nonexistence is never
             // verified and gating it on a proof would mean never serving one. Its evidence is the
@@ -277,7 +281,7 @@ where
     ) -> Result<HashMap<&'a SubstateId, Option<SubstateCacheEntry>>, IndexerError> {
         let mut results = HashMap::with_capacity(substate_ids.len());
         for substate_id in substate_ids {
-            let cache_res = self.substate_cache.read(substate_id, None).await?;
+            let cache_res = self.substate_cache.read(substate_id).await?;
             results.insert(substate_id, cache_res);
         }
         Ok(results)

--- a/crates/indexer_lib/src/substate_cache.rs
+++ b/crates/indexer_lib/src/substate_cache.rs
@@ -77,6 +77,31 @@ pub struct SubstateCacheEntry {
     pub verified: bool,
 }
 
+impl SubstateCacheEntry {
+    /// What this head says about a lookup at `version`, or `None` when it says nothing.
+    ///
+    /// The indexer serves the network's current state, not its history, so a version is only ever
+    /// asked about to learn whether it is still current. The head answers that on its own: the
+    /// version named is the head, or it is below it and therefore down - versions are contiguous
+    /// and upping a substate downs its predecessor - or it is above it, which the cache knows
+    /// nothing about. Nonexistence names no version and answers nothing about one: a destroyed
+    /// substate whose history has been pruned reports the same thing as one never created.
+    pub fn answer_at(self, version: Option<u32>) -> Option<Self> {
+        let Some(version) = version else {
+            return Some(self);
+        };
+        let head = self.version?;
+        if version == head {
+            return Some(self);
+        }
+        (version < head).then(|| Self {
+            version: Some(version),
+            substate_result: SubstateResult::Down { version },
+            ..self
+        })
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct SubstateCacheEntryRef<'a> {
     /// The substate's head version, or `None` when the substate does not exist.
@@ -95,18 +120,11 @@ pub trait SubstateCache: Send + Sync {
         id: &SubstateId,
     ) -> impl Future<Output = Result<Option<FetchWatermark>, SubstateCacheError>> + Send;
 
-    /// The cached answer for `id` at `version`, or for its latest version when `version` is `None`.
-    /// Returns `None` when nothing is cached or the shard has no watermark.
-    ///
-    /// A version below the cached one is answered without any watermark: see
-    /// [`SubstateCache::write`] for what the cache holds and why that conclusion cannot go stale.
-    ///
-    /// A cached nonexistence answers an unversioned read only. It says the substate has no live
-    /// version, never what was true at some version below, so a versioned read misses.
+    /// The cached head of `id`, or `None` when nothing is cached or the shard has no watermark. What
+    /// the head says about a particular version is [`SubstateCacheEntry::answer_at`]'s to decide.
     fn read(
         &self,
         id: &SubstateId,
-        version: Option<u32>,
     ) -> impl Future<Output = Result<Option<SubstateCacheEntry>, SubstateCacheError>> + Send;
 
     /// Records `entry` as the substate's head version, provided no transition for `id` has arrived
@@ -128,4 +146,48 @@ pub trait SubstateCache: Send + Sync {
         entry: SubstateCacheEntryRef<'_>,
         watermark: FetchWatermark,
     ) -> impl Future<Output = Result<(), SubstateCacheError>> + Send;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn head(version: Option<u32>) -> SubstateCacheEntry {
+        SubstateCacheEntry {
+            version,
+            substate_result: version.map_or(SubstateResult::DoesNotExist, |version| SubstateResult::Down { version }),
+            cached_at: 1_000,
+            verified: true,
+        }
+    }
+
+    #[test]
+    fn the_head_answers_an_unversioned_read_and_itself() {
+        assert_eq!(head(Some(6)).answer_at(None).unwrap().version, Some(6));
+        assert_eq!(head(Some(6)).answer_at(Some(6)).unwrap().version, Some(6));
+    }
+
+    /// The head only has to have been real at some point: the real head is at or above it, so every
+    /// version below is down for good. The answer carries the head's age so that it ages out with it.
+    #[test]
+    fn a_version_below_the_head_is_down() {
+        let answer = head(Some(6)).answer_at(Some(3)).unwrap();
+        assert!(matches!(answer.substate_result, SubstateResult::Down { version: 3 }));
+        assert_eq!(answer.version, Some(3));
+        assert_eq!(answer.cached_at, 1_000);
+        assert!(answer.verified);
+    }
+
+    /// Above the head the cache knows nothing: this indexer is behind, or the substate never got there.
+    #[test]
+    fn a_version_above_the_head_is_a_miss() {
+        assert!(head(Some(6)).answer_at(Some(7)).is_none());
+    }
+
+    #[test]
+    fn nonexistence_answers_an_unversioned_read_only() {
+        assert!(head(None).answer_at(None).is_some());
+        assert!(head(None).answer_at(Some(0)).is_none());
+        assert!(head(None).answer_at(Some(3)).is_none());
+    }
 }


### PR DESCRIPTION
Stacked on #2527 (both edit `SqliteSubstateCache::read`); rebase onto `development` once that merges.

## Summary

The indexer is a gateway to the network's current state, not to its history, so a lookup that names a version is only ever asking whether that version is still current. This drops the cache's version-aware read path in favour of a head-only cache:

- `SubstateCache::read(id)` returns the head; there is no `version` parameter.
- What the head says about a named version is decided once, in `SubstateCacheEntry::answer_at`: it is the head → hit; below it → `Down` (versions are contiguous and upping a substate downs its predecessor); above it → miss; nonexistence answers an unversioned lookup only. `CachedSubstateManager::get_substate` applies it to the entry it already has.
- The read-side `head_ttl` check goes, along with the synthesised `Down` entries stamped `cached_at: now`. A `Down` derived from the head carries the head's own age, so the manager's `cache_ttl` bounds it like every other entry.
- `head_ttl` stays on the write path (`substate_cache_put`), where it lets a proven or fresher result displace an unverified head recorded too high.

This settles phase 3 item 8 (whether to gate the down-inference age-out on `verified`) by removing the read-side TTL it was about.

## Behaviour change

A version below the head previously answered without a watermark; it now needs the shard's watermark like every other cached answer. Conservative, and one fewer special case.

## Tests

`answer_at` is covered in `tari_indexer_lib::substate_cache::tests`; the `SqliteSubstateCache` tests are reduced to the watermark gates.
