### PR TITLE
fix(indexer): refuse a cache write below the version the stream has already shown

### DIFF
--- a/applications/tari_indexer/src/bootstrap.rs
+++ b/applications/tari_indexer/src/bootstrap.rs
@@ -108,9 +108,13 @@ use crate::{
 
 const LOG_TARGET: &str = "tari::indexer::bootstrap";
 
-/// How long a substate stays journalled as recently changed. The journal exists only to stop a
-/// committee fetch that started before a transition arrived from writing its result back as current,
-/// so it needs to outlive an in-flight fetch and nothing more.
+/// How long a substate stays journalled as recently changed.
+///
+/// The journal stops a fetch from writing back a version the stream has moved past, which covers two
+/// things with different horizons. A fetch the transition overtook is bounded by how long a fetch
+/// takes. A fetch answered by a committee member that is behind is bounded by how far behind that
+/// member is, which is the longer of the two and the one this must outlive: a member lagging by less
+/// than this serves stale copies only of substates whose journal rows are still here to refuse them.
 const SUBSTATE_CACHE_JOURNAL_RETENTION: Duration = Duration::from_secs(300);
 
 const SUBSTATE_CACHE_PRUNE_INTERVAL: Duration = Duration::from_secs(60);

--- a/applications/tari_indexer/src/storage_sqlite/migrations/2026-09-04-000000_substate_cache_invalidation_version/down.sql
+++ b/applications/tari_indexer/src/storage_sqlite/migrations/2026-09-04-000000_substate_cache_invalidation_version/down.sql
@@ -1,0 +1,10 @@
+drop table substate_cache_invalidations;
+
+create table substate_cache_invalidations
+(
+    substate_id    text   not null primary key,
+    state_version  bigint not null,
+    invalidated_at bigint not null
+);
+
+create index idx_substate_cache_invalidations_expiry on substate_cache_invalidations (invalidated_at);

--- a/applications/tari_indexer/src/storage_sqlite/migrations/2026-09-04-000000_substate_cache_invalidation_version/up.sql
+++ b/applications/tari_indexer/src/storage_sqlite/migrations/2026-09-04-000000_substate_cache_invalidation_version/up.sql
@@ -1,0 +1,22 @@
+-- Record the substate version a transition showed, alongside the shard version it committed at.
+--
+-- The shard version answers "did this fetch start before the transition", which catches a fetch the
+-- transition overtook. It says nothing about a fetch that starts afterwards and lands on a committee
+-- member that is behind: that member answers with a version this indexer has already watched the
+-- substate pass, and with no cached row left to rank against - the transition deleted it - the
+-- answer is installed as the head. Holding the version the stream showed gives that write something
+-- to be refused by.
+--
+-- The journal is derived from the stream and spans a fetch, so it is recreated rather than migrated.
+drop table substate_cache_invalidations;
+
+create table substate_cache_invalidations
+(
+    substate_id      text    not null primary key,
+    state_version    bigint  not null,
+    -- The substate version the transition showed: the version created, or the version destroyed.
+    substate_version integer not null,
+    invalidated_at   bigint  not null
+);
+
+create index idx_substate_cache_invalidations_expiry on substate_cache_invalidations (invalidated_at);

--- a/applications/tari_indexer/src/storage_sqlite/models/substate_cache.rs
+++ b/applications/tari_indexer/src/storage_sqlite/models/substate_cache.rs
@@ -25,6 +25,7 @@ pub struct SubstateCacheInvalidation {
     substate_id: SubstateId,
     retires_up_to: Option<u32>,
     retires_nonexistence: bool,
+    observed_version: u32,
 }
 
 impl SubstateCacheInvalidation {
@@ -45,6 +46,7 @@ impl SubstateCacheInvalidation {
             substate_id,
             retires_up_to,
             retires_nonexistence,
+            observed_version: version,
         })
     }
 
@@ -57,11 +59,18 @@ impl SubstateCacheInvalidation {
             substate_id,
             retires_up_to: Some(version),
             retires_nonexistence: false,
+            observed_version: version,
         }
     }
 
     pub fn substate_id(&self) -> &SubstateId {
         &self.substate_id
+    }
+
+    /// The version the stream showed the substate at: created at it, or destroyed at it. A head
+    /// below this is one the substate has already been watched past, whoever offers it.
+    pub fn observed_version(&self) -> u32 {
+        self.observed_version
     }
 
     /// The highest cached head version this retires, if any.

--- a/applications/tari_indexer/src/storage_sqlite/schema.rs
+++ b/applications/tari_indexer/src/storage_sqlite/schema.rs
@@ -154,6 +154,7 @@ diesel::table! {
     substate_cache_invalidations (substate_id) {
         substate_id -> Text,
         state_version -> BigInt,
+        substate_version -> Integer,
         invalidated_at -> BigInt,
     }
 }

--- a/applications/tari_indexer/src/storage_sqlite/store_factory.rs
+++ b/applications/tari_indexer/src/storage_sqlite/store_factory.rs
@@ -1169,6 +1169,64 @@ mod tests {
             .unwrap();
     }
 
+    /// The hole the substate version closes: the fetch is not overtaken by the transition - it
+    /// started afterwards - but the member it asked is behind and answers with a version the stream
+    /// has already shown this substate past. The transition deleted the row that would have ranked
+    /// it, so the journal is the only thing left to refuse it.
+    #[tokio::test]
+    async fn a_version_the_stream_has_already_seen_past_is_refused() {
+        let (_d, store) = temp_store().await;
+        let id = substate(1);
+        assert!(put(&store, &id, 6, 100).await);
+
+        invalidate(&store, SubstateCacheInvalidation::created(id.clone(), 7).unwrap(), 105).await;
+        assert!(read(&store, &id).await.is_none());
+
+        // A fetch that began after the creation committed, answered by a member still on v6.
+        assert!(!put(&store, &id, 6, 110).await);
+        assert!(read(&store, &id).await.is_none());
+    }
+
+    /// The version the stream showed is a floor, not a target: the substate can move on, and a fetch
+    /// that catches up with it must still be recorded.
+    #[tokio::test]
+    async fn a_version_at_or_above_the_one_the_stream_saw_is_recorded() {
+        let (_d, store) = temp_store().await;
+        let id = substate(1);
+
+        invalidate(&store, SubstateCacheInvalidation::created(id.clone(), 7).unwrap(), 105).await;
+        assert!(put(&store, &id, 7, 110).await);
+        assert_eq!(read(&store, &id).await, Some(7));
+        assert!(put(&store, &id, 9, 110).await);
+        assert_eq!(read(&store, &id).await, Some(9));
+    }
+
+    /// A destroy shows the version it names as reached just as a creation does, so a member still
+    /// answering below it is refused the same way.
+    #[tokio::test]
+    async fn a_destroy_records_the_version_it_saw() {
+        let (_d, store) = temp_store().await;
+        let id = substate(1);
+
+        invalidate(&store, SubstateCacheInvalidation::destroyed(id.clone(), 7), 105).await;
+        assert!(!put(&store, &id, 6, 110).await);
+        // The destroyed version is itself a legitimate head: it is down, which is what a lookup for
+        // it answers.
+        assert!(put(&store, &id, 7, 110).await);
+    }
+
+    /// Nonexistence is settled by f + 1 members rather than one, so a single member being behind
+    /// cannot produce it, and the one that follows a destroy is legitimate.
+    #[tokio::test]
+    async fn a_nonexistence_after_a_destroy_is_still_recorded() {
+        let (_d, store) = temp_store().await;
+        let id = substate(1);
+
+        invalidate(&store, SubstateCacheInvalidation::destroyed(id.clone(), 7), 105).await;
+        assert!(put_nonexistent(&store, &id, 110).await);
+        assert!(is_nonexistent(&read_entry(&store, &id).await.unwrap()));
+    }
+
     /// The point of journalling a first creation: it is the only transition that can retract the
     /// claim that a substate does not exist.
     #[tokio::test]

--- a/applications/tari_indexer/src/storage_sqlite/store_factory.rs
+++ b/applications/tari_indexer/src/storage_sqlite/store_factory.rs
@@ -1215,6 +1215,26 @@ mod tests {
         assert!(put(&store, &id, 7, 110).await);
     }
 
+    /// One transaction downs a version and ups the next, and the two reach the journal in no stated
+    /// order. The floor is the highest version either showed, whichever was journalled last.
+    #[tokio::test]
+    async fn the_floor_is_the_highest_version_a_batch_showed() {
+        let (_d, store) = temp_store().await;
+        let id = substate(1);
+
+        let batch = [
+            SubstateCacheInvalidation::created(&id, 7).unwrap(),
+            SubstateCacheInvalidation::destroyed(id.clone(), 6),
+        ];
+        store
+            .with_write_tx(move |tx| tx.substate_cache_invalidate(batch, StateVersion::new(105)))
+            .await
+            .unwrap();
+
+        assert!(!put(&store, &id, 6, 110).await);
+        assert!(put(&store, &id, 7, 110).await);
+    }
+
     /// Nonexistence is settled by f + 1 members rather than one, so a single member being behind
     /// cannot produce it, and the one that follows a destroy is legitimate.
     #[tokio::test]

--- a/applications/tari_indexer/src/storage_sqlite/writer.rs
+++ b/applications/tari_indexer/src/storage_sqlite/writer.rs
@@ -558,20 +558,42 @@ impl IndexerStoreWriteTransaction for SqliteStoreWriteTransaction<'_> {
 
         // Read inside this transaction so that the journal and the insert cannot straddle a
         // concurrent invalidation commit.
-        let invalidated_at_version: Option<i64> = substate_cache_invalidations::table
-            .select(substate_cache_invalidations::state_version)
+        let journalled: Option<(i64, i32)> = substate_cache_invalidations::table
+            .select((
+                substate_cache_invalidations::state_version,
+                substate_cache_invalidations::substate_version,
+            ))
             .filter(substate_cache_invalidations::substate_id.eq(&id))
             .first(self.connection())
             .optional()
             .map_err(|e| StorageError::general(OPERATION, e))?;
 
-        if invalidated_at_version.is_some_and(|v| v as u64 > watermark.as_u64()) {
-            debug!(
-                target: LOG_TARGET,
-                "Discarding cache write for {substate_id} v{}: its shard advanced past the fetch",
-                entry.version.display()
-            );
-            return Ok(false);
+        if let Some((invalidated_at_version, observed_version)) = journalled {
+            if invalidated_at_version as u64 > watermark.as_u64() {
+                debug!(
+                    target: LOG_TARGET,
+                    "Discarding cache write for {substate_id} v{}: its shard advanced past the fetch",
+                    entry.version.display()
+                );
+                return Ok(false);
+            }
+
+            // A fetch that started after the transition is not overtaken by it, but the member it
+            // asked can be behind: it answers with a version the stream has already shown this
+            // substate past. The transition left no cached row to rank that against, so the journal
+            // is what refuses it.
+            //
+            // A record that the substate does not exist is left to the ranking below. It is settled
+            // by f + 1 members rather than one, so a single member being behind cannot produce it,
+            // and refusing it here would suppress the legitimate one that follows a destroy.
+            if version.is_some_and(|v| v < observed_version) {
+                debug!(
+                    target: LOG_TARGET,
+                    "Discarding cache write for {substate_id} v{}: the stream has already seen v{observed_version}",
+                    entry.version.display()
+                );
+                return Ok(false);
+            }
         }
 
         // A committee member that is behind can answer with a version below the head already held.
@@ -664,12 +686,14 @@ impl IndexerStoreWriteTransaction for SqliteStoreWriteTransaction<'_> {
                 .values((
                     substate_cache_invalidations::substate_id.eq(&id),
                     substate_cache_invalidations::state_version.eq(state_version.as_u64() as i64),
+                    substate_cache_invalidations::substate_version.eq(invalidation.observed_version() as i32),
                     substate_cache_invalidations::invalidated_at.eq(now),
                 ))
                 .on_conflict(substate_cache_invalidations::substate_id)
                 .do_update()
                 .set((
                     substate_cache_invalidations::state_version.eq(state_version.as_u64() as i64),
+                    substate_cache_invalidations::substate_version.eq(invalidation.observed_version() as i32),
                     substate_cache_invalidations::invalidated_at.eq(now),
                 ))
                 .execute(self.connection())

--- a/applications/tari_indexer/src/storage_sqlite/writer.rs
+++ b/applications/tari_indexer/src/storage_sqlite/writer.rs
@@ -833,7 +833,12 @@ impl SqliteStoreWriteTransaction<'_> {
             .do_update()
             .set((
                 substate_cache_invalidations::state_version.eq(state_version.as_u64() as i64),
-                substate_cache_invalidations::substate_version.eq(invalidation.observed_version() as i32),
+                // A floor only ever rises. The transitions of one batch arrive in no stated order,
+                // and a destroy of the version below a creation must not lower what the creation
+                // showed.
+                substate_cache_invalidations::substate_version.eq(diesel::dsl::sql::<diesel::sql_types::Integer>(
+                    "max(substate_version, excluded.substate_version)",
+                )),
                 substate_cache_invalidations::invalidated_at.eq(now),
             ))
             .execute(self.connection())

--- a/applications/tari_indexer/src/substate_cache/mod.rs
+++ b/applications/tari_indexer/src/substate_cache/mod.rs
@@ -424,6 +424,23 @@ mod tests {
         assert!(head_cache.read(&head_id).await.unwrap().is_some());
     }
 
+    async fn write_head(cache: &SqliteSubstateCache, id: &SubstateId, version: u32, watermark: u64) {
+        let result = SubstateResult::Down { version };
+        cache
+            .write(
+                id,
+                SubstateCacheEntryRef {
+                    version: Some(version),
+                    substate_result: &result,
+                    cached_at: now_unix_secs().unwrap(),
+                    verified: true,
+                },
+                FetchWatermark::new(watermark),
+            )
+            .await
+            .unwrap();
+    }
+
     async fn write_nonexistence(cache: &SqliteSubstateCache, id: &SubstateId, watermark: u64) {
         cache
             .write(
@@ -469,7 +486,9 @@ mod tests {
     }
 
     /// The other half of the same race: a head the transaction replaced. The old head is retired,
-    /// and a fetch captured before the commit cannot put it back.
+    /// and nothing puts it back: a fetch captured before the commit is overtaken, and one captured
+    /// after it is below the version the result showed. Only the version the transaction created
+    /// is recorded.
     #[tokio::test]
     async fn a_finalized_result_retires_the_head_it_replaced_ahead_of_the_stream() {
         use tari_engine_types::{
@@ -487,17 +506,12 @@ mod tests {
         cache.retire_committed(&diff).await.unwrap();
         assert!(cache.read(&id).await.unwrap().is_none());
 
-        let stale = SubstateResult::Down { version: 6 };
-        let entry = SubstateCacheEntryRef {
-            version: Some(6),
-            substate_result: &stale,
-            cached_at: now_unix_secs().unwrap(),
-            verified: true,
-        };
-        cache.write(&id, entry, FetchWatermark::new(100)).await.unwrap();
+        write_head(&cache, &id, 6, 100).await;
+        assert!(cache.read(&id).await.unwrap().is_none());
+        write_head(&cache, &id, 6, 101).await;
         assert!(cache.read(&id).await.unwrap().is_none());
 
-        cache.write(&id, entry, FetchWatermark::new(101)).await.unwrap();
-        assert_eq!(cache.read(&id).await.unwrap().unwrap().version, Some(6));
+        write_head(&cache, &id, 7, 101).await;
+        assert_eq!(cache.read(&id).await.unwrap().unwrap().version, Some(7));
     }
 }


### PR DESCRIPTION
## Description

`substate_cache_invalidations` recorded the *shard* state version a transition committed at. That answers one question: did this fetch start before the transition, and get overtaken by it? `substate_cache_put` discards a write whose captured watermark is below the journalled shard version, which closes that race.

It says nothing about a fetch that starts **after** the transition and lands on a committee member that is behind. Such a member answers with a version this indexer has already watched the substate pass — legitimately, from its own point of view — and the transition has already deleted the cached row that would have ranked the answer down (`substate_cache_invalidate` deletes on `version <= retires_up_to`). With no row to rank against and the shard-version guard satisfied, the stale answer is installed as the head and served until it ages out of `DEFAULT_CACHE_TTL` (900s), for as long as the shard stays level.

The trusted-root ring accepts this by design — `substate_cache_put` already says "a committee member that is behind can prove an older version against an older signed root" — and `get_specific_substate_from_committee` keeps `unproven_result` precisely because "a member that is still syncing may respond with a stale copy". Both anticipate the peer; nothing refused its answer.

## Changes

* The journal carries `substate_version`: the version the transition showed, which is the version created or the version destroyed. A write below it is refused.
* It is a floor, not a target. A fetch that catches up with the substate, or overtakes it, is recorded exactly as before — including the destroyed version itself.
* The floor only rises: the journal upsert keeps `max(substate_version, excluded.substate_version)`, so the transitions of one batch (a destroy of v6 and a creation of v7, in either order, from the stream or from `retire_committed`) leave the floor at 7.
* A record that the substate does not exist is left to the existing version ranking. `DoesNotExist` is settled by f + 1 members rather than one, so a single member being behind cannot produce it, and refusing it here would suppress the legitimate one that follows a destroy.
* `SUBSTATE_CACHE_JOURNAL_RETENTION`'s comment now states the quantity it has to outlive: the committee lag, not the length of an in-flight fetch. Both are covered by the same 300s today; tuning it down to a fetch would silently reopen this.

The journal is derived from the stream and spans a fetch, so the migration recreates the table rather than migrating rows into it.

## What this does not close

The guard holds only while the journal row is retained. A member lagging by more than 300s can still answer with a version whose journal row has been pruned, and nothing then remembers the substate reached it.

A destroy with no successor leaves a second, narrower gap: the floor admits the destroyed version itself, so a member that is behind can answer `Up` at that version with the live value and have it installed as the head for the read path's TTL, where a level member answers `Down`. Refusing that needs the journal to record that the row came from a destroy, which is not done here; a destroy without a following creation is the rarer case.

The retention window is the residual hole, and it is bounded: one occurrence serves a stale head for at most the read path's TTL before refetching. Closing it permanently means the head row carrying the version the stream last showed — writing the new head on an up transition rather than deleting the row — which trades a row per substate the indexer has ever seen for the guarantee. Deliberately not done here: the delete is what keeps the cache's storage proportional to what is being read rather than to what has ever existed.

Retention covers the realistic case rather than an arbitrary slice of it. A member answers staley because it is behind, so it answers staley about *recent* changes: a member lagging five minutes serves stale copies of substates changed in the last five minutes and correct copies of everything older.

## Motivation and Context

Raised in review of the phase 2 work, against the substate cache added in #2498 and extended in #2505.

## How Has This Been Tested?

Five tests in `store_factory.rs`: a version the stream has already seen past is refused, a version at or above it is recorded, a destroy records the version it saw (and still admits that version as a head), the floor is the highest version a batch showed regardless of order, and a nonexistence after a destroy is still recorded. The first, third and fourth fail without the guard.

`cargo test -p tari_indexer --lib storage_sqlite` — 48 pass. Clippy clean.

## Breaking Changes

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify

The migration recreates `substate_cache_invalidations`. The journal is rebuilt from the stream within one retention window, and the substate cache itself is rebuilt from the committee on demand, so no data is lost.

