### PR TITLE
fix(networking): close connections that stop answering pings

### DIFF
--- a/networking/core/src/config.rs
+++ b/networking/core/src/config.rs
@@ -18,6 +18,15 @@ pub struct Config {
     pub rendezvous_namespace: String,
     pub rendezvous_peer_limit: Option<u64>,
     pub high_ping_warning_threshold: Option<Duration>,
+    /// Close a connection once this many consecutive pings have failed on it.
+    ///
+    /// A connection whose pings stop completing can no longer carry traffic, but the transport may take a very long
+    /// time to notice: a TCP socket whose local address has been removed (VPN interface torn down, roaming) stays
+    /// established until the kernel exhausts `tcp_retries2`, on the order of 15 minutes. Ping failures are the first
+    /// signal available, so acting on them returns the peer to the dialable pool long before the transport gives up.
+    ///
+    /// `None` disables the check, in which case the connection is only ever dropped by the transport.
+    pub max_consecutive_ping_failures: Option<u32>,
 }
 
 impl Default for Config {
@@ -35,6 +44,7 @@ impl Default for Config {
             rendezvous_namespace: "tari".to_string(),
             rendezvous_peer_limit: Some(1000),
             high_ping_warning_threshold: Some(Duration::from_secs(2)),
+            max_consecutive_ping_failures: Some(3),
         }
     }
 }

--- a/networking/core/src/connection.rs
+++ b/networking/core/src/connection.rs
@@ -18,6 +18,8 @@ pub struct Connection {
     pub num_concurrent_dial_errors: usize,
     pub established_in: Duration,
     pub ping_latency: Option<Duration>,
+    /// Consecutive ping failures on this connection. Reset to zero by any successful ping.
+    pub num_ping_failures: u32,
     pub user_agent: Option<Arc<String>>,
 }
 

--- a/networking/core/src/worker.rs
+++ b/networking/core/src/worker.rs
@@ -507,7 +507,7 @@ where
                 info!(target: LOG_TARGET, "🔌 Connection closed: peer_id={}, endpoint={:?}, cause={:?}", peer_id, endpoint, cause);
                 match self.active_connections.entry(peer_id) {
                     Entry::Occupied(mut entry) => {
-                        entry.get_mut().retain(|c| c.endpoint != endpoint);
+                        entry.get_mut().retain(|c| c.connection_id != connection_id);
                         if entry.get().is_empty() {
                             entry.remove_entry();
                         }
@@ -583,6 +583,7 @@ where
                         .and_then(|c| c.iter_mut().find(|c| c.connection_id == connection))
                     {
                         c.ping_latency = Some(*t);
+                        c.num_ping_failures = 0;
                     }
                     if self.config.high_ping_warning_threshold.is_some_and(|th| th < *t) {
                         warn!(target: LOG_TARGET, "🏓 Slow ping: peer={}, connection={}, t={:.2?}", peer, connection, t);
@@ -590,8 +591,34 @@ where
                         trace!(target: LOG_TARGET, "🏓 Ping: peer={}, connection={}, t={:.2?}", peer, connection, t);
                     }
                 },
+                // A peer that does not speak the ping protocol is not unreachable, so it must not count towards the
+                // failure budget.
+                Err(ping::Failure::Unsupported) => {
+                    debug!(target: LOG_TARGET, "🏓 Peer {} does not support the ping protocol on connection {}", peer, connection);
+                },
                 Err(err) => {
-                    warn!(target: LOG_TARGET, "🏓 Ping failed: peer={}, connection={}, error={}", peer, connection, err);
+                    let mut num_failures = 0;
+                    if let Some(c) = self
+                        .active_connections
+                        .get_mut(&peer)
+                        .and_then(|c| c.iter_mut().find(|c| c.connection_id == connection))
+                    {
+                        c.ping_latency = None;
+                        c.num_ping_failures = c.num_ping_failures.saturating_add(1);
+                        num_failures = c.num_ping_failures;
+                    }
+                    warn!(target: LOG_TARGET, "🏓 Ping failed: peer={}, connection={}, failures={}, error={}", peer, connection, num_failures, err);
+
+                    if self
+                        .config
+                        .max_consecutive_ping_failures
+                        .is_some_and(|max| num_failures >= max)
+                    {
+                        // The peer stays in the peer store, so the messaging behaviour re-dials it the next time it
+                        // has something to send, trying every address held for the peer.
+                        warn!(target: LOG_TARGET, "🔌 Closing unresponsive connection={} to peer={} after {} consecutive ping failures", connection, peer, num_failures);
+                        self.swarm.close_connection(connection);
+                    }
                 },
             },
             Dcutr(dcutr::Event { remote_peer_id, result }) => match &result {
@@ -921,6 +948,7 @@ where
             num_concurrent_dial_errors,
             established_in,
             ping_latency: None,
+            num_ping_failures: 0,
             user_agent: None,
         });
 


### PR DESCRIPTION
## Problem

`libp2p-ping` reports failures and leaves the connection open — the protocol docs are explicit that the policy decision belongs to the user, and point at `Swarm::close_connection`. We were not making that decision: ping failures were logged and nothing else. A connection that could no longer carry traffic was held until the transport gave up on it, and for TCP that means the kernel exhausting `tcp_retries2` — roughly 15 minutes, during which every message routed over it is silently lost.

This is not hypothetical. It was hit on a local swarm when a VPN interface was torn down mid-run. Validators had peer connections bound to the VPN address; removing that address left the sockets `ESTAB` with data piling up in the send queue and no error surfaced. One validator lost its path to three of its six peers, missed every proposal those peers led, and spent the next fifteen minutes saw-toothing behind the chain on catch-up sync alone.

Two details made it worse than it looks:

- The node had **healthy connections to the same peers alongside the wedged ones** (QUIC over LAN and loopback). Traffic did not use them, because `obtain_message_channel` returns the existing active sink and that sink was bound to the dead connection. The node had a working path and stayed pinned to the broken one.
- Recovery, when it finally came, was purely the kernel timing out. Measured on the reproduction: the address was removed at 17:27:04 and the connections closed at 17:43 with `Os { code: 110, kind: TimedOut }`. Consensus resumed within the same minute, which confirms nothing but the stuck connection was in the way.

## Change

Count consecutive ping failures per connection and close the connection once the count reaches `max_consecutive_ping_failures` (new networking config field, default 3; `None` disables the check). A successful ping resets the count.

Closing returns the peer to the dialable pool. The messaging behaviour dials on the next outbound message and that dial tries every address the peer store holds, so it lands on one that still works — or, as in the case above, falls through to a connection that was already healthy. Closing the single failing connection rather than the peer is deliberate for that reason.

`Failure::Unsupported` is excluded from the count. A peer that does not speak ping reports it exactly once and is never pinged again, so counting it could only ever disconnect a healthy peer.

Also switches removal from `active_connections` to key on connection id rather than endpoint, so the new per-connection counter belongs to exactly one entry.

## Timing

At the default ping cadence (15s interval, 20s timeout) three consecutive failures is roughly 45–105 seconds. In the observed failure the errors were substream negotiation timeouts arriving every 10 seconds, so it would have fired in about 30 seconds instead of 16 minutes.

The threshold is deliberately not lower: a message already queued on a sink when the connection closes is dropped rather than re-queued, and consensus does not retry sends.

## Testing

Clippy clean on `tari_networking`, formatted. Not verified at runtime — that needs a release rebuild of the swarm binaries. The behaviour it replaces was reproduced and measured end to end on a local swarm as described above.