### PR TITLE
fix(indexer): retire cached substates a finalized result supersedes

### DIFF
--- a/applications/tari_indexer/src/bootstrap.rs
+++ b/applications/tari_indexer/src/bootstrap.rs
@@ -314,7 +314,7 @@ pub async fn spawn_services(
         store.clone(),
         epoch_manager.clone(),
         validator_node_client_factory.clone(),
-        substate_cache,
+        substate_cache.clone(),
     )
     .with_substate_proof_verification(config.indexer.verify_substate_proofs)
     .with_negative_cache_ttl(config.indexer.substate_cache_negative_ttl);
@@ -430,6 +430,7 @@ pub async fn spawn_services(
         config.network,
         consensus_constants.max_transaction_weight,
         consensus_constants.max_transaction_validity_epochs,
+        substate_cache,
     );
 
     // Save final node identity after comms has initialized. This is required because the public_address can be

--- a/applications/tari_indexer/src/network_state_sync/worker.rs
+++ b/applications/tari_indexer/src/network_state_sync/worker.rs
@@ -1194,7 +1194,7 @@ fn extend_bufs_from_substate_update(
 ) -> Result<(), NetworkStateSyncError> {
     invalidations_buf.extend(match &update {
         SubstateUpdateProof::Create(create) => {
-            SubstateCacheInvalidation::created(create.substate.substate_id().clone(), create.substate.version)
+            SubstateCacheInvalidation::created(create.substate.substate_id(), create.substate.version)
         },
         SubstateUpdateProof::Destroy(destroy) => Some(SubstateCacheInvalidation::destroyed(
             destroy.substate_id.clone(),

--- a/applications/tari_indexer/src/storage_sqlite/models/substate_cache.rs
+++ b/applications/tari_indexer/src/storage_sqlite/models/substate_cache.rs
@@ -35,14 +35,14 @@ impl SubstateCacheInvalidation {
     /// retraction of a cached nonexistence. Where nothing caches that, it carries nothing, and is
     /// not one of these at all: emitting it would put a journal row on the sync path for every
     /// created-once substate in the stream and buy nothing with it.
-    pub fn created(substate_id: SubstateId, version: u32) -> Option<Self> {
+    pub fn created(substate_id: &SubstateId, version: u32) -> Option<Self> {
         let retires_up_to = version.checked_sub(1);
-        let retires_nonexistence = caches_nonexistence(&substate_id);
+        let retires_nonexistence = caches_nonexistence(substate_id);
         if retires_up_to.is_none() && !retires_nonexistence {
             return None;
         }
         Some(Self {
-            substate_id,
+            substate_id: substate_id.clone(),
             retires_up_to,
             retires_nonexistence,
         })
@@ -91,7 +91,7 @@ mod tests {
 
     #[test]
     fn a_first_creation_retires_nothing_but_the_nonexistence() {
-        let invalidation = SubstateCacheInvalidation::created(substate(), 0).unwrap();
+        let invalidation = SubstateCacheInvalidation::created(&substate(), 0).unwrap();
         assert_eq!(invalidation.retires_up_to(), None);
         assert!(invalidation.retires_nonexistence());
     }
@@ -101,17 +101,17 @@ mod tests {
     #[test]
     fn a_first_creation_is_dropped_where_nonexistence_is_not_cached() {
         assert!(!caches_nonexistence(&receipt()));
-        assert!(SubstateCacheInvalidation::created(receipt(), 0).is_none());
+        assert!(SubstateCacheInvalidation::created(&receipt(), 0).is_none());
         // Above the first version it carries a retirement that stands on its own, and does not
         // attempt one that could never match.
-        let above = SubstateCacheInvalidation::created(receipt(), 1).unwrap();
+        let above = SubstateCacheInvalidation::created(&receipt(), 1).unwrap();
         assert_eq!(above.retires_up_to(), Some(0));
         assert!(!above.retires_nonexistence());
     }
 
     #[test]
     fn a_creation_retires_every_version_below_it() {
-        let invalidation = SubstateCacheInvalidation::created(substate(), 6).unwrap();
+        let invalidation = SubstateCacheInvalidation::created(&substate(), 6).unwrap();
         assert_eq!(invalidation.retires_up_to(), Some(5));
         assert!(invalidation.retires_nonexistence());
     }

--- a/applications/tari_indexer/src/storage_sqlite/store_factory.rs
+++ b/applications/tari_indexer/src/storage_sqlite/store_factory.rs
@@ -1178,7 +1178,7 @@ mod tests {
         assert!(put_nonexistent(&store, &id, 100).await);
         assert!(is_nonexistent(&read_entry(&store, &id).await.unwrap()));
 
-        invalidate(&store, SubstateCacheInvalidation::created(id.clone(), 0).unwrap(), 105).await;
+        invalidate(&store, SubstateCacheInvalidation::created(&id, 0).unwrap(), 105).await;
         assert!(read_entry(&store, &id).await.is_none());
     }
 
@@ -1189,7 +1189,7 @@ mod tests {
         let id = substate(1);
         assert!(put_nonexistent(&store, &id, 100).await);
 
-        invalidate(&store, SubstateCacheInvalidation::created(id.clone(), 6).unwrap(), 105).await;
+        invalidate(&store, SubstateCacheInvalidation::created(&id, 6).unwrap(), 105).await;
         assert!(read_entry(&store, &id).await.is_none());
     }
 
@@ -1213,7 +1213,7 @@ mod tests {
         let id = substate(1);
 
         // The fetch captured the watermark at 100; the creation commits at 105 while it is in flight.
-        invalidate(&store, SubstateCacheInvalidation::created(id.clone(), 0).unwrap(), 105).await;
+        invalidate(&store, SubstateCacheInvalidation::created(&id, 0).unwrap(), 105).await;
         assert!(!put_nonexistent(&store, &id, 100).await);
         assert!(read_entry(&store, &id).await.is_none());
     }
@@ -1249,7 +1249,7 @@ mod tests {
         assert!(put(&store, &id, 5, 100).await);
         assert_eq!(read(&store, &id).await, Some(5));
 
-        invalidate(&store, SubstateCacheInvalidation::created(id.clone(), 6).unwrap(), 105).await;
+        invalidate(&store, SubstateCacheInvalidation::created(&id, 6).unwrap(), 105).await;
         assert_eq!(read(&store, &id).await, None);
     }
 
@@ -1272,7 +1272,7 @@ mod tests {
         let id = substate(1);
         assert!(put(&store, &id, 9, 100).await);
 
-        invalidate(&store, SubstateCacheInvalidation::created(id.clone(), 7).unwrap(), 105).await;
+        invalidate(&store, SubstateCacheInvalidation::created(&id, 7).unwrap(), 105).await;
         invalidate(&store, SubstateCacheInvalidation::destroyed(id.clone(), 8), 106).await;
         assert_eq!(read(&store, &id).await, Some(9));
     }
@@ -1329,7 +1329,7 @@ mod tests {
     async fn a_write_is_vetoed_by_a_transition_that_landed_during_the_fetch() {
         let (_d, store) = temp_store().await;
         let id = substate(1);
-        invalidate(&store, SubstateCacheInvalidation::created(id.clone(), 6).unwrap(), 105).await;
+        invalidate(&store, SubstateCacheInvalidation::created(&id, 6).unwrap(), 105).await;
 
         assert!(!put(&store, &id, 6, 100).await);
         assert_eq!(read(&store, &id).await, None);
@@ -1347,7 +1347,12 @@ mod tests {
         for n in 0..5u8 {
             assert!(put_entry(&store, &substate(n), 1, true, now - u64::from(4 - n), 100).await);
         }
-        invalidate(&store, SubstateCacheInvalidation::created(substate(9), 1).unwrap(), 105).await;
+        invalidate(
+            &store,
+            SubstateCacheInvalidation::created(&substate(9), 1).unwrap(),
+            105,
+        )
+        .await;
 
         store
             .with_write_tx(|tx| tx.substate_cache_prune(Duration::ZERO, 2))

--- a/applications/tari_indexer/src/storage_sqlite/writer.rs
+++ b/applications/tari_indexer/src/storage_sqlite/writer.rs
@@ -633,49 +633,21 @@ impl IndexerStoreWriteTransaction for SqliteStoreWriteTransaction<'_> {
         invalidations: I,
         state_version: StateVersion,
     ) -> Result<(), StorageError> {
-        const OPERATION: &str = "substate_cache_invalidate";
-        use crate::storage_sqlite::schema::{substate_cache, substate_cache_invalidations};
-
         let now = unix_timestamp();
         for invalidation in invalidations {
-            let id = invalidation.substate_id().to_string();
-
-            if let Some(retires_up_to) = invalidation.retires_up_to() {
-                diesel::delete(
-                    substate_cache::table
-                        .filter(substate_cache::substate_id.eq(&id))
-                        .filter(substate_cache::version.le(retires_up_to as i32)),
-                )
-                .execute(self.connection())
-                .map_err(|e| StorageError::general(OPERATION, e))?;
-            }
-
-            if invalidation.retires_nonexistence() {
-                diesel::delete(
-                    substate_cache::table
-                        .filter(substate_cache::substate_id.eq(&id))
-                        .filter(substate_cache::version.is_null()),
-                )
-                .execute(self.connection())
-                .map_err(|e| StorageError::general(OPERATION, e))?;
-            }
-
-            diesel::insert_into(substate_cache_invalidations::table)
-                .values((
-                    substate_cache_invalidations::substate_id.eq(&id),
-                    substate_cache_invalidations::state_version.eq(state_version.as_u64() as i64),
-                    substate_cache_invalidations::invalidated_at.eq(now),
-                ))
-                .on_conflict(substate_cache_invalidations::substate_id)
-                .do_update()
-                .set((
-                    substate_cache_invalidations::state_version.eq(state_version.as_u64() as i64),
-                    substate_cache_invalidations::invalidated_at.eq(now),
-                ))
-                .execute(self.connection())
-                .map_err(|e| StorageError::general(OPERATION, e))?;
+            self.apply_substate_cache_invalidation(&invalidation, state_version, now)?;
         }
+        Ok(())
+    }
 
+    fn substate_cache_retire_ahead<I: IntoIterator<Item = (SubstateCacheInvalidation, StateVersion)>>(
+        &mut self,
+        invalidations: I,
+    ) -> Result<(), StorageError> {
+        let now = unix_timestamp();
+        for (invalidation, state_version) in invalidations {
+            self.apply_substate_cache_invalidation(&invalidation, state_version, now)?;
+        }
         Ok(())
     }
 
@@ -793,5 +765,56 @@ impl Drop for SqliteStoreWriteTransaction<'_> {
                 "Substate store write transaction was not committed/rolled back"
             );
         }
+    }
+}
+
+impl SqliteStoreWriteTransaction<'_> {
+    fn apply_substate_cache_invalidation(
+        &mut self,
+        invalidation: &SubstateCacheInvalidation,
+        state_version: StateVersion,
+        now: i64,
+    ) -> Result<(), StorageError> {
+        const OPERATION: &str = "substate_cache_invalidate";
+        use crate::storage_sqlite::schema::{substate_cache, substate_cache_invalidations};
+
+        let id = invalidation.substate_id().to_string();
+
+        if let Some(retires_up_to) = invalidation.retires_up_to() {
+            diesel::delete(
+                substate_cache::table
+                    .filter(substate_cache::substate_id.eq(&id))
+                    .filter(substate_cache::version.le(retires_up_to as i32)),
+            )
+            .execute(self.connection())
+            .map_err(|e| StorageError::general(OPERATION, e))?;
+        }
+
+        if invalidation.retires_nonexistence() {
+            diesel::delete(
+                substate_cache::table
+                    .filter(substate_cache::substate_id.eq(&id))
+                    .filter(substate_cache::version.is_null()),
+            )
+            .execute(self.connection())
+            .map_err(|e| StorageError::general(OPERATION, e))?;
+        }
+
+        diesel::insert_into(substate_cache_invalidations::table)
+            .values((
+                substate_cache_invalidations::substate_id.eq(&id),
+                substate_cache_invalidations::state_version.eq(state_version.as_u64() as i64),
+                substate_cache_invalidations::invalidated_at.eq(now),
+            ))
+            .on_conflict(substate_cache_invalidations::substate_id)
+            .do_update()
+            .set((
+                substate_cache_invalidations::state_version.eq(state_version.as_u64() as i64),
+                substate_cache_invalidations::invalidated_at.eq(now),
+            ))
+            .execute(self.connection())
+            .map_err(|e| StorageError::general(OPERATION, e))?;
+
+        Ok(())
     }
 }

--- a/applications/tari_indexer/src/store.rs
+++ b/applications/tari_indexer/src/store.rs
@@ -365,6 +365,17 @@ pub trait IndexerStoreWriteTransaction {
         state_version: StateVersion,
     ) -> Result<(), StorageError>;
 
+    /// Like [`substate_cache_invalidate`](Self::substate_cache_invalidate), but for transitions
+    /// learnt of ahead of the stream - from a committee's finalized result - so the journalled
+    /// `StateVersion` is not the transition's own. Each is journalled at its own version: the
+    /// caller passes one just past the shard's watermark, so that every fetch captured before the
+    /// stream delivers the transition is vetoed, and the stream's own journal row replaces it when
+    /// it does.
+    fn substate_cache_retire_ahead<I: IntoIterator<Item = (SubstateCacheInvalidation, StateVersion)>>(
+        &mut self,
+        invalidations: I,
+    ) -> Result<(), StorageError>;
+
     /// Drops journal entries older than `journal_retention` and evicts the oldest cache entries down
     /// to `max_entries`.
     fn substate_cache_prune(&mut self, journal_retention: Duration, max_entries: usize) -> Result<(), StorageError>;

--- a/applications/tari_indexer/src/substate_cache.rs
+++ b/applications/tari_indexer/src/substate_cache.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use log::*;
-use tari_engine_types::substate::SubstateId;
+use tari_engine_types::substate::{SubstateDiff, SubstateId};
 use tari_indexer_lib::substate_cache::{
     FetchWatermark,
     SubstateCache,
@@ -15,7 +15,7 @@ use tari_indexer_lib::substate_cache::{
     SubstateCacheEntryRef,
     SubstateCacheError,
 };
-use tari_ootle_common_types::{NumPreshards, SubstateAddress, shard::Shard};
+use tari_ootle_common_types::{NumPreshards, StateVersion, SubstateAddress, shard::Shard};
 use tari_ootle_storage::StorageError;
 use tari_shutdown::ShutdownSignal;
 use tari_validator_node_rpc::client::SubstateResult;
@@ -23,7 +23,7 @@ use tokio::{task, time};
 
 use crate::{
     network_state_sync::ShardWatermarks,
-    storage_sqlite::SqliteIndexerStore,
+    storage_sqlite::{SqliteIndexerStore, models::SubstateCacheInvalidation},
     store::{IndexerStore, IndexerStoreReadTransaction, IndexerStoreReader, IndexerStoreWriteTransaction},
 };
 
@@ -133,6 +133,41 @@ impl SqliteSubstateCache {
                 }
             }
         })
+    }
+
+    /// Retires every entry that `diff` supersedes, for a commit this indexer has learnt of from the
+    /// committee before its own transition stream has delivered it.
+    ///
+    /// The stream is what ordinarily keeps the cache honest, but a caller that is handed a
+    /// finalized result and then reads what it created must not be answered from before the
+    /// commit. Each retirement is journalled just past its shard's watermark so that a fetch which
+    /// started before the result cannot re-cache the stale value; the stream's own journal row
+    /// replaces it once the transition arrives. A shard that has never been confirmed cannot be
+    /// served from anyway, so its entries are only deleted.
+    pub async fn retire_committed(&self, diff: &SubstateDiff) -> Result<(), StorageError> {
+        let created = diff
+            .up_iter()
+            .filter_map(|(id, substate)| SubstateCacheInvalidation::created(id, substate.version()));
+        let destroyed = diff
+            .down_iter()
+            .map(|(id, version)| SubstateCacheInvalidation::destroyed(id.clone(), *version));
+        let invalidations = created
+            .chain(destroyed)
+            .map(|invalidation| {
+                let ahead = self
+                    .watermarks
+                    .get(Self::shard_of(invalidation.substate_id()), Duration::MAX)
+                    .map_or(0, |version| version.as_u64() + 1);
+                (invalidation, StateVersion::new(ahead))
+            })
+            .collect::<Vec<_>>();
+        if invalidations.is_empty() {
+            return Ok(());
+        }
+        debug!(target: LOG_TARGET, "Retiring {} cached substates ahead of the stream", invalidations.len());
+        self.store
+            .with_write_tx(move |tx| tx.substate_cache_retire_ahead(invalidations))
+            .await
     }
 
     async fn prune(&self) -> Result<(), StorageError> {
@@ -261,8 +296,6 @@ impl SubstateCache for SqliteSubstateCache {
 
 #[cfg(test)]
 mod tests {
-    use tari_ootle_common_types::StateVersion;
-
     use super::*;
     use crate::storage_sqlite::SqliteIndexerStore;
 
@@ -425,6 +458,83 @@ mod tests {
         // The same shard, at the same age, still answers for a head.
         let (_d2, head_cache, head_id) = cache_with_head(6, true, Duration::ZERO).await;
         assert!(head_cache.read(&head_id, None).await.unwrap().is_some());
+    }
+
+    async fn write_nonexistence(cache: &SqliteSubstateCache, id: &SubstateId, watermark: u64) {
+        cache
+            .write(
+                id,
+                SubstateCacheEntryRef {
+                    version: None,
+                    substate_result: &SubstateResult::DoesNotExist,
+                    cached_at: now_unix_secs().unwrap(),
+                    verified: false,
+                },
+                FetchWatermark::new(watermark),
+            )
+            .await
+            .unwrap();
+    }
+
+    /// A caller handed a finalized result reads what it created next. The stream that would retract
+    /// the cached nonexistence has not necessarily delivered the commit yet, so the result retires
+    /// it, and holds off any fetch that started before the commit until the stream catches up.
+    #[tokio::test]
+    async fn a_finalized_result_retires_what_it_created_ahead_of_the_stream() {
+        use tari_engine_types::{
+            non_fungible::NonFungibleContainer,
+            substate::{Substate, SubstateValue},
+        };
+
+        let (_d, cache, id) = cache_with_nonexistence(true).await;
+        let mut diff = SubstateDiff::new();
+        diff.up(
+            id.clone(),
+            Substate::new(0, SubstateValue::NonFungible(NonFungibleContainer::no_data())),
+        );
+        cache.retire_committed(&diff).await.unwrap();
+        assert!(cache.read(&id, None).await.unwrap().is_none());
+
+        // A fetch captured at the shard's watermark predates the commit, so its answer is refused.
+        write_nonexistence(&cache, &id, 100).await;
+        assert!(cache.read(&id, None).await.unwrap().is_none());
+
+        // One captured once the stream has moved past it is not.
+        write_nonexistence(&cache, &id, 101).await;
+        assert!(cache.read(&id, None).await.unwrap().is_some());
+    }
+
+    /// The other half of the same race: a head the transaction replaced. The old head is retired,
+    /// and a fetch captured before the commit cannot put it back.
+    #[tokio::test]
+    async fn a_finalized_result_retires_the_head_it_replaced_ahead_of_the_stream() {
+        use tari_engine_types::{
+            non_fungible::NonFungibleContainer,
+            substate::{Substate, SubstateValue},
+        };
+
+        let (_d, cache, id) = cache_with_head(6, true, Duration::ZERO).await;
+        let mut diff = SubstateDiff::new();
+        diff.down(id.clone(), 6);
+        diff.up(
+            id.clone(),
+            Substate::new(7, SubstateValue::NonFungible(NonFungibleContainer::no_data())),
+        );
+        cache.retire_committed(&diff).await.unwrap();
+        assert!(cache.read(&id, None).await.unwrap().is_none());
+
+        let stale = SubstateResult::Down { version: 6 };
+        let entry = SubstateCacheEntryRef {
+            version: Some(6),
+            substate_result: &stale,
+            cached_at: now_unix_secs().unwrap(),
+            verified: true,
+        };
+        cache.write(&id, entry, FetchWatermark::new(100)).await.unwrap();
+        assert!(cache.read(&id, None).await.unwrap().is_none());
+
+        cache.write(&id, entry, FetchWatermark::new(101)).await.unwrap();
+        assert_eq!(cache.read(&id, None).await.unwrap().unwrap().version, Some(6));
     }
 
     /// Above the head the cache knows nothing: this indexer is behind, or the substate never got there.

--- a/applications/tari_indexer/src/transaction_manager/mod.rs
+++ b/applications/tari_indexer/src/transaction_manager/mod.rs
@@ -22,6 +22,10 @@
 
 pub(crate) mod error;
 
+use std::sync::{Arc, Mutex};
+
+use indexmap::IndexSet;
+use log::*;
 use tari_epoch_manager::EpochManagerReader;
 use tari_indexer_client::types::{IndexerTransactionFinalizedResult, TransactionEntry, TransactionSource};
 use tari_ootle_common_types::{Epoch, NodeAddressable, ToSubstateAddress, optional::Optional};
@@ -32,8 +36,17 @@ use tari_validator_node_rpc::client::{TransactionResultStatus, ValidatorNodeClie
 use crate::{
     network_client::TariNetworkClient,
     store::{IndexerStore, IndexerStoreReadTransaction, IndexerStoreWriteTransaction, TransactionRejectionStatus},
+    substate_cache::SqliteSubstateCache,
     transaction_manager::error::TransactionManagerError,
 };
+
+const LOG_TARGET: &str = "tari::indexer::transaction_manager";
+
+/// How many finalized transactions are remembered as already having had their cache entries
+/// retired. Only the first time a result is handed out matters, since that is the only moment a
+/// fetch can be in flight from before this indexer knew of the commit; remembering it stops every
+/// later poll of the same result from taking the write lock again.
+const RETIRED_RESULTS_CAPACITY: usize = 4096;
 
 #[derive(Debug, Clone)]
 pub struct TransactionManager<TEpochManager, TClientFactory, TStore> {
@@ -42,6 +55,13 @@ pub struct TransactionManager<TEpochManager, TClientFactory, TStore> {
     network: Network,
     max_transaction_weight: u64,
     max_transaction_validity_epochs: u64,
+    /// Told of every finalized commit this manager hands out, so that a caller reading what its
+    /// transaction created is not answered from before the commit. See
+    /// [`SqliteSubstateCache::retire_committed`].
+    substate_cache: SqliteSubstateCache,
+    /// Finalized transactions whose commit has already been retired from the cache, most recent
+    /// last, bounded at [`RETIRED_RESULTS_CAPACITY`].
+    retired_results: Arc<Mutex<IndexSet<TransactionId>>>,
 }
 
 impl<TEpochManager, TClientFactory, TAddr, TStore> TransactionManager<TEpochManager, TClientFactory, TStore>
@@ -57,6 +77,7 @@ where
         network: Network,
         max_transaction_weight: u64,
         max_transaction_validity_epochs: u64,
+        substate_cache: SqliteSubstateCache,
     ) -> Self {
         Self {
             network_client,
@@ -64,6 +85,27 @@ where
             network,
             max_transaction_weight,
             max_transaction_validity_epochs,
+            substate_cache,
+            retired_results: Arc::new(Mutex::new(IndexSet::with_capacity(RETIRED_RESULTS_CAPACITY))),
+        }
+    }
+
+    fn is_result_retired(&self, transaction_id: &TransactionId) -> bool {
+        self.retired_results
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .contains(transaction_id)
+    }
+
+    /// Records that `transaction_id`'s commit has been retired from the cache. Recorded only after
+    /// the retirement succeeded, so a failed one is tried again on the next poll and concurrent
+    /// pollers each wait on their own (idempotent) retirement rather than one racing past the
+    /// other's.
+    fn mark_result_retired(&self, transaction_id: TransactionId) {
+        let mut retired = self.retired_results.lock().unwrap_or_else(|e| e.into_inner());
+        retired.insert(transaction_id);
+        if retired.len() > RETIRED_RESULTS_CAPACITY {
+            retired.shift_remove_index(0);
         }
     }
 
@@ -159,6 +201,21 @@ where
                         self.store
                             .with_write_tx(move |tx| tx.set_transaction_rejected(transaction_id, &details))
                             .await?;
+                    }
+                }
+
+                // The committee answered ahead of this indexer's own transition stream. A caller
+                // holding this result will read what it committed next, so the cache must not
+                // answer that from before the commit. A fee-only accept commits its diff too.
+                if let Some(diff) = finalized.execute_result.as_ref().and_then(|r| r.finalize.any_accept()) &&
+                    !self.is_result_retired(&transaction_id)
+                {
+                    match self.substate_cache.retire_committed(diff).await {
+                        Ok(()) => self.mark_result_retired(transaction_id),
+                        Err(e) => warn!(
+                            target: LOG_TARGET,
+                            "Failed to retire cached substates committed by {transaction_id}: {e}"
+                        ),
                     }
                 }
 


### PR DESCRIPTION
## Summary

Fixes the `transfer.feature` failures ("`Substate component_… does not exist`" on the second manifest submit) that started with #2505 — they fail on `development` at `68a9eca20` and passed on the commit before it; cucumber's retry keeps the job green so only "Test Results" shows them.

The race: `TransactionManager::get_transaction_result` answers from the **committee**, ahead of the indexer's own transition stream. The wallet had earlier asked whether the destination account existed (to decide on `create_account!`), which #2505 cached as `DoesNotExist`. It then learns the transfer committed, reads the new account, and gets the stale cached nonexistence. The same ordering bites a cached *old head* when a transaction replaces it.

## Change

- On a finalized accept, the transaction manager hands the result's `SubstateDiff` to `SqliteSubstateCache::retire_committed`, which applies the same `created`/`destroyed` invalidations the stream would.
- Each is journalled at `shard watermark + 1` (new `substate_cache_retire_ahead` store op) so a fetch captured before the commit cannot re-cache the stale value; the stream's own journal row replaces it once the transition arrives. A shard with no watermark can't be served from anyway, so its entries are only deleted.
- Failure to retire is logged, not surfaced: the result itself is still correct.

## Tests

`a_finalized_result_retires_what_it_created_ahead_of_the_stream`: cached nonexistence is gone after the result, a write captured at the old watermark is vetoed, one captured past it is accepted.
