### PR TITLE
feat(indexer): export a gauge of active SSE connections

### DIFF
--- a/applications/tari_indexer/src/rest_api/metrics.rs
+++ b/applications/tari_indexer/src/rest_api/metrics.rs
@@ -25,7 +25,7 @@ use prometheus_client::{
 use tari_ootle_app_utilities::tcp::try_bind_with_fallback;
 use tari_shutdown::ShutdownSignal;
 
-use crate::metrics::CollectorRegister;
+use crate::{metrics::CollectorRegister, rest_api::rate_limit::SseConnectionMetrics};
 
 const LOG_TARGET: &str = "tari::ootle::indexer::rest_api::metrics";
 
@@ -71,27 +71,44 @@ pub struct RequestMetrics {
     response_body_size_histogram: Histogram,
 }
 
-pub fn register(registry: &mut Registry) -> RequestMetrics {
+/// Everything the REST API exports, all of it under the `api` prefix.
+#[derive(Clone)]
+pub struct ApiMetrics {
+    /// State for the [`layer`] middleware wrapping the whole router.
+    pub requests: RequestMetrics,
+    /// Shared with the SSE limit middleware, which maintains the count.
+    pub sse: SseConnectionMetrics,
+}
+
+pub fn register(registry: &mut Registry) -> ApiMetrics {
     let registry = registry.sub_registry_with_prefix("api");
 
-    RequestMetrics {
-        request_counter: Counter::default().register_at(
-            "http_requests_total",
-            "Total number of HTTP requests received",
-            registry,
-        ),
-        response_time_histogram: Histogram::new(
-            exponential_buckets(0.001, 2.0, 15), // buckets from 1ms, doubling, 15 buckets
-        )
-        .register_at("http_response_time_seconds", "HTTP response times in seconds", registry),
-        requests_pending: Gauge::default().register_at(
-            "http_requests_pending",
-            "Number of HTTP requests currently being processed",
-            registry,
-        ),
-        response_body_size_histogram: Histogram::new(
-            exponential_buckets(100.0, 2.0, 15), // buckets from 100B, doubling, 15 buckets
-        ),
+    ApiMetrics {
+        requests: RequestMetrics {
+            request_counter: Counter::default().register_at(
+                "http_requests_total",
+                "Total number of HTTP requests received",
+                registry,
+            ),
+            response_time_histogram: Histogram::new(
+                exponential_buckets(0.001, 2.0, 15), // buckets from 1ms, doubling, 15 buckets
+            )
+            .register_at("http_response_time_seconds", "HTTP response times in seconds", registry),
+            requests_pending: Gauge::default().register_at(
+                "http_requests_pending",
+                "Number of HTTP requests currently being processed",
+                registry,
+            ),
+            response_body_size_histogram: Histogram::new(
+                exponential_buckets(100.0, 2.0, 15), // buckets from 100B, doubling, 15 buckets
+            )
+            .register_at(
+                "http_response_body_size_bytes",
+                "HTTP response body sizes in bytes, for responses of known length",
+                registry,
+            ),
+        },
+        sse: SseConnectionMetrics::register(registry),
     }
 }
 
@@ -175,6 +192,29 @@ mod tests {
         );
         // The OpenMetrics text exposition always ends with an EOF marker
         assert!(response.contains("# EOF"), "unexpected response: {response}");
+    }
+
+    #[tokio::test]
+    async fn it_exports_every_registered_metric() {
+        let shutdown = Shutdown::new();
+        let mut registry = Registry::default();
+        let metrics = register(&mut registry);
+        metrics.sse.endpoint("/events");
+
+        let listen_addr = spawn_metrics_server("127.0.0.1:0".parse().unwrap(), registry, shutdown.to_signal())
+            .await
+            .unwrap();
+        let response = http_get(listen_addr, "/_metrics").await;
+
+        for name in [
+            "api_http_requests_total",
+            "api_http_response_time_seconds",
+            "api_http_requests_pending",
+            "api_http_response_body_size_bytes",
+            "api_sse_connections_active",
+        ] {
+            assert!(response.contains(name), "{name} missing from: {response}");
+        }
     }
 
     #[tokio::test]

--- a/applications/tari_indexer/src/rest_api/metrics.rs
+++ b/applications/tari_indexer/src/rest_api/metrics.rs
@@ -211,10 +211,15 @@ mod tests {
             "api_http_response_time_seconds",
             "api_http_requests_pending",
             "api_http_response_body_size_bytes",
-            "api_sse_connections_active",
         ] {
             assert!(response.contains(name), "{name} missing from: {response}");
         }
+        // A `Family` gets its descriptor written whether or not it has children, so the
+        // labelled series is what shows the endpoint handle reaches the exposition.
+        assert!(
+            response.contains(r#"api_sse_connections_active{endpoint="/events"}"#),
+            "sse gauge series missing from: {response}"
+        );
     }
 
     #[tokio::test]

--- a/applications/tari_indexer/src/rest_api/rate_limit.rs
+++ b/applications/tari_indexer/src/rest_api/rate_limit.rs
@@ -13,6 +13,11 @@
 //! SSE / streaming endpoints use a per-IP concurrent-connection counter
 //! instead of a token bucket — the slot is held for the full lifetime of the
 //! response body and released on disconnect.
+//!
+//! The same middleware maintains [`SseConnectionMetrics`], the gauge of streams
+//! currently being served. It is kept independently of the per-IP limiter so
+//! that a node running with rate limiting switched off still reports its
+//! streams.
 
 use std::{
     net::{IpAddr, SocketAddr},
@@ -30,6 +35,16 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use dashmap::DashMap;
+#[cfg(feature = "metrics")]
+use prometheus_client::{
+    encoding::EncodeLabelSet,
+    metrics::{family::Family, gauge::Gauge},
+    registry::Registry,
+};
+
+#[cfg(feature = "metrics")]
+use crate::metrics::CollectorRegister;
+
 // ---------------------------------------------------------------------------
 // Token-bucket state per IP
 // ---------------------------------------------------------------------------
@@ -230,6 +245,102 @@ impl Drop for SseConnectionGuard {
 }
 
 // ---------------------------------------------------------------------------
+// SSE active-connection gauge
+// ---------------------------------------------------------------------------
+
+/// The route an SSE connection was opened on.
+///
+/// The streaming endpoints share one limiter but serve quite different consumers, so the
+/// connection count is labelled to keep them apart. Values are fixed route paths chosen at
+/// router construction, never taken from the request, so the label cardinality is bounded by
+/// the number of streaming routes.
+#[cfg(feature = "metrics")]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, EncodeLabelSet)]
+struct SseEndpointLabels {
+    endpoint: &'static str,
+}
+
+/// Gauge of the SSE connections the indexer is currently serving, labelled by endpoint.
+///
+/// Registered under the `api` sub-registry, so the exported name is
+/// `api_sse_connections_active`.
+///
+/// Clones share the counts: the value handed to a middleware instance and the value the
+/// registry encodes are the same gauge. Without the `metrics` feature the type is empty and
+/// every operation on it compiles away.
+#[derive(Clone, Default)]
+pub struct SseConnectionMetrics {
+    #[cfg(feature = "metrics")]
+    active: Family<SseEndpointLabels, Gauge>,
+}
+
+impl SseConnectionMetrics {
+    #[cfg(feature = "metrics")]
+    pub fn register(registry: &mut Registry) -> Self {
+        Self {
+            active: Family::default().register_at(
+                "sse_connections_active",
+                "Number of SSE connections currently being served, by endpoint",
+                registry,
+            ),
+        }
+    }
+
+    /// The handle counting connections on one endpoint. Give each streaming route its own.
+    #[cfg(feature = "metrics")]
+    pub fn endpoint(&self, endpoint: &'static str) -> SseEndpointConnections {
+        SseEndpointConnections {
+            active: self.active.get_or_create_owned(&SseEndpointLabels { endpoint }),
+        }
+    }
+
+    #[cfg(not(feature = "metrics"))]
+    pub fn endpoint(&self, _endpoint: &'static str) -> SseEndpointConnections {
+        SseEndpointConnections {}
+    }
+}
+
+/// Counts the SSE connections currently open on one endpoint.
+#[derive(Clone, Default)]
+pub struct SseEndpointConnections {
+    #[cfg(feature = "metrics")]
+    active: Gauge,
+}
+
+impl SseEndpointConnections {
+    /// Counts one connection as open until the returned token is dropped.
+    fn open(&self) -> SseOpenConnection {
+        #[cfg(feature = "metrics")]
+        self.active.inc();
+        SseOpenConnection {
+            #[cfg(feature = "metrics")]
+            active: self.active.clone(),
+        }
+    }
+
+    #[cfg(all(test, feature = "metrics"))]
+    fn count(&self) -> i64 {
+        self.active.get()
+    }
+}
+
+/// Holds one connection open in [`SseEndpointConnections`] for as long as it is alive.
+///
+/// Travels in the response body's stream state next to [`SseConnectionGuard`], so the count
+/// falls when the stream ends or the client disconnects.
+struct SseOpenConnection {
+    #[cfg(feature = "metrics")]
+    active: Gauge,
+}
+
+#[cfg(feature = "metrics")]
+impl Drop for SseOpenConnection {
+    fn drop(&mut self) {
+        self.active.dec();
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Helper: extract peer IP from request
 // ---------------------------------------------------------------------------
 
@@ -282,6 +393,9 @@ pub struct RateLimitConfig {
 }
 
 /// Configuration for the SSE connection-limit middleware layer.
+///
+/// One instance per streaming route: `active_connections` carries that route's label, so
+/// each route must be given its own config even though they share a `limiter`.
 #[derive(Clone)]
 pub struct SseLimitConfig {
     pub enabled: bool,
@@ -289,6 +403,8 @@ pub struct SseLimitConfig {
     /// Whether to trust `X-Forwarded-For` / `X-Real-IP` headers for IP
     /// extraction. Only enable this when running behind a trusted reverse proxy.
     pub trust_proxy_headers: bool,
+    /// Gauge handle for the route this config is attached to.
+    pub active_connections: SseEndpointConnections,
 }
 
 /// Axum middleware that enforces a per-IP token-bucket rate limit.
@@ -322,14 +438,17 @@ pub async fn rate_limit_middleware(
 }
 
 /// Axum middleware that enforces a per-IP concurrent-connection limit on SSE
-/// endpoints.
+/// endpoints and counts the streams it is serving.
 ///
-/// The guard is moved into the response **body**'s stream state, not the
-/// response extensions. Axum/hyper drop response parts (including extensions)
-/// once headers are flushed, so an extension-based guard would be released at
-/// the start of the SSE stream rather than its end. By tying the guard to the
-/// body stream, it lives until the stream is fully drained or the client
-/// disconnects.
+/// Both the connection slot and the gauge token are moved into the response
+/// **body**'s stream state, not the response extensions. Axum/hyper drop
+/// response parts (including extensions) once headers are flushed, so an
+/// extension-based guard would be released at the start of the SSE stream
+/// rather than its end. By tying them to the body stream, they live until the
+/// stream is fully drained or the client disconnects.
+///
+/// A disabled limiter takes no slot but is still counted, so the gauge reflects
+/// the streams in flight on every node.
 pub async fn sse_limit_middleware(
     axum::extract::State(config): axum::extract::State<SseLimitConfig>,
     req: Request,
@@ -337,35 +456,35 @@ pub async fn sse_limit_middleware(
 ) -> Response {
     use futures::StreamExt;
 
-    if !config.enabled {
-        return next.run(req).await;
-    }
+    let slot = if config.enabled {
+        let connect_info = req.extensions().get::<ConnectInfo<SocketAddr>>().copied();
+        let ip = extract_ip(req.headers(), connect_info.as_ref(), config.trust_proxy_headers);
+        let Some(guard) = config.limiter.try_acquire(ip) else {
+            return (
+                StatusCode::TOO_MANY_REQUESTS,
+                [(header::RETRY_AFTER, "60".to_string())],
+                axum::Json(serde_json::json!({
+                    "error": "Too many concurrent SSE connections. Please try again later."
+                })),
+            )
+                .into_response();
+        };
+        Some(guard)
+    } else {
+        None
+    };
 
-    let connect_info = req.extensions().get::<ConnectInfo<SocketAddr>>().copied();
-    let ip = extract_ip(req.headers(), connect_info.as_ref(), config.trust_proxy_headers);
-    match config.limiter.try_acquire(ip) {
-        Some(guard) => {
-            let response = next.run(req).await;
-            let (parts, body) = response.into_parts();
-            let stream = body.into_data_stream();
-            // `unfold` carries `guard` in its state. When the stream completes
-            // or is dropped (client disconnect, server shutdown), the state is
-            // dropped and the guard releases the connection slot.
-            let stream = futures::stream::unfold((stream, guard), |(mut s, g)| async move {
-                s.next().await.map(|item| (item, (s, g)))
-            });
-            let body = axum::body::Body::from_stream(stream);
-            Response::from_parts(parts, body)
-        },
-        None => (
-            StatusCode::TOO_MANY_REQUESTS,
-            [(header::RETRY_AFTER, "60".to_string())],
-            axum::Json(serde_json::json!({
-                "error": "Too many concurrent SSE connections. Please try again later."
-            })),
-        )
-            .into_response(),
-    }
+    let open = config.active_connections.open();
+    let response = next.run(req).await;
+    let (parts, body) = response.into_parts();
+    let stream = body.into_data_stream();
+    // `unfold` carries `slot` and `open` in its state. When the stream completes or is
+    // dropped (client disconnect, server shutdown), the state is dropped, releasing the
+    // connection slot and decrementing the gauge.
+    let stream = futures::stream::unfold((stream, slot, open), |(mut s, slot, open)| async move {
+        s.next().await.map(|item| (item, (s, slot, open)))
+    });
+    Response::from_parts(parts, axum::body::Body::from_stream(stream))
 }
 
 #[cfg(test)]
@@ -594,6 +713,150 @@ mod tests {
         headers.insert("x-real-ip", HeaderValue::from_static("also-garbage"));
         let conn = ci("203.0.113.7:55512");
         assert_eq!(extract_ip(&headers, Some(&conn), true), IpAddr::from([203, 0, 113, 7]));
+    }
+
+    // ------------------------------------------------------ SSE connection gauge --
+
+    #[cfg(feature = "metrics")]
+    mod sse_gauge {
+        use axum::{
+            Router,
+            body::{Body, Bytes},
+            response::Response,
+            routing::get,
+        };
+        use futures::StreamExt;
+        use tokio::{
+            io::{AsyncReadExt, AsyncWriteExt},
+            net::TcpStream,
+        };
+        use tokio_stream::wrappers::IntervalStream;
+
+        use super::*;
+
+        const GAUGE_TIMEOUT: Duration = Duration::from_secs(5);
+
+        /// A response body that keeps sending until the connection goes away. The repeated
+        /// writes are what make the server notice a vanished client.
+        async fn ticking_stream() -> Response {
+            let ticks = IntervalStream::new(tokio::time::interval(Duration::from_millis(20)))
+                .map(|_| Ok::<_, std::io::Error>(Bytes::from_static(b"tick\n")));
+            Response::new(Body::from_stream(ticks))
+        }
+
+        async fn serve(config: SseLimitConfig) -> SocketAddr {
+            let app = Router::new().route(
+                "/stream",
+                get(ticking_stream).route_layer(axum::middleware::from_fn_with_state(config, sse_limit_middleware)),
+            );
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let addr = listener.local_addr().unwrap();
+            tokio::spawn(async move {
+                axum::serve(listener, app.into_make_service()).await.unwrap();
+            });
+            addr
+        }
+
+        /// Opens a request and returns once the response has started arriving, so the caller
+        /// knows the middleware has run.
+        async fn open_stream(addr: SocketAddr) -> TcpStream {
+            let mut stream = TcpStream::connect(addr).await.unwrap();
+            stream
+                .write_all(format!("GET /stream HTTP/1.1\r\nHost: {addr}\r\n\r\n").as_bytes())
+                .await
+                .unwrap();
+            let mut buf = [0u8; 512];
+            let n = stream.read(&mut buf).await.unwrap();
+            assert!(n > 0, "server closed the connection without responding");
+            stream
+        }
+
+        async fn read_response(addr: SocketAddr) -> String {
+            let mut stream = TcpStream::connect(addr).await.unwrap();
+            stream
+                .write_all(format!("GET /stream HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n").as_bytes())
+                .await
+                .unwrap();
+            let mut buf = Vec::new();
+            stream.read_to_end(&mut buf).await.unwrap();
+            String::from_utf8(buf).unwrap()
+        }
+
+        async fn wait_for_count(connections: &SseEndpointConnections, expected: i64) {
+            let deadline = Instant::now() + GAUGE_TIMEOUT;
+            loop {
+                let count = connections.count();
+                if count == expected {
+                    return;
+                }
+                assert!(
+                    Instant::now() < deadline,
+                    "gauge settled at {count}, expected {expected}"
+                );
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        }
+
+        fn config(enabled: bool, max_per_ip: usize, connections: SseEndpointConnections) -> SseLimitConfig {
+            SseLimitConfig {
+                enabled,
+                limiter: SseConnectionLimiter::new(max_per_ip),
+                trust_proxy_headers: false,
+                active_connections: connections,
+            }
+        }
+
+        #[tokio::test]
+        async fn it_counts_a_stream_until_the_client_disconnects() {
+            let events = SseConnectionMetrics::default().endpoint("/events");
+            let addr = serve(config(true, 4, events.clone())).await;
+
+            let client = open_stream(addr).await;
+            wait_for_count(&events, 1).await;
+
+            drop(client);
+            wait_for_count(&events, 0).await;
+        }
+
+        #[tokio::test]
+        async fn it_counts_streams_when_the_limiter_is_disabled() {
+            let events = SseConnectionMetrics::default().endpoint("/events");
+            let addr = serve(config(false, 4, events.clone())).await;
+
+            let client = open_stream(addr).await;
+            wait_for_count(&events, 1).await;
+
+            drop(client);
+            wait_for_count(&events, 0).await;
+        }
+
+        #[tokio::test]
+        async fn it_does_not_count_a_rejected_connection() {
+            let events = SseConnectionMetrics::default().endpoint("/events");
+            let cfg = config(true, 1, events.clone());
+            let held = cfg.limiter.try_acquire(IpAddr::from([127, 0, 0, 1])).unwrap();
+            let addr = serve(cfg).await;
+
+            let response = read_response(addr).await;
+            assert!(response.starts_with("HTTP/1.1 429"), "unexpected response: {response}");
+            assert_eq!(events.count(), 0);
+            drop(held);
+        }
+
+        #[tokio::test]
+        async fn it_counts_each_endpoint_separately() {
+            let metrics = SseConnectionMetrics::default();
+            let events = metrics.endpoint("/events");
+            let utxos = metrics.endpoint("/utxos/stream");
+            let addr = serve(config(true, 4, events.clone())).await;
+
+            let client = open_stream(addr).await;
+            wait_for_count(&events, 1).await;
+            assert_eq!(utxos.count(), 0);
+
+            drop(client);
+            wait_for_count(&events, 0).await;
+        }
     }
 
     #[test]

--- a/applications/tari_indexer/src/rest_api/rate_limit.rs
+++ b/applications/tari_indexer/src/rest_api/rate_limit.rs
@@ -268,7 +268,11 @@ struct SseEndpointLabels {
 /// Clones share the counts: the value handed to a middleware instance and the value the
 /// registry encodes are the same gauge. Without the `metrics` feature the type is empty and
 /// every operation on it compiles away.
-#[derive(Clone, Default)]
+///
+/// The only way to obtain one with the feature on is [`SseConnectionMetrics::register`], so a
+/// gauge that counts but is exported nowhere cannot be built by accident.
+#[derive(Clone)]
+#[cfg_attr(not(feature = "metrics"), derive(Default))]
 pub struct SseConnectionMetrics {
     #[cfg(feature = "metrics")]
     active: Family<SseEndpointLabels, Gauge>,
@@ -301,7 +305,7 @@ impl SseConnectionMetrics {
 }
 
 /// Counts the SSE connections currently open on one endpoint.
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct SseEndpointConnections {
     #[cfg(feature = "metrics")]
     active: Gauge,
@@ -449,6 +453,10 @@ pub async fn rate_limit_middleware(
 ///
 /// A disabled limiter takes no slot but is still counted, so the gauge reflects
 /// the streams in flight on every node.
+///
+/// Only a successful response is a stream. A handler that rejects the request
+/// returns a short body, which passes through untouched so that it holds
+/// neither a slot nor a place in the gauge and keeps its `Content-Length`.
 pub async fn sse_limit_middleware(
     axum::extract::State(config): axum::extract::State<SseLimitConfig>,
     req: Request,
@@ -474,8 +482,12 @@ pub async fn sse_limit_middleware(
         None
     };
 
-    let open = config.active_connections.open();
     let response = next.run(req).await;
+    if !response.status().is_success() {
+        return response;
+    }
+
+    let open = config.active_connections.open();
     let (parts, body) = response.into_parts();
     let stream = body.into_data_stream();
     // `unfold` carries `slot` and `open` in its state. When the stream completes or is
@@ -722,39 +734,69 @@ mod tests {
         use axum::{
             Router,
             body::{Body, Bytes},
+            http::StatusCode,
             response::Response,
             routing::get,
         };
-        use futures::StreamExt;
         use tokio::{
             io::{AsyncReadExt, AsyncWriteExt},
             net::TcpStream,
         };
-        use tokio_stream::wrappers::IntervalStream;
 
         use super::*;
 
         const GAUGE_TIMEOUT: Duration = Duration::from_secs(5);
 
-        /// A response body that keeps sending until the connection goes away. The repeated
+        /// A response whose body keeps sending until the connection goes away. The repeated
         /// writes are what make the server notice a vanished client.
-        async fn ticking_stream() -> Response {
-            let ticks = IntervalStream::new(tokio::time::interval(Duration::from_millis(20)))
-                .map(|_| Ok::<_, std::io::Error>(Bytes::from_static(b"tick\n")));
-            Response::new(Body::from_stream(ticks))
+        fn ticking_response(status: StatusCode) -> Response {
+            let ticks = futures::stream::unfold(
+                tokio::time::interval(Duration::from_millis(20)),
+                |mut tick| async move {
+                    tick.tick().await;
+                    Some((Ok::<_, std::io::Error>(Bytes::from_static(b"tick\n")), tick))
+                },
+            );
+            let mut response = Response::new(Body::from_stream(ticks));
+            *response.status_mut() = status;
+            response
         }
 
-        async fn serve(config: SseLimitConfig) -> SocketAddr {
+        async fn ticking_stream() -> Response {
+            ticking_response(StatusCode::OK)
+        }
+
+        /// Holds the connection open on a failed status, so a wrongly counted rejection stays
+        /// visible in the gauge for as long as the test looks at it.
+        async fn rejected_stream() -> Response {
+            ticking_response(StatusCode::BAD_REQUEST)
+        }
+
+        /// A rejection shaped like the argument validation the real streaming handlers do
+        /// before they open a stream.
+        async fn rejected() -> Response {
+            (StatusCode::BAD_REQUEST, "bad request").into_response()
+        }
+
+        async fn serve_handler(config: SseLimitConfig, handler: axum::routing::MethodRouter) -> SocketAddr {
             let app = Router::new().route(
                 "/stream",
-                get(ticking_stream).route_layer(axum::middleware::from_fn_with_state(config, sse_limit_middleware)),
+                handler.route_layer(axum::middleware::from_fn_with_state(config, sse_limit_middleware)),
             );
             let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
             let addr = listener.local_addr().unwrap();
             tokio::spawn(async move {
-                axum::serve(listener, app.into_make_service()).await.unwrap();
+                // Matches how the REST API is served, so `extract_ip` sees a real peer address
+                // rather than falling back to localhost.
+                axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>())
+                    .await
+                    .unwrap();
             });
             addr
+        }
+
+        async fn serve(config: SseLimitConfig) -> SocketAddr {
+            serve_handler(config, get(ticking_stream)).await
         }
 
         /// Opens a request and returns once the response has started arriving, so the caller
@@ -797,6 +839,10 @@ mod tests {
             }
         }
 
+        fn metrics() -> SseConnectionMetrics {
+            SseConnectionMetrics::register(&mut Registry::default())
+        }
+
         fn config(enabled: bool, max_per_ip: usize, connections: SseEndpointConnections) -> SseLimitConfig {
             SseLimitConfig {
                 enabled,
@@ -808,7 +854,7 @@ mod tests {
 
         #[tokio::test]
         async fn it_counts_a_stream_until_the_client_disconnects() {
-            let events = SseConnectionMetrics::default().endpoint("/events");
+            let events = metrics().endpoint("/events");
             let addr = serve(config(true, 4, events.clone())).await;
 
             let client = open_stream(addr).await;
@@ -820,7 +866,7 @@ mod tests {
 
         #[tokio::test]
         async fn it_counts_streams_when_the_limiter_is_disabled() {
-            let events = SseConnectionMetrics::default().endpoint("/events");
+            let events = metrics().endpoint("/events");
             let addr = serve(config(false, 4, events.clone())).await;
 
             let client = open_stream(addr).await;
@@ -832,7 +878,7 @@ mod tests {
 
         #[tokio::test]
         async fn it_does_not_count_a_rejected_connection() {
-            let events = SseConnectionMetrics::default().endpoint("/events");
+            let events = metrics().endpoint("/events");
             let cfg = config(true, 1, events.clone());
             let held = cfg.limiter.try_acquire(IpAddr::from([127, 0, 0, 1])).unwrap();
             let addr = serve(cfg).await;
@@ -844,8 +890,34 @@ mod tests {
         }
 
         #[tokio::test]
+        async fn it_does_not_count_a_response_the_handler_rejected() {
+            let events = metrics().endpoint("/events");
+            let addr = serve_handler(config(true, 4, events.clone()), get(rejected_stream)).await;
+
+            let client = open_stream(addr).await;
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            assert_eq!(events.count(), 0);
+            drop(client);
+        }
+
+        #[tokio::test]
+        async fn it_leaves_a_rejected_response_untouched() {
+            let events = metrics().endpoint("/events");
+            let addr = serve_handler(config(true, 4, events), get(rejected)).await;
+
+            let response = read_response(addr).await;
+            assert!(response.starts_with("HTTP/1.1 400"), "unexpected response: {response}");
+            // A body that is passed through keeps its length, so it is still observed by the
+            // response-size histogram.
+            assert!(
+                response.to_lowercase().contains("content-length:"),
+                "unexpected response: {response}"
+            );
+        }
+
+        #[tokio::test]
         async fn it_counts_each_endpoint_separately() {
-            let metrics = SseConnectionMetrics::default();
+            let metrics = metrics();
             let events = metrics.endpoint("/events");
             let utxos = metrics.endpoint("/utxos/stream");
             let addr = serve(config(true, 4, events.clone())).await;

--- a/applications/tari_indexer/src/rest_api/server.rs
+++ b/applications/tari_indexer/src/rest_api/server.rs
@@ -97,6 +97,13 @@ impl Server {
     ) -> anyhow::Result<SocketAddr> {
         let context = HandlerContext::from_services(services);
 
+        #[cfg(feature = "metrics")]
+        let api_metrics = metrics::register(registry);
+        #[cfg(feature = "metrics")]
+        let sse_metrics = api_metrics.sse.clone();
+        #[cfg(not(feature = "metrics"))]
+        let sse_metrics = crate::rest_api::rate_limit::SseConnectionMetrics::default();
+
         // Per-IP rate limiters for specific endpoint groups.
         // `trust_proxy_headers` mirrors the value from config – enable only when
         // the indexer is behind a trusted reverse proxy.
@@ -130,10 +137,14 @@ impl Server {
             limiter: IpRateLimiter::new(rate_limits.non_fungibles_rate),
             trust_proxy_headers: rate_limits.trust_proxy_headers,
         };
-        let sse_limiter = SseLimitConfig {
+        // The streaming routes share one per-IP limiter but are counted separately, so each
+        // takes its own config carrying that route's gauge handle.
+        let sse_connections = SseConnectionLimiter::new(rate_limits.sse_max_connections_per_ip);
+        let sse_limiter = |endpoint: &'static str| SseLimitConfig {
             enabled: rate_limits.enabled,
-            limiter: SseConnectionLimiter::new(rate_limits.sse_max_connections_per_ip),
+            limiter: sse_connections.clone(),
             trust_proxy_headers: rate_limits.trust_proxy_headers,
+            active_connections: sse_metrics.endpoint(endpoint),
         };
 
         let router = Router::new()
@@ -193,7 +204,7 @@ impl Server {
                 .route("/events", get(handlers::transactions::query_transaction_events))
                 // SSE stream – per-IP concurrent connection limit
                 .route("/events/stream", get(handlers::transaction_events::sse_transaction_events)
-                    .route_layer(middleware::from_fn_with_state(sse_limiter.clone(), sse_limit_middleware)))
+                    .route_layer(middleware::from_fn_with_state(sse_limiter("/transactions/events/stream"), sse_limit_middleware)))
             )
             .nest("/templates", Router::new()
                 .route("/cached", get(handlers::templates::list_cached_templates))
@@ -220,7 +231,7 @@ impl Server {
                     .route_layer(middleware::from_fn_with_state(utxos_fetch_limiter, rate_limit_middleware)))
                 // POST /utxos/stream (SSE-like streaming) – per-IP concurrent connection limit
                 .route("/stream", post(handlers::utxos::stream_utxo_updates)
-                    .route_layer(middleware::from_fn_with_state(sse_limiter.clone(), sse_limit_middleware)))
+                    .route_layer(middleware::from_fn_with_state(sse_limiter("/utxos/stream"), sse_limit_middleware)))
             )
             .nest(
                 "/transaction-receipts",
@@ -243,7 +254,7 @@ impl Server {
                 .route("/latest", get(handlers::epoch_checkpoints::get_latest_epoch_checkpoint))
             )
             .route("/events", get(handlers::indexer_events::sse_events)
-                .route_layer(middleware::from_fn_with_state(sse_limiter.clone(), sse_limit_middleware)))
+                .route_layer(middleware::from_fn_with_state(sse_limiter("/events"), sse_limit_middleware)))
             // Wraps the API routes so that a handler which sets no policy still denies caching. Applied
             // before the Swagger UI is merged in, whose static assets are fine to cache normally.
             .layer(middleware::from_fn(default_no_store))
@@ -258,7 +269,7 @@ impl Server {
         // metrics are not exposed on the public REST API.
         #[cfg(feature = "metrics")]
         let router = router.layer(axum::middleware::from_fn_with_state(
-            metrics::register(registry),
+            api_metrics.requests,
             metrics::layer,
         ));
 


### PR DESCRIPTION
## Description

The indexer has no metric for how many streaming connections it is serving, and nothing existing stands in for one:

- `api_http_requests_pending` decrements as soon as `next.run(req)` returns, which for a stream is before a single event has been sent. An open stream counts as zero pending requests.
- `api_http_response_time_seconds` observes the same interval, so a stream's observation is handler setup time, not connection lifetime.

This matters because moving the wallet daemon off its poll loop and onto the `/events` SSE stream would make concurrent stream count the indexer's principal load signal from wallets.

## Motivation and Context

Adds `api_sse_connections_active`, a gauge labelled by endpoint. `/events`, `/transactions/events/stream` and `/utxos/stream` all route through the same `SseConnectionLimiter` but serve quite different consumers, so a single number would blur them. Label values are the fixed route paths chosen at router construction and are never taken from the request, so cardinality is bounded by the number of streaming routes.

The count is maintained by `sse_limit_middleware` next to the per-IP connection slot, carried in the response body's stream state rather than the response extensions, so it falls when the stream is fully drained or the client disconnects.

It is kept independently of `SseLimitConfig::enabled`. The middleware previously early-returned before `try_acquire` when limiting was off; a gauge hung off the slot guard would then read zero on exactly the node an operator is most likely to be debugging. The middleware now takes no slot in that case but still wraps the body and counts the stream.

Only a successful response counts. The streaming handlers validate their arguments before they open a stream, and `stream_utxo_updates` has eight early rejections, so counting before the handler ran would let a client sending bad arguments in a loop show up as load. A rejection passes through untouched, keeping its `Content-Length` and its place in the response-size histogram.

Registration moved to the top of `Server::spawn` so one `api` sub-registry produces both the request metrics and the connection gauge, and each streaming route gets its own `SseLimitConfig` carrying that route's gauge handle while sharing one limiter.

Also registers `response_body_size_histogram`, which was constructed with `Histogram::new` and observed on every response but never registered, so it was exported nowhere. It is now `api_http_response_body_size_bytes`.

## New metrics

Both are exported on the metrics listener (`metrics_listen_address`), not the public REST API, and both are behind the default-on `metrics` feature.

| Metric | Type | Labels | Meaning |
| --- | --- | --- | --- |
| `api_sse_connections_active` | Gauge | `endpoint` | Streaming connections currently being served |
| `api_http_response_body_size_bytes` | Histogram | none | Response body size, for responses of known length |

`endpoint` takes one of three values, one per streaming route:

- `/events` — indexer event stream
- `/transactions/events/stream` — transaction event stream
- `/utxos/stream` — UTXO update stream

`api_http_response_body_size_bytes` uses exponential buckets from 100 B, doubling, 15 buckets. Streaming responses have no known length and so are not observed.

## How Has This Been Tested?

`cargo test -p tari_indexer --lib` — 120 passed.

Four new middleware tests drive a real server over TCP: counting a stream until the client disconnects, counting when the limiter is disabled, not counting a rejected 429, and per-endpoint isolation. One new metrics test asserts every registered name appears in the exposition.

Both fixes were confirmed to be covered:

- the disabled-limiter test fails against the naive implementation that counts inside the enabled branch (`gauge settled at 0, expected 1`);
- the exposition test fails when the body-size histogram is left unregistered (`api_http_response_body_size_bytes missing`).

`cargo lints clippy -p tari_indexer --all-targets` is clean, and `cargo check -p tari_indexer --all-targets --no-default-features` confirms the metrics-free build still compiles.

## What process can a PR reviewer use to test or verify this change?

Run an indexer with metrics enabled, open a stream against `/events`, and scrape `/_metrics` on the metrics listener. `api_sse_connections_active{endpoint="/events"}` should read 1 while the stream is open and return to 0 once the client goes away. Repeat with `rate_limits.enabled = false` to check the count is still reported.

## Breaking Changes

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other


