### PR TITLE
feat(rpc)!: prove substates on the batched read path

### DIFF
--- a/applications/tari_validator_node/src/p2p/rpc/rpc_impl.rs
+++ b/applications/tari_validator_node/src/p2p/rpc/rpc_impl.rs
@@ -263,9 +263,9 @@ fn latest_commit_proof<TTx: StateStoreReadTransaction>(
     tx: &TTx,
     epoch: Epoch,
 ) -> Result<Option<CommittedBlockProof>, StorageError> {
-    // `last_executed_get` reports both "nothing committed here" cases as `NotFound`: no row at all,
-    // and a row belonging to another epoch - the latter being exactly the window after an epoch
-    // change, and the former a node that has not started consensus since restarting. Neither is a
+    // `last_executed_get` reports both "nothing committed here" cases as `NotFound`: a node that has
+    // never committed anything has no row, and one whose row belongs to another epoch is either in
+    // the window after an epoch change or has not started consensus since restarting. Neither is a
     // failure to read; both mean there is nothing to anchor to.
     let Some(last_executed) = tx.last_executed_get(epoch).optional()? else {
         return Ok(None);

--- a/applications/tari_validator_node/src/p2p/rpc/rpc_impl.rs
+++ b/applications/tari_validator_node/src/p2p/rpc/rpc_impl.rs
@@ -82,7 +82,6 @@ use tari_ootle_storage::{
         SubstateValueFilterFlags,
         TransactionRecord,
     },
-    generate_substate_proof,
 };
 use tari_ootle_transaction::{Transaction, TransactionId};
 use tari_rpc_framework::{Request, Response, RpcStatus, Streaming};
@@ -152,8 +151,14 @@ impl<TStateStore: StateStore> ValidatorNodeRpcServiceImpl<TStateStore> {
         };
 
         let shard_group = proof_shard_group(&commit_proof).map_err(RpcStatus::log_internal_error(LOG_TARGET))?;
-        let value_proof = generate_substate_proof(tx, shard_group, &substate.to_versioned_substate_id(), num_preshards)
-            .map_err(RpcStatus::log_internal_error(LOG_TARGET))?;
+        // The anchor cannot speak for this substate - its shard is outside the group the anchor
+        // commits, or has nothing committed. Answer unproven rather than not at all.
+        let Some(value_proof) = SubstateProofGenerator::new(tx, shard_group, num_preshards)
+            .and_then(|mut generator| generator.generate(&substate.to_versioned_substate_id()))
+            .map_err(RpcStatus::log_internal_error(LOG_TARGET))?
+        else {
+            return Ok(());
+        };
 
         resp.commit_proof = commit_proof.to_bytes();
         resp.substate_value_proof =
@@ -216,7 +221,7 @@ fn read_substate_batch<TTx: StateStoreReadTransaction>(
             let Some(proof) = generator.generate(&substate.to_versioned_substate_id())? else {
                 warn!(
                     target: LOG_TARGET,
-                    "{} is stored but its shard has no committed state; reporting it as missing",
+                    "{} is stored but cannot be proved against the anchor; reporting it as missing",
                     substate.substate_id()
                 );
                 missing.push(substate.substate_id().to_bytes());
@@ -258,7 +263,13 @@ fn latest_commit_proof<TTx: StateStoreReadTransaction>(
     tx: &TTx,
     epoch: Epoch,
 ) -> Result<Option<CommittedBlockProof>, StorageError> {
-    let last_executed = tx.last_executed_get(epoch)?;
+    // `last_executed_get` reports both "nothing committed here" cases as `NotFound`: no row at all,
+    // and a row belonging to another epoch - the latter being exactly the window after an epoch
+    // change, and the former a node that has not started consensus since restarting. Neither is a
+    // failure to read; both mean there is nothing to anchor to.
+    let Some(last_executed) = tx.last_executed_get(epoch).optional()? else {
+        return Ok(None);
+    };
     if last_executed.height.is_zero() {
         return Ok(None);
     }

--- a/applications/tari_validator_node/src/p2p/rpc/rpc_impl.rs
+++ b/applications/tari_validator_node/src/p2p/rpc/rpc_impl.rs
@@ -141,7 +141,6 @@ impl<TStateStore: StateStore> ValidatorNodeRpcServiceImpl<TStateStore> {
     fn attach_substate_proof<TTx: StateStoreReadTransaction>(
         &self,
         tx: &TTx,
-        shard_group: ShardGroup,
         num_preshards: NumPreshards,
         substate: &SubstateRecord,
         resp: &mut GetSubstateResponse,
@@ -152,6 +151,7 @@ impl<TStateStore: StateStore> ValidatorNodeRpcServiceImpl<TStateStore> {
             return Ok(());
         };
 
+        let shard_group = proof_shard_group(&commit_proof).map_err(RpcStatus::log_internal_error(LOG_TARGET))?;
         let value_proof = generate_substate_proof(tx, shard_group, &substate.to_versioned_substate_id(), num_preshards)
             .map_err(RpcStatus::log_internal_error(LOG_TARGET))?;
 
@@ -163,10 +163,21 @@ impl<TStateStore: StateStore> ValidatorNodeRpcServiceImpl<TStateStore> {
     }
 }
 
+/// The shard group a commit proof's block header commits the state merkle root of.
+///
+/// Value proofs must be built against this group rather than one read from an epoch lookup: the two
+/// disagree across an epoch boundary at which the committee count changed, and level-2 proofs shaped
+/// by the wrong group verify against a root the anchor does not commit. Taking it from the anchor
+/// makes the pair consistent by construction.
+fn proof_shard_group(commit_proof: &CommittedBlockProof) -> Result<ShardGroup, StorageError> {
+    commit_proof.shard_group().map_err(|e| StorageError::QueryError {
+        reason: format!("commit proof has an invalid shard group: {e}"),
+    })
+}
+
 /// What the responder needs to prove a batch of substates against its own committed state.
 struct BatchProofContext {
     epoch: Epoch,
-    shard_group: ShardGroup,
     num_preshards: NumPreshards,
     include_proofs: bool,
 }
@@ -186,16 +197,17 @@ fn read_substate_batch<TTx: StateStoreReadTransaction>(
     ids: &[SubstateId],
     ctx: BatchProofContext,
 ) -> Result<Vec<batch_response::Response>, StorageError> {
-    let (substates, mut missing) = SubstateRecord::get_any_max_version(tx, ids)?;
-    let mut missing = missing.drain().map(|id| id.to_bytes()).collect::<Vec<_>>();
+    let (substates, missing) = SubstateRecord::get_any_max_version(tx, ids)?;
+    let mut missing = missing.into_iter().map(|id| id.to_bytes()).collect::<Vec<_>>();
 
     let mut generator = None;
     let mut messages = Vec::with_capacity(substates.len() + 2);
     if ctx.include_proofs &&
         let Some(commit_proof) = latest_commit_proof(tx, ctx.epoch)?
     {
+        let shard_group = proof_shard_group(&commit_proof)?;
         messages.push(batch_response::Response::CommitProof(commit_proof.to_bytes()));
-        generator = Some(SubstateProofGenerator::new(tx, ctx.shard_group, ctx.num_preshards)?);
+        generator = Some(SubstateProofGenerator::new(tx, shard_group, ctx.num_preshards)?);
     }
 
     for substate in substates {
@@ -300,13 +312,17 @@ impl<TStateStore: StateStore + Clone + Send + Sync + 'static> ValidatorNodeRpcSe
             .ok_or_else(|| RpcStatus::bad_request("Missing substate requirement"))?;
 
         // We need our local committee info to (a) confirm we store a non-global substate and (b) know
-        // our shard group + preshard count when generating a proof. It is read at the epoch consensus
-        // is committing at - the epoch the proved state and its anchor belong to - so that a shard
-        // group from a newer epoch cannot shape a proof the anchor's root does not commit.
+        // the preshard count when generating a proof. The shard group a proof is built against comes
+        // from the anchor rather than from here, so this is only ever a question about the node.
         let local_committee_info = if !substate_requirement.substate_id().is_global() || req.include_proof {
+            let current_epoch = self
+                .epoch_manager
+                .current_epoch()
+                .await
+                .map_err(RpcStatus::log_internal_error(LOG_TARGET))?;
             let info = self
                 .epoch_manager
-                .get_local_committee_info(self.consensus.current_epoch())
+                .get_local_committee_info(current_epoch)
                 .await
                 .map_err(RpcStatus::log_internal_error(LOG_TARGET))?;
             if !substate_requirement.substate_id().is_global() &&
@@ -375,7 +391,7 @@ impl<TStateStore: StateStore + Clone + Send + Sync + 'static> ValidatorNodeRpcSe
             let info = local_committee_info
                 .as_ref()
                 .expect("committee info is fetched whenever include_proof is set");
-            self.attach_substate_proof(&tx, info.shard_group(), info.num_preshards(), &substate, &mut resp)?;
+            self.attach_substate_proof(&tx, info.num_preshards(), &substate, &mut resp)?;
         }
 
         Ok(Response::new(resp))
@@ -748,15 +764,18 @@ impl<TStateStore: StateStore + Clone + Send + Sync + 'static> ValidatorNodeRpcSe
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| RpcStatus::bad_request(format!("Invalid substate ID: {e}")))?;
 
-        // The state being read and the anchor proving it both belong to the epoch consensus is
-        // committing at, so the committee info that shapes the proof must come from that epoch too:
-        // a shard group read at a newer epoch would produce level-2 proofs against a root the anchor
-        // does not commit. It tells us (a) which of the requested ids we are responsible for and
-        // (b) our shard group + preshard count.
-        let consensus_epoch = self.consensus.current_epoch();
+        // Which of the requested ids we are responsible for. This is a membership question about the
+        // node, not about the state being proved - the shard group a proof is built against comes
+        // from the anchor - so it is asked at the epoch manager's epoch, which is set before
+        // consensus starts.
+        let current_epoch = self
+            .epoch_manager
+            .current_epoch()
+            .await
+            .map_err(RpcStatus::log_internal_error(LOG_TARGET))?;
         let local_committee_info = self
             .epoch_manager
-            .get_local_committee_info(consensus_epoch)
+            .get_local_committee_info(current_epoch)
             .await
             .map_err(RpcStatus::log_internal_error(LOG_TARGET))?;
         if let Some(id) = ids.iter().find(|id| !local_committee_info.includes_substate_id(id)) {
@@ -770,7 +789,9 @@ impl<TStateStore: StateStore + Clone + Send + Sync + 'static> ValidatorNodeRpcSe
         let (sender, receiver) = mpsc::channel(req.substate_ids.len() + 2);
 
         let store = self.state_store.clone();
-        let shard_group = local_committee_info.shard_group();
+        // The epoch to look for a committed block at. Before consensus starts this is zero, which
+        // finds nothing and yields no anchor, so results go out unproven rather than failing.
+        let consensus_epoch = self.consensus.current_epoch();
         let num_preshards = local_committee_info.num_preshards();
         let include_proofs = req.include_proofs;
         let responses = task::spawn_blocking(move || {
@@ -779,7 +800,6 @@ impl<TStateStore: StateStore + Clone + Send + Sync + 'static> ValidatorNodeRpcSe
             store.with_read_tx(|tx| {
                 read_substate_batch(tx, &ids, BatchProofContext {
                     epoch: consensus_epoch,
-                    shard_group,
                     num_preshards,
                     include_proofs,
                 })

--- a/applications/tari_validator_node/src/p2p/rpc/rpc_impl.rs
+++ b/applications/tari_validator_node/src/p2p/rpc/rpc_impl.rs
@@ -65,11 +65,14 @@ use tari_ootle_p2p::{
         SyncBlocksResponse,
         SyncStateRequest,
         SyncStateResponse,
+        get_substates_batch_response as batch_response,
     },
 };
 use tari_ootle_storage::{
     StateStore,
     StateStoreReadTransaction,
+    StorageError,
+    SubstateProofGenerator,
     consensus_models::{
         Block,
         BookkeepingEpochAgnosticRead,
@@ -144,28 +147,110 @@ impl<TStateStore: StateStore> ValidatorNodeRpcServiceImpl<TStateStore> {
         resp: &mut GetSubstateResponse,
     ) -> Result<(), RpcStatus> {
         let epoch = self.consensus.current_epoch();
-        let last_executed = tx
-            .last_executed_get(epoch)
-            .map_err(RpcStatus::log_internal_error(LOG_TARGET))?;
-        if last_executed.height.is_zero() {
+        let Some(commit_proof) = latest_commit_proof(tx, epoch).map_err(RpcStatus::log_internal_error(LOG_TARGET))?
+        else {
             return Ok(());
-        }
+        };
 
-        let block = Block::get(tx, &last_executed.block_id).map_err(RpcStatus::log_internal_error(LOG_TARGET))?;
-        let commit_qc = block
-            .get_commit_qc(tx)
-            .map_err(RpcStatus::log_internal_error(LOG_TARGET))?;
-        let commit_proof =
-            generate_block_commit_proof(tx, &commit_qc, &block).map_err(RpcStatus::log_internal_error(LOG_TARGET))?;
         let value_proof = generate_substate_proof(tx, shard_group, &substate.to_versioned_substate_id(), num_preshards)
             .map_err(RpcStatus::log_internal_error(LOG_TARGET))?;
 
-        resp.commit_proof = CommittedBlockProof::new(commit_proof).to_bytes();
+        resp.commit_proof = commit_proof.to_bytes();
         resp.substate_value_proof =
             tari_bor::serde_codec::to_vec(&value_proof).map_err(RpcStatus::log_internal_error(LOG_TARGET))?;
         resp.proof_epoch = substate.created().at_epoch.as_u64();
         Ok(())
     }
+}
+
+/// What the responder needs to prove a batch of substates against its own committed state.
+struct BatchProofContext {
+    epoch: Epoch,
+    shard_group: ShardGroup,
+    num_preshards: NumPreshards,
+    include_proofs: bool,
+}
+
+/// Reads the head version of each of `ids` and, when proofs were asked for, a single anchor followed
+/// by a value proof per substate.
+///
+/// Everything is read in one transaction, so every value proof verifies against the anchor's
+/// shard-group root. The anchor comes first so a client can establish that root before it has to
+/// verify anything against it; `missing` comes last, once the ids that were found are known.
+fn read_substate_batch<TTx: StateStoreReadTransaction>(
+    tx: &TTx,
+    ids: &[SubstateId],
+    ctx: BatchProofContext,
+) -> Result<Vec<batch_response::Response>, StorageError> {
+    let (substates, missing) = SubstateRecord::get_any_max_version(tx, ids)?;
+
+    let mut generator = None;
+    let mut messages = Vec::with_capacity(substates.len() + 2);
+    if ctx.include_proofs &&
+        let Some(commit_proof) = latest_commit_proof(tx, ctx.epoch)?
+    {
+        messages.push(batch_response::Response::CommitProof(commit_proof.to_bytes()));
+        generator = Some(SubstateProofGenerator::new(tx, ctx.shard_group, ctx.num_preshards)?);
+    }
+
+    for substate in substates {
+        let value_proof = generator
+            .as_mut()
+            .map(|generator| {
+                let proof = generator.generate(&substate.to_versioned_substate_id())?;
+                tari_bor::serde_codec::to_vec(&proof).map_err(|e| StorageError::QueryError {
+                    reason: format!("encode substate value proof: {e}"),
+                })
+            })
+            .transpose()?;
+
+        messages.push(batch_response::Response::Substate(proto::rpc::ProvenSubstate {
+            proof_epoch: substate.created().at_epoch.as_u64(),
+            substate_value_proof: value_proof.unwrap_or_default(),
+            substate: Some(proto::consensus::Substate {
+                substate_id: substate.substate_id().to_bytes(),
+                version: substate.version(),
+                substate: substate.substate_value().map(|v| v.to_bytes()).unwrap_or_default(),
+                created: Some(substate.created().into()),
+                destroyed: substate.destroyed().map(Into::into),
+            }),
+        }));
+    }
+
+    if !missing.is_empty() {
+        debug!(
+            target: LOG_TARGET,
+            "{} requested substate(s) not found: {}",
+            missing.len(),
+            missing.display()
+        );
+        messages.push(batch_response::Response::Missing(proto::rpc::MissingSubstates {
+            substate_ids: missing.iter().map(|id| id.to_bytes()).collect(),
+        }));
+    }
+
+    Ok(messages)
+}
+
+/// The commit proof for the latest committed block: the quorum-signed anchor for the shard-group
+/// state merkle root that substate value proofs generated in the same read transaction verify
+/// against. `None` when nothing is committed beyond the epoch genesis yet, in which case results go
+/// out unproven and the caller treats them as unverified.
+fn latest_commit_proof<TTx: StateStoreReadTransaction>(
+    tx: &TTx,
+    epoch: Epoch,
+) -> Result<Option<CommittedBlockProof>, StorageError> {
+    let last_executed = tx.last_executed_get(epoch)?;
+    if last_executed.height.is_zero() {
+        return Ok(None);
+    }
+
+    let block = Block::get(tx, &last_executed.block_id)?;
+    let commit_qc = block.get_commit_qc(tx)?;
+    let proof = generate_block_commit_proof(tx, &commit_qc, &block).map_err(|e| StorageError::QueryError {
+        reason: format!("generate_block_commit_proof: {e}"),
+    })?;
+    Ok(Some(CommittedBlockProof::new(proof)))
 }
 
 #[tari_rpc_framework::async_trait]
@@ -616,21 +701,7 @@ impl<TStateStore: StateStore + Clone + Send + Sync + 'static> ValidatorNodeRpcSe
 
         let maybe_proof = task::spawn_blocking(move || {
             store
-                .with_read_tx(|tx| {
-                    let last_executed = tx.last_executed_get(epoch)?;
-                    // Nothing has been committed beyond the epoch genesis yet - there is no proof to give.
-                    if last_executed.height.is_zero() {
-                        return Ok(None);
-                    }
-                    let block = Block::get(tx, &last_executed.block_id)?;
-                    let commit_qc = block.get_commit_qc(tx)?;
-                    let proof = generate_block_commit_proof(tx, &commit_qc, &block).map_err(|e| {
-                        tari_ootle_storage::StorageError::QueryError {
-                            reason: format!("generate_block_commit_proof: {e}"),
-                        }
-                    })?;
-                    Ok::<_, tari_ootle_storage::StorageError>(Some(CommittedBlockProof::new(proof)))
-                })
+                .with_read_tx(|tx| latest_commit_proof(tx, epoch))
                 .map_err(RpcStatus::log_internal_error(LOG_TARGET))
         })
         .await
@@ -665,40 +736,56 @@ impl<TStateStore: StateStore + Clone + Send + Sync + 'static> ValidatorNodeRpcSe
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| RpcStatus::bad_request(format!("Invalid substate ID: {e}")))?;
 
-        let (sender, receiver) = mpsc::channel(req.substate_ids.len());
+        // Our local committee info tells us (a) which of the requested ids we are actually responsible
+        // for and (b) our shard group + preshard count, needed to generate proofs.
+        let current_epoch = self
+            .epoch_manager
+            .current_epoch()
+            .await
+            .map_err(RpcStatus::log_internal_error(LOG_TARGET))?;
+        let local_committee_info = self
+            .epoch_manager
+            .get_local_committee_info(current_epoch)
+            .await
+            .map_err(RpcStatus::log_internal_error(LOG_TARGET))?;
+        if let Some(id) = ids
+            .iter()
+            .find(|id| !id.is_global() && !local_committee_info.includes_substate_id(id))
+        {
+            return Err(RpcStatus::bad_request(format!(
+                "This node in {} does not store {}",
+                local_committee_info.shard_group(),
+                id
+            )));
+        }
+
+        let (sender, receiver) = mpsc::channel(req.substate_ids.len() + 2);
 
         let store = self.state_store.clone();
+        let consensus_epoch = self.consensus.current_epoch();
+        let shard_group = local_committee_info.shard_group();
+        let num_preshards = local_committee_info.num_preshards();
+        let include_proofs = req.include_proofs;
         let responses = task::spawn_blocking(move || {
             // TODO: we should use a snapshot - will need to refactor the state store to support this, by abstracting
             // the .cf(X) call and implementing read only transaction for all implementors of this trait
-            let (substates, missing) = store
-                .with_read_tx(|tx| SubstateRecord::get_any_max_version(tx, &ids))
-                .map_err(RpcStatus::log_internal_error(LOG_TARGET))?;
-
-            if !missing.is_empty() {
-                debug!(
-                    target: LOG_TARGET,
-                    "{} requested substate(s) not found: {}",
-                    missing.len(),
-                    missing.display()
-                );
-            }
-
-            Ok::<_, RpcStatus>(substates.into_iter().map(|substate| proto::consensus::Substate {
-                substate_id: substate.substate_id().to_bytes(),
-                version: substate.version(),
-                substate: substate.substate_value().map(|v| v.to_bytes()).unwrap_or_default(),
-                created: Some(substate.created().into()),
-                destroyed: substate.destroyed().map(Into::into),
-            }))
+            store.with_read_tx(|tx| {
+                read_substate_batch(tx, &ids, BatchProofContext {
+                    epoch: consensus_epoch,
+                    shard_group,
+                    num_preshards,
+                    include_proofs,
+                })
+            })
         })
         .await
-        .map_err(RpcStatus::log_internal_error(LOG_TARGET))??;
+        .map_err(RpcStatus::log_internal_error(LOG_TARGET))?
+        .map_err(RpcStatus::log_internal_error(LOG_TARGET))?;
 
         task::spawn(async move {
             for resp in responses {
                 if sender
-                    .send(Ok(GetSubstatesBatchResponse { substate: Some(resp) }))
+                    .send(Ok(GetSubstatesBatchResponse { response: Some(resp) }))
                     .await
                     .is_err()
                 {

--- a/applications/tari_validator_node/src/p2p/rpc/rpc_impl.rs
+++ b/applications/tari_validator_node/src/p2p/rpc/rpc_impl.rs
@@ -721,6 +721,12 @@ impl<TStateStore: StateStore + Clone + Send + Sync + 'static> ValidatorNodeRpcSe
         &self,
         req: Request<GetSubstatesBatchRequest>,
     ) -> Result<Streaming<GetSubstatesBatchResponse>, RpcStatus> {
+        // Proving a batch costs a fixed amount per request - reading every shard root in the group and
+        // building the tree over them - plus a leaf traversal per substate. Measured on a 256-shard
+        // group (see the `proof_cost` test), that is ~220us fixed against ~4us per substate, so a
+        // request answering 50 costs ~450us where 50 single-substate requests cost ~11ms. A lower cap
+        // would therefore make a flood *more* expensive to serve, not less; what 50 bounds is the
+        // response, which the responder holds in memory before streaming.
         const MAX_REQUESTS: usize = 50;
         let req = req.into_message();
 

--- a/applications/tari_validator_node/src/p2p/rpc/rpc_impl.rs
+++ b/applications/tari_validator_node/src/p2p/rpc/rpc_impl.rs
@@ -177,12 +177,17 @@ struct BatchProofContext {
 /// Everything is read in one transaction, so every value proof verifies against the anchor's
 /// shard-group root. The anchor comes first so a client can establish that root before it has to
 /// verify anything against it; `missing` comes last, once the ids that were found are known.
+///
+/// A substate whose shard has no committed state cannot be proved against the anchor. It is reported
+/// as missing rather than failing the batch, so the ids that can be answered still are; the client
+/// refetches whatever it did not get.
 fn read_substate_batch<TTx: StateStoreReadTransaction>(
     tx: &TTx,
     ids: &[SubstateId],
     ctx: BatchProofContext,
 ) -> Result<Vec<batch_response::Response>, StorageError> {
-    let (substates, missing) = SubstateRecord::get_any_max_version(tx, ids)?;
+    let (substates, mut missing) = SubstateRecord::get_any_max_version(tx, ids)?;
+    let mut missing = missing.drain().map(|id| id.to_bytes()).collect::<Vec<_>>();
 
     let mut generator = None;
     let mut messages = Vec::with_capacity(substates.len() + 2);
@@ -194,19 +199,25 @@ fn read_substate_batch<TTx: StateStoreReadTransaction>(
     }
 
     for substate in substates {
-        let value_proof = generator
-            .as_mut()
-            .map(|generator| {
-                let proof = generator.generate(&substate.to_versioned_substate_id())?;
-                tari_bor::serde_codec::to_vec(&proof).map_err(|e| StorageError::QueryError {
-                    reason: format!("encode substate value proof: {e}"),
-                })
-            })
-            .transpose()?;
+        let mut value_proof = Vec::new();
+        if let Some(generator) = generator.as_mut() {
+            let Some(proof) = generator.generate(&substate.to_versioned_substate_id())? else {
+                warn!(
+                    target: LOG_TARGET,
+                    "{} is stored but its shard has no committed state; reporting it as missing",
+                    substate.substate_id()
+                );
+                missing.push(substate.substate_id().to_bytes());
+                continue;
+            };
+            value_proof = tari_bor::serde_codec::to_vec(&proof).map_err(|e| StorageError::QueryError {
+                reason: format!("encode substate value proof: {e}"),
+            })?;
+        }
 
         messages.push(batch_response::Response::Substate(proto::rpc::ProvenSubstate {
             proof_epoch: substate.created().at_epoch.as_u64(),
-            substate_value_proof: value_proof.unwrap_or_default(),
+            substate_value_proof: value_proof,
             substate: Some(proto::consensus::Substate {
                 substate_id: substate.substate_id().to_bytes(),
                 version: substate.version(),
@@ -218,14 +229,9 @@ fn read_substate_batch<TTx: StateStoreReadTransaction>(
     }
 
     if !missing.is_empty() {
-        debug!(
-            target: LOG_TARGET,
-            "{} requested substate(s) not found: {}",
-            missing.len(),
-            missing.display()
-        );
+        debug!(target: LOG_TARGET, "{} requested substate(s) not answered", missing.len());
         messages.push(batch_response::Response::Missing(proto::rpc::MissingSubstates {
-            substate_ids: missing.iter().map(|id| id.to_bytes()).collect(),
+            substate_ids: missing,
         }));
     }
 
@@ -294,16 +300,13 @@ impl<TStateStore: StateStore + Clone + Send + Sync + 'static> ValidatorNodeRpcSe
             .ok_or_else(|| RpcStatus::bad_request("Missing substate requirement"))?;
 
         // We need our local committee info to (a) confirm we store a non-global substate and (b) know
-        // our shard group + preshard count when generating a proof.
+        // our shard group + preshard count when generating a proof. It is read at the epoch consensus
+        // is committing at - the epoch the proved state and its anchor belong to - so that a shard
+        // group from a newer epoch cannot shape a proof the anchor's root does not commit.
         let local_committee_info = if !substate_requirement.substate_id().is_global() || req.include_proof {
-            let current_epoch = self
-                .epoch_manager
-                .current_epoch()
-                .await
-                .map_err(RpcStatus::log_internal_error(LOG_TARGET))?;
             let info = self
                 .epoch_manager
-                .get_local_committee_info(current_epoch)
+                .get_local_committee_info(self.consensus.current_epoch())
                 .await
                 .map_err(RpcStatus::log_internal_error(LOG_TARGET))?;
             if !substate_requirement.substate_id().is_global() &&
@@ -724,6 +727,9 @@ impl<TStateStore: StateStore + Clone + Send + Sync + 'static> ValidatorNodeRpcSe
         if req.substate_ids.len() > MAX_REQUESTS {
             return Err(RpcStatus::bad_request("Cannot request more than 50 substates at once"));
         }
+        if req.substate_ids.is_empty() {
+            return Err(RpcStatus::bad_request("No substate ids requested"));
+        }
 
         debug!(
             target: LOG_TARGET,
@@ -736,22 +742,18 @@ impl<TStateStore: StateStore + Clone + Send + Sync + 'static> ValidatorNodeRpcSe
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| RpcStatus::bad_request(format!("Invalid substate ID: {e}")))?;
 
-        // Our local committee info tells us (a) which of the requested ids we are actually responsible
-        // for and (b) our shard group + preshard count, needed to generate proofs.
-        let current_epoch = self
-            .epoch_manager
-            .current_epoch()
-            .await
-            .map_err(RpcStatus::log_internal_error(LOG_TARGET))?;
+        // The state being read and the anchor proving it both belong to the epoch consensus is
+        // committing at, so the committee info that shapes the proof must come from that epoch too:
+        // a shard group read at a newer epoch would produce level-2 proofs against a root the anchor
+        // does not commit. It tells us (a) which of the requested ids we are responsible for and
+        // (b) our shard group + preshard count.
+        let consensus_epoch = self.consensus.current_epoch();
         let local_committee_info = self
             .epoch_manager
-            .get_local_committee_info(current_epoch)
+            .get_local_committee_info(consensus_epoch)
             .await
             .map_err(RpcStatus::log_internal_error(LOG_TARGET))?;
-        if let Some(id) = ids
-            .iter()
-            .find(|id| !id.is_global() && !local_committee_info.includes_substate_id(id))
-        {
+        if let Some(id) = ids.iter().find(|id| !local_committee_info.includes_substate_id(id)) {
             return Err(RpcStatus::bad_request(format!(
                 "This node in {} does not store {}",
                 local_committee_info.shard_group(),
@@ -762,7 +764,6 @@ impl<TStateStore: StateStore + Clone + Send + Sync + 'static> ValidatorNodeRpcSe
         let (sender, receiver) = mpsc::channel(req.substate_ids.len() + 2);
 
         let store = self.state_store.clone();
-        let consensus_epoch = self.consensus.current_epoch();
         let shard_group = local_committee_info.shard_group();
         let num_preshards = local_committee_info.num_preshards();
         let include_proofs = req.include_proofs;

--- a/crates/indexer_lib/src/cached_substate_manager.rs
+++ b/crates/indexer_lib/src/cached_substate_manager.rs
@@ -92,6 +92,26 @@ pub trait TrustedRootStore: std::fmt::Debug + Send + Sync + 'static {
     async fn record(&self, tip: VerifiedBlockTip) -> Result<(), IndexerError>;
 }
 
+/// The most substates a validator will answer for in one batch request.
+const SUBSTATE_BATCH_SIZE: usize = 50;
+
+/// How many committee members a batch chunk is tried against before it is given up on. Unlike
+/// [`READ_RACE_WIDTH`], which bounds concurrent in-flight reads, these are sequential attempts: a
+/// batch is large enough that asking several members at once for the same chunk would waste more
+/// bandwidth than the latency it saves.
+const BATCH_READ_ATTEMPTS: usize = 5;
+
+/// What a batch's proofs establish about the results in it.
+#[derive(Debug, Clone, Copy)]
+enum BatchTrust {
+    /// Proof verification is off, so there was nothing to establish.
+    NotRequired,
+    /// Every result was proven against the batch's anchor.
+    Proven,
+    /// The responder had no committed block to anchor against, so it proved nothing.
+    Unanchored,
+}
+
 /// Outcome of a substate lookup together with whether the value was committee-verified.
 #[derive(Debug, Clone)]
 pub struct SubstateLookupResult {
@@ -336,83 +356,118 @@ where
         let mut results = HashMap::with_capacity(substate_ids.len());
         for (shard_group, (committee, substate_ids)) in committee_map {
             debug!(target: LOG_TARGET, "Fetching {} substates from shard group {}", substate_ids.len(), shard_group);
-            let num_batches = substate_ids.len().div_ceil(50);
-            let mut batch_count = 0;
-            for member in committee.shuffled().take(5) {
-                if batch_count >= num_batches {
-                    break;
+            for chunk in substate_ids.chunks(SUBSTATE_BATCH_SIZE) {
+                let (batch, verified) = self.race_substate_batch(&committee, chunk, shard_group).await?;
+                if !batch.missing.is_empty() {
+                    debug!(
+                        target: LOG_TARGET,
+                        "{} of {} requested substate(s) are unknown to {shard_group}",
+                        batch.missing.len(),
+                        chunk.len()
+                    );
                 }
-                let mut client = self.validator_node_client_factory.create_client(&member.address);
-                let batches = substate_ids.chunks(50).skip(batch_count);
-                for batch in batches {
-                    let resp = match client.get_substates_batch(batch, self.verify_substate_proofs).await {
-                        Ok(resp) => resp,
-                        Err(e) => {
-                            warn!(target: LOG_TARGET, "⚠️Failed to get substate batch for shard group {}: {}", shard_group, e);
-                            break;
-                        },
-                    };
 
-                    // One anchor covers the whole batch, so the commit proof is validated against the
-                    // committee at most once per batch and each result costs only its Merkle path.
-                    let verified = match self.verify_substate_batch(&resp).await {
-                        Ok(verified) => verified,
-                        Err(e) => {
-                            // Fail closed: an unverifiable batch disqualifies this member, and the
-                            // batch is retried against the next one.
-                            warn!(target: LOG_TARGET, "⚠️Rejected substate batch from {}: {}", member.address, e);
-                            break;
-                        },
-                    };
-                    batch_count += 1;
-
-                    for substate in resp.substates {
-                        if let Some(watermark) = watermarks.get(&substate.substate_id).copied() {
-                            let entry = SubstateCacheEntryRef {
-                                version: substate.result.version(),
-                                substate_result: &substate.result,
-                                cached_at: SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)?.as_secs(),
-                                verified,
-                            };
-                            // An unverified entry is not cached while verification is on, so the next
-                            // read retries for a proven copy instead of pinning an unproven value.
-                            if verified || !self.verify_substate_proofs {
-                                self.substate_cache
-                                    .write(&substate.substate_id, entry, watermark)
-                                    .await?;
-                            }
-                        }
-
-                        // A batch answers with the head version; a caller asking for substates by id
-                        // wants the live ones, and a down head is not one.
-                        if let Some(up) = substate.result.into_up() {
-                            results.insert(substate.substate_id, up);
+                for substate in batch.substates {
+                    if let Some(watermark) = watermarks.get(&substate.substate_id).copied() {
+                        let entry = SubstateCacheEntryRef {
+                            version: substate.result.version(),
+                            substate_result: &substate.result,
+                            cached_at: SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)?.as_secs(),
+                            verified,
+                        };
+                        // An unverified entry is not cached while verification is on, so the next
+                        // read retries for a proven copy instead of pinning an unproven value.
+                        if verified || !self.verify_substate_proofs {
+                            self.substate_cache
+                                .write(&substate.substate_id, entry, watermark)
+                                .await?;
                         }
                     }
+
+                    // A batch answers with the head version; a caller asking for substates by id
+                    // wants the live ones, and a down head is not one.
+                    if let Some(up) = substate.result.into_up() {
+                        results.insert(substate.substate_id, up);
+                    }
                 }
-            }
-            if batch_count < num_batches {
-                return Err(IndexerError::ValidatorNodeClientError(format!(
-                    "Failed to get all substate batches for shard group {}. {}/{}",
-                    shard_group, batch_count, num_batches
-                )));
             }
         }
         Ok(results)
     }
 
-    /// Verifies every value proof in `batch` against the batch's single anchor, returning whether the
-    /// results may be cached as verified.
+    /// Fetches one chunk of substate ids, preferring a member that can prove it.
     ///
-    /// Returns `false` (rather than failing) when the batch carries no anchor at all: a validator with
-    /// nothing committed yet cannot prove anything, which is not misbehaviour. A batch that carries an
-    /// anchor must prove every result it returns.
-    async fn verify_substate_batch(&self, batch: &SubstateBatch) -> Result<bool, IndexerError> {
+    /// A member that answers without an anchor has nothing committed to prove against (it is behind,
+    /// or in the window right after an epoch change). Rather than settle for that answer, its batch is
+    /// held and the rest of the committee is asked, the same way [`CommitteeReadTally`] holds an
+    /// unproven single-substate result while it keeps racing. The held batch is served only once every
+    /// member has failed to prove the chunk, and never cached.
+    ///
+    /// Returns the batch and whether it was proven.
+    async fn race_substate_batch(
+        &self,
+        committee: &Committee<TAddr>,
+        chunk: &[&SubstateId],
+        shard_group: ShardGroup,
+    ) -> Result<(SubstateBatch, bool), IndexerError> {
+        let mut unproven = None;
+        for member in committee.shuffled().take(BATCH_READ_ATTEMPTS) {
+            let mut client = self.validator_node_client_factory.create_client(&member.address);
+            let batch = match client.get_substates_batch(chunk, self.verify_substate_proofs).await {
+                Ok(batch) => batch,
+                Err(e) => {
+                    warn!(target: LOG_TARGET, "⚠️Failed to get substate batch from {}: {}", member.address, e);
+                    continue;
+                },
+            };
+
+            // One anchor covers the whole batch, so the commit proof is validated against the
+            // committee at most once per batch and each result costs only its Merkle path.
+            match self.verify_substate_batch(&batch).await {
+                Ok(BatchTrust::NotRequired) => return Ok((batch, false)),
+                Ok(BatchTrust::Proven) => return Ok((batch, true)),
+                Ok(BatchTrust::Unanchored) => {
+                    debug!(
+                        target: LOG_TARGET,
+                        "{} has nothing committed to prove this batch against; asking another member",
+                        member.address
+                    );
+                    unproven.get_or_insert(batch);
+                },
+                // Fail closed: an unverifiable batch disqualifies this member.
+                Err(e) => {
+                    warn!(target: LOG_TARGET, "⚠️Rejected substate batch from {}: {}", member.address, e);
+                },
+            }
+        }
+
+        match unproven {
+            Some(batch) => {
+                warn!(
+                    target: LOG_TARGET,
+                    "⚠️No member of {shard_group} could prove {} substate(s); serving them unproven",
+                    chunk.len()
+                );
+                Ok((batch, false))
+            },
+            None => Err(IndexerError::ValidatorNodeClientError(format!(
+                "No member of {shard_group} answered for {} substate(s)",
+                chunk.len()
+            ))),
+        }
+    }
+
+    /// Verifies every value proof in `batch` against the batch's single anchor.
+    ///
+    /// A batch that carries an anchor must prove every result it returns; one that carries no anchor
+    /// proves nothing, which is not misbehaviour and is reported as [`BatchTrust::Unanchored`] for the
+    /// caller to weigh against what other members offer.
+    async fn verify_substate_batch(&self, batch: &SubstateBatch) -> Result<BatchTrust, IndexerError> {
         if !self.verify_substate_proofs {
-            return Ok(false);
+            return Ok(BatchTrust::NotRequired);
         }
         let Some(commit_proof) = &batch.commit_proof else {
-            return Ok(false);
+            return Ok(BatchTrust::Unanchored);
         };
 
         let root = self.trusted_root_from_commit_proof(commit_proof).await?;
@@ -449,7 +504,7 @@ where
             .map_err(|e| IndexerError::SubstateProofVerificationFailed { details: e.to_string() })?;
         }
 
-        Ok(true)
+        Ok(BatchTrust::Proven)
     }
 
     async fn fetch_substate_from_committee(

--- a/crates/indexer_lib/src/cached_substate_manager.rs
+++ b/crates/indexer_lib/src/cached_substate_manager.rs
@@ -48,10 +48,10 @@ use tari_ootle_common_types::{
 };
 use tari_ootle_storage::{
     consensus_models::{CommittedBlockProof, VerifiedBlockTip},
-    verify_substate_value_proof,
     verify_substate_value_proof_against_root,
 };
 use tari_validator_node_rpc::client::{
+    SubstateBatch,
     SubstateProofData,
     SubstateResult,
     ValidatorNodeClientFactory,
@@ -345,32 +345,50 @@ where
                 let mut client = self.validator_node_client_factory.create_client(&member.address);
                 let batches = substate_ids.chunks(50).skip(batch_count);
                 for batch in batches {
-                    let resp = match client.get_substates_batch(batch).await {
+                    let resp = match client.get_substates_batch(batch, self.verify_substate_proofs).await {
                         Ok(resp) => resp,
                         Err(e) => {
                             warn!(target: LOG_TARGET, "⚠️Failed to get substate batch for shard group {}: {}", shard_group, e);
                             break;
                         },
                     };
+
+                    // One anchor covers the whole batch, so the commit proof is validated against the
+                    // committee at most once per batch and each result costs only its Merkle path.
+                    let verified = match self.verify_substate_batch(&resp).await {
+                        Ok(verified) => verified,
+                        Err(e) => {
+                            // Fail closed: an unverifiable batch disqualifies this member, and the
+                            // batch is retried against the next one.
+                            warn!(target: LOG_TARGET, "⚠️Rejected substate batch from {}: {}", member.address, e);
+                            break;
+                        },
+                    };
                     batch_count += 1;
 
-                    for (substate_id, substate) in &resp {
-                        let Some(watermark) = watermarks.get(substate_id).copied() else {
-                            continue;
-                        };
-                        let substate_result = SubstateResult::Up {
-                            substate: Box::new(substate.clone()),
-                        };
-                        // The batch RPC does not carry proofs, so these entries are always unverified.
-                        let entry = SubstateCacheEntryRef {
-                            version: Some(substate.version()),
-                            substate_result: &substate_result,
-                            cached_at: SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)?.as_secs(),
-                            verified: false,
-                        };
-                        self.substate_cache.write(substate_id, entry, watermark).await?;
+                    for substate in resp.substates {
+                        if let Some(watermark) = watermarks.get(&substate.substate_id).copied() {
+                            let entry = SubstateCacheEntryRef {
+                                version: substate.result.version(),
+                                substate_result: &substate.result,
+                                cached_at: SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)?.as_secs(),
+                                verified,
+                            };
+                            // An unverified entry is not cached while verification is on, so the next
+                            // read retries for a proven copy instead of pinning an unproven value.
+                            if verified || !self.verify_substate_proofs {
+                                self.substate_cache
+                                    .write(&substate.substate_id, entry, watermark)
+                                    .await?;
+                            }
+                        }
+
+                        // A batch answers with the head version; a caller asking for substates by id
+                        // wants the live ones, and a down head is not one.
+                        if let Some(up) = substate.result.into_up() {
+                            results.insert(substate.substate_id, up);
+                        }
                     }
-                    results.extend(resp);
                 }
             }
             if batch_count < num_batches {
@@ -381,6 +399,57 @@ where
             }
         }
         Ok(results)
+    }
+
+    /// Verifies every value proof in `batch` against the batch's single anchor, returning whether the
+    /// results may be cached as verified.
+    ///
+    /// Returns `false` (rather than failing) when the batch carries no anchor at all: a validator with
+    /// nothing committed yet cannot prove anything, which is not misbehaviour. A batch that carries an
+    /// anchor must prove every result it returns.
+    async fn verify_substate_batch(&self, batch: &SubstateBatch) -> Result<bool, IndexerError> {
+        if !self.verify_substate_proofs {
+            return Ok(false);
+        }
+        let Some(commit_proof) = &batch.commit_proof else {
+            return Ok(false);
+        };
+
+        let root = self.trusted_root_from_commit_proof(commit_proof).await?;
+        for substate in &batch.substates {
+            let Some(value_proof) = &substate.value_proof else {
+                return Err(IndexerError::SubstateProofVerificationFailed {
+                    details: format!(
+                        "{} was returned without a proof in an anchored batch",
+                        substate.substate_id
+                    ),
+                });
+            };
+            let (version, value) = match &substate.result {
+                SubstateResult::Up { substate } => (substate.version(), Some(substate.substate_value())),
+                SubstateResult::Down { version } => (*version, None),
+                // A batch returns only substates it holds a record of; the ids it holds none for come
+                // back as `missing`, which no proof can settle. Anything else here would be cached as
+                // verified without a proof having been checked.
+                SubstateResult::DoesNotExist => {
+                    return Err(IndexerError::SubstateProofVerificationFailed {
+                        details: format!("{} was returned as DoesNotExist in a batch", substate.substate_id),
+                    });
+                },
+            };
+            verify_substate_value_proof_against_root(
+                value_proof,
+                &substate.substate_id,
+                version,
+                value,
+                self.network,
+                Epoch(substate.proof_epoch),
+                root,
+            )
+            .map_err(|e| IndexerError::SubstateProofVerificationFailed { details: e.to_string() })?;
+        }
+
+        Ok(true)
     }
 
     async fn fetch_substate_from_committee(
@@ -512,7 +581,29 @@ where
         value: Option<&SubstateValue>,
         proof: SubstateProofData,
     ) -> Result<(), IndexerError> {
-        let commit_proof = CommittedBlockProof::from_bytes(&proof.commit_proof).map_err(|e| {
+        let root = self.trusted_root_from_commit_proof(&proof.commit_proof).await?;
+        verify_substate_value_proof_against_root(
+            &proof.substate_value_proof,
+            substate_id,
+            version,
+            value,
+            self.network,
+            Epoch(proof.proof_epoch),
+            root,
+        )
+        .map_err(|e| IndexerError::SubstateProofVerificationFailed { details: e.to_string() })?;
+        Ok(())
+    }
+
+    /// Establishes the shard-group state merkle root that value proofs anchored to `commit_proof`
+    /// must verify against.
+    ///
+    /// The returned root is trusted because a quorum of the shard group signed the block header
+    /// committing it, independently of any value proof that goes on to cite it. That is what makes it
+    /// safe to establish once and reuse for a whole batch of value proofs, and to record for later
+    /// reads.
+    async fn trusted_root_from_commit_proof(&self, commit_proof: &[u8]) -> Result<FixedHash, IndexerError> {
+        let commit_proof = CommittedBlockProof::from_bytes(commit_proof).map_err(|e| {
             IndexerError::SubstateProofVerificationFailed {
                 details: format!("undecodable commit proof: {e}"),
             }
@@ -524,62 +615,44 @@ where
         let root = commit_proof.state_merkle_root();
 
         // Fast path: if this exact (epoch, shard_group, root) was already committee-validated and
-        // recorded in the trusted-root store, verify the value proof directly against the trusted
-        // root and skip re-validating the commit proof's QC chain (and the committee lookup). A node
-        // cannot forge a value proof that verifies against a root a quorum already signed, so this is
-        // as sound as the full path.
+        // recorded in the trusted-root store, skip re-validating the commit proof's QC chain (and the
+        // committee lookup). A node cannot forge a value proof that verifies against a root a quorum
+        // already signed, so this is as sound as the full path.
         if let Some(store) = &self.trusted_root_store &&
             store.is_trusted(epoch, shard_group, root).await?
         {
-            verify_substate_value_proof_against_root(
-                &proof.substate_value_proof,
-                substate_id,
-                version,
-                value,
-                self.network,
-                Epoch(proof.proof_epoch),
-                root,
-            )
-            .map_err(|e| IndexerError::SubstateProofVerificationFailed { details: e.to_string() })?;
             debug!(
                 target: LOG_TARGET,
-                "trusted-root HIT for {substate_id} at epoch {epoch} {shard_group}: skipped commit-proof validation"
+                "trusted-root HIT at epoch {epoch} {shard_group}: skipped commit-proof validation"
             );
-            return Ok(());
+            return Ok(root);
         }
 
-        // Slow path: validate the commit proof against the shard group committee, yielding a trusted
-        // root, then verify the value proof against it.
+        // Slow path: validate the commit proof against the shard group committee.
         let committee = self
             .committee_provider
             .get_committee_by_shard_group(epoch, shard_group)
             .await?;
 
-        let verified_tip = verify_substate_value_proof(
-            &commit_proof,
-            &proof.substate_value_proof,
-            substate_id,
-            version,
-            value,
-            self.network,
-            Epoch(proof.proof_epoch),
-            committee.quorum_threshold(),
-            |pk| Ok(committee.get_power_by_public_key(pk).unwrap_or_else(VotePower::zero)),
-        )
-        .map_err(|e| IndexerError::SubstateProofVerificationFailed { details: e.to_string() })?;
+        let verified_tip = commit_proof
+            .validate(committee.quorum_threshold(), |pk| {
+                Ok(committee.get_power_by_public_key(pk).unwrap_or_else(VotePower::zero))
+            })
+            .map_err(|e| IndexerError::SubstateProofVerificationFailed { details: e.to_string() })?;
         debug!(
             target: LOG_TARGET,
-            "trusted-root MISS for {substate_id} at epoch {epoch} {shard_group}: validated commit proof"
+            "trusted-root MISS at epoch {epoch} {shard_group}: validated commit proof"
         );
 
+        let root = verified_tip.state_merkle_root;
         // Warm the store so subsequent reads at this tip hit the fast path. A write failure must not
         // fail an otherwise-verified read.
         if let Some(store) = &self.trusted_root_store &&
             let Err(e) = store.record(verified_tip).await
         {
-            warn!(target: LOG_TARGET, "Failed to record verified root for {substate_id}: {e}");
+            warn!(target: LOG_TARGET, "Failed to record verified root at epoch {epoch} {shard_group}: {e}");
         }
 
-        Ok(())
+        Ok(root)
     }
 }

--- a/crates/p2p/proto/rpc.proto
+++ b/crates/p2p/proto/rpc.proto
@@ -347,7 +347,7 @@ message GetSubstatesBatchResponse {
     // root every value proof in this stream verifies against.
     bytes commit_proof = 1;
     ProvenSubstate substate = 2;
-    // Sent once, after every substate, naming the requested ids the responder holds no record of.
+    // Sent once, after every substate, naming the requested ids this response does not answer for.
     MissingSubstates missing = 3;
   }
 }
@@ -364,9 +364,12 @@ message ProvenSubstate {
 }
 
 message MissingSubstates {
-  // Encoded SubstateIds the responder holds no record of at any version. Unproven: leaf keys are
-  // version-scoped, so an exclusion proof states that one version is not up, never that an id was
-  // never created.
+  // Encoded SubstateIds this response does not answer for, whatever the reason: the responder holds
+  // no record of them, or it holds one it cannot prove because the substate's shard has no committed
+  // state. This is never evidence that a substate does not exist - a consumer may only use it to
+  // decide what to ask for again, never to conclude absence. Absence is not provable at all here:
+  // leaf keys are version-scoped, so an exclusion proof states that one version is not up, never
+  // that an id was never created.
   repeated bytes substate_ids = 1;
 }
 

--- a/crates/p2p/proto/rpc.proto
+++ b/crates/p2p/proto/rpc.proto
@@ -334,11 +334,40 @@ message GetChainSummary {}
 message GetSubstatesBatchRequest {
   // Encoded SubstateIds
   repeated bytes substate_ids = 1;
+  // If true, the responder anchors the stream with a commit proof and attaches a value proof to each
+  // substate it returns.
+  bool include_proofs = 2;
 }
 
 // Streaming response
 message GetSubstatesBatchResponse {
+  oneof response {
+    // Sent once, before any substate, when `include_proofs` was set and the responder has a committed
+    // block to anchor against: the CBOR-encoded CommittedBlockProof whose shard-group state merkle
+    // root every value proof in this stream verifies against.
+    bytes commit_proof = 1;
+    ProvenSubstate substate = 2;
+    // Sent once, after every substate, naming the requested ids the responder holds no record of.
+    MissingSubstates missing = 3;
+  }
+}
+
+message ProvenSubstate {
   tari.ootle.consensus.Substate substate = 1;
+  // CBOR-encoded SubstateValueProof: the substate leaf is included in (up) / excluded from (down) its
+  // shard, which is in turn committed in the anchor's shard-group state merkle root. Empty when the
+  // request did not ask for proofs, or when the responder had no committed block to anchor against.
+  bytes substate_value_proof = 2;
+  // The epoch the substate value hash was computed at, needed by the verifier to re-derive the leaf
+  // value hash and bind it to the returned value. Only meaningful for an up substate.
+  uint64 proof_epoch = 3;
+}
+
+message MissingSubstates {
+  // Encoded SubstateIds the responder holds no record of at any version. Unproven: leaf keys are
+  // version-scoped, so an exclusion proof states that one version is not up, never that an id was
+  // never created.
+  repeated bytes substate_ids = 1;
 }
 
 message GetConsensusStateRequest {}

--- a/crates/state_store_rocksdb/tests/helpers.rs
+++ b/crates/state_store_rocksdb/tests/helpers.rs
@@ -1,7 +1,7 @@
 //   Copyright 2026 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::{io::Write, ops::Deref};
+use std::{collections::BTreeMap, io::Write, ops::Deref};
 
 use rand::{Rng, RngExt};
 use tari_bor::cbor;
@@ -23,6 +23,8 @@ use tari_ootle_common_types::{
     shard::Shard,
 };
 use tari_ootle_storage::{
+    ShardScopedTreeStoreWriter,
+    StateStore,
     StateStoreReadTransaction,
     StateStoreWriteTransaction,
     consensus_models::{
@@ -43,7 +45,7 @@ use tari_ootle_storage::{
 use tari_ootle_transaction::{Network, TransactionId};
 use tari_sidechain::{CommitProofElement, QuorumDecision, SidechainBlockCommitProof, SidechainBlockHeader};
 use tari_state_store_rocksdb::{DatabaseOptions, RocksDbStateStore};
-use tari_state_tree::Version;
+use tari_state_tree::{SpreadPrefixStateTree, SubstateTreeChange, Version};
 use tari_template_lib::types::{
     ComponentAddress,
     ComponentKey,
@@ -469,4 +471,38 @@ pub fn create_foreign_proposal(parent_id: BlockId, epoch: Epoch) -> ForeignPropo
     });
 
     ForeignProposalRecord::new(ForeignProposal::new(commit_proof, BlockPledge::default()))
+}
+
+/// The state-tree version the substates committed by [`commit_substates`] land at.
+pub const PROOF_TEST_TREE_VERSION: Version = 1;
+
+/// Commits `substates` to the store and to their shards' state trees, as a validator does when a
+/// block commits, so that proofs can be generated against the resulting shard-group root.
+pub fn commit_substates(db: &impl StateStore, substates: &[SubstateRecord]) {
+    let mut by_shard: BTreeMap<Shard, Vec<&SubstateRecord>> = BTreeMap::new();
+    for substate in substates {
+        by_shard.entry(substate.created().in_shard).or_default().push(substate);
+    }
+
+    let mut tx = db.create_write_tx().unwrap();
+    Block::zero_block(NETWORK, num_preshards()).insert(&mut tx).unwrap();
+
+    for (shard, substates) in &by_shard {
+        let changes = substates.iter().map(|s| SubstateTreeChange::Up {
+            id: s.to_versioned_substate_id(),
+            value_hash: *s.state_hash(),
+        });
+        {
+            let mut store = ShardScopedTreeStoreWriter::new(&mut tx, *shard);
+            SpreadPrefixStateTree::new(&mut store)
+                .batch_put_substate_changes(None, PROOF_TEST_TREE_VERSION, changes)
+                .unwrap();
+        }
+        tx.state_tree_shard_versions_set(*shard, PROOF_TEST_TREE_VERSION)
+            .unwrap();
+    }
+
+    tx.substates_commit_batch(create_substate_update_batch(Epoch::zero(), substates))
+        .unwrap();
+    tx.commit().unwrap();
 }

--- a/crates/state_store_rocksdb/tests/proof_cost.rs
+++ b/crates/state_store_rocksdb/tests/proof_cost.rs
@@ -5,17 +5,9 @@ pub mod helpers;
 
 use std::{collections::BTreeMap, time::Instant};
 
-use helpers::{NETWORK, build_substate_record, create_rocksdb, create_substate_update_batch, num_preshards};
-use tari_ootle_common_types::{Epoch, ShardGroup, shard::Shard};
-use tari_ootle_storage::{
-    ShardScopedTreeStoreWriter,
-    StateStore,
-    StateStoreWriteTransaction,
-    SubstateProofGenerator,
-    consensus_models::{Block, SubstateRecord},
-    generate_substate_proof,
-};
-use tari_state_tree::{SpreadPrefixStateTree, SubstateTreeChange};
+use helpers::{PROOF_TEST_TREE_VERSION, build_substate_record, commit_substates, create_rocksdb, num_preshards};
+use tari_ootle_common_types::{ShardGroup, shard::Shard};
+use tari_ootle_storage::{StateStore, SubstateProofGenerator, consensus_models::SubstateRecord};
 
 use crate::helpers::substate_id_seed;
 
@@ -31,7 +23,7 @@ fn proof_cost() {
     let shard_group = ShardGroup::all_shards(num_preshards());
 
     let substates = (0..BATCH)
-        .map(|seed| build_substate_record(&substate_id_seed(seed << 24), 0, 1))
+        .map(|seed| build_substate_record(&substate_id_seed(seed << 24), 0, PROOF_TEST_TREE_VERSION))
         .collect::<Vec<_>>();
     let mut by_shard: BTreeMap<Shard, Vec<&SubstateRecord>> = BTreeMap::new();
     for s in &substates {
@@ -44,31 +36,18 @@ fn proof_cost() {
         shard_group.len()
     );
 
-    let mut tx = db.create_write_tx().unwrap();
-    Block::zero_block(NETWORK, num_preshards()).insert(&mut tx).unwrap();
-    for (shard, records) in &by_shard {
-        let changes = records.iter().map(|s| SubstateTreeChange::Up {
-            id: s.to_versioned_substate_id(),
-            value_hash: *s.state_hash(),
-        });
-        {
-            let mut store = ShardScopedTreeStoreWriter::new(&mut tx, *shard);
-            SpreadPrefixStateTree::new(&mut store)
-                .batch_put_substate_changes(None, 1, changes)
-                .unwrap();
-        }
-        tx.state_tree_shard_versions_set(*shard, 1).unwrap();
-    }
-    tx.substates_commit_batch(create_substate_update_batch(Epoch::zero(), &substates))
-        .unwrap();
-    tx.commit().unwrap();
+    commit_substates(&db, &substates);
 
     let tx = db.create_read_tx().unwrap();
 
-    // One-shot per substate: what the batch would cost without hoisting.
+    // One generator per substate: what the batch would cost without hoisting.
     let t = Instant::now();
     for s in &substates {
-        generate_substate_proof(&tx, shard_group, &s.to_versioned_substate_id(), num_preshards()).unwrap();
+        SubstateProofGenerator::new(&tx, shard_group, num_preshards())
+            .unwrap()
+            .generate(&s.to_versioned_substate_id())
+            .unwrap()
+            .unwrap();
     }
     let one_shot = t.elapsed();
 
@@ -89,12 +68,10 @@ fn proof_cost() {
 
     // A single-substate request pays the whole fixed cost too.
     let t = Instant::now();
-    generate_substate_proof(
-        &tx,
-        shard_group,
-        &substates[0].to_versioned_substate_id(),
-        num_preshards(),
-    )
-    .unwrap();
+    SubstateProofGenerator::new(&tx, shard_group, num_preshards())
+        .unwrap()
+        .generate(&substates[0].to_versioned_substate_id())
+        .unwrap()
+        .unwrap();
     println!("one substate alone:  {:?}", t.elapsed());
 }

--- a/crates/state_store_rocksdb/tests/proof_cost.rs
+++ b/crates/state_store_rocksdb/tests/proof_cost.rs
@@ -1,0 +1,100 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+pub mod helpers;
+
+use std::{collections::BTreeMap, time::Instant};
+
+use helpers::{NETWORK, build_substate_record, create_rocksdb, create_substate_update_batch, num_preshards};
+use tari_ootle_common_types::{Epoch, ShardGroup, shard::Shard};
+use tari_ootle_storage::{
+    ShardScopedTreeStoreWriter,
+    StateStore,
+    StateStoreWriteTransaction,
+    SubstateProofGenerator,
+    consensus_models::{Block, SubstateRecord},
+    generate_substate_proof,
+};
+use tari_state_tree::{SpreadPrefixStateTree, SubstateTreeChange};
+
+use crate::helpers::substate_id_seed;
+
+/// Measures what a batch of proofs costs a validator to produce, which is what bounds how large a
+/// batch a validator is willing to answer. Run with `--release --nocapture`; ignored by default
+/// because it asserts nothing - wall-clock thresholds would only make CI flaky.
+#[test]
+#[ignore = "timing measurement, run manually"]
+fn proof_cost() {
+    const BATCH: u32 = 50;
+    let (db, _tmp) = create_rocksdb();
+    // Worst case for the fixed cost: one committee, so the shard group is every preshard.
+    let shard_group = ShardGroup::all_shards(num_preshards());
+
+    let substates = (0..BATCH)
+        .map(|seed| build_substate_record(&substate_id_seed(seed << 24), 0, 1))
+        .collect::<Vec<_>>();
+    let mut by_shard: BTreeMap<Shard, Vec<&SubstateRecord>> = BTreeMap::new();
+    for s in &substates {
+        by_shard.entry(s.created().in_shard).or_default().push(s);
+    }
+    println!(
+        "{} substates over {} distinct shards, shard group of {}",
+        substates.len(),
+        by_shard.len(),
+        shard_group.len()
+    );
+
+    let mut tx = db.create_write_tx().unwrap();
+    Block::zero_block(NETWORK, num_preshards()).insert(&mut tx).unwrap();
+    for (shard, records) in &by_shard {
+        let changes = records.iter().map(|s| SubstateTreeChange::Up {
+            id: s.to_versioned_substate_id(),
+            value_hash: *s.state_hash(),
+        });
+        {
+            let mut store = ShardScopedTreeStoreWriter::new(&mut tx, *shard);
+            SpreadPrefixStateTree::new(&mut store)
+                .batch_put_substate_changes(None, 1, changes)
+                .unwrap();
+        }
+        tx.state_tree_shard_versions_set(*shard, 1).unwrap();
+    }
+    tx.substates_commit_batch(create_substate_update_batch(Epoch::zero(), &substates))
+        .unwrap();
+    tx.commit().unwrap();
+
+    let tx = db.create_read_tx().unwrap();
+
+    // One-shot per substate: what the batch would cost without hoisting.
+    let t = Instant::now();
+    for s in &substates {
+        generate_substate_proof(&tx, shard_group, &s.to_versioned_substate_id(), num_preshards()).unwrap();
+    }
+    let one_shot = t.elapsed();
+
+    // Hoisted: one generator for the whole batch.
+    let t = Instant::now();
+    let mut generator = SubstateProofGenerator::new(&tx, shard_group, num_preshards()).unwrap();
+    let construct = t.elapsed();
+    let t = Instant::now();
+    for s in &substates {
+        generator.generate(&s.to_versioned_substate_id()).unwrap().unwrap();
+    }
+    let per_substate = t.elapsed();
+
+    println!("one-shot x{BATCH}:      {one_shot:?}");
+    println!("generator construct: {construct:?}");
+    println!("generator x{BATCH}:     {per_substate:?}");
+    println!("hoisted total:       {:?}", construct + per_substate);
+
+    // A single-substate request pays the whole fixed cost too.
+    let t = Instant::now();
+    generate_substate_proof(
+        &tx,
+        shard_group,
+        &substates[0].to_versioned_substate_id(),
+        num_preshards(),
+    )
+    .unwrap();
+    println!("one substate alone:  {:?}", t.elapsed());
+}

--- a/crates/state_store_rocksdb/tests/substate_proofs.rs
+++ b/crates/state_store_rocksdb/tests/substate_proofs.rs
@@ -108,7 +108,7 @@ fn proofs_for_a_batch_verify_against_one_shard_group_root() {
 
     for substate in &substates {
         let versioned_id = substate.to_versioned_substate_id();
-        let proof = generator.generate(&versioned_id).unwrap();
+        let proof = generator.generate(&versioned_id).unwrap().expect("shard has state");
         proof
             .verify_inclusion(&group_root, &versioned_id, &value_hash(substate))
             .unwrap_or_else(|e| panic!("{versioned_id} in {}: {e}", substate.created().in_shard));
@@ -125,22 +125,20 @@ fn a_reused_shard_root_proof_belongs_to_its_own_shard() {
     commit_substates(&db, &substates);
 
     let tx = db.create_read_tx().unwrap();
+    let group_root = shard_group_root(&tx, shard_group);
     let mut generator = SubstateProofGenerator::new(&tx, shard_group, num_preshards()).unwrap();
 
-    // Prove every substate once to fill the cache, then again to read it back.
-    let first = substates
-        .iter()
-        .map(|s| generator.generate(&s.to_versioned_substate_id()).unwrap())
-        .collect::<Vec<_>>();
-    for (substate, first) in substates.iter().zip(first) {
-        let again = generator.generate(&substate.to_versioned_substate_id()).unwrap();
-        assert_eq!(
-            tari_bor::serde_codec::to_vec(&again).unwrap(),
-            tari_bor::serde_codec::to_vec(&first).unwrap(),
-            "{} in {}",
-            substate.substate_id(),
-            substate.created().in_shard
-        );
+    // Fill the cache for every shard the substates live in, so that the second pass is served
+    // entirely from it, then check each cached proof still verifies for its own substate.
+    for substate in &substates {
+        generator.generate(&substate.to_versioned_substate_id()).unwrap();
+    }
+    for substate in &substates {
+        let versioned_id = substate.to_versioned_substate_id();
+        let proof = generator.generate(&versioned_id).unwrap().expect("shard has state");
+        proof
+            .verify_inclusion(&group_root, &versioned_id, &value_hash(substate))
+            .unwrap_or_else(|e| panic!("{versioned_id} in {}: {e}", substate.created().in_shard));
     }
 }
 
@@ -156,7 +154,7 @@ fn a_batched_proof_matches_the_single_substate_proof() {
 
     for substate in &substates {
         let versioned_id = substate.to_versioned_substate_id();
-        let batched = generator.generate(&versioned_id).unwrap();
+        let batched = generator.generate(&versioned_id).unwrap().expect("shard has state");
         let single = generate_substate_proof(&tx, shard_group, &versioned_id, num_preshards()).unwrap();
         assert_eq!(
             tari_bor::serde_codec::to_vec(&batched).unwrap(),
@@ -181,7 +179,7 @@ fn a_version_that_is_not_up_gets_an_exclusion_proof() {
 
     for substate in &substates {
         let next_version = VersionedSubstateId::new(substate.substate_id().clone(), substate.version() + 1);
-        let proof = generator.generate(&next_version).unwrap();
+        let proof = generator.generate(&next_version).unwrap().expect("shard has state");
         proof.verify_exclusion(&group_root, &next_version).unwrap();
         proof
             .verify_inclusion(&group_root, &next_version, &value_hash(substate))
@@ -213,4 +211,31 @@ fn a_substate_outside_the_shard_group_is_refused() {
         .generate(&outsider.to_versioned_substate_id())
         .expect_err("outside the shard group");
     assert!(err.to_string().contains("outside this shard group"), "{err}");
+}
+
+/// A shard with no committed state has no root to prove against. That is not a read failure, so the
+/// responder can drop the one substate and still answer for the rest of its batch.
+#[test]
+fn a_shard_with_no_committed_state_proves_nothing() {
+    let (db, _tmp) = create_rocksdb();
+    let shard_group = ShardGroup::all_shards(num_preshards());
+    let substates = substates_spanning_shards(2, 2);
+    // Commit only the first substate, so the second one's shard has no state tree at all.
+    commit_substates(&db, &substates[..1]);
+
+    let tx = db.create_read_tx().unwrap();
+    let mut generator = SubstateProofGenerator::new(&tx, shard_group, num_preshards()).unwrap();
+
+    assert!(
+        generator
+            .generate(&substates[0].to_versioned_substate_id())
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        generator
+            .generate(&substates[1].to_versioned_substate_id())
+            .unwrap()
+            .is_none()
+    );
 }

--- a/crates/state_store_rocksdb/tests/substate_proofs.rs
+++ b/crates/state_store_rocksdb/tests/substate_proofs.rs
@@ -3,62 +3,25 @@
 
 pub mod helpers;
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::HashSet;
 
-use helpers::{NETWORK, build_substate_record, create_rocksdb, create_substate_update_batch, num_preshards};
-use tari_ootle_common_types::{Epoch, ShardGroup, VersionedSubstateId, shard::Shard};
+use helpers::{PROOF_TEST_TREE_VERSION, build_substate_record, commit_substates, create_rocksdb, num_preshards};
+use tari_ootle_common_types::{ShardGroup, VersionedSubstateId};
 use tari_ootle_storage::{
     ShardScopedTreeStoreReader,
-    ShardScopedTreeStoreWriter,
     StateStore,
     StateStoreReadTransaction,
-    StateStoreWriteTransaction,
     SubstateProofGenerator,
-    consensus_models::{Block, SubstateRecord},
-    generate_substate_proof,
+    consensus_models::SubstateRecord,
 };
 use tari_state_tree::{
     SPARSE_MERKLE_PLACEHOLDER_HASH,
     SpreadPrefixStateTree,
-    SubstateTreeChange,
     TreeHash,
     compute_merkle_root_for_hashes,
 };
 
 use crate::helpers::substate_id_seed;
-
-/// The state-tree version every shard in these tests is committed at.
-const TREE_VERSION: u64 = 1;
-
-/// Commits `substates` to the store and to their shards' state trees, as a validator does when a
-/// block commits.
-fn commit_substates(db: &impl StateStore, substates: &[SubstateRecord]) {
-    let mut by_shard: BTreeMap<Shard, Vec<&SubstateRecord>> = BTreeMap::new();
-    for substate in substates {
-        by_shard.entry(substate.created().in_shard).or_default().push(substate);
-    }
-
-    let mut tx = db.create_write_tx().unwrap();
-    Block::zero_block(NETWORK, num_preshards()).insert(&mut tx).unwrap();
-
-    for (shard, substates) in &by_shard {
-        let changes = substates.iter().map(|s| SubstateTreeChange::Up {
-            id: s.to_versioned_substate_id(),
-            value_hash: *s.state_hash(),
-        });
-        {
-            let mut store = ShardScopedTreeStoreWriter::new(&mut tx, *shard);
-            SpreadPrefixStateTree::new(&mut store)
-                .batch_put_substate_changes(None, TREE_VERSION, changes)
-                .unwrap();
-        }
-        tx.state_tree_shard_versions_set(*shard, TREE_VERSION).unwrap();
-    }
-
-    tx.substates_commit_batch(create_substate_update_batch(Epoch::zero(), substates))
-        .unwrap();
-    tx.commit().unwrap();
-}
 
 /// The shard-group state merkle root a block header commits: the root of the tree over the shard
 /// group's per-shard roots, in the canonical `[global, shard_0, ...]` order.
@@ -84,7 +47,7 @@ fn substates_spanning_shards(count: u32, min_shards: usize) -> Vec<SubstateRecor
     // A substate's shard is read off the leading byte of its entity id, and `substate_id_seed` writes
     // the seed there big-endian, so the seed has to vary in its top byte to move between shards.
     let substates = (0..count)
-        .map(|seed| build_substate_record(&substate_id_seed(seed << 24), 0, TREE_VERSION))
+        .map(|seed| build_substate_record(&substate_id_seed(seed << 24), 0, PROOF_TEST_TREE_VERSION))
         .collect::<Vec<_>>();
     let shards = substates.iter().map(|s| s.created().in_shard).collect::<HashSet<_>>();
     assert!(
@@ -142,28 +105,6 @@ fn a_reused_shard_root_proof_belongs_to_its_own_shard() {
     }
 }
 
-#[test]
-fn a_batched_proof_matches_the_single_substate_proof() {
-    let (db, _tmp) = create_rocksdb();
-    let shard_group = ShardGroup::all_shards(num_preshards());
-    let substates = substates_spanning_shards(4, 2);
-    commit_substates(&db, &substates);
-
-    let tx = db.create_read_tx().unwrap();
-    let mut generator = SubstateProofGenerator::new(&tx, shard_group, num_preshards()).unwrap();
-
-    for substate in &substates {
-        let versioned_id = substate.to_versioned_substate_id();
-        let batched = generator.generate(&versioned_id).unwrap().expect("shard has state");
-        let single = generate_substate_proof(&tx, shard_group, &versioned_id, num_preshards()).unwrap();
-        assert_eq!(
-            tari_bor::serde_codec::to_vec(&batched).unwrap(),
-            tari_bor::serde_codec::to_vec(&single).unwrap(),
-            "{versioned_id}"
-        );
-    }
-}
-
 /// A version that is not up gets an exclusion proof - the shape a down substate in a batch is
 /// answered with.
 #[test]
@@ -187,8 +128,10 @@ fn a_version_that_is_not_up_gets_an_exclusion_proof() {
     }
 }
 
+/// A substate the shard group does not cover cannot be proved against its root - which is a fact
+/// about the group, not a read failure, so the rest of a batch is still answerable.
 #[test]
-fn a_substate_outside_the_shard_group_is_refused() {
+fn a_substate_outside_the_shard_group_proves_nothing() {
     let (db, _tmp) = create_rocksdb();
     let substates = substates_spanning_shards(8, 2);
     commit_substates(&db, &substates);
@@ -204,13 +147,18 @@ fn a_substate_outside_the_shard_group_is_refused() {
     let tx = db.create_read_tx().unwrap();
     let mut generator = SubstateProofGenerator::new(&tx, shard_group, num_preshards()).unwrap();
 
-    generator
-        .generate(&substates[0].to_versioned_substate_id())
-        .expect("in the shard group");
-    let err = generator
-        .generate(&outsider.to_versioned_substate_id())
-        .expect_err("outside the shard group");
-    assert!(err.to_string().contains("outside this shard group"), "{err}");
+    assert!(
+        generator
+            .generate(&substates[0].to_versioned_substate_id())
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        generator
+            .generate(&outsider.to_versioned_substate_id())
+            .unwrap()
+            .is_none()
+    );
 }
 
 /// A shard with no committed state has no root to prove against. That is not a read failure, so the

--- a/crates/state_store_rocksdb/tests/substate_proofs.rs
+++ b/crates/state_store_rocksdb/tests/substate_proofs.rs
@@ -1,0 +1,216 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+pub mod helpers;
+
+use std::collections::{BTreeMap, HashSet};
+
+use helpers::{NETWORK, build_substate_record, create_rocksdb, create_substate_update_batch, num_preshards};
+use tari_ootle_common_types::{Epoch, ShardGroup, VersionedSubstateId, shard::Shard};
+use tari_ootle_storage::{
+    ShardScopedTreeStoreReader,
+    ShardScopedTreeStoreWriter,
+    StateStore,
+    StateStoreReadTransaction,
+    StateStoreWriteTransaction,
+    SubstateProofGenerator,
+    consensus_models::{Block, SubstateRecord},
+    generate_substate_proof,
+};
+use tari_state_tree::{
+    SPARSE_MERKLE_PLACEHOLDER_HASH,
+    SpreadPrefixStateTree,
+    SubstateTreeChange,
+    TreeHash,
+    compute_merkle_root_for_hashes,
+};
+
+use crate::helpers::substate_id_seed;
+
+/// The state-tree version every shard in these tests is committed at.
+const TREE_VERSION: u64 = 1;
+
+/// Commits `substates` to the store and to their shards' state trees, as a validator does when a
+/// block commits.
+fn commit_substates(db: &impl StateStore, substates: &[SubstateRecord]) {
+    let mut by_shard: BTreeMap<Shard, Vec<&SubstateRecord>> = BTreeMap::new();
+    for substate in substates {
+        by_shard.entry(substate.created().in_shard).or_default().push(substate);
+    }
+
+    let mut tx = db.create_write_tx().unwrap();
+    Block::zero_block(NETWORK, num_preshards()).insert(&mut tx).unwrap();
+
+    for (shard, substates) in &by_shard {
+        let changes = substates.iter().map(|s| SubstateTreeChange::Up {
+            id: s.to_versioned_substate_id(),
+            value_hash: *s.state_hash(),
+        });
+        {
+            let mut store = ShardScopedTreeStoreWriter::new(&mut tx, *shard);
+            SpreadPrefixStateTree::new(&mut store)
+                .batch_put_substate_changes(None, TREE_VERSION, changes)
+                .unwrap();
+        }
+        tx.state_tree_shard_versions_set(*shard, TREE_VERSION).unwrap();
+    }
+
+    tx.substates_commit_batch(create_substate_update_batch(Epoch::zero(), substates))
+        .unwrap();
+    tx.commit().unwrap();
+}
+
+/// The shard-group state merkle root a block header commits: the root of the tree over the shard
+/// group's per-shard roots, in the canonical `[global, shard_0, ...]` order.
+fn shard_group_root(tx: &impl StateStoreReadTransaction, shard_group: ShardGroup) -> TreeHash {
+    let roots = shard_group.shard_iter_with_global().map(|shard| {
+        let Some(version) = tx.state_tree_versions_get_latest(shard).unwrap() else {
+            return SPARSE_MERKLE_PLACEHOLDER_HASH;
+        };
+        let mut store = ShardScopedTreeStoreReader::new(tx, shard);
+        SpreadPrefixStateTree::new(&mut store).get_root_hash(version).unwrap()
+    });
+    compute_merkle_root_for_hashes(roots.collect::<Vec<_>>()).unwrap()
+}
+
+/// The leaf value hash a verifier re-derives from the substate value to bind it to the committed leaf.
+fn value_hash(substate: &SubstateRecord) -> TreeHash {
+    TreeHash::new((*substate.state_hash()).into_array())
+}
+
+/// Substates whose ids land in at least `min_shards` distinct shards, so that a batch over them
+/// exercises both a fresh and a reused shard-root proof.
+fn substates_spanning_shards(count: u32, min_shards: usize) -> Vec<SubstateRecord> {
+    // A substate's shard is read off the leading byte of its entity id, and `substate_id_seed` writes
+    // the seed there big-endian, so the seed has to vary in its top byte to move between shards.
+    let substates = (0..count)
+        .map(|seed| build_substate_record(&substate_id_seed(seed << 24), 0, TREE_VERSION))
+        .collect::<Vec<_>>();
+    let shards = substates.iter().map(|s| s.created().in_shard).collect::<HashSet<_>>();
+    assert!(
+        shards.len() >= min_shards,
+        "{count} substates landed in {} shard(s), need {min_shards}",
+        shards.len()
+    );
+    substates
+}
+
+#[test]
+fn proofs_for_a_batch_verify_against_one_shard_group_root() {
+    let (db, _tmp) = create_rocksdb();
+    let shard_group = ShardGroup::all_shards(num_preshards());
+    let substates = substates_spanning_shards(8, 2);
+    commit_substates(&db, &substates);
+
+    let tx = db.create_read_tx().unwrap();
+    let group_root = shard_group_root(&tx, shard_group);
+    let mut generator = SubstateProofGenerator::new(&tx, shard_group, num_preshards()).unwrap();
+
+    for substate in &substates {
+        let versioned_id = substate.to_versioned_substate_id();
+        let proof = generator.generate(&versioned_id).unwrap();
+        proof
+            .verify_inclusion(&group_root, &versioned_id, &value_hash(substate))
+            .unwrap_or_else(|e| panic!("{versioned_id} in {}: {e}", substate.created().in_shard));
+    }
+}
+
+/// The level-2 proof is cached per shard, so a batch that revisits a shard must not be served the
+/// proof of a different shard's root.
+#[test]
+fn a_reused_shard_root_proof_belongs_to_its_own_shard() {
+    let (db, _tmp) = create_rocksdb();
+    let shard_group = ShardGroup::all_shards(num_preshards());
+    let substates = substates_spanning_shards(8, 2);
+    commit_substates(&db, &substates);
+
+    let tx = db.create_read_tx().unwrap();
+    let mut generator = SubstateProofGenerator::new(&tx, shard_group, num_preshards()).unwrap();
+
+    // Prove every substate once to fill the cache, then again to read it back.
+    let first = substates
+        .iter()
+        .map(|s| generator.generate(&s.to_versioned_substate_id()).unwrap())
+        .collect::<Vec<_>>();
+    for (substate, first) in substates.iter().zip(first) {
+        let again = generator.generate(&substate.to_versioned_substate_id()).unwrap();
+        assert_eq!(
+            tari_bor::serde_codec::to_vec(&again).unwrap(),
+            tari_bor::serde_codec::to_vec(&first).unwrap(),
+            "{} in {}",
+            substate.substate_id(),
+            substate.created().in_shard
+        );
+    }
+}
+
+#[test]
+fn a_batched_proof_matches_the_single_substate_proof() {
+    let (db, _tmp) = create_rocksdb();
+    let shard_group = ShardGroup::all_shards(num_preshards());
+    let substates = substates_spanning_shards(4, 2);
+    commit_substates(&db, &substates);
+
+    let tx = db.create_read_tx().unwrap();
+    let mut generator = SubstateProofGenerator::new(&tx, shard_group, num_preshards()).unwrap();
+
+    for substate in &substates {
+        let versioned_id = substate.to_versioned_substate_id();
+        let batched = generator.generate(&versioned_id).unwrap();
+        let single = generate_substate_proof(&tx, shard_group, &versioned_id, num_preshards()).unwrap();
+        assert_eq!(
+            tari_bor::serde_codec::to_vec(&batched).unwrap(),
+            tari_bor::serde_codec::to_vec(&single).unwrap(),
+            "{versioned_id}"
+        );
+    }
+}
+
+/// A version that is not up gets an exclusion proof - the shape a down substate in a batch is
+/// answered with.
+#[test]
+fn a_version_that_is_not_up_gets_an_exclusion_proof() {
+    let (db, _tmp) = create_rocksdb();
+    let shard_group = ShardGroup::all_shards(num_preshards());
+    let substates = substates_spanning_shards(4, 2);
+    commit_substates(&db, &substates);
+
+    let tx = db.create_read_tx().unwrap();
+    let group_root = shard_group_root(&tx, shard_group);
+    let mut generator = SubstateProofGenerator::new(&tx, shard_group, num_preshards()).unwrap();
+
+    for substate in &substates {
+        let next_version = VersionedSubstateId::new(substate.substate_id().clone(), substate.version() + 1);
+        let proof = generator.generate(&next_version).unwrap();
+        proof.verify_exclusion(&group_root, &next_version).unwrap();
+        proof
+            .verify_inclusion(&group_root, &next_version, &value_hash(substate))
+            .unwrap_err();
+    }
+}
+
+#[test]
+fn a_substate_outside_the_shard_group_is_refused() {
+    let (db, _tmp) = create_rocksdb();
+    let substates = substates_spanning_shards(8, 2);
+    commit_substates(&db, &substates);
+
+    // A shard group holding the first substate's shard but not every substate's.
+    let first_shard = substates[0].created().in_shard;
+    let shard_group = ShardGroup::new_checked(first_shard, first_shard).unwrap();
+    let outsider = substates
+        .iter()
+        .find(|s| s.created().in_shard != first_shard)
+        .expect("substates span more than one shard");
+
+    let tx = db.create_read_tx().unwrap();
+    let mut generator = SubstateProofGenerator::new(&tx, shard_group, num_preshards()).unwrap();
+
+    generator
+        .generate(&substates[0].to_versioned_substate_id())
+        .expect("in the shard group");
+    let err = generator
+        .generate(&outsider.to_versioned_substate_id())
+        .expect_err("outside the shard group");
+    assert!(err.to_string().contains("outside this shard group"), "{err}");
+}

--- a/crates/state_tree/src/tree.rs
+++ b/crates/state_tree/src/tree.rs
@@ -300,17 +300,41 @@ pub fn compute_merkle_root_for_hashes<I: IntoIterator<Item = TreeHash>>(hashes: 
     Ok(hash)
 }
 
+/// An ephemeral tree over a set of hashes, held so that several of them can be proved against the
+/// same root without rebuilding it.
+///
+/// Building costs O(n log n) hashes in n, the size of the set; each proof after that is one
+/// traversal. Callers proving more than one hash against the same set should build this once -
+/// [`compute_proof_for_hashes`] is the one-shot form and rebuilds the tree per proof.
+pub struct RootProofTree {
+    store: MemoryTreeStore<()>,
+}
+
+impl RootProofTree {
+    pub fn build<I: IntoIterator<Item = TreeHash>>(hashes: I) -> Result<Self, StateTreeError> {
+        let mut store = MemoryTreeStore::new();
+        RootStateTree::new(&mut store).put_changes(None, 1, hashes)?;
+        Ok(Self { store })
+    }
+
+    /// Proves that `hash_to_prove` is one of the hashes the tree was built over, or that it is not.
+    /// Returns the value (if it exists) and the Merkle proof.
+    pub fn get_proof(
+        &self,
+        hash_to_prove: TreeHash,
+    ) -> Result<(Option<ProofValue<()>>, SparseMerkleProofExt), StateTreeError> {
+        let jmt = JellyfishMerkleTree::new(&self.store);
+        let key = HashIdentityKeyMapper::map_to_leaf_key(&hash_to_prove);
+        let proof_tuple = jmt.get_with_proof_ext(key.as_ref(), 1)?;
+        Ok(proof_tuple)
+    }
+}
+
 /// Computes a Merkle proof for the given hash is either included in the provided the hashes, or proof of absence.
 /// Returns the value (if it exists) and the Merkle proof.
 pub fn compute_proof_for_hashes<I: Iterator<Item = TreeHash>>(
     hashes: I,
     hash_to_prove: TreeHash,
 ) -> Result<(Option<ProofValue<()>>, SparseMerkleProofExt), StateTreeError> {
-    let mut mem_store = MemoryTreeStore::new();
-    let mut root_tree = RootStateTree::new(&mut mem_store);
-    root_tree.put_changes(None, 1, hashes)?;
-    let jmt = JellyfishMerkleTree::new(&mem_store);
-    let key = HashIdentityKeyMapper::map_to_leaf_key(&hash_to_prove);
-    let proof_tuple = jmt.get_with_proof_ext(key.as_ref(), 1)?;
-    Ok(proof_tuple)
+    RootProofTree::build(hashes)?.get_proof(hash_to_prove)
 }

--- a/crates/storage/src/state_store/substate_value_proof.rs
+++ b/crates/storage/src/state_store/substate_value_proof.rs
@@ -84,15 +84,14 @@ impl<'a, TTx: StateStoreReadTransaction> SubstateProofGenerator<'a, TTx> {
 
     /// Proves `versioned_id`'s committed value, or its absence, against the shard-group root.
     ///
-    /// `Ok(None)` means the substate's shard has no committed state at all, so there is no root to
-    /// prove anything against. A caller proving many substates can drop that one and keep the rest;
-    /// an error means the read itself failed and nothing in the batch can be trusted.
+    /// `Ok(None)` means this state cannot prove anything about the substate, either way: its shard
+    /// lies outside the shard group, or that shard has no committed state to root a proof at. A
+    /// caller proving many substates can drop that one and keep the rest; an error means the read
+    /// itself failed and nothing it produced can be trusted.
     pub fn generate(&mut self, versioned_id: &VersionedSubstateId) -> Result<Option<SubstateValueProof>, StorageError> {
         let shard = versioned_id.to_shard(self.num_preshards);
         let Some(state) = self.shards.get(&shard).copied() else {
-            return Err(StorageError::QueryError {
-                reason: format!("generate_substate_proof: {versioned_id} is in {shard}, outside this shard group"),
-            });
+            return Ok(None);
         };
         let Some(version) = state.version else {
             return Ok(None);
@@ -123,25 +122,6 @@ impl<'a, TTx: StateStoreReadTransaction> SubstateProofGenerator<'a, TTx> {
 
         Ok(Some(SubstateValueProof::new(state.root, shard_root_proof, leaf_proof)))
     }
-}
-
-/// Generates a two-level [`SubstateValueProof`] for a single `versioned_id` against the latest
-/// committed shard-group state. See [`SubstateProofGenerator`], which proves many substates against
-/// the same state without repeating the per-shard-group work.
-pub fn generate_substate_proof<TTx: StateStoreReadTransaction>(
-    tx: &TTx,
-    shard_group: ShardGroup,
-    versioned_id: &VersionedSubstateId,
-    num_preshards: NumPreshards,
-) -> Result<SubstateValueProof, StorageError> {
-    SubstateProofGenerator::new(tx, shard_group, num_preshards)?
-        .generate(versioned_id)?
-        .ok_or_else(|| StorageError::QueryError {
-            reason: format!(
-                "generate_substate_proof: shard {} has no committed state",
-                versioned_id.to_shard(num_preshards)
-            ),
-        })
 }
 
 /// Verifies a substate value proof against an *already-trusted* shard-group state merkle root,

--- a/crates/storage/src/state_store/substate_value_proof.rs
+++ b/crates/storage/src/state_store/substate_value_proof.rs
@@ -8,6 +8,7 @@ use tari_common_types::types::FixedHash;
 use tari_engine_types::substate::{SubstateId, SubstateValue, hash_substate};
 use tari_ootle_common_types::{Epoch, NumPreshards, ShardGroup, VersionedSubstateId, shard::Shard};
 use tari_state_tree::{
+    RootProofTree,
     SPARSE_MERKLE_PLACEHOLDER_HASH,
     SparseMerkleProofExt,
     SpreadPrefixStateTree,
@@ -15,7 +16,6 @@ use tari_state_tree::{
     SubstateValueProofError,
     TreeHash,
     Version,
-    compute_proof_for_hashes,
 };
 
 use crate::{StateStoreReadTransaction, StorageError, state_store::ShardScopedTreeStoreReader};
@@ -41,12 +41,14 @@ use crate::{StateStoreReadTransaction, StorageError, state_store::ShardScopedTre
 pub struct SubstateProofGenerator<'a, TTx> {
     tx: &'a TTx,
     num_preshards: NumPreshards,
-    /// Per-shard roots in the canonical order the block header commits them: [global, shard_0, ...].
-    ordered_roots: Vec<TreeHash>,
-    /// The committed state of each shard in `ordered_roots`, keyed by shard.
+    /// The tree over the shard group's per-shard roots, in the canonical order the block header
+    /// commits them: [global, shard_0, ...]. Every level-2 proof is a leaf of this one tree, so it is
+    /// built once however many substates are proved - which is what keeps the cost of a batch
+    /// independent of the size of the shard group.
+    root_tree: RootProofTree,
+    /// The committed state of each shard in the root tree, keyed by shard.
     shards: HashMap<Shard, CommittedShardState>,
-    /// Level-2 proofs, computed on first use of each shard. They all come out of the same tree over
-    /// `ordered_roots`; only the leaf extracted from it differs.
+    /// Level-2 proofs, extracted from `root_tree` on first use of each shard.
     shard_root_proofs: HashMap<Shard, SparseMerkleProofExt>,
 }
 
@@ -72,7 +74,9 @@ impl<'a, TTx: StateStoreReadTransaction> SubstateProofGenerator<'a, TTx> {
         Ok(Self {
             tx,
             num_preshards,
-            ordered_roots,
+            root_tree: RootProofTree::build(ordered_roots).map_err(|e| StorageError::QueryError {
+                reason: format!("generate_substate_proof shard group root tree: {e}"),
+            })?,
             shards,
             shard_root_proofs: HashMap::new(),
         })
@@ -107,11 +111,11 @@ impl<'a, TTx: StateStoreReadTransaction> SubstateProofGenerator<'a, TTx> {
         let shard_root_proof = match self.shard_root_proofs.entry(shard) {
             Entry::Occupied(entry) => entry.get().clone(),
             Entry::Vacant(entry) => {
-                let (_, proof) =
-                    compute_proof_for_hashes(self.ordered_roots.iter().copied(), state.root).map_err(|e| {
-                        StorageError::QueryError {
-                            reason: format!("generate_substate_proof shard root proof: {e}"),
-                        }
+                let (_, proof) = self
+                    .root_tree
+                    .get_proof(state.root)
+                    .map_err(|e| StorageError::QueryError {
+                        reason: format!("generate_substate_proof shard root proof: {e}"),
                     })?;
                 entry.insert(proof).clone()
             },

--- a/crates/storage/src/state_store/substate_value_proof.rs
+++ b/crates/storage/src/state_store/substate_value_proof.rs
@@ -1,6 +1,8 @@
 //   Copyright 2026 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+use std::collections::{HashMap, hash_map::Entry};
+
 use ootle_network::Network;
 use tari_common_types::types::FixedHash;
 use tari_engine_types::substate::{SubstateId, SubstateValue, hash_substate};
@@ -8,10 +10,12 @@ use tari_ootle_common_types::{Epoch, NumPreshards, ShardGroup, VersionedSubstate
 use tari_sidechain::SidechainProofValidationError;
 use tari_state_tree::{
     SPARSE_MERKLE_PLACEHOLDER_HASH,
+    SparseMerkleProofExt,
     SpreadPrefixStateTree,
     SubstateValueProof,
     SubstateValueProofError,
     TreeHash,
+    Version,
     compute_proof_for_hashes,
 };
 use tari_template_lib_types::crypto::RistrettoPublicKeyBytes;
@@ -23,54 +27,113 @@ use crate::{
     state_store::ShardScopedTreeStoreReader,
 };
 
-/// Generates a two-level [`SubstateValueProof`] for `versioned_id` against the latest committed
-/// shard-group state.
+/// Generates two-level [`SubstateValueProof`]s against one committed shard-group state.
 ///
-/// The proof is rooted at the shard-group `state_merkle_root` - the same root the latest committed
+/// A proof has three parts, and only the last of them varies per substate:
+/// - the shard group's per-shard roots, in the canonical order the block header commits them,
+/// - level 2: the proof that a shard's root is committed in the shard-group root - one per shard,
+/// - level 1: the JMT leaf proof (inclusion or exclusion) for the substate within its shard.
+///
+/// The first two are read and computed once and reused, so proving N substates costs N leaf
+/// traversals rather than N scans of the whole shard group.
+///
+/// Every proof is rooted at the shard-group `state_merkle_root` - the same root the latest committed
 /// block header commits - so a caller that independently trusts that root (e.g. via a verified
-/// committed block proof) can verify the substate's committed value or its absence without trusting
-/// the node that produced the proof.
+/// committed block proof) can verify each substate's committed value or its absence without trusting
+/// the node that produced the proofs. One commit proof therefore authenticates every proof a single
+/// generator produces, provided both are generated in the same read transaction.
 ///
-/// Whether the leaf proof is an inclusion or exclusion proof depends on whether `versioned_id` is
+/// Whether a leaf proof is an inclusion or exclusion proof depends on whether the substate is
 /// currently up in its shard; the caller chooses `verify_inclusion`/`verify_exclusion` accordingly.
+pub struct SubstateProofGenerator<'a, TTx> {
+    tx: &'a TTx,
+    num_preshards: NumPreshards,
+    /// Per-shard roots in the canonical order the block header commits them: [global, shard_0, ...].
+    ordered_roots: Vec<TreeHash>,
+    /// The committed state of each shard in `ordered_roots`, keyed by shard.
+    shards: HashMap<Shard, CommittedShardState>,
+    /// Level-2 proofs, computed on first use of each shard. They all come out of the same tree over
+    /// `ordered_roots`; only the leaf extracted from it differs.
+    shard_root_proofs: HashMap<Shard, SparseMerkleProofExt>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CommittedShardState {
+    root: TreeHash,
+    /// `None` if the shard has no committed state yet, in which case `root` is the empty-tree
+    /// placeholder and no substate in the shard can be proved.
+    version: Option<Version>,
+}
+
+impl<'a, TTx: StateStoreReadTransaction> SubstateProofGenerator<'a, TTx> {
+    /// Reads the committed root of every shard in `shard_group`, plus the global shard.
+    pub fn new(tx: &'a TTx, shard_group: ShardGroup, num_preshards: NumPreshards) -> Result<Self, StorageError> {
+        let mut ordered_roots = Vec::with_capacity(shard_group.len() + 1);
+        let mut shards = HashMap::with_capacity(shard_group.len() + 1);
+        for shard in shard_group.shard_iter_with_global() {
+            let state = committed_shard_state(tx, shard)?;
+            ordered_roots.push(state.root);
+            shards.insert(shard, state);
+        }
+
+        Ok(Self {
+            tx,
+            num_preshards,
+            ordered_roots,
+            shards,
+            shard_root_proofs: HashMap::new(),
+        })
+    }
+
+    /// Proves `versioned_id`'s committed value, or its absence, against the shard-group root.
+    pub fn generate(&mut self, versioned_id: &VersionedSubstateId) -> Result<SubstateValueProof, StorageError> {
+        let shard = versioned_id.to_shard(self.num_preshards);
+        let Some(state) = self.shards.get(&shard).copied() else {
+            return Err(StorageError::QueryError {
+                reason: format!("generate_substate_proof: {versioned_id} is in {shard}, outside this shard group"),
+            });
+        };
+        let version = state.version.ok_or_else(|| StorageError::QueryError {
+            reason: format!("generate_substate_proof: shard {shard} has no committed state"),
+        })?;
+
+        // Level 1: leaf proof (inclusion or exclusion) for the substate within its shard.
+        let mut scoped = ShardScopedTreeStoreReader::new(self.tx, shard);
+        let tree = SpreadPrefixStateTree::new(&mut scoped);
+        let (_leaf_key, _proof_value, leaf_proof) =
+            tree.get_proof(version, versioned_id)
+                .map_err(|e| StorageError::QueryError {
+                    reason: format!("generate_substate_proof get_proof: {e}"),
+                })?;
+
+        // Level 2: prove the shard root is committed in the shard-group root.
+        let shard_root_proof = match self.shard_root_proofs.entry(shard) {
+            Entry::Occupied(entry) => entry.get().clone(),
+            Entry::Vacant(entry) => {
+                let (_, proof) =
+                    compute_proof_for_hashes(self.ordered_roots.iter().copied(), state.root).map_err(|e| {
+                        StorageError::QueryError {
+                            reason: format!("generate_substate_proof shard root proof: {e}"),
+                        }
+                    })?;
+                entry.insert(proof).clone()
+            },
+        };
+
+        Ok(SubstateValueProof::new(state.root, shard_root_proof, leaf_proof))
+    }
+}
+
+/// Generates a two-level [`SubstateValueProof`] for a single `versioned_id` against the latest
+/// committed shard-group state. See [`SubstateProofGenerator`], which proves many substates against
+/// the same state without repeating the per-shard-group work.
 pub fn generate_substate_proof<TTx: StateStoreReadTransaction>(
     tx: &TTx,
     shard_group: ShardGroup,
     versioned_id: &VersionedSubstateId,
     num_preshards: NumPreshards,
 ) -> Result<SubstateValueProof, StorageError> {
-    // Per-shard roots in the canonical order the block header commits them: [global, shard_0, ...].
-    let mut ordered_roots = Vec::with_capacity(shard_group.len() + 1);
-    ordered_roots.push(shard_state_root(tx, Shard::global())?);
-    for shard in shard_group.shard_iter() {
-        ordered_roots.push(shard_state_root(tx, shard)?);
-    }
-
-    // Level 1: leaf proof (inclusion or exclusion) for the substate within its shard.
-    let shard = versioned_id.to_shard(num_preshards);
-    let version = tx
-        .state_tree_versions_get_latest(shard)?
-        .ok_or_else(|| StorageError::QueryError {
-            reason: format!("generate_substate_proof: shard {shard} has no committed state"),
-        })?;
-    let mut scoped = ShardScopedTreeStoreReader::new(tx, shard);
-    let tree = SpreadPrefixStateTree::new(&mut scoped);
-    let (_leaf_key, _proof_value, leaf_proof) =
-        tree.get_proof(version, versioned_id)
-            .map_err(|e| StorageError::QueryError {
-                reason: format!("generate_substate_proof get_proof: {e}"),
-            })?;
-    let shard_root = tree.get_root_hash(version).map_err(|e| StorageError::QueryError {
-        reason: format!("generate_substate_proof get_root_hash: {e}"),
-    })?;
-
-    // Level 2: prove the shard root is committed in the shard-group root.
-    let (_, shard_root_proof) =
-        compute_proof_for_hashes(ordered_roots.into_iter(), shard_root).map_err(|e| StorageError::QueryError {
-            reason: format!("generate_substate_proof shard root proof: {e}"),
-        })?;
-
-    Ok(SubstateValueProof::new(shard_root, shard_root_proof, leaf_proof))
+    SubstateProofGenerator::new(tx, shard_group, num_preshards)?.generate(versioned_id)
 }
 
 /// Verifies a substate value proof served by a (possibly untrusted) validator.
@@ -161,14 +224,25 @@ pub enum SubstateProofVerifyError {
     ValueProof(#[from] SubstateValueProofError),
 }
 
-/// The committed JMT root of `shard`, or the empty-tree placeholder if the shard has no state yet.
-fn shard_state_root<TTx: StateStoreReadTransaction>(tx: &TTx, shard: Shard) -> Result<TreeHash, StorageError> {
+/// The committed JMT root and state-tree version of `shard`. A shard with no committed state has the
+/// empty-tree placeholder for a root and no version.
+fn committed_shard_state<TTx: StateStoreReadTransaction>(
+    tx: &TTx,
+    shard: Shard,
+) -> Result<CommittedShardState, StorageError> {
     let Some(version) = tx.state_tree_versions_get_latest(shard)? else {
-        return Ok(SPARSE_MERKLE_PLACEHOLDER_HASH);
+        return Ok(CommittedShardState {
+            root: SPARSE_MERKLE_PLACEHOLDER_HASH,
+            version: None,
+        });
     };
     let mut scoped = ShardScopedTreeStoreReader::new(tx, shard);
     let tree = SpreadPrefixStateTree::new(&mut scoped);
-    tree.get_root_hash(version).map_err(|e| StorageError::QueryError {
+    let root = tree.get_root_hash(version).map_err(|e| StorageError::QueryError {
         reason: format!("generate_substate_proof shard {shard} root: {e}"),
+    })?;
+    Ok(CommittedShardState {
+        root,
+        version: Some(version),
     })
 }

--- a/crates/storage/src/state_store/substate_value_proof.rs
+++ b/crates/storage/src/state_store/substate_value_proof.rs
@@ -75,7 +75,7 @@ impl<'a, TTx: StateStoreReadTransaction> SubstateProofGenerator<'a, TTx> {
             tx,
             num_preshards,
             root_tree: RootProofTree::build(ordered_roots).map_err(|e| StorageError::QueryError {
-                reason: format!("generate_substate_proof shard group root tree: {e}"),
+                reason: format!("SubstateProofGenerator shard group root tree: {e}"),
             })?,
             shards,
             shard_root_proofs: HashMap::new(),
@@ -103,7 +103,7 @@ impl<'a, TTx: StateStoreReadTransaction> SubstateProofGenerator<'a, TTx> {
         let (_leaf_key, _proof_value, leaf_proof) =
             tree.get_proof(version, versioned_id)
                 .map_err(|e| StorageError::QueryError {
-                    reason: format!("generate_substate_proof get_proof: {e}"),
+                    reason: format!("SubstateProofGenerator get_proof: {e}"),
                 })?;
 
         // Level 2: prove the shard root is committed in the shard-group root.
@@ -114,7 +114,7 @@ impl<'a, TTx: StateStoreReadTransaction> SubstateProofGenerator<'a, TTx> {
                     .root_tree
                     .get_proof(state.root)
                     .map_err(|e| StorageError::QueryError {
-                        reason: format!("generate_substate_proof shard root proof: {e}"),
+                        reason: format!("SubstateProofGenerator shard root proof: {e}"),
                     })?;
                 entry.insert(proof).clone()
             },
@@ -187,7 +187,7 @@ fn committed_shard_state<TTx: StateStoreReadTransaction>(
     let mut scoped = ShardScopedTreeStoreReader::new(tx, shard);
     let tree = SpreadPrefixStateTree::new(&mut scoped);
     let root = tree.get_root_hash(version).map_err(|e| StorageError::QueryError {
-        reason: format!("generate_substate_proof shard {shard} root: {e}"),
+        reason: format!("SubstateProofGenerator shard {shard} root: {e}"),
     })?;
     Ok(CommittedShardState {
         root,

--- a/crates/storage/src/state_store/substate_value_proof.rs
+++ b/crates/storage/src/state_store/substate_value_proof.rs
@@ -6,8 +6,7 @@ use std::collections::{HashMap, hash_map::Entry};
 use ootle_network::Network;
 use tari_common_types::types::FixedHash;
 use tari_engine_types::substate::{SubstateId, SubstateValue, hash_substate};
-use tari_ootle_common_types::{Epoch, NumPreshards, ShardGroup, VersionedSubstateId, VotePower, shard::Shard};
-use tari_sidechain::SidechainProofValidationError;
+use tari_ootle_common_types::{Epoch, NumPreshards, ShardGroup, VersionedSubstateId, shard::Shard};
 use tari_state_tree::{
     SPARSE_MERKLE_PLACEHOLDER_HASH,
     SparseMerkleProofExt,
@@ -18,14 +17,8 @@ use tari_state_tree::{
     Version,
     compute_proof_for_hashes,
 };
-use tari_template_lib_types::crypto::RistrettoPublicKeyBytes;
 
-use crate::{
-    StateStoreReadTransaction,
-    StorageError,
-    consensus_models::{CommittedBlockProof, CommittedBlockProofError, VerifiedBlockTip},
-    state_store::ShardScopedTreeStoreReader,
-};
+use crate::{StateStoreReadTransaction, StorageError, state_store::ShardScopedTreeStoreReader};
 
 /// Generates two-level [`SubstateValueProof`]s against one committed shard-group state.
 ///
@@ -86,16 +79,20 @@ impl<'a, TTx: StateStoreReadTransaction> SubstateProofGenerator<'a, TTx> {
     }
 
     /// Proves `versioned_id`'s committed value, or its absence, against the shard-group root.
-    pub fn generate(&mut self, versioned_id: &VersionedSubstateId) -> Result<SubstateValueProof, StorageError> {
+    ///
+    /// `Ok(None)` means the substate's shard has no committed state at all, so there is no root to
+    /// prove anything against. A caller proving many substates can drop that one and keep the rest;
+    /// an error means the read itself failed and nothing in the batch can be trusted.
+    pub fn generate(&mut self, versioned_id: &VersionedSubstateId) -> Result<Option<SubstateValueProof>, StorageError> {
         let shard = versioned_id.to_shard(self.num_preshards);
         let Some(state) = self.shards.get(&shard).copied() else {
             return Err(StorageError::QueryError {
                 reason: format!("generate_substate_proof: {versioned_id} is in {shard}, outside this shard group"),
             });
         };
-        let version = state.version.ok_or_else(|| StorageError::QueryError {
-            reason: format!("generate_substate_proof: shard {shard} has no committed state"),
-        })?;
+        let Some(version) = state.version else {
+            return Ok(None);
+        };
 
         // Level 1: leaf proof (inclusion or exclusion) for the substate within its shard.
         let mut scoped = ShardScopedTreeStoreReader::new(self.tx, shard);
@@ -120,7 +117,7 @@ impl<'a, TTx: StateStoreReadTransaction> SubstateProofGenerator<'a, TTx> {
             },
         };
 
-        Ok(SubstateValueProof::new(state.root, shard_root_proof, leaf_proof))
+        Ok(Some(SubstateValueProof::new(state.root, shard_root_proof, leaf_proof)))
     }
 }
 
@@ -133,57 +130,26 @@ pub fn generate_substate_proof<TTx: StateStoreReadTransaction>(
     versioned_id: &VersionedSubstateId,
     num_preshards: NumPreshards,
 ) -> Result<SubstateValueProof, StorageError> {
-    SubstateProofGenerator::new(tx, shard_group, num_preshards)?.generate(versioned_id)
-}
-
-/// Verifies a substate value proof served by a (possibly untrusted) validator.
-///
-/// 1. The commit proof is validated against the shard group committee, yielding a trusted shard-group state merkle
-///    root.
-/// 2. The substate value proof is verified against that root - an inclusion proof for an up substate (binding the
-///    returned `value` by re-deriving its leaf value hash), or an exclusion proof for a down substate (`value` is
-///    `None`).
-///
-/// `check_vn` must return the voting power of the given validator in the committee for the commit
-/// proof's epoch/shard group (zero if not a member); the caller is responsible for fetching that
-/// committee (see [`CommittedBlockProof::epoch`]/[`CommittedBlockProof::shard_group`]).
-#[allow(clippy::too_many_arguments)]
-pub fn verify_substate_value_proof(
-    commit_proof: &CommittedBlockProof,
-    value_proof_bytes: &[u8],
-    substate_id: &SubstateId,
-    version: u32,
-    value: Option<&SubstateValue>,
-    network: Network,
-    proof_epoch: Epoch,
-    quorum_threshold: VotePower,
-    check_vn: impl Fn(&RistrettoPublicKeyBytes) -> Result<VotePower, SidechainProofValidationError>,
-) -> Result<VerifiedBlockTip, SubstateProofVerifyError> {
-    // Anchor: a quorum-signed shard-group state merkle root.
-    let verified_tip = commit_proof.validate(quorum_threshold, check_vn)?;
-    verify_substate_value_proof_against_root(
-        value_proof_bytes,
-        substate_id,
-        version,
-        value,
-        network,
-        proof_epoch,
-        verified_tip.state_merkle_root,
-    )?;
-    Ok(verified_tip)
+    SubstateProofGenerator::new(tx, shard_group, num_preshards)?
+        .generate(versioned_id)?
+        .ok_or_else(|| StorageError::QueryError {
+            reason: format!(
+                "generate_substate_proof: shard {} has no committed state",
+                versioned_id.to_shard(num_preshards)
+            ),
+        })
 }
 
 /// Verifies a substate value proof against an *already-trusted* shard-group state merkle root,
 /// skipping commit-proof (QC chain) validation.
 ///
-/// This is the inner half of [`verify_substate_value_proof`] for callers that have independently
-/// established `trusted_root` - e.g. from a commit proof that was committee-validated in an earlier
-/// round and recorded in a trusted-root store. Soundness is identical to the full path: the
-/// validator pins the substate value proof to the same committed block whose `state_merkle_root` we
-/// trust (proof and commit proof are generated in one read transaction against the same committed
-/// block), so verifying the proof against that root is exactly what [`verify_substate_value_proof`]
-/// does after `validate()`. The trust decision must therefore be keyed on `trusted_root` itself: a
-/// node cannot forge a substate proof that verifies against a root a quorum already signed.
+/// `trusted_root` must have been established independently - from a commit proof validated against
+/// the shard group committee (`CommittedBlockProof::validate`), either for this read or in an earlier
+/// round and recorded in a trusted-root store. The validator pins the substate value proof to the
+/// same committed block whose `state_merkle_root` is trusted (proof and commit proof are generated in
+/// one read transaction against the same committed block), so verifying against that root is the
+/// whole of the check. The trust decision must therefore be keyed on `trusted_root` itself: a node
+/// cannot forge a substate proof that verifies against a root a quorum already signed.
 pub fn verify_substate_value_proof_against_root(
     value_proof_bytes: &[u8],
     substate_id: &SubstateId,
@@ -216,8 +182,6 @@ pub fn verify_substate_value_proof_against_root(
 
 #[derive(Debug, thiserror::Error)]
 pub enum SubstateProofVerifyError {
-    #[error("commit proof invalid: {0}")]
-    CommitProof(#[from] CommittedBlockProofError),
     #[error("failed to decode substate value proof: {0}")]
     Decode(String),
     #[error("substate value proof invalid: {0}")]

--- a/crates/validator_node_rpc/src/client.rs
+++ b/crates/validator_node_rpc/src/client.rs
@@ -1,10 +1,10 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::{collections::HashMap, convert::TryInto, future, future::Future, sync::Arc, time::Duration};
+use std::{collections::HashMap, convert::TryInto, future::Future, sync::Arc, time::Duration};
 
 use anyhow::anyhow;
-use futures::{StreamExt, TryStreamExt};
+use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 use tari_bor::decode;
 use tari_consensus_types::Decision;
@@ -18,7 +18,13 @@ use tari_ootle_p2p::{
     TariMessagingSpec,
     ToPeerId,
     proto,
-    proto::rpc::{GetTransactionResultRequest, PayloadResultStatus, SubmitTransactionRequest, SubstateStatus},
+    proto::rpc::{
+        GetTransactionResultRequest,
+        PayloadResultStatus,
+        SubmitTransactionRequest,
+        SubstateStatus,
+        get_substates_batch_response as batch_response,
+    },
 };
 use tari_ootle_storage::time::{PrimitiveDateTime, UtcDateTime};
 use tari_ootle_transaction::{Transaction, TransactionId};
@@ -55,10 +61,37 @@ pub trait ValidatorNodeRpcClient<TAddr: NodeAddressable>: Send + Sync {
         substate_req: SubstateRequirementRef<'_>,
     ) -> impl Future<Output = Result<(SubstateResult, Option<SubstateProofData>), ValidatorNodeRpcClientError>> + Send;
 
+    /// Fetches the head version of many substates in one round trip. With `include_proofs` the
+    /// responder anchors the batch with a single commit proof and proves each result against it.
     fn get_substates_batch(
         &mut self,
-        substate_reqs: &[&SubstateId],
-    ) -> impl Future<Output = Result<HashMap<SubstateId, Substate>, ValidatorNodeRpcClientError>> + Send;
+        substate_ids: &[&SubstateId],
+        include_proofs: bool,
+    ) -> impl Future<Output = Result<SubstateBatch, ValidatorNodeRpcClientError>> + Send;
+}
+
+/// The results of one [`get_substates_batch`](ValidatorNodeRpcClient::get_substates_batch) call.
+#[derive(Debug, Clone, Default)]
+pub struct SubstateBatch {
+    /// CBOR-encoded CommittedBlockProof anchoring every value proof in the batch. `None` when proofs
+    /// were not requested, or when the responder had no committed block to anchor against.
+    pub commit_proof: Option<Vec<u8>>,
+    pub substates: Vec<BatchedSubstate>,
+    /// Ids the responder holds no record of at any version. Unproven: a leaf key is version-scoped,
+    /// so an exclusion proof states that one version is not up, never that an id was never created.
+    pub missing: Vec<SubstateId>,
+}
+
+#[derive(Debug, Clone)]
+pub struct BatchedSubstate {
+    pub substate_id: SubstateId,
+    pub result: SubstateResult,
+    /// CBOR-encoded SubstateValueProof, verified against [`SubstateBatch::commit_proof`]'s root.
+    /// `None` when the batch carries no anchor.
+    pub value_proof: Option<Vec<u8>>,
+    /// Epoch the substate value hash was computed at; needed to re-derive the leaf value hash when
+    /// verifying an inclusion proof.
+    pub proof_epoch: u64,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -310,33 +343,76 @@ impl<TAddr: NodeAddressable + ToPeerId, TMsg: MessageSpec> ValidatorNodeRpcClien
 
     async fn get_substates_batch(
         &mut self,
-        substate_reqs: &[&SubstateId],
-    ) -> Result<HashMap<SubstateId, Substate>, ValidatorNodeRpcClientError> {
+        substate_ids: &[&SubstateId],
+        include_proofs: bool,
+    ) -> Result<SubstateBatch, ValidatorNodeRpcClientError> {
         let mut conn = self.client_connection().await?;
         // NOTE: current maximum is 50 substates per request
-        let stream = conn
+        let mut stream = conn
             .get_substate_batch(proto::rpc::GetSubstatesBatchRequest {
-                substate_ids: substate_reqs.iter().map(|id| id.to_bytes()).collect(),
+                substate_ids: substate_ids.iter().map(|id| id.to_bytes()).collect(),
+                include_proofs,
             })
             .await?;
 
         // For simplicity, we'll collect the stream instead of returning a decoded stream
-        stream
-            .map_err(ValidatorNodeRpcClientError::from)
-            .map_ok(|resp| resp.substate)
-            .filter_map(|res| future::ready(res.transpose()))
-            .and_then(|substate| async move {
-                let version = substate.version;
-                let value = SubstateValue::from_bytes(&substate.substate)
-                    .map_err(|e| ValidatorNodeRpcClientError::InvalidResponse(anyhow!("{}", e)))?;
-                let substate_id = SubstateId::from_bytes(&substate.substate_id)
-                    .map_err(|e| ValidatorNodeRpcClientError::InvalidResponse(anyhow!("{}", e)))?;
+        let mut batch = SubstateBatch {
+            substates: Vec::with_capacity(substate_ids.len()),
+            ..Default::default()
+        };
+        while let Some(resp) = stream.next().await {
+            let Some(response) = resp?.response else {
+                continue;
+            };
+            match response {
+                batch_response::Response::CommitProof(commit_proof) => {
+                    batch.commit_proof = Some(commit_proof);
+                },
+                batch_response::Response::Substate(proven) => {
+                    batch.substates.push(decode_batched_substate(proven)?);
+                },
+                batch_response::Response::Missing(missing) => {
+                    for id in &missing.substate_ids {
+                        batch.missing.push(
+                            SubstateId::from_bytes(id)
+                                .map_err(|e| ValidatorNodeRpcClientError::InvalidResponse(anyhow!("{}", e)))?,
+                        );
+                    }
+                },
+            }
+        }
 
-                Ok::<_, ValidatorNodeRpcClientError>((substate_id, Substate::new(version, value)))
-            })
-            .try_collect()
-            .await
+        Ok(batch)
     }
+}
+
+fn decode_batched_substate(proven: proto::rpc::ProvenSubstate) -> Result<BatchedSubstate, ValidatorNodeRpcClientError> {
+    let substate = proven
+        .substate
+        .ok_or_else(|| ValidatorNodeRpcClientError::InvalidResponse(anyhow!("Batched substate has no substate")))?;
+    let substate_id = SubstateId::from_bytes(&substate.substate_id)
+        .map_err(|e| ValidatorNodeRpcClientError::InvalidResponse(anyhow!("{}", e)))?;
+
+    // A batch always answers with the head version, which is down when the substate's latest version
+    // has been spent. Only an up substate carries a value.
+    let result = if substate.destroyed.is_some() {
+        SubstateResult::Down {
+            version: substate.version,
+        }
+    } else {
+        let value = SubstateValue::from_bytes(&substate.substate)
+            .map_err(|e| ValidatorNodeRpcClientError::InvalidResponse(anyhow!("{}", e)))?;
+        SubstateResult::Up {
+            substate: Box::new(Substate::new(substate.version, value)),
+        }
+    };
+
+    Ok(BatchedSubstate {
+        substate_id,
+        result,
+        value_proof: Some(proven.substate_value_proof).filter(|proof| !proof.is_empty()),
+        proof_epoch: proven.proof_epoch,
+    })
 }
 
 #[derive(Clone, Debug)]

--- a/crates/validator_node_rpc/src/client.rs
+++ b/crates/validator_node_rpc/src/client.rs
@@ -83,8 +83,11 @@ pub struct SubstateBatch {
     /// were not requested, or when the responder had no committed block to anchor against.
     pub commit_proof: Option<Vec<u8>>,
     pub substates: Vec<BatchedSubstate>,
-    /// Ids the responder holds no record of at any version. Unproven: a leaf key is version-scoped,
-    /// so an exclusion proof states that one version is not up, never that an id was never created.
+    /// Ids this response does not answer for, whatever the reason: the responder holds no record of
+    /// them, or holds one it cannot prove. Never evidence that a substate does not exist - use it to
+    /// decide what to ask for again, never to conclude absence, which is not provable here at all: a
+    /// leaf key is version-scoped, so an exclusion proof states that one version is not up, never
+    /// that an id was never created.
     pub missing: Vec<SubstateId>,
 }
 

--- a/crates/validator_node_rpc/src/client.rs
+++ b/crates/validator_node_rpc/src/client.rs
@@ -1,7 +1,13 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::{collections::HashMap, convert::TryInto, future::Future, sync::Arc, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    convert::TryInto,
+    future::Future,
+    sync::Arc,
+    time::Duration,
+};
 
 use anyhow::anyhow;
 use futures::StreamExt;
@@ -356,6 +362,7 @@ impl<TAddr: NodeAddressable + ToPeerId, TMsg: MessageSpec> ValidatorNodeRpcClien
             .await?;
 
         // For simplicity, we'll collect the stream instead of returning a decoded stream
+        let requested = substate_ids.iter().copied().collect::<HashSet<_>>();
         let mut batch = SubstateBatch {
             substates: Vec::with_capacity(substate_ids.len()),
             ..Default::default()
@@ -369,7 +376,23 @@ impl<TAddr: NodeAddressable + ToPeerId, TMsg: MessageSpec> ValidatorNodeRpcClien
                     batch.commit_proof = Some(commit_proof);
                 },
                 batch_response::Response::Substate(proven) => {
-                    batch.substates.push(decode_batched_substate(proven)?);
+                    // A responder can only answer for what was asked. Bounding the stream by the
+                    // request keeps a peer from growing this vec without limit, and dropping ids we
+                    // did not ask for keeps them out of the caller's results.
+                    if batch.substates.len() >= substate_ids.len() {
+                        return Err(ValidatorNodeRpcClientError::InvalidResponse(anyhow!(
+                            "Node returned more substates than the {} requested",
+                            substate_ids.len()
+                        )));
+                    }
+                    let substate = decode_batched_substate(proven)?;
+                    if !requested.contains(&substate.substate_id) {
+                        return Err(ValidatorNodeRpcClientError::InvalidResponse(anyhow!(
+                            "Node returned {} which was not requested",
+                            substate.substate_id
+                        )));
+                    }
+                    batch.substates.push(substate);
                 },
                 batch_response::Response::Missing(missing) => {
                     for id in &missing.substate_ids {
@@ -380,6 +403,17 @@ impl<TAddr: NodeAddressable + ToPeerId, TMsg: MessageSpec> ValidatorNodeRpcClien
                     }
                 },
             }
+        }
+
+        // Every requested id is either answered or named as missing. A responder that accounts for
+        // none of them is not answering this protocol - most likely it predates the batch response
+        // becoming a oneof, and its substates decoded as an unknown field. Failing here keeps that
+        // skew from reading as "none of these substates exist".
+        if batch.substates.is_empty() && batch.missing.is_empty() {
+            return Err(ValidatorNodeRpcClientError::InvalidResponse(anyhow!(
+                "Node accounted for none of the {} requested substates",
+                substate_ids.len()
+            )));
         }
 
         Ok(batch)


### PR DESCRIPTION
## Description

`get_substate_batch` streamed bare `proto::consensus::Substate` values with no proof of any kind, so `CachedSubstateManager::fetch_and_cache_substates` wrote every batch result with `verified: false`. With proof verification on, the read path refuses those entries and refetches singly — the batch populated a cache it could not then use.

This makes the batch carry proofs, and hoists the parts that do not vary per substate out of the per-substate loop.

### The hoist

A `SubstateValueProof` has three parts, with three different natural scopes:

| Part | Scope | Cost |
|---|---|---|
| Commit proof (the anchor) | once per response | ~10–30 KB, ~C signature verifications *on the client* |
| Level 2: shard root in the shard-group root | one tree per response, one leaf per shard | ~250 B |
| Level 1: JMT leaf proof | genuinely per substate | ~1 KB, an O(log N) traversal |

`SubstateProofGenerator` holds the per-shard-group state — the ordered roots, the single `RootProofTree` built over them, each shard's root and version, and level-2 proofs extracted on first use of a shard. `generate_substate_proof` is a one-shot wrapper over it, so the single-substate path behaves exactly as before.

Measured on the worst case (256-shard group, 50 substates in 50 distinct shards; `proof_cost`, release):

```
one-shot x50:        10.68 ms     <- what the batch would have cost unhoisted
generator construct:  228 µs
generator x50:        221 µs      <- ~4.4 µs per substate
hoisted total:        449 µs
one substate alone:   219 µs      <- essentially all fixed cost
```

### On the 50-substate cap and DoS

Those numbers say the cap is not the DoS lever. Cost per request is ~220 µs fixed (reading every shard root in the group and building one tree over them) plus ~4.4 µs per substate. So one request answering 50 costs ~450 µs, while **50 single-substate requests cost ~11 ms for the same data** — 25× more validator CPU. Lowering the cap would make a flood *more* expensive to serve, not less. What 50 actually bounds is the response, which the responder materialises before streaming. The rationale is recorded at the constant so it isn't re-litigated blind. Concurrency is separately bounded by the RPC framework's `BoundedExecutor`.

### The anchor

Anchor, substates and value proofs are all read in one transaction, so every proof in a stream verifies against the anchor's shard-group root — the responder's existing `TODO` about wanting a snapshot is the same concern. The shard group a proof is built against is taken **from the anchor's own block header**, not from an epoch lookup, so the two cannot disagree across an epoch boundary or before consensus has started.

On the client, `trusted_root_from_commit_proof` establishes that root once per batch: a hit in the trusted-root store (recorded by `validator_status.probe`) skips QC-chain validation and the committee lookup entirely; a miss validates the commit proof and warms the store. Each result then costs only its Merkle path. The single-substate path is rewritten in terms of the same helper, so there is one place where a root becomes trusted. The root is trusted because a quorum signed the header committing it, independently of any value proof that cites it — that is what makes it safe to establish once for a batch and to record.

A member that answers without an anchor has nothing committed to prove against. `race_substate_batch` holds that answer and keeps asking the rest of the committee — the shape `CommitteeReadTally` uses for single substates — and serves the held batch only once every member has failed, with a warning, never cached.

### Two responder defects fixed alongside

- **It never checked it stores the requested ids.** `get_substate` guards with `includes_substate_id`; the batch responder read whatever ids it was handed out of its local store. Same class as the `sync_state` hole fixed in #2511.
- **`missing` was logged and dropped.** It is now on the wire and reaches `SubstateBatch::missing`, where the indexer logs it per chunk. It is *not* wired into any caching decision, and must not be: it names ids a response does not answer for, for any reason — including a substate the responder holds but cannot prove — so it is never evidence of nonexistence.

Down heads are also now decoded as `Down` instead of failing the whole batch on `SubstateValue::from_bytes(&[])`, and are cached as such — which is what #2528's head-only cache wants. A substate whose shard has no committed state is reported as missing rather than failing the batch: `SubstateProofGenerator::generate` returns `Ok(None)` for it, while a read failure stays an `Err`.

## Correcting the handoff on one point

The workstream-D notes suggested a batch could answer "provably not here" for ids it holds no record of, using an exclusion proof. It cannot. `SpreadPrefixKeyMapper::map_to_leaf_key` hashes the whole `VersionedSubstateId`, so a leaf key is version-scoped and an exclusion proof states only that *one version* is not up — which is equally true of a live substate at a higher version. Absence of an id is not provable under this scheme, which is why the existing single-substate path already leaves `DoesNotExist` to f+1 agreement.

## Known gaps

- A batch from a validator with **no anchor at all** is served unproven and uncached, after every other member has been asked. Making that a hard failure would turn a legitimate post-epoch-change state into an error for the REST batch endpoint.
- `verify_substate_batch` and `race_substate_batch` have no unit tests — exercising them needs a mock `ValidatorNodeRpcClient` and cache, which `indexer_lib` has no scaffolding for. The proof generation half is covered.

## Test plan

`crates/state_store_rocksdb/tests/substate_proofs.rs`:

- proofs for a batch spanning several shards all verify against one shard-group root
- a reused (memoised) shard-root proof still verifies for its own substate
- a batched proof is byte-identical to the single-substate `generate_substate_proof`
- a version that is not up gets a verifying exclusion proof, and fails inclusion
- a substate outside the generator's shard group is refused
- a shard with no committed state yields `Ok(None)` rather than an error

Mutation-checked: keying the level-2 memo by a constant shard fails 4 of the 6.

`crates/state_store_rocksdb/tests/proof_cost.rs` is the measurement above, `#[ignore]`d because wall-clock thresholds would only make CI flaky.

```
cargo test -p tari_state_store_rocksdb -p tari_indexer_lib -p tari_ootle_storage -p tari_state_tree   # 31 binaries, all pass
cargo lints clippy -p tari_ootle_storage -p tari_state_tree -p tari_validator_node_rpc \
  -p tari_indexer_lib -p tari_state_store_rocksdb -p tari_validator_node -p tari_indexer --all-targets   # clean
```

Integration tests are left to CI.

## Breaking change

`GetSubstatesBatchResponse` becomes a `oneof` carrying the anchor, proven substates, and the missing ids; `GetSubstatesBatchRequest` gains `include_proofs`. Both sides ship together. The client rejects a response that accounts for none of the requested ids, so a pre-oneof responder fails loudly rather than looking like "none of these exist". `verify_substate_value_proof` is deleted — the block this PR rewrote was its last caller.
