### PR TITLE
feat(swarm): page log files instead of loading them whole

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12693,6 +12693,7 @@ dependencies = [
  "indexmap 2.13.0",
  "lockfile",
  "log",
+ "memmap2 0.9.9",
  "mime_guess",
  "minotari_node_grpc_client",
  "minotari_wallet_grpc_client",

--- a/applications/tari_indexer/src/bin/main.rs
+++ b/applications/tari_indexer/src/bin/main.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{fs, panic, path::PathBuf, process};
+use std::{fs, io::IsTerminal, panic, path::PathBuf, process};
 
 use anyhow::Context;
 use futures::stream;
@@ -85,21 +85,20 @@ fn init_tracing_subscriber(cli: &Cli) -> anyhow::Result<WorkerGuard> {
     let (ootle_log, guard) = tracing_appender::non_blocking(appender);
 
     tracing_subscriber::registry()
-        .with(
-            fmt::Layer::new()
-                .with_writer(ootle_log)
-                .with_filter(filter::Targets::new().with_targets([
-                    ("tari::application", tracing::Level::DEBUG),
-                    ("tari::indexer", tracing::Level::DEBUG),
-                    ("tari::ootle", tracing::Level::DEBUG),
-                    ("tower_http", tracing::Level::DEBUG),
-                ])),
-        )
+        .with(fmt::Layer::new().with_writer(ootle_log).with_ansi(false).with_filter(
+            filter::Targets::new().with_targets([
+                ("tari::application", tracing::Level::DEBUG),
+                ("tari::indexer", tracing::Level::DEBUG),
+                ("tari::ootle", tracing::Level::DEBUG),
+                ("tower_http", tracing::Level::DEBUG),
+            ]),
+        ))
         .with(
             fmt::Layer::new()
                 .without_time()
                 .with_target(false)
                 .with_writer(std::io::stdout)
+                .with_ansi(std::io::stdout().is_terminal())
                 .with_filter(filter::Targets::new().with_targets([
                     ("tari::application", tracing::Level::INFO),
                     ("tari::indexer", tracing::Level::INFO),

--- a/applications/tari_swarm_daemon/Cargo.toml
+++ b/applications/tari_swarm_daemon/Cargo.toml
@@ -39,6 +39,7 @@ lockfile = "0.4.0"
 indexmap = { workspace = true }
 slug = "0.1.6"
 log = { workspace = true }
+memmap2 = { workspace = true }
 mime_guess = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/applications/tari_swarm_daemon/src/logfile.rs
+++ b/applications/tari_swarm_daemon/src/logfile.rs
@@ -1,0 +1,211 @@
+//   Copyright 2024 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! Bounded, mmap-backed reads over process log files.
+//!
+//! Swarm log files grow without bound, so nothing here ever reads a whole file: callers ask for a byte window and
+//! get back the lines fully contained in it.
+
+use std::{fs::File, io, path::Path};
+
+use memmap2::{Mmap, MmapOptions};
+
+/// Window size used when a caller does not ask for one.
+pub const DEFAULT_CHUNK_BYTES: u64 = 512 * 1024;
+/// Ceiling on a single window, so one request cannot pull a multi-gigabyte log into memory.
+pub const MAX_CHUNK_BYTES: u64 = 4 * 1024 * 1024;
+/// How far back [`tail_lines`] is willing to look for its lines.
+const TAIL_SCAN_BYTES: u64 = 1024 * 1024;
+
+/// A contiguous byte window of a log file, trimmed to whole lines.
+#[derive(Debug)]
+pub struct LogChunk {
+    pub contents: String,
+    /// Offset of the first byte returned. `0` means the window reaches the start of the file.
+    pub start: u64,
+    /// Offset one past the last byte returned. Ask for a window ending here to get the preceding lines.
+    pub end: u64,
+    /// Size of the file at the time of the read, so a caller can tell whether more has been appended since.
+    pub file_size: u64,
+}
+
+/// Reads at most `max_bytes` ending at `end`, defaulting to the tail of the file.
+///
+/// The returned window starts on a line boundary: unless it reaches offset 0 the leading partial line is dropped and
+/// `start` moves past it. `end` is returned unchanged, so paging backwards - passing the previous `start` as the next
+/// `end` - neither drops nor repeats a line.
+pub fn read_chunk(path: &Path, end: Option<u64>, max_bytes: Option<u64>) -> io::Result<LogChunk> {
+    let file = File::open(path)?;
+    let file_size = file.metadata()?.len();
+
+    let end = end.unwrap_or(file_size).min(file_size);
+    let max_bytes = max_bytes.unwrap_or(DEFAULT_CHUNK_BYTES).clamp(1, MAX_CHUNK_BYTES);
+    let mut start = end.saturating_sub(max_bytes);
+
+    if start == end {
+        return Ok(LogChunk {
+            contents: String::new(),
+            start,
+            end,
+            file_size,
+        });
+    }
+
+    let window = map_window(&file, start, end)?;
+    let mut bytes = &window[..];
+
+    // A window that does not begin at the start of the file almost certainly begins mid-line.
+    if start > 0 {
+        match bytes.iter().position(|b| *b == b'\n') {
+            Some(nl) => {
+                bytes = &bytes[nl + 1..];
+                start += nl as u64 + 1;
+            },
+            None => {
+                bytes = &[];
+                start = end;
+            },
+        }
+    }
+
+    Ok(LogChunk {
+        contents: String::from_utf8_lossy(bytes).into_owned(),
+        start,
+        end,
+        file_size,
+    })
+}
+
+/// Returns up to the last `n` lines of the file, scanning back at most [`TAIL_SCAN_BYTES`].
+pub fn tail_lines(path: &Path, n: usize) -> io::Result<Vec<String>> {
+    let file = File::open(path)?;
+    let file_size = file.metadata()?.len();
+    let start = file_size.saturating_sub(TAIL_SCAN_BYTES);
+    if start == file_size {
+        return Ok(Vec::new());
+    }
+
+    let window = map_window(&file, start, file_size)?;
+    let text = String::from_utf8_lossy(&window);
+    let mut lines = text
+        .lines()
+        .rev()
+        .take(n)
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>();
+    lines.reverse();
+
+    // The first line of a window that started mid-file is a fragment, and is only worth keeping if it is all we have.
+    if start > 0 && lines.len() > 1 {
+        lines.remove(0);
+    }
+
+    Ok(lines)
+}
+
+fn map_window(file: &File, start: u64, end: u64) -> io::Result<Mmap> {
+    let len = usize::try_from(end - start).map_err(|_| io::Error::other("log window exceeds addressable memory"))?;
+    // SAFETY: the mapping is read-only and is dropped before the caller returns. Swarm rotates logs by rename and
+    // otherwise only appends, so a mapped region is never truncated underneath us.
+    unsafe { MmapOptions::new().offset(start).len(len).map(file) }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use super::*;
+
+    fn write_temp(name: &str, contents: &str) -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(format!("swarm-logfile-{name}.log"));
+        let mut file = File::create(&path).unwrap();
+        file.write_all(contents.as_bytes()).unwrap();
+        path
+    }
+
+    #[test]
+    fn empty_file_yields_an_empty_chunk() {
+        let path = write_temp("empty", "");
+        let chunk = read_chunk(&path, None, None).unwrap();
+        assert_eq!(chunk.contents, "");
+        assert_eq!(chunk.file_size, 0);
+        assert_eq!(chunk.start, 0);
+        assert_eq!(chunk.end, 0);
+    }
+
+    #[test]
+    fn a_window_reaching_the_start_keeps_the_first_line() {
+        let path = write_temp("whole", "one\ntwo\nthree\n");
+        let chunk = read_chunk(&path, None, None).unwrap();
+        assert_eq!(chunk.contents, "one\ntwo\nthree\n");
+        assert_eq!(chunk.start, 0);
+        assert_eq!(chunk.end, 14);
+    }
+
+    #[test]
+    fn a_partial_leading_line_is_dropped() {
+        let path = write_temp("partial", "one\ntwo\nthree\n");
+        let chunk = read_chunk(&path, None, Some(9)).unwrap();
+        assert_eq!(chunk.contents, "three\n");
+        assert_eq!(chunk.start, 8);
+    }
+
+    #[test]
+    fn paging_backwards_covers_every_line_exactly_once() {
+        let path = write_temp("paging", "one\ntwo\nthree\n");
+        let tail = read_chunk(&path, None, Some(9)).unwrap();
+        let older = read_chunk(&path, Some(tail.start), Some(9)).unwrap();
+        assert_eq!(older.contents, "one\ntwo\n");
+        assert_eq!(older.start, 0);
+    }
+
+    #[test]
+    fn paging_a_multi_megabyte_file_reconstructs_it_exactly() {
+        let body = (0..40_000)
+            .map(|i| format!("2026-09-07 10:58:49.9563 [tari::ootle] INFO line {i} 🌐 padded out a little\n"))
+            .collect::<String>();
+        let path = write_temp("large", &body);
+
+        let mut pages = Vec::new();
+        let mut end = None;
+        loop {
+            let chunk = read_chunk(&path, end, Some(256 * 1024)).unwrap();
+            assert_eq!(chunk.file_size, body.len() as u64);
+            pages.push(chunk.contents);
+            if chunk.start == 0 {
+                break;
+            }
+            end = Some(chunk.start);
+        }
+
+        assert!(
+            pages.len() > 10,
+            "expected the file to span many pages, got {}",
+            pages.len()
+        );
+        pages.reverse();
+        assert_eq!(pages.concat(), body);
+    }
+
+    #[test]
+    fn a_window_never_splits_a_multibyte_character() {
+        // Chosen so that the window boundary lands inside the four-byte emoji rather than between lines.
+        let body = "aaaa\n🌐🌐🌐\nbbbb\n";
+        let path = write_temp("utf8", body);
+        for max in 1..=body.len() as u64 {
+            let chunk = read_chunk(&path, None, Some(max)).unwrap();
+            assert!(
+                body.ends_with(&chunk.contents),
+                "max={max} returned {:?}, which is not a suffix of the file",
+                chunk.contents
+            );
+        }
+    }
+
+    #[test]
+    fn tail_lines_returns_the_last_lines_in_order() {
+        let path = write_temp("tail", "one\ntwo\nthree\n");
+        assert_eq!(tail_lines(&path, 2).unwrap(), vec!["two", "three"]);
+        assert_eq!(tail_lines(&path, 50).unwrap(), vec!["one", "two", "three"]);
+    }
+}

--- a/applications/tari_swarm_daemon/src/logfile.rs
+++ b/applications/tari_swarm_daemon/src/logfile.rs
@@ -54,17 +54,16 @@ pub fn read_chunk(path: &Path, end: Option<u64>, max_bytes: Option<u64>) -> io::
     let window = map_window(&file, start, end)?;
     let mut bytes = &window[..];
 
-    // A window that does not begin at the start of the file almost certainly begins mid-line.
+    // A window that does not begin at the start of the file almost certainly begins mid-line. Trimming that
+    // fragment is only worth doing while it leaves a line behind: a line longer than the window has no interior
+    // boundary, and returning nothing there would leave `start` at `end`, so the caller would ask for the same
+    // empty window forever. One rendered partial line is the cheaper end of that trade.
     if start > 0 {
-        match bytes.iter().position(|b| *b == b'\n') {
-            Some(nl) => {
+        if let Some(nl) = bytes.iter().position(|b| *b == b'\n') {
+            if nl + 1 < bytes.len() {
                 bytes = &bytes[nl + 1..];
                 start += nl as u64 + 1;
-            },
-            None => {
-                bytes = &[];
-                start = end;
-            },
+            }
         }
     }
 
@@ -78,16 +77,32 @@ pub fn read_chunk(path: &Path, end: Option<u64>, max_bytes: Option<u64>) -> io::
 
 /// Returns up to the last `n` lines of the file, scanning back at most [`TAIL_SCAN_BYTES`].
 pub fn tail_lines(path: &Path, n: usize) -> io::Result<Vec<String>> {
+    tail_lines_within(path, n, TAIL_SCAN_BYTES)
+}
+
+fn tail_lines_within(path: &Path, n: usize, scan_bytes: u64) -> io::Result<Vec<String>> {
     let file = File::open(path)?;
     let file_size = file.metadata()?.len();
-    let start = file_size.saturating_sub(TAIL_SCAN_BYTES);
+    let start = file_size.saturating_sub(scan_bytes);
     if start == file_size {
         return Ok(Vec::new());
     }
 
     let window = map_window(&file, start, file_size)?;
     let text = String::from_utf8_lossy(&window);
-    let mut lines = text
+    // A window that began mid-file opens on a fragment. It must go before the last `n` lines are taken, or the
+    // fragment survives whenever the window holds more than `n` lines and a whole line is dropped in its place.
+    // A window with no boundary at all is one long line, and the fragment is all there is to show.
+    let body = if start > 0 {
+        match text.find('\n') {
+            Some(nl) if nl + 1 < text.len() => &text[nl + 1..],
+            _ => &text[..],
+        }
+    } else {
+        &text[..]
+    };
+
+    let mut lines = body
         .lines()
         .rev()
         .take(n)
@@ -95,18 +110,14 @@ pub fn tail_lines(path: &Path, n: usize) -> io::Result<Vec<String>> {
         .collect::<Vec<_>>();
     lines.reverse();
 
-    // The first line of a window that started mid-file is a fragment, and is only worth keeping if it is all we have.
-    if start > 0 && lines.len() > 1 {
-        lines.remove(0);
-    }
-
     Ok(lines)
 }
 
 fn map_window(file: &File, start: u64, end: u64) -> io::Result<Mmap> {
     let len = usize::try_from(end - start).map_err(|_| io::Error::other("log window exceeds addressable memory"))?;
-    // SAFETY: the mapping is read-only and is dropped before the caller returns. Swarm rotates logs by rename and
-    // otherwise only appends, so a mapped region is never truncated underneath us.
+    // SAFETY: the mapping is read-only and is dropped before the caller returns. Touching a page past a shortened
+    // file raises SIGBUS rather than an error, so the mapped region must never shrink: swarm's writers only append,
+    // and rotation renames the file, which leaves this mapping on the original inode.
     unsafe { MmapOptions::new().offset(start).len(len).map(file) }
 }
 
@@ -194,6 +205,7 @@ mod tests {
         let path = write_temp("utf8", body);
         for max in 1..=body.len() as u64 {
             let chunk = read_chunk(&path, None, Some(max)).unwrap();
+            assert!(chunk.start < chunk.end, "max={max} returned an empty window");
             assert!(
                 body.ends_with(&chunk.contents),
                 "max={max} returned {:?}, which is not a suffix of the file",
@@ -203,9 +215,61 @@ mod tests {
     }
 
     #[test]
+    fn a_line_longer_than_the_window_still_pages_to_the_start() {
+        let body = format!("{}\n{}\n", "a".repeat(1000), "b".repeat(1000));
+        let path = write_temp("oversized", &body);
+
+        let mut pages = Vec::new();
+        let mut end = None;
+        for _ in 0..64 {
+            let chunk = read_chunk(&path, end, Some(300)).unwrap();
+            assert!(
+                chunk.start < chunk.end,
+                "window [{}, {}) addresses nothing new, so paging cannot terminate",
+                chunk.start,
+                chunk.end
+            );
+            pages.push(chunk.contents);
+            if chunk.start == 0 {
+                break;
+            }
+            end = Some(chunk.start);
+        }
+
+        assert_eq!(
+            pages.iter().map(String::len).sum::<usize>(),
+            body.len(),
+            "paging did not reach the start of the file within the iteration budget"
+        );
+        assert_eq!(pages.last().map(|page| page.starts_with('a')), Some(true));
+        pages.reverse();
+        assert_eq!(pages.concat(), body);
+    }
+
+    #[test]
     fn tail_lines_returns_the_last_lines_in_order() {
         let path = write_temp("tail", "one\ntwo\nthree\n");
         assert_eq!(tail_lines(&path, 2).unwrap(), vec!["two", "three"]);
         assert_eq!(tail_lines(&path, 50).unwrap(), vec!["one", "two", "three"]);
+    }
+
+    #[test]
+    fn tail_lines_keeps_every_whole_line_in_a_window_that_began_mid_file() {
+        let body = (0..100).map(|i| format!("line {i}\n")).collect::<String>();
+        let path = write_temp("tail-mid", &body);
+
+        // A scan window that starts mid-file and holds far more than the requested number of lines: the fragment
+        // it opens on falls outside the last `n`, so dropping it after the fact would delete a real line.
+        let lines = tail_lines_within(&path, 5, 200).unwrap();
+        assert_eq!(lines, vec!["line 95", "line 96", "line 97", "line 98", "line 99"]);
+    }
+
+    #[test]
+    fn tail_lines_shows_the_fragment_when_the_window_holds_no_whole_line() {
+        let body = format!("{}\n", "a".repeat(500));
+        let path = write_temp("tail-fragment", &body);
+
+        let lines = tail_lines_within(&path, 5, 100).unwrap();
+        assert_eq!(lines, vec!["a".repeat(99)]);
     }
 }

--- a/applications/tari_swarm_daemon/src/logfile.rs
+++ b/applications/tari_swarm_daemon/src/logfile.rs
@@ -58,13 +58,14 @@ pub fn read_chunk(path: &Path, end: Option<u64>, max_bytes: Option<u64>) -> io::
     // fragment is only worth doing while it leaves a line behind: a line longer than the window has no interior
     // boundary, and returning nothing there would leave `start` at `end`, so the caller would ask for the same
     // empty window forever. One rendered partial line is the cheaper end of that trade.
-    if start > 0 {
-        if let Some(nl) = bytes.iter().position(|b| *b == b'\n') {
-            if nl + 1 < bytes.len() {
-                bytes = &bytes[nl + 1..];
-                start += nl as u64 + 1;
-            }
-        }
+    let boundary = if start > 0 {
+        bytes.iter().position(|b| *b == b'\n').filter(|nl| nl + 1 < bytes.len())
+    } else {
+        None
+    };
+    if let Some(nl) = boundary {
+        bytes = &bytes[nl + 1..];
+        start += nl as u64 + 1;
     }
 
     Ok(LogChunk {

--- a/applications/tari_swarm_daemon/src/logger.rs
+++ b/applications/tari_swarm_daemon/src/logger.rs
@@ -5,6 +5,9 @@ use std::{fs, path::PathBuf};
 
 use fern::FormatCallback;
 
+/// Target used by [`crate::process_manager`] when it relays a child process's own output.
+pub const FORWARDED_TARGET: &str = "swarm";
+
 pub fn init_logger(log_to_file: Option<PathBuf>) -> Result<(), log::SetLoggerError> {
     fn should_skip(target: &str) -> bool {
         const SKIP: &[&str] = &[
@@ -35,6 +38,13 @@ pub fn init_logger(log_to_file: Option<PathBuf>) -> Result<(), log::SetLoggerErr
                     message
                 ))
             };
+
+            // Only forwarded child output embeds the process's own target and level in the message text, and only it
+            // is guaranteed to be a single line. Every other record is formatted as written.
+            if record.target() != FORWARDED_TARGET {
+                fallback(out);
+                return;
+            }
 
             // Example: [Validator node-#1] 12:55 INFO Received vote for block #NodeHeight(88)
             // d9abc7b1bb66fd912848f5bc4e5a69376571237e3243dc7f6a91db02bb5cf37c from

--- a/applications/tari_swarm_daemon/src/main.rs
+++ b/applications/tari_swarm_daemon/src/main.rs
@@ -22,6 +22,7 @@ use crate::{
 mod cli;
 mod config;
 mod layer_one_transactions;
+mod logfile;
 mod logger;
 mod process_definitions;
 mod process_manager;

--- a/applications/tari_swarm_daemon/src/process_manager/crash_report.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/crash_report.rs
@@ -1,0 +1,123 @@
+//   Copyright 2024 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! Turns a dead child process into something readable on the swarm daemon's own stdout.
+//!
+//! A crashed node is otherwise silent here: the reason is buried in one of its log files, which the operator has to
+//! know to go and find.
+
+use std::{fmt::Write, path::Path};
+
+use crate::{logfile, process_manager::Instance};
+
+/// Lines of context shown when there is no panic to point at.
+const TAIL_LINES: usize = 50;
+/// Lines of a panic's backtrace worth showing before it turns into noise.
+const PANIC_CONTEXT_LINES: usize = 30;
+
+/// Renders the panic message, or failing that the tail of the process's output, as an indented block.
+pub fn crash_report(instance: &Instance) -> String {
+    let mut report = String::new();
+    // Rust panics go to stderr, so it is both the likelier place to find one and the shorter file to scan.
+    for path in [instance.stderr_log_path(), instance.stdout_log_path()] {
+        let Some(section) = report_for(&path) else {
+            continue;
+        };
+        let _ = write!(report, "\n  ── {} ──\n{}", path.display(), section);
+    }
+
+    if report.is_empty() {
+        format!(
+            "\n  ── no output captured for {} in {} ──\n",
+            instance.name(),
+            instance.stdout_log_path().display()
+        )
+    } else {
+        report
+    }
+}
+
+fn report_for(path: &Path) -> Option<String> {
+    let lines = logfile::tail_lines(path, TAIL_LINES.max(PANIC_CONTEXT_LINES)).ok()?;
+    if lines.is_empty() {
+        return None;
+    }
+
+    let lines = match find_panic(&lines) {
+        Some(at) => &lines[at..(at + PANIC_CONTEXT_LINES).min(lines.len())],
+        None => &lines[lines.len().saturating_sub(TAIL_LINES)..],
+    };
+
+    Some(lines.iter().fold(String::new(), |mut out, line| {
+        let _ = writeln!(out, "  {line}");
+        out
+    }))
+}
+
+/// Index of the last panic header in `lines`, so that a process that recovered from an earlier panic still reports the
+/// one it died on.
+fn find_panic(lines: &[String]) -> Option<usize> {
+    lines
+        .iter()
+        .rposition(|line| line.contains("panicked at") || line.contains("fatal runtime error"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lines(text: &str) -> Vec<String> {
+        text.lines().map(ToString::to_string).collect()
+    }
+
+    #[test]
+    fn the_last_panic_wins() {
+        let found = find_panic(&lines(
+            "thread 'main' panicked at src/a.rs:1\nrecovered\nthread 'x' panicked at src/b.rs:2\nnote: backtrace",
+        ));
+        assert_eq!(found, Some(2));
+    }
+
+    #[test]
+    fn clean_output_has_no_panic() {
+        assert_eq!(find_panic(&lines("starting\nready\n")), None);
+    }
+
+    fn write_temp(name: &str, contents: &str) -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(format!("swarm-crash-{name}.log"));
+        std::fs::write(&path, contents).unwrap();
+        path
+    }
+
+    #[test]
+    fn a_panic_is_reported_with_its_backtrace_and_nothing_before_it() {
+        let mut body = (0..200).map(|i| format!("noise {i}\n")).collect::<String>();
+        body.push_str("thread 'tokio-runtime-worker' panicked at crates/consensus/src/lib.rs:12:9:\n");
+        body.push_str("assertion failed: leaf.height() > 0\n");
+        body.push_str("note: run with `RUST_BACKTRACE=1` for a backtrace\n");
+
+        let report = report_for(&write_temp("panic", &body)).unwrap();
+        assert!(
+            report.contains("panicked at crates/consensus/src/lib.rs:12:9"),
+            "{report}"
+        );
+        assert!(report.contains("assertion failed: leaf.height() > 0"), "{report}");
+        assert!(!report.contains("noise 199"), "{report}");
+    }
+
+    #[test]
+    fn output_without_a_panic_falls_back_to_the_tail() {
+        let body = (0..200).map(|i| format!("noise {i}\n")).collect::<String>();
+
+        let report = report_for(&write_temp("tail", &body)).unwrap();
+        assert!(report.contains("noise 199"), "{report}");
+        assert!(report.contains("noise 150"), "{report}");
+        assert!(!report.contains("noise 149"), "{report}");
+    }
+
+    #[test]
+    fn a_missing_or_empty_file_reports_nothing() {
+        assert!(report_for(&write_temp("blank", "")).is_none());
+        assert!(report_for(std::path::Path::new("/nonexistent/stderr.log")).is_none());
+    }
+}

--- a/applications/tari_swarm_daemon/src/process_manager/crash_report.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/crash_report.rs
@@ -14,6 +14,9 @@ use crate::{logfile, process_manager::Instance};
 const TAIL_LINES: usize = 50;
 /// Lines of a panic's backtrace worth showing before it turns into noise.
 const PANIC_CONTEXT_LINES: usize = 30;
+/// Lines searched for a panic header. A backtrace easily runs longer than what is shown, and the header sits above
+/// all of it, so the search has to reach further back than either window.
+const SCAN_LINES: usize = 500;
 
 /// Renders the panic message, or failing that the tail of the process's output, as an indented block.
 pub fn crash_report(instance: &Instance) -> String {
@@ -38,7 +41,7 @@ pub fn crash_report(instance: &Instance) -> String {
 }
 
 fn report_for(path: &Path) -> Option<String> {
-    let lines = logfile::tail_lines(path, TAIL_LINES.max(PANIC_CONTEXT_LINES)).ok()?;
+    let lines = logfile::tail_lines(path, SCAN_LINES).ok()?;
     if lines.is_empty() {
         return None;
     }
@@ -113,6 +116,24 @@ mod tests {
         assert!(report.contains("noise 199"), "{report}");
         assert!(report.contains("noise 150"), "{report}");
         assert!(!report.contains("noise 149"), "{report}");
+    }
+
+    #[test]
+    fn a_panic_above_a_long_backtrace_is_still_found() {
+        let mut body = String::from("thread 'main' panicked at crates/consensus/src/lib.rs:12:9:\n");
+        body.push_str("assertion failed: leaf.height() > 0\n");
+        body.push_str("stack backtrace:\n");
+        for frame in 0..300 {
+            body.push_str(&format!("  {frame}: tari_consensus::hotstuff::frame_{frame}\n"));
+        }
+
+        let report = report_for(&write_temp("deep-panic", &body)).unwrap();
+        assert!(
+            report.contains("panicked at crates/consensus/src/lib.rs:12:9"),
+            "{report}"
+        );
+        assert!(report.contains("assertion failed: leaf.height() > 0"), "{report}");
+        assert!(!report.contains("frame_299"), "backtrace should be truncated: {report}");
     }
 
     #[test]

--- a/applications/tari_swarm_daemon/src/process_manager/handle.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/handle.rs
@@ -76,6 +76,10 @@ pub struct InstanceInfo {
     pub name: String,
     pub ports: AllocatedPorts,
     pub base_path: PathBuf,
+    /// Where the daemon captures this process's stdout and stderr. The parent of `base_path`, which points at the
+    /// network subdirectory the process writes its own logs into.
+    pub stdout_log_path: PathBuf,
+    pub stderr_log_path: PathBuf,
     pub instance_type: InstanceType,
     pub settings: HashMap<String, String>,
     pub is_running: bool,
@@ -190,6 +194,8 @@ impl From<&Instance> for InstanceInfo {
             name: instance.name().to_string(),
             ports: instance.allocated_ports().clone(),
             base_path: instance.base_path().clone(),
+            stdout_log_path: instance.stdout_log_path(),
+            stderr_log_path: instance.stderr_log_path(),
             instance_type: instance.instance_type(),
             settings: instance.settings().clone(),
             is_running: instance.is_running(),

--- a/applications/tari_swarm_daemon/src/process_manager/instances/instance.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/instances/instance.rs
@@ -16,6 +16,9 @@ pub struct Instance {
     child: Child,
     allocated_ports: AllocatedPorts,
     base_path: PathBuf,
+    /// Directory holding the forwarded stdout/stderr of this process. The parent of `base_path`, which points at the
+    /// network subdirectory the process itself writes to.
+    process_dir: PathBuf,
     settings: HashMap<String, String>,
     envs: Vec<(String, String)>,
     exit_status: Option<ExitStatus>,
@@ -30,6 +33,7 @@ impl Instance {
         child: Child,
         allocated_ports: AllocatedPorts,
         base_path: PathBuf,
+        process_dir: PathBuf,
         envs: Vec<(String, String)>,
         settings: HashMap<String, String>,
     ) -> Self {
@@ -40,6 +44,7 @@ impl Instance {
             child,
             allocated_ports,
             base_path,
+            process_dir,
             envs,
             settings,
             exit_status: None,
@@ -73,6 +78,14 @@ impl Instance {
 
     pub fn base_path(&self) -> &PathBuf {
         &self.base_path
+    }
+
+    pub fn stdout_log_path(&self) -> PathBuf {
+        self.process_dir.join("stdout.log")
+    }
+
+    pub fn stderr_log_path(&self) -> PathBuf {
+        self.process_dir.join("stderr.log")
     }
 
     pub fn envs(&self) -> &[(String, String)] {

--- a/applications/tari_swarm_daemon/src/process_manager/instances/manager.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/instances/manager.rs
@@ -47,6 +47,7 @@ const CONSENSUS_CONSTANTS_TEMPLATE: &str = r#"# Consensus constants for this swa
 "#;
 use crate::{
     config::{InstanceConfig, InstanceType},
+    logger::FORWARDED_TARGET,
     process_definitions::{CONSENSUS_CONSTANTS_FILE_NAME, ProcessContext, get_definition},
     process_manager::{
         AllocatedPorts,
@@ -282,6 +283,7 @@ impl InstanceManager {
             // This saves us from having to join the network string to the path all over the place, since everything we
             // want is under {base_dir}/{network}
             base_path.join(self.network.to_string()),
+            base_path,
             instance_envs,
             instance_settings,
         );
@@ -556,7 +558,7 @@ fn forward_logs<R: AsyncRead + Unpin + Send + 'static>(path: PathBuf, reader: R,
             },
         };
         while let Some(output) = lines.next_line().await.unwrap() {
-            log::debug!(target: "swarm", "[{target}] {output}");
+            log::debug!(target: FORWARDED_TARGET, "[{target}] {output}");
             if let Err(err) = log_file.write_all(output.as_bytes()).await {
                 log::error!("forward_logs: {err}");
                 return;
@@ -570,6 +572,6 @@ fn forward_logs<R: AsyncRead + Unpin + Send + 'static>(path: PathBuf, reader: R,
                 return;
             }
         }
-        log::debug!(target: "swarm", "Process exited ({target})");
+        log::debug!(target: FORWARDED_TARGET, "Process exited ({target})");
     });
 }

--- a/applications/tari_swarm_daemon/src/process_manager/manager.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/manager.rs
@@ -31,6 +31,7 @@ use crate::{
         InstanceId,
         MinoTariWalletProcess,
         MinotariNodeDetails,
+        crash_report,
         executables::ExecutableManager,
         handle::{ProcessManagerHandle, ProcessManagerRequest},
         instances::InstanceManager,
@@ -238,10 +239,11 @@ impl ProcessManager {
         }) {
             if let Some(status) = instance.check_running()? {
                 return Err(anyhow!(
-                    "Failed to start instance: {} {} {}",
+                    "Failed to start instance: {} {} {}{}",
                     instance.name(),
                     instance.instance_type(),
-                    status
+                    status,
+                    crash_report::crash_report(instance)
                 ));
             }
         }
@@ -264,10 +266,11 @@ impl ProcessManager {
                     );
                 } else {
                     log::error!(
-                        "Instance exited with status {}: {} {}",
+                        "💥 Instance exited with status {}: {} {}{}",
                         status.code().unwrap_or(-1),
                         instance.name(),
-                        instance.instance_type()
+                        instance.instance_type(),
+                        crash_report::crash_report(instance)
                     );
                 }
                 // We only want to clear the miners, the rest we keep around to display that they are terminated

--- a/applications/tari_swarm_daemon/src/process_manager/mod.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/mod.rs
@@ -7,6 +7,7 @@ use tokio::task;
 
 use crate::config::Config;
 
+mod crash_report;
 mod executables;
 mod handle;
 

--- a/applications/tari_swarm_daemon/src/webserver/rpc/logs.rs
+++ b/applications/tari_swarm_daemon/src/webserver/rpc/logs.rs
@@ -8,10 +8,13 @@ use std::{
 };
 
 use axum_jrpc::error::{JsonRpcError, JsonRpcErrorReason};
-use serde::Deserialize;
-use tokio::fs;
+use serde::{Deserialize, Serialize};
 
-use crate::{config::InstanceType, webserver::context::HandlerContext};
+use crate::{
+    config::InstanceType,
+    logfile::{self, MAX_CHUNK_BYTES},
+    webserver::context::HandlerContext,
+};
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct ListLogFilesRequest {
@@ -42,33 +45,37 @@ pub async fn list_log_files(
             )
         })?;
         visit_dirs(&instance.base_path.join("log"), &mut |dir| {
-            if dir.path().extension() == Some("log".as_ref()) {
-                let path = dir.path();
-                let path_without_ext = path.with_extension("");
-                log_files.push((
-                    path.to_string_lossy().to_string(),
-                    instance.name.clone(),
-                    path_without_ext.to_string_lossy().to_string(),
-                ));
-            }
+            collect_current_log(dir, &instance.name, &mut log_files);
         })?;
     } else {
         for instance in instances {
             visit_dirs(&instance.base_path.join("log"), &mut |dir| {
-                if dir.path().extension() == Some("log".as_ref()) {
-                    let path = dir.path();
-                    let path_without_ext = path.with_extension("");
-                    log_files.push((
-                        path.to_string_lossy().to_string(),
-                        instance.name.clone(),
-                        path_without_ext.to_string_lossy().to_string(),
-                    ));
-                }
+                collect_current_log(dir, &instance.name, &mut log_files);
             })?;
         }
     }
 
     Ok(log_files)
+}
+
+fn collect_current_log(entry: &DirEntry, instance_name: &str, log_files: &mut ListValidatorNodesResponse) {
+    let path = entry.path();
+    if path.extension() != Some("log".as_ref()) || is_rotated(&path) {
+        return;
+    }
+    let path_without_ext = path.with_extension("");
+    log_files.push((
+        path.to_string_lossy().to_string(),
+        instance_name.to_string(),
+        path_without_ext.to_string_lossy().to_string(),
+    ));
+}
+
+/// True for a rotated sibling such as `ootle.2.log`, which only clutters the log list next to its live `ootle.log`.
+fn is_rotated(path: &Path) -> bool {
+    path.file_stem()
+        .and_then(|stem| Path::new(stem).extension())
+        .is_some_and(|rotation| rotation.to_string_lossy().chars().all(|c| c.is_ascii_digit()))
 }
 
 fn visit_dirs<F: FnMut(&DirEntry)>(dir: &Path, cb: &mut F) -> io::Result<()> {
@@ -140,19 +147,48 @@ pub async fn list_stdout_files(
     Ok(log_files)
 }
 
-// TODO: this is to preserve the existing API, but it should be changed to a struct
-pub type GetLogFileRequest = PathBuf;
-pub type GetLogFileResponse = String;
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum GetLogFileRequest {
+    /// The whole tail of the file, addressed by path alone.
+    Path(PathBuf),
+    Window {
+        path: PathBuf,
+        /// Offset one past the last byte to return. Omitted means the end of the file.
+        #[serde(default)]
+        end: Option<u64>,
+        /// Largest window to return, capped at [`MAX_CHUNK_BYTES`].
+        #[serde(default)]
+        max_bytes: Option<u64>,
+    },
+}
+
+impl GetLogFileRequest {
+    fn parts(self) -> (PathBuf, Option<u64>, Option<u64>) {
+        match self {
+            Self::Path(path) => (path, None, None),
+            Self::Window { path, end, max_bytes } => (path, end, max_bytes),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GetLogFileResponse {
+    pub contents: String,
+    pub start: u64,
+    pub end: u64,
+    pub file_size: u64,
+    /// Largest window this server will return, so a client can size its own buffer.
+    pub max_chunk_bytes: u64,
+}
+
 pub async fn get_log_file(
     context: &HandlerContext,
     req: GetLogFileRequest,
 ) -> Result<GetLogFileResponse, anyhow::Error> {
-    let file_path = &req;
+    let (path, end, max_bytes) = req.parts();
 
-    if !file_path.starts_with(&context.config().base_dir) ||
-        file_path.extension() != Some("log".as_ref()) ||
-        !file_path.exists()
-    {
+    if !path.starts_with(&context.config().base_dir) || path.extension() != Some("log".as_ref()) || !path.exists() {
         return Err(JsonRpcError::new(
             JsonRpcErrorReason::InvalidParams,
             "Invalid file path".to_string(),
@@ -161,7 +197,50 @@ pub async fn get_log_file(
         .into());
     }
 
-    let contents = fs::read_to_string(file_path).await?;
+    let chunk = tokio::task::spawn_blocking(move || logfile::read_chunk(&path, end, max_bytes)).await??;
 
-    Ok(contents)
+    Ok(GetLogFileResponse {
+        contents: chunk.contents,
+        start: chunk.start,
+        end: chunk.end,
+        file_size: chunk.file_size,
+        max_chunk_bytes: MAX_CHUNK_BYTES,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_bare_path_still_requests_the_tail() {
+        let req: GetLogFileRequest = serde_json::from_str(r#""/base/log/ootle.log""#).unwrap();
+        assert_eq!(req.parts(), (PathBuf::from("/base/log/ootle.log"), None, None));
+    }
+
+    #[test]
+    fn a_window_request_carries_its_bounds() {
+        let req: GetLogFileRequest =
+            serde_json::from_str(r#"{"path":"/base/log/ootle.log","end":4096,"max_bytes":1024}"#).unwrap();
+        assert_eq!(
+            req.parts(),
+            (PathBuf::from("/base/log/ootle.log"), Some(4096), Some(1024))
+        );
+    }
+
+    #[test]
+    fn a_window_request_may_leave_its_bounds_null() {
+        let req: GetLogFileRequest =
+            serde_json::from_str(r#"{"path":"/base/log/ootle.log","end":null,"max_bytes":262144}"#).unwrap();
+        assert_eq!(req.parts(), (PathBuf::from("/base/log/ootle.log"), None, Some(262144)));
+    }
+
+    #[test]
+    fn rotated_siblings_are_recognised() {
+        assert!(is_rotated(Path::new("/x/log/ootle.1.log")));
+        assert!(is_rotated(Path::new("/x/log/consensus.12.log")));
+        assert!(!is_rotated(Path::new("/x/log/ootle.log")));
+        assert!(!is_rotated(Path::new("/x/log/json_rpc.log")));
+        assert!(!is_rotated(Path::new("/x/log/some.name.log")));
+    }
 }

--- a/applications/tari_swarm_daemon/src/webserver/rpc/logs.rs
+++ b/applications/tari_swarm_daemon/src/webserver/rpc/logs.rs
@@ -10,11 +10,7 @@ use std::{
 use axum_jrpc::error::{JsonRpcError, JsonRpcErrorReason};
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    config::InstanceType,
-    logfile::{self, MAX_CHUNK_BYTES},
-    webserver::context::HandlerContext,
-};
+use crate::{config::InstanceType, logfile, process_manager::InstanceInfo, webserver::context::HandlerContext};
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct ListLogFilesRequest {
@@ -115,36 +111,27 @@ pub async fn list_stdout_files(
                 serde_json::Value::Null,
             )
         })?;
-        if instance.base_path.join("stdout.log").exists() {
-            log_files.push((
-                instance.base_path.join("stdout.log").to_string_lossy().to_string(),
-                "stdout",
-            ));
-        }
-        if instance.base_path.join("stderr.log").exists() {
-            log_files.push((
-                instance.base_path.join("stderr.log").to_string_lossy().to_string(),
-                "stdout",
-            ));
-        }
+        collect_captured_output(instance, &mut log_files);
     } else {
-        for instance in instances {
-            if instance.base_path.join("stdout.log").exists() {
-                log_files.push((
-                    instance.base_path.join("stdout.log").to_string_lossy().to_string(),
-                    "stdout",
-                ));
-            }
-            if instance.base_path.join("stderr.log").exists() {
-                log_files.push((
-                    instance.base_path.join("stderr.log").to_string_lossy().to_string(),
-                    "stdout",
-                ));
-            }
+        for instance in &instances {
+            collect_captured_output(instance, &mut log_files);
         }
     }
 
     Ok(log_files)
+}
+
+/// The daemon captures a child's stdout and stderr into its process directory, which is the parent of the
+/// `base_path` the child writes its own logs under.
+fn collect_captured_output(instance: &InstanceInfo, log_files: &mut ListStdoutLogsResponse) {
+    for (path, name) in [
+        (&instance.stdout_log_path, "stdout"),
+        (&instance.stderr_log_path, "stderr"),
+    ] {
+        if path.exists() {
+            log_files.push((path.to_string_lossy().to_string(), name));
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -157,7 +144,7 @@ pub enum GetLogFileRequest {
         /// Offset one past the last byte to return. Omitted means the end of the file.
         #[serde(default)]
         end: Option<u64>,
-        /// Largest window to return, capped at [`MAX_CHUNK_BYTES`].
+        /// Largest window to return, capped at [`logfile::MAX_CHUNK_BYTES`].
         #[serde(default)]
         max_bytes: Option<u64>,
     },
@@ -178,8 +165,6 @@ pub struct GetLogFileResponse {
     pub start: u64,
     pub end: u64,
     pub file_size: u64,
-    /// Largest window this server will return, so a client can size its own buffer.
-    pub max_chunk_bytes: u64,
 }
 
 pub async fn get_log_file(
@@ -187,15 +172,13 @@ pub async fn get_log_file(
     req: GetLogFileRequest,
 ) -> Result<GetLogFileResponse, anyhow::Error> {
     let (path, end, max_bytes) = req.parts();
-
-    if !path.starts_with(&context.config().base_dir) || path.extension() != Some("log".as_ref()) || !path.exists() {
-        return Err(JsonRpcError::new(
+    let path = resolve_log_path(&path, &context.config().base_dir).ok_or_else(|| {
+        JsonRpcError::new(
             JsonRpcErrorReason::InvalidParams,
             "Invalid file path".to_string(),
             serde_json::Value::Null,
         )
-        .into());
-    }
+    })?;
 
     let chunk = tokio::task::spawn_blocking(move || logfile::read_chunk(&path, end, max_bytes)).await??;
 
@@ -204,8 +187,23 @@ pub async fn get_log_file(
         start: chunk.start,
         end: chunk.end,
         file_size: chunk.file_size,
-        max_chunk_bytes: MAX_CHUNK_BYTES,
     })
+}
+
+/// Resolves a client-supplied path to a log file inside `base_dir`.
+///
+/// Both sides are canonicalised first: `starts_with` compares path components, so an uncanonicalised
+/// `<base_dir>/../../etc/passwd.log` carries the prefix while resolving outside the directory entirely.
+fn resolve_log_path(path: &Path, base_dir: &Path) -> Option<PathBuf> {
+    if path.extension() != Some("log".as_ref()) {
+        return None;
+    }
+    let path = path.canonicalize().ok()?;
+    let base_dir = base_dir.canonicalize().ok()?;
+    if !path.starts_with(&base_dir) || !path.is_file() {
+        return None;
+    }
+    Some(path)
 }
 
 #[cfg(test)]
@@ -233,6 +231,24 @@ mod tests {
         let req: GetLogFileRequest =
             serde_json::from_str(r#"{"path":"/base/log/ootle.log","end":null,"max_bytes":262144}"#).unwrap();
         assert_eq!(req.parts(), (PathBuf::from("/base/log/ootle.log"), None, Some(262144)));
+    }
+
+    #[test]
+    fn a_traversal_out_of_the_base_dir_is_rejected() {
+        let base = std::env::temp_dir().join("swarm-logs-base");
+        std::fs::create_dir_all(base.join("log")).unwrap();
+        let inside = base.join("log/ootle.log");
+        std::fs::write(&inside, "hello\n").unwrap();
+        let outside = std::env::temp_dir().join("swarm-logs-outside.log");
+        std::fs::write(&outside, "hello\n").unwrap();
+
+        assert!(resolve_log_path(&inside, &base).is_some());
+        // Component-wise `starts_with` alone accepts this, because the prefix is literally present.
+        let traversal = base.join("log/../../swarm-logs-outside.log");
+        assert!(traversal.starts_with(&base));
+        assert!(resolve_log_path(&traversal, &base).is_none());
+        assert!(resolve_log_path(&base.join("log/ootle.txt"), &base).is_none());
+        assert!(resolve_log_path(&base.join("log/missing.log"), &base).is_none());
     }
 
     #[test]

--- a/applications/tari_swarm_daemon/webui/src/routes/LogView.tsx
+++ b/applications/tari_swarm_daemon/webui/src/routes/LogView.tsx
@@ -13,7 +13,7 @@ import {
 } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { describeError, swarmRpc } from "../api/rpc";
-import { LEVELS, Level, Line, TARGET_RE, TIME_RE, parse } from "./logFormat";
+import { LEVELS, Level, Line, TARGET_RE, TIME_RE, parse, toEntries } from "./logFormat";
 
 /** Bytes fetched per request. The daemon trims each window to whole lines. */
 const CHUNK_BYTES = 256 * 1024;
@@ -114,8 +114,12 @@ export default function LogView() {
   const [loadingOlder, setLoadingOlder] = useState(false);
   const view = useRef<HTMLDivElement>(null);
   const loadingRef = useRef(false);
-  /** Line to hold still across a buffer trim, which removes rendered lines above the viewport. */
-  const anchor = useRef<{ n: number; top: number } | null>(null);
+  /**
+   * Line to hold still across a buffer trim, which removes rendered lines above the viewport. `from` records the
+   * oldest offset at capture time, so an anchor left behind by a load that never committed is discarded rather
+   * than applied to some later, unrelated re-render.
+   */
+  const anchor = useRef<{ n: number; top: number; from: number } | null>(null);
 
   const atStartOfFile = chunks !== null && chunks[chunks.length - 1]?.start === 0;
 
@@ -165,7 +169,7 @@ export default function LogView() {
     const anchorN = oldestRendered?.dataset.n;
     anchor.current =
       oldestRendered && anchorN !== undefined
-        ? { n: Number(anchorN), top: oldestRendered.getBoundingClientRect().top }
+        ? { n: Number(anchorN), top: oldestRendered.getBoundingClientRect().top, from: oldest.start }
         : null;
 
     try {
@@ -203,22 +207,27 @@ export default function LogView() {
     }
   };
 
-  const lines = useMemo(
-    () => (chunks === null ? null : chunks.flatMap((chunk) => chunk.lines.slice().reverse())),
+  // Newest entry first, but the lines inside each entry stay in the order they were written.
+  const entries = useMemo(
+    () => (chunks === null ? null : chunks.flatMap((chunk) => toEntries(chunk.lines).reverse())),
     [chunks],
   );
 
   const visible = useMemo(() => {
-    if (lines === null) {
+    if (entries === null) {
       return [];
     }
     const lowerNeedle = needle.trim().toLowerCase();
-    return lines.filter(
-      (line) =>
-        !(line.level && hidden.has(line.level)) &&
-        (!lowerNeedle || line.text.toLowerCase().includes(lowerNeedle)),
-    );
-  }, [lines, hidden, needle]);
+    // An entry's level is its opening line's - a continuation carries none of its own, and hiding a record has
+    // to take its continuations with it.
+    return entries
+      .filter(
+        (entry) =>
+          !(entry[0].level && hidden.has(entry[0].level)) &&
+          (!lowerNeedle || entry.some((line) => line.text.toLowerCase().includes(lowerNeedle))),
+      )
+      .flat();
+  }, [entries, hidden, needle]);
 
   useLayoutEffect(() => {
     const el = view.current;
@@ -229,14 +238,14 @@ export default function LogView() {
     }
     const held = anchor.current;
     anchor.current = null;
-    if (!el || !held) {
+    if (!el || !held || chunks?.[chunks.length - 1]?.start === held.from) {
       return;
     }
     const moved = el.querySelector<HTMLElement>(`.logline[data-n="${held.n}"]`);
     if (moved) {
       el.scrollTop += moved.getBoundingClientRect().top - held.top;
     }
-  }, [visible, follow]);
+  }, [visible, follow, chunks]);
 
   // Level filters can leave too few lines to fill the view, which would strand it with nothing to scroll.
   useEffect(() => {
@@ -248,13 +257,13 @@ export default function LogView() {
 
   const counts = useMemo(() => {
     const tally: Record<string, number> = {};
-    for (const line of lines ?? []) {
+    for (const [line] of entries ?? []) {
       if (line.level) {
         tally[line.level] = (tally[line.level] ?? 0) + 1;
       }
     }
     return tally;
-  }, [lines]);
+  }, [entries]);
 
   const toggle = (level: Level) =>
     setHidden((current) => {
@@ -313,9 +322,13 @@ export default function LogView() {
 
       <div className="logview" ref={view} onScroll={onScroll}>
         {error && <p className="empty">{error}</p>}
-        {!error && lines === null && <p className="empty">Loading…</p>}
-        {!error && lines !== null && !visible.length && (
-          <p className="empty">{lines.length ? "No lines match the filters." : "This file is empty."}</p>
+        {!error && entries === null && <p className="empty">Loading…</p>}
+        {!error && entries !== null && !visible.length && (
+          <p className="empty">{entries.length ? "No lines match the filters." : "This file is empty."}</p>
+        )}
+        {/* Paging back trims the newest chunks, so the head of the file is only reachable through Follow. */}
+        {!error && !follow && visible.length > 0 && (
+          <p className="logstart">Paused · Follow to jump back to the newest lines</p>
         )}
         {visible.map((line) => (
           <div className={`logline${wrap ? "" : " nowrap"}`} data-n={line.n} key={line.n}>

--- a/applications/tari_swarm_daemon/webui/src/routes/LogView.tsx
+++ b/applications/tari_swarm_daemon/webui/src/routes/LogView.tsx
@@ -1,32 +1,42 @@
 //  Copyright 2024 The Tari Project
 //  SPDX-License-Identifier: BSD-3-Clause
 
-import { Fragment, ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Fragment,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { describeError, swarmRpc } from "../api/rpc";
+import { LEVELS, Level, Line, TARGET_RE, TIME_RE, parse } from "./logFormat";
 
-const LEVELS = ["ERROR", "WARN", "INFO", "DEBUG", "TRACE"] as const;
-type Level = (typeof LEVELS)[number];
-
-/** Rendering every line of a long-running node log locks the tab up. */
-const MAX_LINES = 4000;
+/** Bytes fetched per request. The daemon trims each window to whole lines. */
+const CHUNK_BYTES = 256 * 1024;
+/**
+ * Chunks held at once. Paging further back drops the newest ones, so however long a session runs the buffer stays
+ * bounded and the tab stays responsive.
+ */
+const MAX_CHUNKS = 6;
 const FOLLOW_MS = 2000;
+/** Distance from the older end of the view at which the next chunk starts loading. */
+const LOAD_MARGIN_PX = 400;
 
-interface Line {
-  n: number;
-  level: Level | null;
-  text: string;
+interface Chunk {
+  start: number;
+  end: number;
+  lines: Line[];
 }
 
-const LEVEL_RE = /\b(ERROR|WARN|INFO|DEBUG|TRACE)\b/;
-const TIME_RE = /^(\d{4}-\d{2}-\d{2}[T ]\d+:\d{2}:\d{2}[.\d]*Z?)/;
-const TARGET_RE = /\[([\w:]+::[\w:]+)\]/;
-
-function parse(body: string): Line[] {
-  return body.split("\n").map((text, i) => {
-    const match = LEVEL_RE.exec(text);
-    return { n: i + 1, level: (match?.[1] as Level) ?? null, text };
-  });
+interface ChunkResponse {
+  contents: string;
+  start: number;
+  end: number;
+  file_size: number;
 }
 
 /** Highlights the timestamp, the log target and every search hit, without raw HTML. */
@@ -76,6 +86,11 @@ function renderText(text: string, needle: string): ReactNode {
   return parts;
 }
 
+async function fetchChunk(path: string, end: number | null): Promise<Chunk> {
+  const res: ChunkResponse = await swarmRpc("get_file", { path, end, max_bytes: CHUNK_BYTES });
+  return { start: res.start, end: res.end, lines: parse(res.contents, res.start) };
+}
+
 export default function LogView() {
   const navigate = useNavigate();
   const { name } = useParams<{ name: string; format: string }>();
@@ -87,7 +102,8 @@ export default function LogView() {
     }
   }, [name]);
 
-  const [body, setBody] = useState<string | null>(null);
+  // Newest chunk first, matching the rendered order.
+  const [chunks, setChunks] = useState<Chunk[] | null>(null);
   const [fetchError, setFetchError] = useState<string | null>(null);
   // A malformed link is a property of the URL, not something to store and sync.
   const error = path === null ? "That log link is not valid." : fetchError;
@@ -95,10 +111,17 @@ export default function LogView() {
   const [needle, setNeedle] = useState("");
   const [wrap, setWrap] = useState(true);
   const [follow, setFollow] = useState(true);
-  const bottom = useRef<HTMLDivElement>(null);
+  const [loadingOlder, setLoadingOlder] = useState(false);
+  const view = useRef<HTMLDivElement>(null);
+  const loadingRef = useRef(false);
+  /** Line to hold still across a buffer trim, which removes rendered lines above the viewport. */
+  const anchor = useRef<{ n: number; top: number } | null>(null);
 
+  const atStartOfFile = chunks !== null && chunks[chunks.length - 1]?.start === 0;
+
+  // Entering follow mode starts a fresh window at the tail; leaving it keeps whatever is on screen.
   useEffect(() => {
-    if (!path) {
+    if (!path || !follow) {
       return;
     }
     let cancelled = false;
@@ -106,9 +129,9 @@ export default function LogView() {
 
     const load = async () => {
       try {
-        const contents = await swarmRpc("get_file", path);
+        const chunk = await fetchChunk(path, null);
         if (!cancelled) {
-          setBody(contents);
+          setChunks([chunk]);
           setFetchError(null);
         }
       } catch (err) {
@@ -116,7 +139,7 @@ export default function LogView() {
           setFetchError(describeError(err));
         }
       }
-      if (!cancelled && follow) {
+      if (!cancelled) {
         timer = window.setTimeout(load, FOLLOW_MS);
       }
     };
@@ -128,27 +151,104 @@ export default function LogView() {
     };
   }, [path, follow]);
 
-  const lines = useMemo(() => (body === null ? [] : parse(body)), [body]);
+  const loadOlder = useCallback(async () => {
+    const oldest = chunks?.[chunks.length - 1];
+    if (!path || !oldest || loadingRef.current || oldest.start === 0) {
+      return;
+    }
+    loadingRef.current = true;
+    setLoadingOlder(true);
+
+    // The oldest rendered line survives any trim, so it can hold the view still if one happens.
+    const rendered = view.current?.querySelectorAll<HTMLElement>(".logline");
+    const oldestRendered = rendered?.length ? rendered[rendered.length - 1] : undefined;
+    const anchorN = oldestRendered?.dataset.n;
+    anchor.current =
+      oldestRendered && anchorN !== undefined
+        ? { n: Number(anchorN), top: oldestRendered.getBoundingClientRect().top }
+        : null;
+
+    try {
+      const chunk = await fetchChunk(path, oldest.start);
+      setChunks((current) => {
+        // Follow mode may have replaced the buffer while the request was in flight.
+        if (!current || current[current.length - 1]?.start !== oldest.start) {
+          return current;
+        }
+        return [...current, chunk].slice(-MAX_CHUNKS);
+      });
+      setFetchError(null);
+    } catch (err) {
+      setFetchError(describeError(err));
+    } finally {
+      loadingRef.current = false;
+      setLoadingOlder(false);
+    }
+  }, [path, chunks]);
+
+  // Newest lines sit at the top, so scrolling down walks backwards through the file.
+  const onScroll = () => {
+    const el = view.current;
+    if (!el) {
+      return;
+    }
+    if (follow) {
+      if (el.scrollTop > LOAD_MARGIN_PX) {
+        setFollow(false);
+      }
+      return;
+    }
+    if (el.scrollHeight - el.scrollTop - el.clientHeight < LOAD_MARGIN_PX) {
+      void loadOlder();
+    }
+  };
+
+  const lines = useMemo(
+    () => (chunks === null ? null : chunks.flatMap((chunk) => chunk.lines.slice().reverse())),
+    [chunks],
+  );
 
   const visible = useMemo(() => {
+    if (lines === null) {
+      return [];
+    }
     const lowerNeedle = needle.trim().toLowerCase();
-    const kept = lines.filter(
+    return lines.filter(
       (line) =>
         !(line.level && hidden.has(line.level)) &&
         (!lowerNeedle || line.text.toLowerCase().includes(lowerNeedle)),
     );
-    return kept.length > MAX_LINES ? kept.slice(-MAX_LINES) : kept;
   }, [lines, hidden, needle]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
+    const el = view.current;
     if (follow) {
-      bottom.current?.scrollIntoView({ block: "end" });
+      el?.scrollTo({ top: 0 });
+      anchor.current = null;
+      return;
+    }
+    const held = anchor.current;
+    anchor.current = null;
+    if (!el || !held) {
+      return;
+    }
+    const moved = el.querySelector<HTMLElement>(`.logline[data-n="${held.n}"]`);
+    if (moved) {
+      el.scrollTop += moved.getBoundingClientRect().top - held.top;
     }
   }, [visible, follow]);
 
+  // Level filters can leave too few lines to fill the view, which would strand it with nothing to scroll.
+  useEffect(() => {
+    const el = view.current;
+    if (el && !follow && !loadingOlder && !atStartOfFile && el.scrollHeight <= el.clientHeight) {
+      void loadOlder();
+    }
+  }, [visible, follow, loadingOlder, atStartOfFile, loadOlder]);
+
   const counts = useMemo(() => {
     const tally: Record<string, number> = {};
-    for (const line of lines) {
+    for (const line of lines ?? []) {
       if (line.level) {
         tally[line.level] = (tally[line.level] ?? 0) + 1;
       }
@@ -202,26 +302,36 @@ export default function LogView() {
         <button className={`btn sm${wrap ? " primary" : ""}`} onClick={() => setWrap(!wrap)}>
           Wrap
         </button>
-        <button className={`btn sm${follow ? " primary" : ""}`} onClick={() => setFollow(!follow)}>
+        <button
+          className={`btn sm${follow ? " primary" : ""}`}
+          onClick={() => setFollow(!follow)}
+          title={follow ? "Stop following the end of the file" : "Jump back to the newest lines"}
+        >
           Follow
         </button>
       </div>
 
-      <div className="logview">
+      <div className="logview" ref={view} onScroll={onScroll}>
         {error && <p className="empty">{error}</p>}
-        {!error && body === null && <p className="empty">Loading…</p>}
-        {!error && body !== null && !visible.length && (
-          <p className="empty">
-            {lines.length ? "No lines match the filters." : "This file is empty."}
-          </p>
+        {!error && lines === null && <p className="empty">Loading…</p>}
+        {!error && lines !== null && !visible.length && (
+          <p className="empty">{lines.length ? "No lines match the filters." : "This file is empty."}</p>
         )}
         {visible.map((line) => (
-          <div className={`logline${wrap ? "" : " nowrap"}`} key={line.n}>
+          <div className={`logline${wrap ? "" : " nowrap"}`} data-n={line.n} key={line.n}>
             <span className={`lvl lvl-${line.level ?? ""}`}>{line.level ?? ""}</span>
             <span className="txt">{renderText(line.text, needle.trim())}</span>
           </div>
         ))}
-        <div ref={bottom} />
+        {!error && visible.length > 0 && (
+          <p className="logend">
+            {loadingOlder
+              ? "Loading older lines…"
+              : atStartOfFile
+                ? "Start of file"
+                : "Scroll down for older lines"}
+          </p>
+        )}
       </div>
     </div>
   );

--- a/applications/tari_swarm_daemon/webui/src/routes/logFormat.ts
+++ b/applications/tari_swarm_daemon/webui/src/routes/logFormat.ts
@@ -1,0 +1,72 @@
+//  Copyright 2024 The Tari Project
+//  SPDX-License-Identifier: BSD-3-Clause
+
+export const LEVELS = ["ERROR", "WARN", "INFO", "DEBUG", "TRACE"] as const;
+export type Level = (typeof LEVELS)[number];
+
+export interface Line {
+  /** Byte offset of the line in the file: unique across chunks and stable when follow mode refetches the tail. */
+  n: number;
+  level: Level | null;
+  text: string;
+}
+
+/** log4rs writes the level bare; tracing writes it after an RFC 3339 timestamp. Both are matched here. */
+const LEVEL_RE = /\b(ERROR|WARN|INFO|DEBUG|TRACE)\b/;
+export const TIME_RE = /^(\d{4}-\d{2}-\d{2}[T ]\d+:\d{2}:\d{2}[.\d]*Z?)/;
+export const TARGET_RE = /\[([\w:]+::[\w:]+)\]/;
+/**
+ * A tracing line is `<timestamp> <LEVEL> [<spans>: ]<target>: <message>`, with no brackets around the target.
+ * Rewriting it into log4rs' shape lets one renderer highlight both.
+ */
+const TRACING_RE = /^(\d{4}-\d{2}-\d{2}T[\d:.]+Z)\s+(ERROR|WARN|INFO|DEBUG|TRACE)\s+([\s\S]*)$/;
+const TRACING_TARGET_RE = /^([\w:]+::[\w:]+):\s([\s\S]*)$/;
+const TARGET_SEARCH_RE = /[\w:]+::[\w:]+:\s/;
+const ANSI_RE = /\u001b\[[0-9;]*m/g;
+
+const ENCODER = new TextEncoder();
+
+/**
+ * Normalises one raw line to `<timestamp> [<target>] <LEVEL> <message>`.
+ *
+ * The indexer logs through `tracing`, which orders the fields differently from log4rs and, in files written before
+ * ANSI output was turned off, wraps every one of them in colour escapes.
+ */
+export function normalise(raw: string): string {
+  const text = raw.replace(ANSI_RE, "");
+  const tracing = TRACING_RE.exec(text);
+  if (!tracing) {
+    return text;
+  }
+
+  const [, time, level, rest] = tracing;
+  // Anything ahead of the target is span context, e.g. `request{method=POST uri=/x}:`.
+  const at = rest.search(TARGET_SEARCH_RE);
+  const spans = at > 0 ? rest.slice(0, at).replace(/:\s*$/, "").trim() : "";
+  const targeted = TRACING_TARGET_RE.exec(at > 0 ? rest.slice(at) : rest);
+  if (!targeted) {
+    return `${time} ${level.padEnd(5)} ${rest}`;
+  }
+
+  const [, target, message] = targeted;
+  return `${time} [${target}] ${level.padEnd(5)} ${spans ? `${spans} ` : ""}${message}`;
+}
+
+/** Splits a chunk of file bytes into lines, keyed by their byte offset in the file. */
+export function parse(body: string, start: number): Line[] {
+  const raw = body.split("\n");
+  // A chunk ends on a newline, so the split leaves a trailing empty element that is not a line of the file.
+  if (raw.length && raw[raw.length - 1] === "") {
+    raw.pop();
+  }
+
+  const lines: Line[] = [];
+  let offset = start;
+  for (const text of raw) {
+    const normalised = normalise(text);
+    const match = LEVEL_RE.exec(normalised);
+    lines.push({ n: offset, level: (match?.[1] as Level) ?? null, text: normalised });
+    offset += ENCODER.encode(text).length + 1;
+  }
+  return lines;
+}

--- a/applications/tari_swarm_daemon/webui/src/routes/logFormat.ts
+++ b/applications/tari_swarm_daemon/webui/src/routes/logFormat.ts
@@ -52,6 +52,47 @@ export function normalise(raw: string): string {
   return `${time} [${target}] ${level.padEnd(5)} ${spans ? `${spans} ` : ""}${message}`;
 }
 
+/**
+ * Groups lines into whole log entries.
+ *
+ * The view shows the newest entry first, and reversing bare lines to get there would turn every multi-line
+ * entry - a record whose message contains newlines, a panic and its backtrace - upside down. Reversing entries
+ * instead keeps each one readable top to bottom.
+ *
+ * A timestamped file starts a new entry at each timestamp. Raw stdout and stderr carry no timestamps, so each
+ * line stands alone there, except inside a panic block: that runs from the `panicked at` header to the next
+ * blank line, which is the one multi-line shape those files reliably contain.
+ */
+export function toEntries(lines: Line[]): Line[][] {
+  const timestamped = lines.some((line) => TIME_RE.test(line.text));
+  const entries: Line[][] = [];
+  let inPanic = false;
+
+  for (const line of lines) {
+    const startsRecord = TIME_RE.test(line.text);
+    if (startsRecord) {
+      inPanic = false;
+    } else if (!timestamped) {
+      if (inPanic && line.text.trim() === "") {
+        inPanic = false;
+      } else if (!inPanic && line.text.includes("panicked at")) {
+        inPanic = true;
+        entries.push([line]);
+        continue;
+      }
+    }
+
+    const continues = !startsRecord && (timestamped ? entries.length > 0 : inPanic);
+    if (continues) {
+      entries[entries.length - 1].push(line);
+    } else {
+      entries.push([line]);
+    }
+  }
+
+  return entries;
+}
+
 /** Splits a chunk of file bytes into lines, keyed by their byte offset in the file. */
 export function parse(body: string, start: number): Line[] {
   const raw = body.split("\n");

--- a/applications/tari_swarm_daemon/webui/src/theme/theme.css
+++ b/applications/tari_swarm_daemon/webui/src/theme/theme.css
@@ -999,6 +999,15 @@ td.nowrap,
   color: var(--rail-text);
 }
 
+.logend {
+  padding: 14px;
+  text-align: center;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--ink-3);
+  border-top: 1px dashed var(--line);
+}
+
 /* ============================================================== toasts == */
 
 .toasts {

--- a/applications/tari_swarm_daemon/webui/src/theme/theme.css
+++ b/applications/tari_swarm_daemon/webui/src/theme/theme.css
@@ -999,13 +999,21 @@ td.nowrap,
   color: var(--rail-text);
 }
 
-.logend {
+.logend,
+.logstart {
   padding: 14px;
   text-align: center;
   font-family: var(--mono);
   font-size: 11px;
   color: var(--ink-3);
+}
+
+.logend {
   border-top: 1px dashed var(--line);
+}
+
+.logstart {
+  border-bottom: 1px dashed var(--line);
 }
 
 /* ============================================================== toasts == */


### PR DESCRIPTION
## What

The swarm web UI's log view fetched every byte of a node log on each poll and rendered it in one pass. On a swarm that had been up for a while that locked the tab up or killed it outright. This reworks how swarm reads and shows logs.

### Paged, mmap-backed reads

New `logfile` module in the swarm daemon returns a byte window of a log file, trimmed to whole lines, read through `memmap2`. The `get_file` RPC now takes an optional `end` and `max_bytes` and returns `{contents, start, end, file_size}`; passing a chunk's `start` back as the next `end` walks backwards through the file with no gaps or repeats. A bare path string is still accepted and means "the tail".

The web UI keeps at most six 256 KiB chunks. It opens on the tail with the newest lines at the top; scrolling down pages further back and pauses follow mode; re-enabling follow clears the buffer and returns to the head. Trimming the buffer holds the scroll position against the oldest rendered line, so paging back does not jump.

### Crash reports on stdout

A process that exits non-zero now prints its panic message — or, failing that, the last 50 lines of its stderr and stdout — to the swarm daemon's own stdout, instead of leaving the reason buried in a file the operator has to go find.

The daemon's log formatter reparses forwarded child output to recover the child's target and level from the message text. That now applies only to records actually forwarded from a child (target `swarm`), so a multi-line report is printed as written rather than being mangled by the naive parser.

### Only live log links

The log list showed `ootle.log` alongside `ootle.1.log` … `ootle.5.log`, so every entry appeared six times over. Rotated siblings are now filtered out.

### Indexer log format

The indexer logs through `tracing`, not log4rs, and its file layer was writing ANSI colour escapes into `indexer.log` — a file that is never a terminal. The view rendered those as literal text, which made indexer logs unreadable.

Two halves to the fix: the indexer's file layer no longer emits ANSI (and its stdout layer only colours when stdout is really a terminal), and the UI's line parser understands `tracing`'s `<timestamp> <LEVEL> [<spans>: ]<target>: <message>` shape and strips escapes, so logs already on disk render correctly too.

## Testing

- 16 unit tests in `tari_swarm_daemon`, covering line-boundary trimming, backwards paging over a multi-megabyte file (reconstructs the file byte for byte), UTF-8 boundaries at every window size, rotated-file detection, both `get_file` request shapes, and panic extraction vs. tail fallback.
- The UI's `parse`/`normalise` was run over real `indexer.log`, validator-node `ootle.log`, wallet-daemon `ootle.log` and both stdout captures from a local swarm run: every line comes out with a level and, where the format carries one, a target, with no escapes left behind.
- `cargo clippy -p tari_swarm_daemon --all-targets` clean; webui `tsc --noEmit` and `eslint --max-warnings 0` clean; `vite build` succeeds.

Not verified in a browser — no extension connected in this environment — so the scroll and follow interactions are worth a quick manual pass.
