### PR TITLE
fix(indexer): refuse a live head at a version the stream saw spent

### DIFF
--- a/applications/tari_indexer/src/storage_sqlite/migrations/2026-09-07-000000_substate_cache_invalidation_spent/down.sql
+++ b/applications/tari_indexer/src/storage_sqlite/migrations/2026-09-07-000000_substate_cache_invalidation_spent/down.sql
@@ -1,0 +1,11 @@
+drop table substate_cache_invalidations;
+
+create table substate_cache_invalidations
+(
+    substate_id      text    not null primary key,
+    state_version    bigint  not null,
+    substate_version integer not null,
+    invalidated_at   bigint  not null
+);
+
+create index idx_substate_cache_invalidations_expiry on substate_cache_invalidations (invalidated_at);

--- a/applications/tari_indexer/src/storage_sqlite/migrations/2026-09-07-000000_substate_cache_invalidation_spent/up.sql
+++ b/applications/tari_indexer/src/storage_sqlite/migrations/2026-09-07-000000_substate_cache_invalidation_spent/up.sql
@@ -1,0 +1,23 @@
+-- Record whether the version a transition showed is itself spent, alongside the version.
+--
+-- The version alone is a floor: a result below it is refused. It cannot also express that the floor
+-- version is down, which a destroy with no successor leaves true - the successor is what would
+-- otherwise raise the floor past it. Without the provenance a lagging committee member's `Up` at the
+-- destroyed version is admitted as the live head and a spent substate is served as spendable, while
+-- a `Down` at that same version is a legitimate head and must still be admitted.
+--
+-- The journal is derived from the stream and spans a fetch, so it is recreated rather than migrated.
+drop table substate_cache_invalidations;
+
+create table substate_cache_invalidations
+(
+    substate_id      text    not null primary key,
+    state_version    bigint  not null,
+    -- The substate version the transition showed: the version created, or the version destroyed.
+    substate_version integer not null,
+    -- Whether `substate_version` was destroyed rather than created.
+    spent            boolean not null,
+    invalidated_at   bigint  not null
+);
+
+create index idx_substate_cache_invalidations_expiry on substate_cache_invalidations (invalidated_at);

--- a/applications/tari_indexer/src/storage_sqlite/models/substate_cache.rs
+++ b/applications/tari_indexer/src/storage_sqlite/models/substate_cache.rs
@@ -26,6 +26,7 @@ pub struct SubstateCacheInvalidation {
     retires_up_to: Option<u32>,
     retires_nonexistence: bool,
     observed_version: u32,
+    spent: bool,
 }
 
 impl SubstateCacheInvalidation {
@@ -47,6 +48,7 @@ impl SubstateCacheInvalidation {
             retires_up_to,
             retires_nonexistence,
             observed_version: version,
+            spent: false,
         })
     }
 
@@ -60,6 +62,7 @@ impl SubstateCacheInvalidation {
             retires_up_to: Some(version),
             retires_nonexistence: false,
             observed_version: version,
+            spent: true,
         }
     }
 
@@ -71,6 +74,14 @@ impl SubstateCacheInvalidation {
     /// below this is one the substate has already been watched past, whoever offers it.
     pub fn observed_version(&self) -> u32 {
         self.observed_version
+    }
+
+    /// Whether [`observed_version`](Self::observed_version) is spent: it was destroyed rather than
+    /// created. A `Down` at a spent version is still a legitimate head - it is what a lookup for that
+    /// version answers - but an `Up` at it is not, so the version alone does not settle a result
+    /// landing there.
+    pub fn is_observed_version_spent(&self) -> bool {
+        self.spent
     }
 
     /// The highest cached head version this retires, if any.
@@ -123,6 +134,7 @@ mod tests {
         let invalidation = SubstateCacheInvalidation::created(&substate(), 6).unwrap();
         assert_eq!(invalidation.retires_up_to(), Some(5));
         assert!(invalidation.retires_nonexistence());
+        assert!(!invalidation.is_observed_version_spent());
     }
 
     #[test]
@@ -130,5 +142,6 @@ mod tests {
         let invalidation = SubstateCacheInvalidation::destroyed(substate(), 6);
         assert_eq!(invalidation.retires_up_to(), Some(6));
         assert!(!invalidation.retires_nonexistence());
+        assert!(invalidation.is_observed_version_spent());
     }
 }

--- a/applications/tari_indexer/src/storage_sqlite/schema.rs
+++ b/applications/tari_indexer/src/storage_sqlite/schema.rs
@@ -155,6 +155,7 @@ diesel::table! {
         substate_id -> Text,
         state_version -> BigInt,
         substate_version -> Integer,
+        spent -> Bool,
         invalidated_at -> BigInt,
     }
 }

--- a/applications/tari_indexer/src/storage_sqlite/store_factory.rs
+++ b/applications/tari_indexer/src/storage_sqlite/store_factory.rs
@@ -1126,6 +1126,39 @@ mod tests {
         put_entry(store, id, version, true, now_secs(), watermark).await
     }
 
+    /// A committee member answering that `version` is live, as against the `Down` every other put
+    /// helper here records.
+    async fn put_up(store: &SqliteIndexerStore, id: &SubstateId, version: u32, watermark: u64) -> bool {
+        use tari_engine_types::{
+            non_fungible::NonFungibleContainer,
+            substate::{Substate, SubstateValue},
+        };
+
+        let result = SubstateResult::Up {
+            substate: Box::new(Substate::new(
+                version,
+                SubstateValue::NonFungible(NonFungibleContainer::no_data()),
+            )),
+        };
+        let id = id.clone();
+        store
+            .with_write_tx(move |tx| {
+                tx.substate_cache_put(
+                    &id,
+                    SubstateCacheEntryRef {
+                        version: Some(version),
+                        substate_result: &result,
+                        cached_at: now_secs(),
+                        verified: true,
+                    },
+                    FetchWatermark::new(watermark),
+                    HEAD_TTL,
+                )
+            })
+            .await
+            .unwrap()
+    }
+
     /// The cached head version. `None` covers both no row at all and a row recording that the
     /// substate does not exist; use [`read_entry`] where the two must be told apart.
     async fn read(store: &SqliteIndexerStore, id: &SubstateId) -> Option<u32> {
@@ -1213,6 +1246,81 @@ mod tests {
         // The destroyed version is itself a legitimate head: it is down, which is what a lookup for
         // it answers.
         assert!(put(&store, &id, 7, 110).await);
+    }
+
+    /// A destroy with no successor leaves the version it named as the floor, and that version is
+    /// spent. A member still holding it live offers an `Up` at exactly the floor, which the version
+    /// alone does not refuse.
+    #[tokio::test]
+    async fn a_destroy_with_no_successor_refuses_a_live_head_at_the_version_it_spent() {
+        let (_d, store) = temp_store().await;
+        let id = substate(1);
+
+        invalidate(&store, SubstateCacheInvalidation::destroyed(id.clone(), 7), 105).await;
+        assert!(!put_up(&store, &id, 7, 110).await);
+        assert!(read(&store, &id).await.is_none());
+    }
+
+    /// The other half of the same floor: a lookup for a destroyed version answers `Down`, so that
+    /// result is the substate's legitimate head and is recorded.
+    #[tokio::test]
+    async fn a_destroy_with_no_successor_still_admits_the_down_at_that_version() {
+        let (_d, store) = temp_store().await;
+        let id = substate(1);
+
+        invalidate(&store, SubstateCacheInvalidation::destroyed(id.clone(), 7), 105).await;
+        assert!(put(&store, &id, 7, 110).await);
+        assert_eq!(read(&store, &id).await, Some(7));
+    }
+
+    /// A destroy with a successor is not a spend of the floor: the creation raises it to the version
+    /// that is live, which must be admitted as an `Up`. The two reach the journal in no stated order.
+    #[tokio::test]
+    async fn a_destroy_with_a_successor_admits_the_created_version_live() {
+        for reversed in [false, true] {
+            let (_d, store) = temp_store().await;
+            let id = substate(1);
+            let mut batch = vec![
+                SubstateCacheInvalidation::destroyed(id.clone(), 6),
+                SubstateCacheInvalidation::created(&id, 7).unwrap(),
+            ];
+            if reversed {
+                batch.reverse();
+            }
+            store
+                .with_write_tx(move |tx| tx.substate_cache_invalidate(batch, StateVersion::new(105)))
+                .await
+                .unwrap();
+
+            assert!(!put_up(&store, &id, 6, 110).await);
+            assert!(put_up(&store, &id, 7, 110).await);
+            assert_eq!(read(&store, &id).await, Some(7));
+        }
+    }
+
+    /// A substate created and destroyed within one batch reaches the journal at a single version
+    /// from both sides. The spend is the later of the two whichever order they arrive in, so it
+    /// stands.
+    #[tokio::test]
+    async fn a_version_both_created_and_destroyed_in_one_batch_is_spent() {
+        for reversed in [false, true] {
+            let (_d, store) = temp_store().await;
+            let id = substate(1);
+            let mut batch = vec![
+                SubstateCacheInvalidation::created(&id, 7).unwrap(),
+                SubstateCacheInvalidation::destroyed(id.clone(), 7),
+            ];
+            if reversed {
+                batch.reverse();
+            }
+            store
+                .with_write_tx(move |tx| tx.substate_cache_invalidate(batch, StateVersion::new(105)))
+                .await
+                .unwrap();
+
+            assert!(!put_up(&store, &id, 7, 110).await);
+            assert!(put(&store, &id, 7, 110).await);
+        }
     }
 
     /// One transaction downs a version and ups the next, and the two reach the journal in no stated
@@ -1415,6 +1523,35 @@ mod tests {
         // The same result fetched against a watermark that already covers the transition is current.
         assert!(put(&store, &id, 6, 105).await);
         assert_eq!(read(&store, &id).await, Some(6));
+    }
+
+    /// Retirements driven by a finalized result are counted like the stream's own, so the counter
+    /// means what its name says.
+    #[tokio::test]
+    async fn retiring_ahead_of_the_stream_reports_what_it_retired() {
+        let (_d, store) = temp_store().await;
+        let held = substate(1);
+        let spent = substate(2);
+        let untouched = substate(3);
+        assert!(put(&store, &held, 6, 100).await);
+        assert!(put(&store, &spent, 6, 100).await);
+        assert!(put(&store, &untouched, 6, 100).await);
+
+        let ahead = StateVersion::new(101);
+        let invalidations = vec![
+            // Below the cached head, so it retires nothing.
+            (SubstateCacheInvalidation::created(&held, 4).unwrap(), ahead),
+            (SubstateCacheInvalidation::destroyed(spent.clone(), 6), ahead),
+        ];
+        let retired = store
+            .with_write_tx(move |tx| tx.substate_cache_retire_ahead(invalidations))
+            .await
+            .unwrap();
+
+        assert_eq!(retired, 1);
+        assert_eq!(read(&store, &held).await, Some(6));
+        assert_eq!(read(&store, &spent).await, None);
+        assert_eq!(read(&store, &untouched).await, Some(6));
     }
 
     #[tokio::test]

--- a/applications/tari_indexer/src/storage_sqlite/writer.rs
+++ b/applications/tari_indexer/src/storage_sqlite/writer.rs
@@ -33,6 +33,7 @@ use tari_ootle_storage::{
 use tari_ootle_storage_sqlite::SqliteTransaction;
 use tari_ootle_transaction::{Transaction, TransactionId};
 use tari_template_lib_types::{TemplateAddress, TransactionReceiptAddress};
+use tari_validator_node_rpc::client::SubstateResult;
 
 use crate::{
     diesel::ExpressionMethods,
@@ -558,17 +559,18 @@ impl IndexerStoreWriteTransaction for SqliteStoreWriteTransaction<'_> {
 
         // Read inside this transaction so that the journal and the insert cannot straddle a
         // concurrent invalidation commit.
-        let journalled: Option<(i64, i32)> = substate_cache_invalidations::table
+        let journalled: Option<(i64, i32, bool)> = substate_cache_invalidations::table
             .select((
                 substate_cache_invalidations::state_version,
                 substate_cache_invalidations::substate_version,
+                substate_cache_invalidations::spent,
             ))
             .filter(substate_cache_invalidations::substate_id.eq(&id))
             .first(self.connection())
             .optional()
             .map_err(|e| StorageError::general(OPERATION, e))?;
 
-        if let Some((invalidated_at_version, observed_version)) = journalled {
+        if let Some((invalidated_at_version, observed_version, observed_version_spent)) = journalled {
             if invalidated_at_version as u64 > watermark.as_u64() {
                 debug!(
                     target: LOG_TARGET,
@@ -591,6 +593,19 @@ impl IndexerStoreWriteTransaction for SqliteStoreWriteTransaction<'_> {
                     target: LOG_TARGET,
                     "Discarding cache write for {substate_id} v{}: the stream has already seen v{observed_version}",
                     entry.version.display()
+                );
+                return Ok(false);
+            }
+
+            // Where the journalled version is one the stream saw destroyed, it is the head only as a
+            // `Down`, which is what a lookup for it answers. A member behind enough to still hold it
+            // live offers an `Up` at the same version, and only the provenance tells the two apart.
+            let claims_live_at_floor =
+                version == Some(observed_version) && matches!(entry.substate_result, SubstateResult::Up { .. });
+            if observed_version_spent && claims_live_at_floor {
+                debug!(
+                    target: LOG_TARGET,
+                    "Discarding cache write for {substate_id} v{observed_version}: the stream saw that version spent"
                 );
                 return Ok(false);
             }
@@ -666,12 +681,13 @@ impl IndexerStoreWriteTransaction for SqliteStoreWriteTransaction<'_> {
     fn substate_cache_retire_ahead<I: IntoIterator<Item = (SubstateCacheInvalidation, StateVersion)>>(
         &mut self,
         invalidations: I,
-    ) -> Result<(), StorageError> {
+    ) -> Result<usize, StorageError> {
         let now = unix_timestamp();
+        let mut retired = 0;
         for (invalidation, state_version) in invalidations {
-            self.apply_substate_cache_invalidation(&invalidation, state_version, now)?;
+            retired += self.apply_substate_cache_invalidation(&invalidation, state_version, now)?;
         }
-        Ok(())
+        Ok(retired)
     }
 
     fn substate_cache_prune(&mut self, journal_retention: Duration, max_entries: usize) -> Result<usize, StorageError> {
@@ -827,6 +843,7 @@ impl SqliteStoreWriteTransaction<'_> {
                 substate_cache_invalidations::substate_id.eq(&id),
                 substate_cache_invalidations::state_version.eq(state_version.as_u64() as i64),
                 substate_cache_invalidations::substate_version.eq(invalidation.observed_version() as i32),
+                substate_cache_invalidations::spent.eq(invalidation.is_observed_version_spent()),
                 substate_cache_invalidations::invalidated_at.eq(now),
             ))
             .on_conflict(substate_cache_invalidations::substate_id)
@@ -838,6 +855,14 @@ impl SqliteStoreWriteTransaction<'_> {
                 // showed.
                 substate_cache_invalidations::substate_version.eq(diesel::dsl::sql::<diesel::sql_types::Integer>(
                     "max(substate_version, excluded.substate_version)",
+                )),
+                // The provenance belongs to whichever version the floor ends up holding, so it
+                // follows that same comparison rather than being overwritten. At the one version
+                // both a creation and a destroy can show, a spend stands: it is the later of the
+                // two whatever order they arrive in.
+                substate_cache_invalidations::spent.eq(diesel::dsl::sql::<diesel::sql_types::Bool>(
+                    "case when excluded.substate_version > substate_version then excluded.spent when \
+                     excluded.substate_version = substate_version then (spent or excluded.spent) else spent end",
                 )),
                 substate_cache_invalidations::invalidated_at.eq(now),
             ))

--- a/applications/tari_indexer/src/store.rs
+++ b/applications/tari_indexer/src/store.rs
@@ -376,10 +376,12 @@ pub trait IndexerStoreWriteTransaction {
     /// caller passes one just past the shard's watermark, so that every fetch captured before the
     /// stream delivers the transition is vetoed, and the stream's own journal row replaces it when
     /// it does.
+    ///
+    /// Returns how many cached entries were retired.
     fn substate_cache_retire_ahead<I: IntoIterator<Item = (SubstateCacheInvalidation, StateVersion)>>(
         &mut self,
         invalidations: I,
-    ) -> Result<(), StorageError>;
+    ) -> Result<usize, StorageError>;
 
     /// Drops journal entries older than `journal_retention` and evicts the oldest cache entries down
     /// to `max_entries`. Returns how many entries were evicted.

--- a/applications/tari_indexer/src/substate_cache/metrics.rs
+++ b/applications/tari_indexer/src/substate_cache/metrics.rs
@@ -5,10 +5,10 @@ use prometheus_client::{metrics::counter::Counter, registry::Registry};
 
 use crate::metrics::CollectorRegister;
 
-/// Counters for what the cache does that a hit/miss ratio alone cannot explain: entries retired by
-/// the transition stream, entries evicted at the size cap, and reads refused because the shard's
-/// stream has fallen behind. A miss rate that climbs alongside `refused_stale` is a sync problem,
-/// not a cache one.
+/// Counters for what the cache does that a hit/miss ratio alone cannot explain: entries retired
+/// because the state they held was superseded, entries evicted at the size cap, and reads refused
+/// because the shard's stream has fallen behind. A miss rate that climbs alongside `refused_stale`
+/// is a sync problem, not a cache one.
 ///
 /// The hit/miss pair itself is recorded by the manager that fronts the cache, under
 /// `substate_scanner_cache_hits` and `substate_scanner_cache_misses`.
@@ -25,7 +25,8 @@ impl SubstateCacheMetrics {
         Self {
             invalidations: Counter::default().register_at(
                 "invalidations",
-                "Number of cached substate entries retired by a transition from the state sync stream",
+                "Number of cached substate entries retired by a transition from the state sync stream or by a \
+                 finalized transaction result ahead of it",
                 registry,
             ),
             evictions: Counter::default().register_at(

--- a/applications/tari_indexer/src/substate_cache/mod.rs
+++ b/applications/tari_indexer/src/substate_cache/mod.rs
@@ -161,10 +161,15 @@ impl SqliteSubstateCache {
         if invalidations.is_empty() {
             return Ok(());
         }
-        debug!(target: LOG_TARGET, "Retiring {} cached substates ahead of the stream", invalidations.len());
-        self.store
+        let transitions = invalidations.len();
+        let retired = self
+            .store
             .with_write_tx(move |tx| tx.substate_cache_retire_ahead(invalidations))
-            .await
+            .await?;
+        debug!(target: LOG_TARGET, "Retired {retired} cached substates ahead of the stream, from {transitions} transitions");
+        #[cfg(feature = "metrics")]
+        self.metrics.as_ref().inspect(|m| m.add_invalidations(retired));
+        Ok(())
     }
 
     async fn prune(&self) -> Result<(), StorageError> {
@@ -441,6 +446,35 @@ mod tests {
             .unwrap();
     }
 
+    /// A committee member answering that `version` is live, as against the `Down` [`write_head`]
+    /// records.
+    async fn write_live_head(cache: &SqliteSubstateCache, id: &SubstateId, version: u32, watermark: u64) {
+        use tari_engine_types::{
+            non_fungible::NonFungibleContainer,
+            substate::{Substate, SubstateValue},
+        };
+
+        let result = SubstateResult::Up {
+            substate: Box::new(Substate::new(
+                version,
+                SubstateValue::NonFungible(NonFungibleContainer::no_data()),
+            )),
+        };
+        cache
+            .write(
+                id,
+                SubstateCacheEntryRef {
+                    version: Some(version),
+                    substate_result: &result,
+                    cached_at: now_unix_secs().unwrap(),
+                    verified: true,
+                },
+                FetchWatermark::new(watermark),
+            )
+            .await
+            .unwrap();
+    }
+
     async fn write_nonexistence(cache: &SqliteSubstateCache, id: &SubstateId, watermark: u64) {
         cache
             .write(
@@ -513,5 +547,24 @@ mod tests {
 
         write_head(&cache, &id, 7, 101).await;
         assert_eq!(cache.read(&id).await.unwrap().unwrap().version, Some(7));
+    }
+
+    /// A destroy the result carries with no successor: the substate is spent and has no live version
+    /// left. A member that has not caught up still answers that the destroyed version is live, and
+    /// nothing but the journal's provenance separates that from the `Down` a lookup for the same
+    /// version legitimately returns.
+    #[tokio::test]
+    async fn a_finalized_result_refuses_a_live_head_at_the_version_it_spent() {
+        let (_d, cache, id) = cache_with_head(6, true).await;
+        let mut diff = SubstateDiff::new();
+        diff.down(id.clone(), 6);
+        cache.retire_committed(&diff).await.unwrap();
+        assert!(cache.read(&id).await.unwrap().is_none());
+
+        write_live_head(&cache, &id, 6, 101).await;
+        assert!(cache.read(&id).await.unwrap().is_none());
+
+        write_head(&cache, &id, 6, 101).await;
+        assert_eq!(cache.read(&id).await.unwrap().unwrap().version, Some(6));
     }
 }


### PR DESCRIPTION
Two follow-ups to #2529 and #2531, in the same three files.

## A destroy with no successor admitted a live head at the spent version

`SubstateCacheInvalidation::destroyed(id, v)` journalled `observed_version = v`, and the guard in `substate_cache_put` refused only `version < observed_version`. A write of `Up { v }` at exactly the destroyed version was therefore admitted, so a lagging committee member could install a spent substate as the live head where a level member would answer `Down`.

Only the no-successor case was open: a destroy with a successor is accompanied by `created(id, v + 1)` in the same batch, and the `max(...)` upsert lifts the floor to `v + 1`, which already refuses `Up { v }`.

One integer cannot express both "nothing below v" and "v itself is spent, unless you are claiming it is down", so the journal now carries the provenance alongside the version. The guard refuses an `Up` result at the floor when the floor came from a destroy, and still admits a `Down` at it — that is a legitimate head, and what a lookup for that version answers.

The flag follows the same comparison the floor does rather than being overwritten: a `created(v + 1)` arriving after a `destroyed(v)` both raises the floor and clears the flag, while a `destroyed(v)` arriving after a `created(v + 1)` does neither. At the one version both a creation and a destroy can show — a substate created and destroyed within a single batch — the spend stands whichever order they arrive in.

The journal is ephemeral, rebuilt from the stream within one retention window, so the migration recreates the table as #2529's did.

## Result-driven retirements were not counted

`substate_cache_retire_ahead` returned `()`, so the retirements #2531 performs from a finalized transaction result never reached `substate_cache_invalidations` — the counter quietly meant "retirements from the stream". It now returns the count, and `retire_committed` feeds it to the metric the way the eviction and refused-stale paths already do.

## Tests

In `store_factory.rs`, alongside #2529's journal tests: a destroy with no successor refuses `Up` at the destroyed version and still admits `Down` at it; a destroy with a successor admits the created version live in both arrival orders; a version both created and destroyed in one batch is spent in both arrival orders; and the count returned by `substate_cache_retire_ahead` matches the rows removed. In `substate_cache/mod.rs`, the end-to-end path through `retire_committed`.

Each was checked to fail without its half of the change, including against a fix written as a plain floor bump (which the "still admits `Down`" case catches) and against an unconditional flag overwrite in the upsert.