### PR TITLE
perf(abi): carry engine responses as their encoding, not a Value tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11205,7 +11205,7 @@ dependencies = [
 
 [[package]]
 name = "tari_bor"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "borsh",
  "indexmap 2.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,7 +145,7 @@ tari_template_lib = { version = "0.32", path = "crates/template_lib" }
 tari_template_lib_types = { version = "0.32", path = "crates/template_lib_types", default-features = false }
 tari_template_abi = { version = "0.20", path = "crates/template_abi", default-features = false }
 tari_template_macros = { version = "0.23", path = "crates/template_macros" }
-tari_bor = { version = "0.15.0", path = "crates/tari_bor", default-features = false }
+tari_bor = { version = "0.15.1", path = "crates/tari_bor", default-features = false }
 
 ootle_byte_type = { path = "crates/ootle_byte_type", version = "0.13" }
 ootle_serde = { path = "crates/ootle_serde", version = "0.5", default-features = false }

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -37,6 +37,11 @@ memmap2 = { workspace = true, optional = true }
 
 [features]
 default = []
+# Instruments the WASM ABI boundary (`tari_engine::abi_metrics`) so
+# `examples/abi_measure.rs` can attribute host time and wire bytes per engine
+# op. Measurement only: it adds two clock reads per ABI phase and is never
+# enabled by a validator build.
+abi-metrics = ["tari_template_lib/metrics"]
 # Enables the on-disk wasmer module cache (`tari_engine::wasm::cache`). Pulls
 # in `tari_template_builtin` to bypass caching for builtin addresses, plus the
 # filesystem I/O surface (memmap + bytes). Disable if embedding the engine in

--- a/crates/engine/examples/abi_measure.rs
+++ b/crates/engine/examples/abi_measure.rs
@@ -103,10 +103,9 @@ mod measure {
         /// Points for an engine call whose response is a bare `()`: envelope encode, the host call
         /// and the length-prefixed free.
         bare_call: f64,
-        /// Points to bring a small response back as `InvokeResult(Value)`, over [`Self::bare_call`].
-        response_value: f64,
-        /// Points to convert that `Value` into the concrete type.
-        from_value: f64,
+        /// Points to decode an engine call's response into the concrete type, over
+        /// [`Self::bare_call`].
+        response_decode: f64,
     }
 
     fn probe_points() -> Fits {
@@ -168,15 +167,18 @@ mod measure {
         println!("One engine call with payloads of a few tens of bytes, by stage (guest points):");
         println!("  argument encode + host call + unit response     {bare_call:>8.0}   (EmitLog, empty message)");
         println!(
-            "  response arrives as InvokeResult(Value)         {:>8.0}   (CallerContextInvoke, 32-byte key)",
+            "  response decoded into the concrete type         {:>8.0}   (CallerContextInvoke, 32-byte key)",
+            floor - bare_call
+        );
+        println!("  total                                          {floor:>8.0}");
+        println!(
+            "  the same response built as a Value tree         {:>8.0}   (what a response no longer does)",
             raw - bare_call
         );
-        println!("  from_value into the concrete type              {:>8.0}", floor - raw);
-        println!("  total                                          {floor:>8.0}");
 
         let (state_get_typed, state_get_value, state_set) = state_fits(&mut test);
-        let from_value_fixed = state_get_typed.intercept - state_get_value.intercept;
-        let from_value_slope = state_get_typed.slope - state_get_value.slope;
+        let value_tree_fixed = state_get_value.intercept - state_get_typed.intercept;
+        let value_tree_slope = state_get_value.slope - state_get_typed.slope;
 
         println!(
             "\nOne argument costs {:.0} points before its first byte: the {noop}-point empty invocation is already \
@@ -197,8 +199,8 @@ mod measure {
             println!("{:<34} {:>14.0} {:>10.3} /{}", f.label, f.intercept, f.slope, f.unit);
         }
         println!(
-            "\nGuest-side `from_value` on a GetState response: {from_value_fixed:.0} points fixed, \
-             {from_value_slope:.3} points/byte"
+            "\nBuilding a Value tree from a GetState response rather than decoding it: {value_tree_fixed:.0} points \
+             fixed, {value_tree_slope:.3} points/byte"
         );
 
         Fits {
@@ -207,8 +209,7 @@ mod measure {
             hop3_arg,
             state_get_typed,
             bare_call,
-            response_value: raw - bare_call,
-            from_value: floor - raw,
+            response_decode: floor - bare_call,
         }
     }
 
@@ -247,7 +248,7 @@ mod measure {
         table("Hop 3: one SetState call", "state bytes", &set);
         (
             fit("hop 4: GetState into a type", "state byte", &typed),
-            fit("hop 4: GetState, response Value only", "state byte", &value_only),
+            fit("hop 4: GetState, response as a Value", "state byte", &value_only),
             fit("hop 3: SetState", "state byte", &set),
         )
     }
@@ -336,11 +337,13 @@ mod measure {
     /// encodes a realistic `SetState` argument, varying only how the destination buffer is obtained.
     fn buffer_strategies() {
         const COUNTS: [u32; 2] = [64, 512];
-        const STRATEGIES: [(&str, u32); 4] = [
+        const PAYLOADS: [u32; 4] = [64, 512, 4_096, 16_384];
+        const STRATEGIES: [(&str, u32); 5] = [
             ("encoded_len, exact buffer", 0),
             ("empty buffer, grown", 1),
             ("512-byte buffer", 2),
             ("1024-byte buffer", 3),
+            ("4096-byte buffer", 4),
         ];
 
         let mut test = TemplateTest::new(CRATE_PATH, [PROBE]);
@@ -348,14 +351,14 @@ mod measure {
 
         println!("\n== Guest points per engine-call argument encode ==");
         print!("{:<28}", "buffer strategy");
-        for size in [64u32, 512, 4096] {
+        for size in PAYLOADS {
             print!("{:>16}", format!("{size} B payload"));
         }
         println!();
         println!("{}", "-".repeat(76));
         for (label, strategy) in STRATEGIES {
             print!("{label:<28}");
-            for size in [64u32, 512, 4096] {
+            for size in PAYLOADS {
                 let low = method_points(&mut test, component, "encode_buffered", args![
                     COUNTS[0], size, strategy
                 ]);
@@ -442,9 +445,12 @@ mod measure {
         name: &'static str,
         wall_ns: u64,
         wasm_points: u64,
+        /// Whether the trials disagreed on points, i.e. the workload did not run the same
+        /// transaction each time.
+        points_vary: bool,
         census: abi_metrics::Census,
-        to_value: value_metrics::Phase,
-        from_value: value_metrics::Phase,
+        result_encode: value_metrics::Phase,
+        result_decode: value_metrics::Phase,
     }
 
     impl WorkloadCensus {
@@ -457,8 +463,8 @@ mod measure {
                     .ns
                     .saturating_sub(self.census.guest_alloc().ns) +
                 self.census.return_decode().ns +
-                self.to_value.ns +
-                self.from_value.ns
+                self.result_encode.ns +
+                self.result_decode.ns
         }
 
         fn engine_calls(&self) -> u64 {
@@ -517,6 +523,7 @@ mod measure {
         execute(test);
 
         let mut best: Option<WorkloadCensus> = None;
+        let mut all_points = Vec::with_capacity(CENSUS_TRIALS);
         for _ in 0..CENSUS_TRIALS {
             abi_metrics::reset();
             value_metrics::reset();
@@ -527,23 +534,37 @@ mod measure {
                 name,
                 wall_ns,
                 wasm_points: test.last_execution_points().wasm,
+                points_vary: false,
                 census: abi_metrics::snapshot(),
-                to_value: value_metrics::to_value(),
-                from_value: value_metrics::from_value(),
+                result_encode: value_metrics::encode(),
+                result_decode: value_metrics::decode(),
             };
+            all_points.push(candidate.wasm_points);
             if best.as_ref().is_none_or(|best| candidate.wall_ns < best.wall_ns) {
                 best = Some(candidate);
             }
         }
-        best.expect("at least one trial")
+        let mut best = best.expect("at least one trial");
+        // Every figure reported describes one trial, so a ratio drawn between two of them is a
+        // ratio over the same transaction. Points are deterministic per transaction, so trials
+        // that disagree mean the workload mutated state and ran a different transaction each time;
+        // that makes the points column incomparable across runs, which the flag says rather than
+        // the numbers hiding it.
+        best.points_vary = all_points.iter().any(|p| *p != all_points[0]);
+        best
     }
 
     fn report_workload(workload: &WorkloadCensus, timer_ns: f64) {
         println!("\n== Census: {} ==", workload.name);
         println!(
-            "Wall time {:.1} µs, {} WASM points, {} engine calls",
+            "Wall time {:.1} µs, {} WASM points{}, {} engine calls",
             workload.wall_ns as f64 / 1000.0,
             workload.wasm_points,
+            if workload.points_vary {
+                " (lowest; trials differ, so this workload is not a stable point comparison)"
+            } else {
+                ""
+            },
             workload.engine_calls()
         );
         println!();
@@ -595,14 +616,14 @@ mod measure {
             returns.mean_ns()
         );
         println!(
-            "InvokeResult to_value (host):        {:>4} calls, {:>19.0} ns/call",
-            workload.to_value.calls,
-            workload.to_value.mean_ns()
+            "InvokeResult encode (host):          {:>4} calls, {:>19.0} ns/call",
+            workload.result_encode.calls,
+            workload.result_encode.mean_ns()
         );
         println!(
-            "InvokeResult from_value (host):      {:>4} calls, {:>19.0} ns/call",
-            workload.from_value.calls,
-            workload.from_value.mean_ns()
+            "InvokeResult decode (host):          {:>4} calls, {:>19.0} ns/call",
+            workload.result_decode.calls,
+            workload.result_decode.mean_ns()
         );
 
         let phases = workload.engine_calls() * 4 + size_pass.count + call_info.count * 2 + returns.count;
@@ -659,18 +680,17 @@ mod measure {
              adds {:.0} more.\nHost wall time is the whole harness execution, so the boundary's share of a \
              validator's own work is higher than it reads here.\nA nested call's handler time contains the whole \
              sub-invocation, ABI hops included.",
-            fits.bare_call,
-            fits.response_value + fits.from_value,
+            fits.bare_call, fits.response_decode,
         );
     }
 
     /// Guest points the boundary costs one op, from the probe fits: hop 3 for its argument, then
-    /// hop 4 for its response. A response of one or two bytes is a bare `()`, which the guest
-    /// decodes directly; anything larger arrives as an `InvokeResult` and pays the `Value` detour.
+    /// hop 4 for its response. A response of one or two bytes is a bare `()`; anything larger
+    /// arrives as an `InvokeResult` and pays its framing on top.
     fn op_points(fits: &Fits, arg_bytes: f64, resp_bytes: f64) -> f64 {
         let mut points = fits.bare_call + fits.hop3_arg.slope * arg_bytes;
         if resp_bytes > 2.0 {
-            points += fits.response_value + fits.from_value + fits.state_get_typed.slope * resp_bytes;
+            points += fits.response_decode + fits.state_get_typed.slope * resp_bytes;
         }
         points
     }
@@ -705,7 +725,7 @@ mod measure {
         let resp_bytes = per_call(sum(|op| op.resp_bytes));
         let decode_ns = per_call(sum(|op| op.decode_ns));
         let encode_ns = per_call(sum(|op| op.encode_ns));
-        let to_value_ns = per_call(workload.to_value.ns);
+        let result_encode_ns = per_call(workload.result_encode.ns);
 
         println!("\n== Per hop: {} ==", workload.name);
         println!(
@@ -739,7 +759,7 @@ mod measure {
                 "4 host -> guest, engine responses",
                 calls,
                 resp_bytes,
-                encode_ns + to_value_ns,
+                encode_ns + result_encode_ns,
                 op_points(fits, arg_bytes, resp_bytes) - fits.bare_call - fits.hop3_arg.slope * arg_bytes,
             ),
         ];

--- a/crates/engine/examples/abi_measure.rs
+++ b/crates/engine/examples/abi_measure.rs
@@ -1,0 +1,866 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! Measures what the WASM ABI boundary costs today, in validator wall time and in guest metering
+//! points, so a decision to replace minicbor on that boundary rests on numbers rather than on
+//! intuition. It changes nothing about the ABI itself.
+//!
+//!     cargo run -p tari_engine --example abi_measure --release --features abi-metrics
+//!
+//! Four hops cross the boundary per template invocation:
+//!
+//! | Hop | Direction | Cost falls on |
+//! |---|---|---|
+//! | 1 | host to guest, call arguments | host encode, guest decode (metered) |
+//! | 2 | guest to host, return value | guest encode (metered), host `IndexedValue` walk |
+//! | 3 | guest to host, engine-call argument | guest encode (metered), host decode |
+//! | 4 | host to guest, engine-call response | host encode, guest decode (metered) |
+//!
+//! The report has three parts. The **probe** section prices each hop in guest points by running
+//! `tests/templates/abi_probe`, whose functions come in pairs that differ by exactly one boundary
+//! crossing; subtracting the pair and taking a slope across payload size or call count leaves the
+//! hop's own cost. The **census** section runs realistic transactions with
+//! `tari_engine::abi_metrics` on and reports, per engine op, how many calls were made, how many
+//! bytes crossed, and how much host time went to serialisation rather than to the runtime handler.
+//! The **summary** applies the probe's fits to the census counts to estimate what share of a real
+//! transaction's points and wall time the boundary accounts for.
+
+#[cfg(not(feature = "abi-metrics"))]
+fn main() {
+    eprintln!(
+        "abi_measure needs the instrumentation it reads on:\n    cargo run -p tari_engine --example abi_measure \
+         --release --features abi-metrics"
+    );
+    std::process::exit(1);
+}
+
+#[cfg(feature = "abi-metrics")]
+fn main() {
+    measure::run();
+}
+
+#[cfg(feature = "abi-metrics")]
+mod measure {
+    use std::time::Instant;
+
+    use tari_engine::abi_metrics;
+    use tari_ootle_common_types::substate_type::SubstateType;
+    use tari_ootle_transaction::{Epoch, Transaction, args, builder::named_args::NamedArg};
+    use tari_template_abi::EngineOp;
+    use tari_template_lib::{
+        args::metrics as value_metrics,
+        types::{Amount, ComponentAddress, NonFungibleAddress, ResourceAddress, bytes::Bytes},
+    };
+    use tari_template_test_tooling::TemplateTest;
+
+    const CRATE_PATH: &str = env!("CARGO_MANIFEST_DIR");
+    const PROBE: &str = "tests/templates/abi_probe";
+    const TARISWAP: &str = "tests/templates/tariswap";
+    const FAUCET: &str = "tests/templates/faucet";
+
+    /// Payload sizes for the size-scaling fits, in bytes. The largest stays under
+    /// `ENGINE_LIMITS.max_call_size` (128 KiB) so hop 1 can carry it.
+    const SIZES: [u32; 5] = [0, 1_024, 8_192, 32_768, 65_536];
+    /// Call counts for the per-call slope fits. `max_logs` (256) bounds the upper one.
+    const COUNTS: [u32; 2] = [32, 224];
+    /// Transactions per census workload. The fastest run is reported: a slower run differs by
+    /// scheduling noise, not by work done.
+    const CENSUS_TRIALS: usize = 7;
+
+    pub fn run() {
+        let timer_ns = abi_metrics::timer_overhead_ns();
+        println!("Timer overhead per instrumented phase: {timer_ns:.1} ns (two clock reads).");
+        println!("Host nanoseconds below include it; subtract it once per phase call to compare against the handler.");
+
+        let fits = probe_points();
+        buffer_strategies();
+        metering_of_bulk_copies();
+        let censuses = census(timer_ns);
+        summary(&fits, &censuses, timer_ns);
+    }
+
+    // -- Part 1: guest points per hop ---------------------------------------------------------
+
+    /// A hop priced as `points = intercept + slope * x`, where `x` is payload bytes or call count.
+    struct Fit {
+        label: &'static str,
+        unit: &'static str,
+        intercept: f64,
+        slope: f64,
+    }
+
+    impl Fit {
+        fn at(&self, x: f64) -> f64 {
+            self.intercept + self.slope * x
+        }
+    }
+
+    struct Fits {
+        hop1_arg: Fit,
+        hop2_return: Fit,
+        hop3_arg: Fit,
+        state_get_typed: Fit,
+        /// Points for an engine call whose response is a bare `()`: envelope encode, the host call
+        /// and the length-prefixed free.
+        bare_call: f64,
+        /// Points to bring a small response back as `InvokeResult(Value)`, over [`Self::bare_call`].
+        response_value: f64,
+        /// Points to convert that `Value` into the concrete type.
+        from_value: f64,
+    }
+
+    fn probe_points() -> Fits {
+        println!("\nCompiling probe template...");
+        let mut test = TemplateTest::new(CRATE_PATH, [PROBE]);
+
+        let noop = call_points(&mut test, "noop", args![]);
+        println!("\n== Guest points, by hop ==");
+        println!("Empty call (dispatch, header decode, unit return): {noop} points");
+
+        // Hop 1: argument decode. `sink_bytes` returns a u32, so only the argument scales.
+        let hop1: Vec<(f64, f64)> = SIZES
+            .iter()
+            .map(|&size| {
+                let points = call_points(&mut test, "sink_bytes", args![Bytes::from_vec(vec![
+                    0x5A;
+                    size as usize
+                ])]);
+                (f64::from(size), points as f64)
+            })
+            .collect();
+        let hop1_arg = fit("hop 1: whole call, arg decode", "byte", &hop1);
+        table(
+            "Hop 1: one `sink_bytes(Bytes)` call, whole invocation",
+            "arg bytes",
+            &hop1,
+        );
+
+        // Hop 2: return encode, less the allocation its twin also performs.
+        let hop2: Vec<(f64, f64)> = SIZES
+            .iter()
+            .map(|&size| {
+                let full = call_points(&mut test, "make_bytes", args![size]);
+                let glue = call_points(&mut test, "make_bytes_glue", args![size]);
+                (f64::from(size), full.saturating_sub(glue) as f64)
+            })
+            .collect();
+        let hop2_return = fit("hop 2: return encode", "byte", &hop2);
+        table("Hop 2: returning `Bytes` rather than a scalar", "return bytes", &hop2);
+
+        // Hop 3: engine-call argument encode, sized by the log message it carries.
+        let hop3: Vec<(f64, f64)> = SIZES
+            .iter()
+            .filter(|&&size| size <= 16_384)
+            .map(|&size| {
+                let per_call = slope_over_counts(&mut test, "emit_logs", "emit_logs_glue", size);
+                (f64::from(size), per_call)
+            })
+            .collect();
+        let hop3_arg = fit("hop 3: engine arg encode", "byte", &hop3);
+        table("Hop 3: one `EmitLog` call, argument only", "message bytes", &hop3);
+
+        // Hops 3 and 4 with payloads of a few bytes each way: the per-engine-call floor, split
+        // into the three stages a response passes through.
+        let floor = slope_over_counts_single(&mut test, "caller_context_calls");
+        let raw = slope_over_counts_single(&mut test, "caller_context_raw");
+        let bare_call = hop3_arg.intercept;
+        println!();
+        println!("One engine call with payloads of a few tens of bytes, by stage (guest points):");
+        println!("  argument encode + host call + unit response     {bare_call:>8.0}   (EmitLog, empty message)");
+        println!(
+            "  response arrives as InvokeResult(Value)         {:>8.0}   (CallerContextInvoke, 32-byte key)",
+            raw - bare_call
+        );
+        println!("  from_value into the concrete type              {:>8.0}", floor - raw);
+        println!("  total                                          {floor:>8.0}");
+
+        let (state_get_typed, state_get_value, state_set) = state_fits(&mut test);
+        let from_value_fixed = state_get_typed.intercept - state_get_value.intercept;
+        let from_value_slope = state_get_typed.slope - state_get_value.slope;
+
+        println!(
+            "\nOne argument costs {:.0} points before its first byte: the {noop}-point empty invocation is already \
+             paid.",
+            hop1_arg.intercept - noop as f64
+        );
+        println!();
+        println!("{:<34} {:>14} {:>16}", "hop", "fixed (points)", "per unit (points)");
+        println!("{}", "-".repeat(66));
+        for f in [
+            &hop1_arg,
+            &hop2_return,
+            &hop3_arg,
+            &state_get_typed,
+            &state_get_value,
+            &state_set,
+        ] {
+            println!("{:<34} {:>14.0} {:>10.3} /{}", f.label, f.intercept, f.slope, f.unit);
+        }
+        println!(
+            "\nGuest-side `from_value` on a GetState response: {from_value_fixed:.0} points fixed, \
+             {from_value_slope:.3} points/byte"
+        );
+
+        Fits {
+            hop1_arg,
+            hop2_return,
+            hop3_arg,
+            state_get_typed,
+            bare_call,
+            response_value: raw - bare_call,
+            from_value: floor - raw,
+        }
+    }
+
+    /// Points consumed by one call of a probe function. The return value is discarded: decoding it
+    /// happens on the host and is not what is being priced.
+    /// Component state round-trips, priced against the size of the state that crosses.
+    fn state_fits(test: &mut TemplateTest) -> (Fit, Fit, Fit) {
+        let mut typed = Vec::new();
+        let mut value_only = Vec::new();
+        let mut set = Vec::new();
+        for &size in &[0u32, 1_024, 8_192, 32_768] {
+            let component: ComponentAddress = test.call_function("AbiProbe", "new", args![size], vec![]);
+            typed.push((
+                f64::from(size),
+                method_slope_over_counts(test, component, "get_state_typed", None),
+            ));
+            value_only.push((
+                f64::from(size),
+                method_slope_over_counts(test, component, "get_state_raw", None),
+            ));
+            set.push((
+                f64::from(size),
+                method_slope_over_counts(test, component, "set_state", Some("set_state_glue")),
+            ));
+        }
+        table(
+            "Hop 4: one GetState round trip, decoded into the type",
+            "state bytes",
+            &typed,
+        );
+        table(
+            "Hop 4: one GetState round trip, response Value only",
+            "state bytes",
+            &value_only,
+        );
+        table("Hop 3: one SetState call", "state bytes", &set);
+        (
+            fit("hop 4: GetState into a type", "state byte", &typed),
+            fit("hop 4: GetState, response Value only", "state byte", &value_only),
+            fit("hop 3: SetState", "state byte", &set),
+        )
+    }
+
+    fn call_points(test: &mut TemplateTest, func: &str, args: Vec<NamedArg>) -> u64 {
+        let template = test.get_template_address("AbiProbe");
+        test.execute_expect_success(
+            test.transaction()
+                .call_function(template, func, args)
+                .build_and_seal(test.secret_key()),
+            vec![],
+        );
+        test.last_execution_points().wasm
+    }
+
+    fn method_points(test: &mut TemplateTest, component: ComponentAddress, method: &str, args: Vec<NamedArg>) -> u64 {
+        test.execute_expect_success(
+            test.transaction()
+                .call_method(component, method, args)
+                .build_and_seal(test.secret_key()),
+            vec![],
+        );
+        test.last_execution_points().wasm
+    }
+
+    /// Points per iteration of `func`, less those of `glue`, from the slope across [`COUNTS`].
+    fn slope_over_counts(test: &mut TemplateTest, func: &str, glue: &str, size: u32) -> f64 {
+        let net = |test: &mut TemplateTest, n: u32| -> f64 {
+            let full = call_points(test, func, args![n, size]);
+            let glue = call_points(test, glue, args![n, size]);
+            full.saturating_sub(glue) as f64
+        };
+        let low = net(test, COUNTS[0]);
+        let high = net(test, COUNTS[1]);
+        (high - low) / f64::from(COUNTS[1] - COUNTS[0])
+    }
+
+    fn slope_over_counts_single(test: &mut TemplateTest, func: &str) -> f64 {
+        let low = call_points(test, func, args![COUNTS[0]]) as f64;
+        let high = call_points(test, func, args![COUNTS[1]]) as f64;
+        (high - low) / f64::from(COUNTS[1] - COUNTS[0])
+    }
+
+    fn method_slope_over_counts(
+        test: &mut TemplateTest,
+        component: ComponentAddress,
+        method: &str,
+        glue: Option<&str>,
+    ) -> f64 {
+        let net = |test: &mut TemplateTest, n: u32| -> f64 {
+            let full = method_points(test, component, method, args![n]);
+            let glue_points = glue.map_or(0, |glue| method_points(test, component, glue, args![n]));
+            full.saturating_sub(glue_points) as f64
+        };
+        let low = net(test, COUNTS[0]);
+        let high = net(test, COUNTS[1]);
+        (high - low) / f64::from(COUNTS[1] - COUNTS[0])
+    }
+
+    /// The measurements a fit is drawn through. Points are deterministic, so these are exact.
+    fn table(title: &str, x_label: &str, points: &[(f64, f64)]) {
+        println!("\n{title}:");
+        println!("  {x_label:>14} {:>10}", "points");
+        for (x, y) in points {
+            println!("  {x:>14.0} {y:>10.0}");
+        }
+    }
+
+    /// Ordinary least squares through `(x, y)`.
+    fn fit(label: &'static str, unit: &'static str, points: &[(f64, f64)]) -> Fit {
+        let n = points.len() as f64;
+        let mean_x = points.iter().map(|(x, _)| x).sum::<f64>() / n;
+        let mean_y = points.iter().map(|(_, y)| y).sum::<f64>() / n;
+        let covariance: f64 = points.iter().map(|(x, y)| (x - mean_x) * (y - mean_y)).sum();
+        let variance: f64 = points.iter().map(|(x, _)| (x - mean_x).powi(2)).sum();
+        let slope = if variance == 0.0 { 0.0 } else { covariance / variance };
+        Fit {
+            label,
+            unit,
+            intercept: mean_y - slope * mean_x,
+            slope,
+        }
+    }
+
+    /// What the `encoded_len` pre-pass costs the guest, and what the alternatives cost. The probe
+    /// encodes a realistic `SetState` argument, varying only how the destination buffer is obtained.
+    fn buffer_strategies() {
+        const COUNTS: [u32; 2] = [64, 512];
+        const STRATEGIES: [(&str, u32); 4] = [
+            ("encoded_len, exact buffer", 0),
+            ("empty buffer, grown", 1),
+            ("512-byte buffer", 2),
+            ("1024-byte buffer", 3),
+        ];
+
+        let mut test = TemplateTest::new(CRATE_PATH, [PROBE]);
+        let component: ComponentAddress = test.call_function("AbiProbe", "new", args![0u32], vec![]);
+
+        println!("\n== Guest points per engine-call argument encode ==");
+        print!("{:<28}", "buffer strategy");
+        for size in [64u32, 512, 4096] {
+            print!("{:>16}", format!("{size} B payload"));
+        }
+        println!();
+        println!("{}", "-".repeat(76));
+        for (label, strategy) in STRATEGIES {
+            print!("{label:<28}");
+            for size in [64u32, 512, 4096] {
+                let low = method_points(&mut test, component, "encode_buffered", args![
+                    COUNTS[0], size, strategy
+                ]);
+                let high = method_points(&mut test, component, "encode_buffered", args![
+                    COUNTS[1], size, strategy
+                ]);
+                let slope = (high - low) as f64 / f64::from(COUNTS[1] - COUNTS[0]);
+                print!("{slope:>16.0}");
+            }
+            println!();
+        }
+    }
+
+    /// Why the per-byte figures above are near zero: `memory.copy` is metered at a flat rate
+    /// whatever its length, so bytes crossing the boundary are close to free in points while
+    /// costing the validator real time. Reported as points per microsecond of execution against a
+    /// dependent integer chain, work whose points do track time.
+    fn metering_of_bulk_copies() {
+        const COPY_BYTES: u32 = 256 * 1024;
+        const COPY_ROUNDS: [u32; 2] = [2_000, 10_000];
+        const SPIN_ROUNDS: [u32; 2] = [200_000, 1_000_000];
+
+        let mut test = TemplateTest::new(CRATE_PATH, [PROBE]);
+        let slope = |test: &mut TemplateTest, func: &str, rounds: [u32; 2], extra: Option<u32>| -> (f64, f64) {
+            let run = |test: &mut TemplateTest, n: u32| -> (f64, f64) {
+                let args = extra.map_or_else(|| args![n], |extra| args![n, extra]);
+                let start = Instant::now();
+                let points = call_points(test, func, args);
+                (start.elapsed().as_nanos() as f64, points as f64)
+            };
+            let (low_ns, low_points) = run(test, rounds[0]);
+            let (high_ns, high_points) = run(test, rounds[1]);
+            let span = f64::from(rounds[1] - rounds[0]);
+            ((high_ns - low_ns) / span, (high_points - low_points) / span)
+        };
+
+        let (spin_ns, spin_points) = slope(&mut test, "spin", SPIN_ROUNDS, None);
+
+        println!("\n== Side finding: what a byte costs the meter ==");
+        println!(
+            "{:<24} {:>10} {:>12} {:>14}",
+            "work per round", "points", "ns", "points/µs"
+        );
+        println!("{}", "-".repeat(62));
+        println!(
+            "{:<24} {spin_points:>10.1} {spin_ns:>12.1} {:>14.1}",
+            "dependent integer chain",
+            spin_points * 1000.0 / spin_ns
+        );
+        let mut copy = (0.0, 0.0);
+        for bytes in [16 * 1024, 64 * 1024, COPY_BYTES] {
+            copy = slope(&mut test, "bulk_copy", COPY_ROUNDS, Some(bytes));
+            println!(
+                "{:<24} {:>10.1} {:>12.1} {:>14.3}",
+                format!("{} KiB memory.copy", bytes / 1024),
+                copy.1,
+                copy.0,
+                copy.1 * 1000.0 / copy.0
+            );
+        }
+        let (copy_ns, copy_points) = copy;
+        println!(
+            "A copied byte costs {:.4} points, so the meter charges {:.0}x less per microsecond for copying than for \
+             arithmetic.",
+            copy_points / f64::from(COPY_BYTES),
+            (spin_points / spin_ns) / (copy_points / copy_ns),
+        );
+        println!(
+            "At the {} million point per-transaction cap that is {:.0} GB of copying in one transaction, {:.1} s of \
+             validator time.",
+            tari_engine_types::limits::MAX_WASM_POINTS_PER_TRANSACTION / 1_000_000,
+            (limits_cap() / copy_points) * f64::from(COPY_BYTES) / 1e9,
+            (limits_cap() / copy_points) * copy_ns / 1e9,
+        );
+    }
+
+    fn limits_cap() -> f64 {
+        tari_engine_types::limits::MAX_WASM_POINTS_PER_TRANSACTION as f64
+    }
+
+    // -- Part 2: host time and wire bytes on real transactions --------------------------------
+
+    struct WorkloadCensus {
+        name: &'static str,
+        wall_ns: u64,
+        wasm_points: u64,
+        census: abi_metrics::Census,
+        to_value: value_metrics::Phase,
+        from_value: value_metrics::Phase,
+    }
+
+    impl WorkloadCensus {
+        /// Every host nanosecond attributed to ABI serialisation, the `Value` conversions included.
+        fn serde_ns(&self) -> u64 {
+            self.census.ops().values().map(|op| op.serde_ns()).sum::<u64>() +
+                self.census.call_info_size_pass().ns +
+                self.census
+                    .call_info_encode()
+                    .ns
+                    .saturating_sub(self.census.guest_alloc().ns) +
+                self.census.return_decode().ns +
+                self.to_value.ns +
+                self.from_value.ns
+        }
+
+        fn engine_calls(&self) -> u64 {
+            self.census.ops().values().map(|op| op.calls).sum()
+        }
+    }
+
+    fn census(timer_ns: f64) -> Vec<WorkloadCensus> {
+        println!("\n\nCompiling census workload templates...");
+        let mut test = TemplateTest::new(CRATE_PATH, [TARISWAP, FAUCET, PROBE]);
+        let swap = SwapFixture::setup(&mut test);
+        let probe = test.get_template_address("AbiProbe");
+
+        let mut out = Vec::new();
+        out.push(measure_workload("account create + fund", &mut test, |test| {
+            test.create_funded_account();
+        }));
+        out.push(measure_workload("tariswap swap", &mut test, |test| {
+            swap.swap(test, Amount::from(10u32));
+        }));
+        out.push(measure_workload("account balance read", &mut test, |test| {
+            let _: Amount = test.call_method(swap.account, "balance", args![swap.a_resource], vec![]);
+        }));
+        // Hops 1 and 2 at a size where the host's own work is visible: a 64 KiB argument, then a
+        // 64 KiB return value walked by `IndexedValue`.
+        let payload = Bytes::from_vec(vec![0x5A; 64 * 1024]);
+        out.push(measure_workload("64 KiB call argument", &mut test, |test| {
+            test.execute_expect_success(
+                test.transaction()
+                    .call_function(probe, "sink_bytes", args![payload])
+                    .build_and_seal(test.secret_key()),
+                vec![],
+            );
+        }));
+        out.push(measure_workload("64 KiB return value", &mut test, |test| {
+            test.execute_expect_success(
+                test.transaction()
+                    .call_function(probe, "make_bytes", args![64u32 * 1024])
+                    .build_and_seal(test.secret_key()),
+                vec![],
+            );
+        }));
+
+        for workload in &out {
+            report_workload(workload, timer_ns);
+        }
+        out
+    }
+
+    fn measure_workload(
+        name: &'static str,
+        test: &mut TemplateTest,
+        mut execute: impl FnMut(&mut TemplateTest),
+    ) -> WorkloadCensus {
+        // One untimed run pays for anything the first execution caches.
+        execute(test);
+
+        let mut best: Option<WorkloadCensus> = None;
+        for _ in 0..CENSUS_TRIALS {
+            abi_metrics::reset();
+            value_metrics::reset();
+            let start = Instant::now();
+            execute(test);
+            let wall_ns = start.elapsed().as_nanos() as u64;
+            let candidate = WorkloadCensus {
+                name,
+                wall_ns,
+                wasm_points: test.last_execution_points().wasm,
+                census: abi_metrics::snapshot(),
+                to_value: value_metrics::to_value(),
+                from_value: value_metrics::from_value(),
+            };
+            if best.as_ref().is_none_or(|best| candidate.wall_ns < best.wall_ns) {
+                best = Some(candidate);
+            }
+        }
+        best.expect("at least one trial")
+    }
+
+    fn report_workload(workload: &WorkloadCensus, timer_ns: f64) {
+        println!("\n== Census: {} ==", workload.name);
+        println!(
+            "Wall time {:.1} µs, {} WASM points, {} engine calls",
+            workload.wall_ns as f64 / 1000.0,
+            workload.wasm_points,
+            workload.engine_calls()
+        );
+        println!();
+        println!(
+            "{:<26} {:>6} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10}",
+            "engine op", "calls", "arg B/call", "rsp B/call", "decode ns", "encode ns", "alloc ns", "handler ns"
+        );
+        println!("{}", "-".repeat(98));
+        let mut ops: Vec<_> = workload.census.ops().iter().collect();
+        ops.sort_by_key(|(_, stats)| std::cmp::Reverse(stats.serde_ns()));
+        for (op, stats) in ops {
+            let calls = stats.calls as f64;
+            println!(
+                "{:<26} {:>6} {:>10.0} {:>10.0} {:>10.0} {:>10.0} {:>10.0} {:>10.0}",
+                EngineOp::from_i32(*op).map_or_else(|| format!("op {op:#x}"), |op| op.to_string()),
+                stats.calls,
+                stats.arg_bytes as f64 / calls,
+                stats.resp_bytes as f64 / calls,
+                stats.decode_ns as f64 / calls,
+                stats.encode_ns as f64 / calls,
+                stats.alloc_ns as f64 / calls,
+                stats.handler_ns as f64 / calls,
+            );
+        }
+
+        let size_pass = workload.census.call_info_size_pass();
+        let call_info = workload.census.call_info_encode();
+        let alloc = workload.census.guest_alloc();
+        let returns = workload.census.return_decode();
+        println!();
+        println!(
+            "hop 1 host size pass (CallInfo):     {:>4} calls, {:>8.0} B/call, {:>8.0} ns/call",
+            size_pass.count,
+            size_pass.mean_bytes(),
+            size_pass.mean_ns()
+        );
+        println!(
+            "hop 1 host encode (CallInfo):        {:>4} calls, {:>8.0} B/call, {:>8.0} ns/call, of which {:.0} ns is \
+             the guest tari_alloc",
+            call_info.count,
+            call_info.mean_bytes(),
+            call_info.mean_ns(),
+            alloc.mean_ns()
+        );
+        println!(
+            "hop 2 host decode (IndexedValue):    {:>4} calls, {:>8.0} B/call, {:>8.0} ns/call",
+            returns.count,
+            returns.mean_bytes(),
+            returns.mean_ns()
+        );
+        println!(
+            "InvokeResult to_value (host):        {:>4} calls, {:>19.0} ns/call",
+            workload.to_value.calls,
+            workload.to_value.mean_ns()
+        );
+        println!(
+            "InvokeResult from_value (host):      {:>4} calls, {:>19.0} ns/call",
+            workload.from_value.calls,
+            workload.from_value.mean_ns()
+        );
+
+        let phases = workload.engine_calls() * 4 + size_pass.count + call_info.count * 2 + returns.count;
+        let overhead = phases as f64 * timer_ns;
+        let serde = workload.serde_ns() as f64;
+        println!();
+        println!(
+            "ABI serialisation: {:.1} µs of {:.1} µs wall time = {:.1}% (timer overhead in that figure: {:.1} µs, \
+             {:.1}% of wall)",
+            serde / 1000.0,
+            workload.wall_ns as f64 / 1000.0,
+            100.0 * serde / workload.wall_ns as f64,
+            overhead / 1000.0,
+            100.0 * overhead / workload.wall_ns as f64,
+        );
+    }
+
+    // -- Part 3: what the boundary costs a real transaction -----------------------------------
+
+    fn summary(fits: &Fits, censuses: &[WorkloadCensus], timer_ns: f64) {
+        for workload in censuses {
+            per_hop_table(fits, workload);
+        }
+
+        println!("\n\n== Summary ==");
+        println!(
+            "{:<26} {:>12} {:>12} {:>14} {:>12}",
+            "workload", "host serde", "host total", "guest ABI pts", "of WASM pts"
+        );
+        println!("{}", "-".repeat(80));
+        for workload in censuses {
+            let phases = workload.engine_calls() * 4 +
+                workload.census.call_info_size_pass().count +
+                workload.census.call_info_encode().count * 2 +
+                workload.census.return_decode().count;
+            let serde = (workload.serde_ns() as f64 - phases as f64 * timer_ns).max(0.0);
+            let guest = estimate_guest_points(fits, workload);
+            println!(
+                "{:<26} {:>10.1} µs {:>10.1} µs {:>14.0} {:>11.1}%",
+                workload.name,
+                serde / 1000.0,
+                workload.wall_ns as f64 / 1000.0,
+                guest,
+                if workload.wasm_points == 0 {
+                    0.0
+                } else {
+                    100.0 * guest / workload.wasm_points as f64
+                },
+            );
+        }
+        println!(
+            "\nGuest ABI points are the probe fits applied to the census counts and byte sizes, not a direct \
+             measurement.\nEvery engine call pays {:.0} points before any payload; a response that is not a bare unit \
+             adds {:.0} more.\nHost wall time is the whole harness execution, so the boundary's share of a \
+             validator's own work is higher than it reads here.\nA nested call's handler time contains the whole \
+             sub-invocation, ABI hops included.",
+            fits.bare_call,
+            fits.response_value + fits.from_value,
+        );
+    }
+
+    /// Guest points the boundary costs one op, from the probe fits: hop 3 for its argument, then
+    /// hop 4 for its response. A response of one or two bytes is a bare `()`, which the guest
+    /// decodes directly; anything larger arrives as an `InvokeResult` and pays the `Value` detour.
+    fn op_points(fits: &Fits, arg_bytes: f64, resp_bytes: f64) -> f64 {
+        let mut points = fits.bare_call + fits.hop3_arg.slope * arg_bytes;
+        if resp_bytes > 2.0 {
+            points += fits.response_value + fits.from_value + fits.state_get_typed.slope * resp_bytes;
+        }
+        points
+    }
+
+    fn estimate_guest_points(fits: &Fits, workload: &WorkloadCensus) -> f64 {
+        let mut total = 0.0;
+        for stats in workload.census.ops().values() {
+            let calls = stats.calls as f64;
+            total += op_points(fits, stats.arg_bytes as f64 / calls, stats.resp_bytes as f64 / calls) * calls;
+        }
+        // The hop 1 fit is the cost of a whole `sink_bytes` invocation, so it already carries the
+        // dispatch framing and a scalar return; hop 2 adds only what a payload return costs above
+        // that scalar.
+        total += fits.hop1_arg.at(workload.census.call_info_encode().mean_bytes()) *
+            workload.census.call_info_encode().count as f64;
+        total += fits.hop2_return.at(workload.census.return_decode().mean_bytes()) *
+            workload.census.return_decode().count as f64 -
+            fits.hop2_return.intercept * workload.census.return_decode().count as f64;
+        total
+    }
+
+    /// The plan's per-hop deliverable for one workload: crossings, bytes, host time, guest points.
+    fn per_hop_table(fits: &Fits, workload: &WorkloadCensus) {
+        let size_pass = workload.census.call_info_size_pass();
+        let call_info = workload.census.call_info_encode();
+        let alloc = workload.census.guest_alloc();
+        let returns = workload.census.return_decode();
+        let calls = workload.engine_calls() as f64;
+        let per_call = |total: u64| if calls == 0.0 { 0.0 } else { total as f64 / calls };
+        let sum = |field: fn(&abi_metrics::OpStats) -> u64| workload.census.ops().values().map(field).sum::<u64>();
+        let arg_bytes = per_call(sum(|op| op.arg_bytes));
+        let resp_bytes = per_call(sum(|op| op.resp_bytes));
+        let decode_ns = per_call(sum(|op| op.decode_ns));
+        let encode_ns = per_call(sum(|op| op.encode_ns));
+        let to_value_ns = per_call(workload.to_value.ns);
+
+        println!("\n== Per hop: {} ==", workload.name);
+        println!(
+            "{:<38} {:>10} {:>10} {:>12} {:>14}",
+            "hop", "crossings", "bytes", "host ns", "guest points"
+        );
+        println!("{}", "-".repeat(88));
+        let rows: [(&str, f64, f64, f64, f64); 4] = [
+            (
+                "1 host -> guest, call arguments",
+                call_info.count as f64,
+                call_info.mean_bytes(),
+                size_pass.mean_ns() + call_info.mean_ns() - alloc.mean_ns(),
+                fits.hop1_arg.at(call_info.mean_bytes()),
+            ),
+            (
+                "2 guest -> host, return value",
+                returns.count as f64,
+                returns.mean_bytes(),
+                returns.mean_ns(),
+                fits.hop2_return.slope * returns.mean_bytes(),
+            ),
+            (
+                "3 guest -> host, engine arguments",
+                calls,
+                arg_bytes,
+                decode_ns,
+                fits.bare_call + fits.hop3_arg.slope * arg_bytes,
+            ),
+            (
+                "4 host -> guest, engine responses",
+                calls,
+                resp_bytes,
+                encode_ns + to_value_ns,
+                op_points(fits, arg_bytes, resp_bytes) - fits.bare_call - fits.hop3_arg.slope * arg_bytes,
+            ),
+        ];
+        for (label, crossings, bytes, ns, points) in rows {
+            let points = if crossings == 0.0 { 0.0 } else { points };
+            println!(
+                "{:<38} {:>10.0} {:>10.0} {:>12.0} {:>14.0}",
+                label, crossings, bytes, ns, points
+            );
+        }
+        println!(
+            "Totals: {:.1} µs host, {:.0} guest points of {} measured.",
+            rows.iter().map(|r| r.1 * r.3).sum::<f64>() / 1000.0,
+            rows.iter().map(|r| r.1 * r.4).sum::<f64>(),
+            workload.wasm_points
+        );
+    }
+
+    // -- Workload fixture ----------------------------------------------------------------------
+
+    struct SwapFixture {
+        a_resource: ResourceAddress,
+        pool: ComponentAddress,
+        account: ComponentAddress,
+        account_proof: NonFungibleAddress,
+        b_resource: ResourceAddress,
+    }
+
+    impl SwapFixture {
+        fn setup(test: &mut TemplateTest) -> Self {
+            let (a_faucet, a_resource) = faucet(test, "A".to_string());
+            let (b_faucet, b_resource) = faucet(test, "B".to_string());
+            let pool = pool(test, a_resource, b_resource);
+            let (account, account_proof, _) = test.create_funded_account();
+            fund(test, account, a_faucet);
+            fund(test, account, b_faucet);
+
+            let fixture = Self {
+                a_resource,
+                b_resource,
+                pool,
+                account,
+                account_proof,
+            };
+            fixture.add_liquidity(test, Amount::from(400u32), Amount::from(400u32));
+            fixture
+        }
+
+        fn add_liquidity(&self, test: &mut TemplateTest, a: Amount, b: Amount) {
+            let owner = test.owner_proof();
+            test.build_and_execute(
+                Transaction::builder_localnet(Epoch(1))
+                    .call_method(self.account, "withdraw", args![self.a_resource, a])
+                    .put_last_instruction_output_on_workspace("a_bucket")
+                    .call_method(self.account, "withdraw", args![self.b_resource, b])
+                    .put_last_instruction_output_on_workspace("b_bucket")
+                    .call_method(self.pool, "add_liquidity", args![
+                        Workspace("a_bucket"),
+                        Workspace("b_bucket")
+                    ])
+                    .put_last_instruction_output_on_workspace("lp_bucket")
+                    .call_method(self.account, "deposit", args![Workspace("lp_bucket")]),
+                vec![self.account_proof.clone(), owner],
+            )
+            .expect_success();
+        }
+
+        fn swap(&self, test: &mut TemplateTest, amount: Amount) {
+            test.build_and_execute(
+                Transaction::builder_localnet(Epoch(1))
+                    .call_method(self.account, "withdraw", args![self.a_resource, amount])
+                    .put_last_instruction_output_on_workspace("input_bucket")
+                    .call_method(self.pool, "swap", args![Workspace("input_bucket"), self.b_resource])
+                    .put_last_instruction_output_on_workspace("output_bucket")
+                    .call_method(self.account, "deposit", args![Workspace("output_bucket")]),
+                vec![self.account_proof.clone()],
+            )
+            .expect_success();
+        }
+    }
+
+    fn faucet(test: &mut TemplateTest, symbol: String) -> (ComponentAddress, ResourceAddress) {
+        let component: ComponentAddress = test.call_function(
+            "TestFaucet",
+            "mint_with_symbol",
+            args![Amount::from(1_000_000_000_000u64), symbol],
+            vec![],
+        );
+        let resource = test
+            .get_previous_output_address(SubstateType::Resource)
+            .as_resource_address()
+            .unwrap();
+        (component, resource)
+    }
+
+    fn pool(test: &mut TemplateTest, a: ResourceAddress, b: ResourceAddress) -> ComponentAddress {
+        let template = test.get_template_address("TariSwapPool");
+        let result = test.execute_expect_success(
+            test.transaction()
+                .call_function(template, "new", args![a, b, 1u16])
+                .build_and_seal(test.secret_key()),
+            vec![],
+        );
+        let (address, _) = result
+            .expect_success()
+            .up_iter()
+            .find(|(address, substate)| {
+                address.is_component() && *substate.substate_value().component().unwrap().template_address() == template
+            })
+            .unwrap();
+        address.as_component_address().unwrap()
+    }
+
+    fn fund(test: &mut TemplateTest, account: ComponentAddress, faucet: ComponentAddress) {
+        test.build_and_execute(
+            Transaction::builder_localnet(Epoch(1))
+                .call_method(faucet, "take_free_coins", args![])
+                .put_last_instruction_output_on_workspace("free_coins")
+                .call_method(account, "deposit", args![Workspace("free_coins")]),
+            vec![],
+        )
+        .expect_success();
+    }
+}

--- a/crates/engine/src/abi_metrics.rs
+++ b/crates/engine/src/abi_metrics.rs
@@ -1,0 +1,250 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! Off-by-default instrumentation of the WASM ABI boundary, for the measurement described in
+//! `crates/engine/examples/abi_measure.rs`.
+//!
+//! Compiled out unless the `abi-metrics` feature is on: with the feature off every entry point is
+//! an empty inline function and [`Span`] is a zero-sized token, so nothing is timed, allocated or
+//! branched on. With it on, the counters live in a thread-local, matching the engine's
+//! single-threaded execution of one transaction.
+//!
+//! Timing a phase costs two `Instant::now()` reads. That overhead is not subtracted here — the
+//! reader calibrates it (see `timer_overhead_ns`) and accounts for it against the phase counts.
+
+pub use imp::*;
+
+/// One engine call's measurements, handed to [`record_engine_op`] once the call completes.
+///
+/// The fields are populated whether or not the feature is on, so the call sites in
+/// `wasm::process` read the same either way; with it off, nothing reads them back.
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(not(feature = "abi-metrics"), allow(dead_code))]
+pub struct OpSample {
+    /// Encoded argument bytes read out of linear memory (hop 3 wire size).
+    pub arg_bytes: usize,
+    /// Encoded response bytes written into linear memory (hop 4 wire size).
+    pub resp_bytes: usize,
+    /// Decoding the argument.
+    pub decode_ns: u64,
+    /// The runtime handler itself: everything that is not ABI serialisation.
+    pub handler_ns: u64,
+    /// `encoded_len` plus `encode_into_writer` for the response.
+    pub encode_ns: u64,
+    /// The guest-side `tari_alloc` call that reserves room for the response.
+    pub alloc_ns: u64,
+}
+
+#[cfg(not(feature = "abi-metrics"))]
+mod imp {
+    use tari_template_abi::EngineOp;
+
+    use super::OpSample;
+
+    /// A timing span. Without the `abi-metrics` feature it holds nothing and measures nothing.
+    #[derive(Clone, Copy)]
+    pub struct Span;
+
+    impl Span {
+        #[inline]
+        pub fn start() -> Self {
+            Span
+        }
+
+        #[inline]
+        pub fn finish(self) -> u64 {
+            0
+        }
+    }
+
+    #[inline]
+    pub fn record_engine_op(_op: EngineOp, _sample: OpSample) {}
+
+    #[inline]
+    pub fn record_call_info_size_pass(_bytes: usize, _ns: u64) {}
+
+    #[inline]
+    pub fn record_call_info_encode(_bytes: usize, _ns: u64) {}
+
+    #[inline]
+    pub fn record_guest_alloc(_bytes: usize, _ns: u64) {}
+
+    #[inline]
+    pub fn record_return_decode(_bytes: usize, _ns: u64) {}
+}
+
+#[cfg(feature = "abi-metrics")]
+mod imp {
+    use std::{cell::RefCell, collections::BTreeMap, time::Instant};
+
+    use tari_template_abi::EngineOp;
+
+    use super::OpSample;
+
+    thread_local! {
+        static CENSUS: RefCell<Census> = RefCell::new(Census::default());
+    }
+
+    /// A timing span over one ABI phase.
+    #[derive(Clone, Copy)]
+    pub struct Span(Instant);
+
+    impl Span {
+        #[inline]
+        pub fn start() -> Self {
+            Span(Instant::now())
+        }
+
+        /// Nanoseconds elapsed since [`Self::start`], including the cost of the two clock reads.
+        #[inline]
+        pub fn finish(self) -> u64 {
+            self.0.elapsed().as_nanos() as u64
+        }
+    }
+
+    pub fn record_engine_op(op: EngineOp, sample: OpSample) {
+        CENSUS.with_borrow_mut(|census| census.ops.entry(op.as_i32()).or_default().add(&sample));
+    }
+
+    pub fn record_call_info_size_pass(bytes: usize, ns: u64) {
+        CENSUS.with_borrow_mut(|census| census.call_info_size_pass.add(bytes, ns));
+    }
+
+    pub fn record_call_info_encode(bytes: usize, ns: u64) {
+        CENSUS.with_borrow_mut(|census| census.call_info_encode.add(bytes, ns));
+    }
+
+    pub fn record_guest_alloc(bytes: usize, ns: u64) {
+        CENSUS.with_borrow_mut(|census| census.guest_alloc.add(bytes, ns));
+    }
+
+    pub fn record_return_decode(bytes: usize, ns: u64) {
+        CENSUS.with_borrow_mut(|census| census.return_decode.add(bytes, ns));
+    }
+
+    /// Clears every counter on the calling thread.
+    pub fn reset() {
+        CENSUS.with_borrow_mut(|census| *census = Census::default());
+    }
+
+    /// The counters accumulated on the calling thread since the last [`reset`].
+    pub fn snapshot() -> Census {
+        CENSUS.with_borrow(Clone::clone)
+    }
+
+    /// Measured cost of one [`Span`] (two clock reads), for accounting the instrumentation's own
+    /// overhead against a phase's call count.
+    pub fn timer_overhead_ns() -> f64 {
+        const ROUNDS: u32 = 200_000;
+        // One untimed pass warms the clock's vDSO path so the measured pass is steady-state.
+        for _ in 0..ROUNDS {
+            std::hint::black_box(Span::start().finish());
+        }
+        let start = Instant::now();
+        for _ in 0..ROUNDS {
+            std::hint::black_box(Span::start().finish());
+        }
+        start.elapsed().as_nanos() as f64 / f64::from(ROUNDS)
+    }
+
+    /// Totals for one ABI phase.
+    #[derive(Clone, Copy, Default, Debug)]
+    pub struct PhaseStats {
+        pub count: u64,
+        pub bytes: u64,
+        pub ns: u64,
+    }
+
+    impl PhaseStats {
+        fn add(&mut self, bytes: usize, ns: u64) {
+            self.count += 1;
+            self.bytes += bytes as u64;
+            self.ns += ns;
+        }
+
+        pub fn mean_ns(&self) -> f64 {
+            if self.count == 0 {
+                return 0.0;
+            }
+            self.ns as f64 / self.count as f64
+        }
+
+        pub fn mean_bytes(&self) -> f64 {
+            if self.count == 0 {
+                return 0.0;
+            }
+            self.bytes as f64 / self.count as f64
+        }
+    }
+
+    /// Per-op totals across every call of one engine op.
+    #[derive(Clone, Copy, Default, Debug)]
+    pub struct OpStats {
+        pub calls: u64,
+        pub arg_bytes: u64,
+        pub resp_bytes: u64,
+        pub max_arg_bytes: usize,
+        pub max_resp_bytes: usize,
+        pub decode_ns: u64,
+        pub handler_ns: u64,
+        pub encode_ns: u64,
+        pub alloc_ns: u64,
+    }
+
+    impl OpStats {
+        fn add(&mut self, sample: &OpSample) {
+            self.calls += 1;
+            self.arg_bytes += sample.arg_bytes as u64;
+            self.resp_bytes += sample.resp_bytes as u64;
+            self.max_arg_bytes = self.max_arg_bytes.max(sample.arg_bytes);
+            self.max_resp_bytes = self.max_resp_bytes.max(sample.resp_bytes);
+            self.decode_ns += sample.decode_ns;
+            self.handler_ns += sample.handler_ns;
+            self.encode_ns += sample.encode_ns;
+            self.alloc_ns += sample.alloc_ns;
+        }
+
+        /// Every nanosecond spent on serialisation, i.e. everything but the handler.
+        pub fn serde_ns(&self) -> u64 {
+            self.decode_ns + self.encode_ns
+        }
+    }
+
+    /// Every counter accumulated on one thread.
+    #[derive(Clone, Default, Debug)]
+    pub struct Census {
+        ops: BTreeMap<i32, OpStats>,
+        /// Hop 1, host side: the `encoded_len` pre-pass over a `CallInfo`.
+        call_info_size_pass: PhaseStats,
+        /// Hop 1, host side: allocating guest memory for a `CallInfo` and encoding into it.
+        call_info_encode: PhaseStats,
+        /// The `tari_alloc` call inside [`Self::call_info_encode`].
+        guest_alloc: PhaseStats,
+        /// Hop 2, host side: `IndexedValue::from_raw` over a template's return value.
+        return_decode: PhaseStats,
+    }
+
+    impl Census {
+        pub fn ops(&self) -> &BTreeMap<i32, OpStats> {
+            &self.ops
+        }
+
+        pub fn call_info_size_pass(&self) -> &PhaseStats {
+            &self.call_info_size_pass
+        }
+
+        pub fn call_info_encode(&self) -> &PhaseStats {
+            &self.call_info_encode
+        }
+
+        /// The `tari_alloc` call that reserves guest memory for a `CallInfo`, counted inside
+        /// [`Self::call_info_encode`]'s time: it enters WASM, so it is not serialisation.
+        pub fn guest_alloc(&self) -> &PhaseStats {
+            &self.guest_alloc
+        }
+
+        pub fn return_decode(&self) -> &PhaseStats {
+            &self.return_decode
+        }
+    }
+}

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright 2022 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
+pub mod abi_metrics;
 pub mod executables;
 pub mod fees;
 pub mod intrinsics;

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -3347,7 +3347,7 @@ where
                                 id,
                                 existing_ids: state.workspace().all_ids_iter().collect(),
                             })?;
-                    Ok(InvokeResult::from_value(value))
+                    Ok(InvokeResult::from_value(value)?)
                 })
             },
 
@@ -3421,7 +3421,7 @@ where
                         .data()
                         .clone();
                     state.unlock_substate(nft_lock)?;
-                    Ok(InvokeResult::from_value(contents))
+                    Ok(InvokeResult::from_value(contents)?)
                 })
             },
             NonFungibleAction::GetMutableData => {
@@ -3441,7 +3441,7 @@ where
                         .clone();
                     state.unlock_substate(nft_lock)?;
 
-                    Ok(InvokeResult::from_value(contents))
+                    Ok(InvokeResult::from_value(contents)?)
                 })
             },
         }
@@ -3729,7 +3729,7 @@ where
             },
         };
 
-        Ok(InvokeResult::from_value(exec_result.indexed.into_value()))
+        Ok(InvokeResult::from_value(exec_result.indexed.into_value())?)
     }
 
     fn builtin_template_invoke(&mut self, action: BuiltinTemplateAction) -> Result<InvokeResult, RuntimeError> {

--- a/crates/engine/src/wasm/process.rs
+++ b/crates/engine/src/wasm/process.rs
@@ -56,6 +56,7 @@ use wasmer::{AsStoreMut, AsStoreRef, Function, FunctionEnv, FunctionEnvMut, Inst
 use wasmer_middlewares::metering::{MeteringPoints, get_remaining_points, set_remaining_points};
 
 use crate::{
+    abi_metrics,
     runtime::{ComputeAllowance, ComputeFunding, Runtime, RuntimeError},
     traits::Invokable,
     wasm::{
@@ -120,7 +121,9 @@ impl WasmProcess {
         }
         let len = u32::try_from(alloc_size).map_err(|_| WasmExecutionError::MemoryAllocationTooLarge)?;
 
+        let span = abi_metrics::Span::start();
         let ptr = self.alloc_checked(store, len)?;
+        abi_metrics::record_guest_alloc(alloc_size, span.finish());
         let mut fn_env = self.env_and_store(store);
         let (env, mut store) = fn_env.data_and_store_mut();
         let mut writer = env.memory_writer(&mut store, ptr)?;
@@ -281,78 +284,90 @@ impl WasmProcess {
         log::debug!(target: LOG_TARGET, "Engine call: {:?}", op);
 
         let result = match op {
-            EngineOp::EmitLog => Self::handle(&mut env, arg_ptr, arg_len, |state, arg: EmitLogArg| {
+            EngineOp::EmitLog => Self::handle(&mut env, op, arg_ptr, arg_len, |state, arg: EmitLogArg| {
                 state.interface_mut().emit_log(arg.level, arg.message)
             }),
-            EngineOp::ComponentInvoke => Self::handle(&mut env, arg_ptr, arg_len, |state, arg: ComponentInvokeArg| {
-                state
-                    .interface_mut()
-                    .component_invoke(arg.component_ref, arg.action, arg.args.into())
-            }),
-            EngineOp::ResourceInvoke => Self::handle(&mut env, arg_ptr, arg_len, |state, arg: ResourceInvokeArg| {
-                state
-                    .interface_mut()
-                    .resource_invoke(arg.resource_ref, arg.action, arg.args.into())
-            }),
-            EngineOp::VaultInvoke => Self::handle(&mut env, arg_ptr, arg_len, |state, arg: VaultInvokeArg| {
+            EngineOp::ComponentInvoke => {
+                Self::handle(&mut env, op, arg_ptr, arg_len, |state, arg: ComponentInvokeArg| {
+                    state
+                        .interface_mut()
+                        .component_invoke(arg.component_ref, arg.action, arg.args.into())
+                })
+            },
+            EngineOp::ResourceInvoke => {
+                Self::handle(&mut env, op, arg_ptr, arg_len, |state, arg: ResourceInvokeArg| {
+                    state
+                        .interface_mut()
+                        .resource_invoke(arg.resource_ref, arg.action, arg.args.into())
+                })
+            },
+            EngineOp::VaultInvoke => Self::handle(&mut env, op, arg_ptr, arg_len, |state, arg: VaultInvokeArg| {
                 state
                     .interface_mut()
                     .vault_invoke(arg.vault_ref, arg.action, arg.args.into())
             }),
-            EngineOp::BucketInvoke => Self::handle(&mut env, arg_ptr, arg_len, |state, arg: BucketInvokeArg| {
+            EngineOp::BucketInvoke => Self::handle(&mut env, op, arg_ptr, arg_len, |state, arg: BucketInvokeArg| {
                 state
                     .interface_mut()
                     .bucket_invoke(arg.bucket_ref, arg.action, arg.args.into())
             }),
             EngineOp::NonFungibleInvoke => {
-                Self::handle(&mut env, arg_ptr, arg_len, |state, arg: NonFungibleInvokeArg| {
+                Self::handle(&mut env, op, arg_ptr, arg_len, |state, arg: NonFungibleInvokeArg| {
                     state
                         .interface_mut()
                         .non_fungible_invoke(arg.address, arg.action, arg.args.into())
                 })
             },
-            EngineOp::GenerateUniqueId => Self::handle(&mut env, arg_ptr, arg_len, |state, _arg: ()| {
+            EngineOp::GenerateUniqueId => Self::handle(&mut env, op, arg_ptr, arg_len, |state, _arg: ()| {
                 state.interface_mut().generate_uuid()
             }),
-            EngineOp::ConsensusInvoke => Self::handle(&mut env, arg_ptr, arg_len, |state, arg: ConsensusInvokeArg| {
-                state.interface_mut().consensus_invoke(arg.action)
-            }),
+            EngineOp::ConsensusInvoke => {
+                Self::handle(&mut env, op, arg_ptr, arg_len, |state, arg: ConsensusInvokeArg| {
+                    state.interface_mut().consensus_invoke(arg.action)
+                })
+            },
             EngineOp::CallerContextInvoke => {
-                Self::handle(&mut env, arg_ptr, arg_len, |state, arg: CallerContextInvokeArg| {
+                Self::handle(&mut env, op, arg_ptr, arg_len, |state, arg: CallerContextInvokeArg| {
                     state.interface_mut().caller_context_invoke(arg.action, arg.args.into())
                 })
             },
-            EngineOp::AddressAllocationInvoke => {
-                Self::handle(&mut env, arg_ptr, arg_len, |state, arg: AddressAllocationInvokeArg| {
-                    state.interface_mut().allocate_address_invoke(arg)
-                })
-            },
+            EngineOp::AddressAllocationInvoke => Self::handle(
+                &mut env,
+                op,
+                arg_ptr,
+                arg_len,
+                |state, arg: AddressAllocationInvokeArg| state.interface_mut().allocate_address_invoke(arg),
+            ),
             EngineOp::GenerateRandomInvoke => {
-                Self::handle(&mut env, arg_ptr, arg_len, |state, arg: GenerateRandomInvokeArg| {
+                Self::handle(&mut env, op, arg_ptr, arg_len, |state, arg: GenerateRandomInvokeArg| {
                     state.interface_mut().generate_random_invoke(arg.action)
                 })
             },
-            EngineOp::EmitEvent => Self::handle(&mut env, arg_ptr, arg_len, |state, arg: EmitEventArg| {
+            EngineOp::EmitEvent => Self::handle(&mut env, op, arg_ptr, arg_len, |state, arg: EmitEventArg| {
                 state.interface_mut().emit_event(arg.topic, arg.payload)
             }),
-            EngineOp::CallInvoke => Self::handle(&mut env, arg_ptr, arg_len, |state, arg: CallInvokeArg| {
+            EngineOp::CallInvoke => Self::handle(&mut env, op, arg_ptr, arg_len, |state, arg: CallInvokeArg| {
                 state.interface_mut().call_invoke(arg.action, arg.args.into())
             }),
-            EngineOp::ProofInvoke => Self::handle(&mut env, arg_ptr, arg_len, |state, arg: ProofInvokeArg| {
+            EngineOp::ProofInvoke => Self::handle(&mut env, op, arg_ptr, arg_len, |state, arg: ProofInvokeArg| {
                 state
                     .interface_mut()
                     .proof_invoke(arg.proof_ref, arg.action, arg.args.into())
             }),
-            EngineOp::BuiltinTemplateInvoke => {
-                Self::handle(&mut env, arg_ptr, arg_len, |state, arg: BuiltinTemplateInvokeArg| {
-                    state.interface_mut().builtin_template_invoke(arg.action)
+            EngineOp::BuiltinTemplateInvoke => Self::handle(
+                &mut env,
+                op,
+                arg_ptr,
+                arg_len,
+                |state, arg: BuiltinTemplateInvokeArg| state.interface_mut().builtin_template_invoke(arg.action),
+            ),
+            EngineOp::IntrinsicInvoke => {
+                Self::handle(&mut env, op, arg_ptr, arg_len, |state, arg: IntrinsicInvokeArg| {
+                    state.interface_mut().intrinsic_invoke(arg.intrinsic, arg.args.into())
                 })
             },
-            EngineOp::IntrinsicInvoke => Self::handle(&mut env, arg_ptr, arg_len, |state, arg: IntrinsicInvokeArg| {
-                state.interface_mut().intrinsic_invoke(arg.intrinsic, arg.args.into())
-            }),
             EngineOp::SpendContextInvoke => {
-                Self::handle(&mut env, arg_ptr, arg_len, |state, arg: SpendContextInvokeArg| {
+                Self::handle(&mut env, op, arg_ptr, arg_len, |state, arg: SpendContextInvokeArg| {
                     state.interface_mut().spend_context_invoke(arg.action)
                 })
             },
@@ -369,6 +384,7 @@ impl WasmProcess {
 
     fn handle<T, U, E>(
         env: &mut FunctionEnvMut<WasmEnv<Runtime>>,
+        op: EngineOp,
         arg_ptr: WasmPtr<u8>,
         arg_len: u32,
         f: fn(&mut Runtime, T) -> Result<U, E>,
@@ -378,6 +394,12 @@ impl WasmProcess {
         U: tari_bor::Encode<()> + tari_bor::CborLen<()>,
         WasmExecutionError: From<E>,
     {
+        let mut sample = abi_metrics::OpSample {
+            arg_bytes: arg_len as usize,
+            ..Default::default()
+        };
+
+        let span = abi_metrics::Span::start();
         let decoded = {
             let (env_mut, mut store) = env.data_and_store_mut();
             // SAFETY: WasmProcess is not used concurrently and templates are not able to spawn threads
@@ -390,14 +412,29 @@ impl WasmProcess {
                 })
             }??
         };
+        sample.decode_ns = span.finish();
+
+        let span = abi_metrics::Span::start();
         let resp = f(env.data_mut().state_mut(), decoded)?;
+        sample.handler_ns = span.finish();
+
+        let span = abi_metrics::Span::start();
         let len = encoded_len(&resp)?;
+        sample.encode_ns = span.finish();
+        sample.resp_bytes = len;
+
+        let span = abi_metrics::Span::start();
         let ptr = Self::alloc_response(env, len)?;
+        sample.alloc_ns = span.finish();
 
         // Encode response directly into the WASM memory. The WASM code is responsible for freeing it.
+        let span = abi_metrics::Span::start();
         let (env_mut, mut store) = env.data_and_store_mut();
         let mut writer = env_mut.memory_writer(&mut store, ptr)?;
         encode_into_writer(&resp, &mut writer)?;
+        sample.encode_ns += span.finish();
+
+        abi_metrics::record_engine_op(op, sample);
         Ok(ptr)
     }
 
@@ -470,13 +507,18 @@ impl Invokable<Store> for WasmProcess {
         }
 
         let func_ident = hash_function_name(&func_def.name);
+        let span = abi_metrics::Span::start();
         let mut counter = ByteCounter::new();
         CallInfo::encode_v1_packed(&mut counter, func_ident, args)?;
         let call_info_size = counter.get();
+        abi_metrics::record_call_info_size_pass(call_info_size, span.finish());
+
+        let span = abi_metrics::Span::start();
         let call_info_ptr = self.with_alloc_and_mem_writer(store, call_info_size, |mem_writer| {
             CallInfo::encode_v1_packed(mem_writer, func_ident, args)?;
             Ok(())
         })?;
+        abi_metrics::record_call_info_encode(call_info_size, span.finish());
 
         let MeteringAllowance {
             consumed,
@@ -529,11 +571,17 @@ impl Invokable<Store> for WasmProcess {
             Ok(return_ptr) => {
                 // Read response from memory
                 // SAFETY: WasmProcess is not used concurrently
+                let span = abi_metrics::Span::start();
+                let mut return_bytes = 0usize;
                 let value = unsafe {
                     let mut fn_env = self.env_and_store(store);
                     let (env, mut store) = fn_env.data_and_store_mut();
-                    env.with_memory_embedded_len(&mut store, return_ptr.offset(), IndexedValue::from_raw)??
+                    env.with_memory_embedded_len(&mut store, return_ptr.offset(), |raw| {
+                        return_bytes = raw.len();
+                        IndexedValue::from_raw(raw)
+                    })??
                 };
+                abi_metrics::record_return_decode(return_bytes, span.finish());
 
                 // Free allocated memory containing the result
                 self.free_checked(store, return_ptr)?;

--- a/crates/engine/tests/templates/abi_probe/Cargo.toml
+++ b/crates/engine/tests/templates/abi_probe/Cargo.toml
@@ -1,0 +1,12 @@
+[workspace]
+[package]
+name = "abi_probe"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+tari_template_lib = { path = "../../../../template_lib" }
+tari_template_abi = { path = "../../../../template_abi", default-features = false }
+
+[lib]
+crate-type = ["cdylib"]

--- a/crates/engine/tests/templates/abi_probe/src/lib.rs
+++ b/crates/engine/tests/templates/abi_probe/src/lib.rs
@@ -1,0 +1,261 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! Microbenchmark template for pricing the WASM ABI boundary in guest metering points, driven by
+//! `crates/engine/examples/abi_measure.rs`.
+//!
+//! Four hops cross the boundary: host-to-guest call arguments (1), guest-to-host return values (2),
+//! guest-to-host engine-call arguments (3) and host-to-guest engine-call responses (4). Each probe
+//! below isolates one of them, and each has a `*_glue` twin that performs the identical work minus
+//! the boundary crossing. Subtracting the twin leaves the hop's own cost, the way
+//! `metering_bench` isolates a single WASM operator. Probes that take a count `n` are read as a
+//! slope across two values of `n`, which also cancels the fixed dispatch cost of the call itself.
+
+use tari_template_abi::{EngineOp, call_engine};
+use tari_template_lib::{
+    args::{
+        CallerContextAction,
+        CallerContextInvokeArg,
+        ComponentAction,
+        ComponentInvokeArg,
+        ComponentRef,
+        InvokeResult,
+    },
+    prelude::*,
+};
+
+/// Bytes of log message per `emit_logs` iteration must stay under
+/// `ENGINE_LIMITS.max_log_size_bytes`, and the iteration count under `max_logs`.
+const LOG_LEVEL: tari_template_lib::types::LogLevel = tari_template_lib::types::LogLevel::Debug;
+
+#[template]
+mod abi_probe {
+    use super::*;
+
+    pub struct AbiProbe {
+        blob: Bytes,
+    }
+
+    impl AbiProbe {
+        /// A component whose state encodes to roughly `state_bytes`, so state round-trips can be
+        /// priced against payload size.
+        pub fn new(state_bytes: u32) -> Component<Self> {
+            Component::new(Self {
+                blob: Bytes::from_vec(vec![0x5A; state_bytes as usize]),
+            })
+            .with_access_rules(AccessRules::new().default(rule!(allow_all)))
+            .create()
+        }
+
+        // Hop 0: dispatch ------------------------------------------------------------------
+        /// Baseline: enter the dispatcher, decode a header, encode a unit return.
+        pub fn noop() {}
+
+        // Metering reference ---------------------------------------------------------------
+        /// A dependent integer chain: work whose metering points track real execution time closely,
+        /// as the reference the copy loop below is compared against.
+        pub fn spin(rounds: u32) -> u64 {
+            let mut acc: u64 = 0x9E37_79B9_7F4A_7C17;
+            for _ in 0..rounds {
+                acc = (acc ^ (acc >> 7)).wrapping_mul(0xD1B5_4A32_D192_ED03).rotate_left(13);
+            }
+            acc
+        }
+
+        /// `rounds` copies of `size` bytes. `copy_from_slice` lowers to a single `memory.copy`,
+        /// which metering charges a flat rate regardless of length.
+        pub fn bulk_copy(rounds: u32, size: u32) -> u32 {
+            let src = vec![0x5Au8; size as usize];
+            let mut dst = vec![0u8; size as usize];
+            let mut acc = 0u32;
+            for _ in 0..rounds {
+                dst.copy_from_slice(&src);
+                acc = acc.wrapping_add(u32::from(core::hint::black_box(&dst)[0]));
+            }
+            acc
+        }
+
+        // Buffer strategy for the hop 3 encode ----------------------------------------------
+        /// `n` encodes of a realistic `SetState` engine-call argument carrying a `size`-byte
+        /// payload, buffered one of four ways. Nothing but the encode's own buffer differs, so the
+        /// slopes across `n` price the `encoded_len` pre-pass against the alternatives.
+        ///
+        /// 0: `encoded_len` pre-pass, then an exactly sized buffer, which is what `call_engine`
+        /// does today. 1: an empty buffer left to grow. 2 and 3: one 512- or 1024-byte allocation
+        /// up front, growing only for an argument larger than that.
+        pub fn encode_buffered(&self, n: u32, size: u32, strategy: u32) -> u32 {
+            let arg = ComponentInvokeArg {
+                component_ref: ComponentRef::Ref(CallerContext::current_component_address()),
+                action: ComponentAction::SetState,
+                args: vec![Bytes::from_vec(vec![0x5A; size as usize])],
+            };
+            let mut acc = 0u32;
+            // The branch sits outside the loop so every strategy runs identical loop glue.
+            match strategy {
+                0 => {
+                    for _ in 0..n {
+                        let len = tari_bor::encoded_len(&arg).unwrap();
+                        let mut buf = Vec::with_capacity(len);
+                        tari_bor::encode_into_writer(&arg, &mut buf).unwrap();
+                        acc = acc.wrapping_add(core::hint::black_box(&buf).len() as u32);
+                    }
+                },
+                1 => {
+                    for _ in 0..n {
+                        let mut buf = Vec::new();
+                        tari_bor::encode_into_writer(&arg, &mut buf).unwrap();
+                        acc = acc.wrapping_add(core::hint::black_box(&buf).len() as u32);
+                    }
+                },
+                2 => {
+                    for _ in 0..n {
+                        let mut buf = Vec::with_capacity(512);
+                        tari_bor::encode_into_writer(&arg, &mut buf).unwrap();
+                        acc = acc.wrapping_add(core::hint::black_box(&buf).len() as u32);
+                    }
+                },
+                _ => {
+                    for _ in 0..n {
+                        let mut buf = Vec::with_capacity(1024);
+                        tari_bor::encode_into_writer(&arg, &mut buf).unwrap();
+                        acc = acc.wrapping_add(core::hint::black_box(&buf).len() as u32);
+                    }
+                },
+            }
+            acc
+        }
+
+        // Hop 1: call argument decode ------------------------------------------------------
+        /// Decodes `v` and drops it. Return is unit, so only hop 1 scales with size. The payload is
+        /// a CBOR byte string (`Bytes`), the compact encoding a real payload uses; a `Vec<u8>`
+        /// would arrive as an array of integers and price a different path.
+        pub fn sink_bytes(v: Bytes) -> u32 {
+            v.len() as u32
+        }
+
+        // Hop 2: return value encode -------------------------------------------------------
+        /// Builds `n` bytes and returns them: hop 2 plus the allocation.
+        pub fn make_bytes(n: u32) -> Bytes {
+            Bytes::from_vec(vec![0x5A; n as usize])
+        }
+
+        /// `make_bytes` without the return crossing: the allocation alone.
+        pub fn make_bytes_glue(n: u32) -> u32 {
+            core::hint::black_box(Bytes::from_vec(vec![0x5A; n as usize])).len() as u32
+        }
+
+        // Hop 3: engine call argument encode ------------------------------------------------
+        /// `n` `EmitLog` calls carrying a `size`-byte message. The response is unit, so cost
+        /// scales with the argument only. Bounded by `max_logs` and `max_log_size_bytes`.
+        pub fn emit_logs(n: u32, size: u32) -> u32 {
+            let msg = message(size);
+            let mut acc = 0u32;
+            for _ in 0..n {
+                let m = msg.clone();
+                acc = acc.wrapping_add(m.len() as u32);
+                engine().emit_log(LOG_LEVEL, m);
+            }
+            acc
+        }
+
+        /// `emit_logs` without the engine call: the message clone alone.
+        pub fn emit_logs_glue(n: u32, size: u32) -> u32 {
+            let msg = message(size);
+            let mut acc = 0u32;
+            for _ in 0..n {
+                let m = core::hint::black_box(msg.clone());
+                acc = acc.wrapping_add(m.len() as u32);
+            }
+            acc
+        }
+
+        // Hops 3 and 4: fixed per-call cost --------------------------------------------------
+        /// `n` `CallerContextInvoke` calls. Both payloads are a handful of bytes, so this is the
+        /// per-engine-call floor: envelope encode, response decode, `tari_alloc`, `tari_free`.
+        pub fn caller_context_calls(n: u32) -> u32 {
+            let mut acc = 0u32;
+            for _ in 0..n {
+                let pk = CallerContext::transaction_signer_public_key();
+                acc = acc.wrapping_add(u32::from(pk.as_bytes()[0]));
+            }
+            acc
+        }
+
+        /// `n` `CallerContextInvoke` calls stopping at the response `Value`. The difference
+        /// against `caller_context_calls` is the `InvokeResult` `from_value` conversion into a
+        /// concrete type, which no change of codec removes.
+        pub fn caller_context_raw(n: u32) -> u32 {
+            let mut acc = 0u32;
+            for _ in 0..n {
+                let result: InvokeResult = call_engine(EngineOp::CallerContextInvoke, &CallerContextInvokeArg {
+                    action: CallerContextAction::GetCallerPublicKey,
+                    args: args![],
+                });
+                let value = core::hint::black_box(result.into_value().unwrap());
+                acc = acc.wrapping_add(u32::from(!matches!(value, tari_bor::Value::Null)));
+            }
+            acc
+        }
+
+        // Hops 3 and 4 with a payload: component state ---------------------------------------
+        /// `n` `GetState` round-trips decoded into the concrete type: hop 4 plus the
+        /// `InvokeResult` `from_value` conversion.
+        pub fn get_state_typed(&self, n: u32) -> u32 {
+            let manager = engine().component_manager(CallerContext::current_component_address());
+            let mut acc = 0u32;
+            for _ in 0..n {
+                let state = manager.get_state::<Self>();
+                acc = acc.wrapping_add(state.blob.len() as u32);
+            }
+            acc
+        }
+
+        /// `n` `GetState` round-trips stopping at the `InvokeResult`'s own `Value`: hop 4 without
+        /// the `from_value` conversion into a concrete type. The difference against
+        /// `get_state_typed` is that conversion, which no change of codec removes.
+        pub fn get_state_raw(&self, n: u32) -> u32 {
+            let component = CallerContext::current_component_address();
+            let mut acc = 0u32;
+            for _ in 0..n {
+                let result: InvokeResult = call_engine(EngineOp::ComponentInvoke, &ComponentInvokeArg {
+                    component_ref: ComponentRef::Ref(component),
+                    action: ComponentAction::GetState,
+                    args: args![],
+                });
+                let value = core::hint::black_box(result.into_value().unwrap());
+                acc = acc.wrapping_add(u32::from(!matches!(value, tari_bor::Value::Null)));
+            }
+            acc
+        }
+
+        /// `n` `SetState` calls: hop 3 with the state as payload.
+        pub fn set_state(&mut self, n: u32) -> u32 {
+            let manager = engine().component_manager(CallerContext::current_component_address());
+            let mut acc = 0u32;
+            for _ in 0..n {
+                manager.set_state(Self {
+                    blob: self.blob.clone(),
+                });
+                acc = acc.wrapping_add(1);
+            }
+            acc
+        }
+
+        /// `set_state` without the engine call: the state clone alone.
+        pub fn set_state_glue(&mut self, n: u32) -> u32 {
+            let mut acc = 0u32;
+            for _ in 0..n {
+                let state = core::hint::black_box(Self {
+                    blob: self.blob.clone(),
+                });
+                acc = acc.wrapping_add(state.blob.len() as u32);
+            }
+            acc
+        }
+    }
+}
+
+/// A `size`-byte ASCII message. Built once per probe call so the per-iteration work is a clone.
+fn message(size: u32) -> String {
+    core::iter::repeat_n('x', size as usize).collect()
+}

--- a/crates/engine/tests/templates/abi_probe/src/lib.rs
+++ b/crates/engine/tests/templates/abi_probe/src/lib.rs
@@ -77,12 +77,12 @@ mod abi_probe {
 
         // Buffer strategy for the hop 3 encode ----------------------------------------------
         /// `n` encodes of a realistic `SetState` engine-call argument carrying a `size`-byte
-        /// payload, buffered one of four ways. Nothing but the encode's own buffer differs, so the
+        /// payload, buffered one of five ways. Nothing but the encode's own buffer differs, so the
         /// slopes across `n` price the `encoded_len` pre-pass against the alternatives.
         ///
-        /// 0: `encoded_len` pre-pass, then an exactly sized buffer, which is what `call_engine`
-        /// does today. 1: an empty buffer left to grow. 2 and 3: one 512- or 1024-byte allocation
-        /// up front, growing only for an argument larger than that.
+        /// 0: `encoded_len` pre-pass, then an exactly sized buffer. 1: an empty buffer left to
+        /// grow. 2, 3 and 4: one 512-, 1024- or 4096-byte allocation up front, growing only for an
+        /// argument larger than that.
         pub fn encode_buffered(&self, n: u32, size: u32, strategy: u32) -> u32 {
             let arg = ComponentInvokeArg {
                 component_ref: ComponentRef::Ref(CallerContext::current_component_address()),
@@ -114,9 +114,16 @@ mod abi_probe {
                         acc = acc.wrapping_add(core::hint::black_box(&buf).len() as u32);
                     }
                 },
-                _ => {
+                3 => {
                     for _ in 0..n {
                         let mut buf = Vec::with_capacity(1024);
+                        tari_bor::encode_into_writer(&arg, &mut buf).unwrap();
+                        acc = acc.wrapping_add(core::hint::black_box(&buf).len() as u32);
+                    }
+                },
+                _ => {
+                    for _ in 0..n {
+                        let mut buf = Vec::with_capacity(4096);
                         tari_bor::encode_into_writer(&arg, &mut buf).unwrap();
                         acc = acc.wrapping_add(core::hint::black_box(&buf).len() as u32);
                     }
@@ -181,9 +188,9 @@ mod abi_probe {
             acc
         }
 
-        /// `n` `CallerContextInvoke` calls stopping at the response `Value`. The difference
-        /// against `caller_context_calls` is the `InvokeResult` `from_value` conversion into a
-        /// concrete type, which no change of codec removes.
+        /// `n` `CallerContextInvoke` calls that materialise the response as a `tari_bor::Value`
+        /// instead of decoding it into the concrete type. The difference against
+        /// `caller_context_calls` is what the value tree costs over a direct decode.
         pub fn caller_context_raw(n: u32) -> u32 {
             let mut acc = 0u32;
             for _ in 0..n {
@@ -210,9 +217,9 @@ mod abi_probe {
             acc
         }
 
-        /// `n` `GetState` round-trips stopping at the `InvokeResult`'s own `Value`: hop 4 without
-        /// the `from_value` conversion into a concrete type. The difference against
-        /// `get_state_typed` is that conversion, which no change of codec removes.
+        /// `n` `GetState` round-trips that materialise the response as a `tari_bor::Value` instead
+        /// of decoding it into the concrete type. The difference against `get_state_typed` is what
+        /// the value tree costs over a direct decode.
         pub fn get_state_raw(&self, n: u32) -> u32 {
             let component = CallerContext::current_component_address();
             let mut acc = 0u32;

--- a/crates/tari_bor/Cargo.toml
+++ b/crates/tari_bor/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_bor"
 description = "The binary object representation (BOR) crate provides a binary encoding for template/engine data types"
-version = "0.15.0"
+version = "0.15.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/tari_bor/src/lib.rs
+++ b/crates/tari_bor/src/lib.rs
@@ -12,6 +12,7 @@ use alloc::{format, vec::Vec};
 pub mod adapters;
 mod error;
 mod macros;
+mod raw;
 #[cfg(feature = "serde")]
 pub mod serde_codec;
 mod tag;
@@ -26,6 +27,7 @@ pub use byte_counter::ByteCounter;
 pub use error::BorError;
 pub use macros::__cbor_macro;
 pub use minicbor::{self, CborLen, Decode, Encode};
+pub use raw::RawCbor;
 #[cfg(feature = "serde")]
 pub use serde::{self, Deserialize, Serialize, de::DeserializeOwned};
 pub use tag::*;

--- a/crates/tari_bor/src/raw.rs
+++ b/crates/tari_bor/src/raw.rs
@@ -1,0 +1,215 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+
+use minicbor::{
+    CborLen,
+    Decoder,
+    Encoder,
+    decode,
+    encode::{self, Write},
+};
+
+use crate::{BorError, Value, decode_exact, encode as encode_to_vec};
+
+/// One CBOR item held as its own encoding.
+///
+/// Encoding writes the bytes back verbatim and decoding captures them without interpreting the
+/// item, so encoding a `RawCbor` yields the same bytes as encoding the value it was built from.
+///
+/// The bytes are always exactly one complete item — [`Self::from_encodable`] and the [`Decode`]
+/// impl are the only ways to build one, and both guarantee it. Nothing mutates them afterwards.
+///
+/// [`Decode`]: minicbor::Decode
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RawCbor(Box<[u8]>);
+
+impl RawCbor {
+    /// Encodes `value` and keeps the result.
+    pub fn from_encodable<T: minicbor::Encode<()> + ?Sized>(value: &T) -> Result<Self, BorError> {
+        Ok(Self(encode_to_vec(value)?.into_boxed_slice()))
+    }
+
+    /// Encodes a dynamic value tree and keeps the result.
+    pub fn from_value(value: &Value) -> Result<Self, BorError> {
+        Self::from_encodable(value)
+    }
+
+    /// Decodes the item into `T`.
+    pub fn decode<T: for<'b> minicbor::Decode<'b, ()>>(&self) -> Result<T, BorError> {
+        decode_exact(&self.0)
+    }
+
+    /// Decodes the item into a dynamic value tree.
+    pub fn to_value(&self) -> Result<Value, BorError> {
+        self.decode()
+    }
+
+    /// The item's CBOR encoding.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl<C> minicbor::Encode<C> for RawCbor {
+    fn encode<W: Write>(&self, e: &mut Encoder<W>, _ctx: &mut C) -> Result<(), encode::Error<W::Error>> {
+        e.writer_mut().write_all(&self.0).map_err(encode::Error::write)
+    }
+}
+
+impl<'b, C> minicbor::Decode<'b, C> for RawCbor {
+    fn decode(d: &mut Decoder<'b>, _ctx: &mut C) -> Result<Self, decode::Error> {
+        let start = d.position();
+        // Iterative in minicbor, with its own heap stack, so nesting depth in untrusted input
+        // cannot drive this into a stack overflow the way a recursive walk would.
+        d.skip()?;
+        let end = d.position();
+        let bytes = d
+            .input()
+            .get(start..end)
+            .ok_or_else(|| decode::Error::message("RawCbor: skipped past the end of the input"))?;
+        Ok(Self(Box::from(bytes)))
+    }
+}
+
+impl<C> CborLen<C> for RawCbor {
+    fn cbor_len(&self, _ctx: &mut C) -> usize {
+        self.0.len()
+    }
+}
+
+/// Serde sees the item, not its encoding: a `RawCbor` serialises as the [`Value`] it holds, so a
+/// field carrying one has the same JSON as a field carrying the value itself. Serde is a JSON-style
+/// path only — CBOR never travels through it — so the conversion is off the encoding path.
+///
+/// Unlike the CBOR path this is not byte-preserving in both directions. Deserialising rebuilds the
+/// encoding from the value, so an item that arrived non-canonically comes back canonical, and
+/// serialising fails for an item `Value` cannot represent.
+#[cfg(feature = "serde")]
+impl serde::Serialize for RawCbor {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.to_value()
+            .map_err(serde::ser::Error::custom)?
+            .serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for RawCbor {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = Value::deserialize(deserializer)?;
+        Self::from_value(&value).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(not(feature = "std"))]
+    use alloc::string::ToString;
+
+    use super::*;
+    use crate::{encode, to_value};
+
+    /// A payload routed through a `Value` tree and back encodes to the payload's own bytes.
+    #[test]
+    fn value_round_trip_is_byte_identical() {
+        fn check<T: minicbor::Encode<()> + ?Sized>(value: &T) {
+            let direct = encode(value).unwrap();
+            let via_value = encode(&to_value(value).unwrap()).unwrap();
+            assert_eq!(direct, via_value);
+            assert_eq!(RawCbor::from_encodable(value).unwrap().as_bytes(), direct.as_slice());
+        }
+
+        check(&());
+        check(&u64::MAX);
+        check(&i64::MIN);
+        check(&0u8);
+        check(&true);
+        check("a string");
+        check(&vec![1u64, 2, 3]);
+        check(&(1u8, "two", vec![3u8]));
+        check(&Some(vec![vec![1u8, 2], vec![3]]));
+        check(&None::<u32>);
+    }
+
+    /// The limit of the substitution: `Value` has no `f32`, so a float widens to `f64` passing
+    /// through one. Every type crossing the ABI must therefore be float-free, and this fails if
+    /// that widening ever stops happening.
+    #[test]
+    fn a_float_is_the_one_shape_a_value_does_not_reproduce() {
+        let direct = encode(&1.5f32).unwrap();
+        let via_value = encode(&to_value(&1.5f32).unwrap()).unwrap();
+        assert_ne!(direct, via_value);
+        assert_eq!(direct.len(), 5, "f32 header plus four bytes");
+        assert_eq!(via_value.len(), 9, "f64 header plus eight bytes");
+    }
+
+    /// An integer outside CBOR's own range has no encoding, so it never reaches a `RawCbor` — which
+    /// is why the JSON round trip above does not cover it.
+    #[test]
+    fn an_integer_beyond_cbor_range_cannot_be_held() {
+        assert!(RawCbor::from_value(&Value::Integer(i128::from(u64::MAX) + 1)).is_err());
+        assert!(RawCbor::from_value(&Value::Integer(i128::from(i64::MIN) - 1)).is_err());
+    }
+
+    #[test]
+    fn decode_captures_exactly_one_item() {
+        // Two items back to back: decoding the first must stop at its own end.
+        let mut buf = encode(&vec![1u64, 2, 3]).unwrap();
+        let second = encode(&"tail").unwrap();
+        buf.extend_from_slice(&second);
+
+        let mut decoder = Decoder::new(&buf);
+        let first: RawCbor = decoder.decode().unwrap();
+        assert_eq!(first.as_bytes(), encode(&vec![1u64, 2, 3]).unwrap().as_slice());
+        let rest: RawCbor = decoder.decode().unwrap();
+        assert_eq!(rest.as_bytes(), second.as_slice());
+    }
+
+    #[test]
+    fn encode_writes_the_item_back_verbatim() {
+        let raw = RawCbor::from_encodable(&vec!["a", "b"]).unwrap();
+        assert_eq!(encode(&raw).unwrap(), raw.as_bytes());
+        assert_eq!(raw.decode::<Vec<String>>().unwrap(), vec![
+            "a".to_string(),
+            "b".to_string()
+        ]);
+    }
+
+    /// A `RawCbor` field and a `Value` field holding the same item have the same JSON.
+    #[cfg(feature = "serde")]
+    #[test]
+    fn json_matches_the_value_it_holds() {
+        for value in [
+            Value::Null,
+            Value::Bool(true),
+            Value::Integer(-7),
+            Value::Integer(i128::from(u64::MAX)),
+            Value::Bytes(vec![0xAB, 0x12]),
+            Value::Text("text".to_string()),
+            Value::Array(vec![Value::Integer(1), Value::Text("two".to_string())]),
+            Value::Map(vec![(Value::Text("k".to_string()), Value::Integer(1))]),
+            // The variants `value_serde` routes through its `@cbor` sentinel rather than a natural
+            // JSON shape, where a round trip has the furthest to fall.
+            Value::Map(vec![(Value::Integer(1), Value::Text("non-text key".to_string()))]),
+            Value::Tag(42, Box::new(Value::Integer(7))),
+            Value::Tag(42, Box::new(Value::Bytes(vec![1, 2, 3]))),
+        ] {
+            let raw = RawCbor::from_value(&value).unwrap();
+            assert_eq!(
+                serde_json::to_string(&raw).unwrap(),
+                serde_json::to_string(&value).unwrap()
+            );
+            let back: RawCbor = serde_json::from_str(&serde_json::to_string(&raw).unwrap()).unwrap();
+            assert_eq!(back, raw);
+        }
+    }
+
+    #[test]
+    fn cbor_len_matches_the_encoding() {
+        let raw = RawCbor::from_encodable(&vec![0u8; 300]).unwrap();
+        assert_eq!(crate::encoded_len(&raw).unwrap(), raw.as_bytes().len());
+    }
+}

--- a/crates/template_lib/Cargo.toml
+++ b/crates/template_lib/Cargo.toml
@@ -29,3 +29,8 @@ borsh = ["dep:borsh", "tari_template_lib_types/borsh", "tari_bor/borsh"]
 extra-arith = ["tari_template_lib_types/extra-arith"]
 precision = ["tari_template_lib_types/precision"]
 extra-maps = ["tari_template_lib_types/extra-maps"]
+# Times the `tari_bor::Value` conversions an `InvokeResult` performs, so a host
+# measuring the ABI boundary can separate them from the codec itself. Host-side
+# measurement only (see `tari_engine::abi_metrics`); it needs a thread-local, so
+# it implies `std` and is never on in a template build.
+metrics = ["std"]

--- a/crates/template_lib/Cargo.toml
+++ b/crates/template_lib/Cargo.toml
@@ -29,8 +29,8 @@ borsh = ["dep:borsh", "tari_template_lib_types/borsh", "tari_bor/borsh"]
 extra-arith = ["tari_template_lib_types/extra-arith"]
 precision = ["tari_template_lib_types/precision"]
 extra-maps = ["tari_template_lib_types/extra-maps"]
-# Times the `tari_bor::Value` conversions an `InvokeResult` performs, so a host
-# measuring the ABI boundary can separate them from the codec itself. Host-side
+# Times the encode and decode an `InvokeResult` performs, so a host measuring the
+# ABI boundary can separate them from the rest of an engine call. Host-side
 # measurement only (see `tari_engine::abi_metrics`); it needs a thread-local, so
 # it implies `std` and is never on in a template build.
 metrics = ["std"]

--- a/crates/template_lib/src/args/result.rs
+++ b/crates/template_lib/src/args/result.rs
@@ -17,13 +17,20 @@ impl InvokeResult {
     }
 
     pub fn encode<T: Encode<()> + ?Sized>(output: &T) -> Result<Self, BorError> {
+        let span = metrics::Span::start();
         let value = to_value(output)?;
+        metrics::record_to_value(span);
         Ok(Self(Ok(value)))
     }
 
     pub fn decode<T: for<'b> Decode<'b, ()>>(self) -> Result<T, BorError> {
         match self.0 {
-            Ok(output) => from_value(&output),
+            Ok(output) => {
+                let span = metrics::Span::start();
+                let decoded = from_value(&output);
+                metrics::record_from_value(span);
+                decoded
+            },
             Err(err) => Err(BorError::new(err)),
         }
     }
@@ -34,6 +41,101 @@ impl InvokeResult {
 
     pub fn unit() -> Self {
         Self(Ok(tari_bor::Value::Array(Vec::new())))
+    }
+}
+
+/// Timing of the `tari_bor::Value` conversions on either side of an [`InvokeResult`], compiled out
+/// unless the `metrics` feature is on. See `tari_engine::abi_metrics`.
+#[cfg(not(feature = "metrics"))]
+pub mod metrics {
+    /// A timing span. Without the `metrics` feature it holds nothing and measures nothing.
+    #[derive(Clone, Copy)]
+    pub struct Span;
+
+    impl Span {
+        #[inline]
+        pub fn start() -> Self {
+            Span
+        }
+    }
+
+    #[inline]
+    pub fn record_to_value(_span: Span) {}
+
+    #[inline]
+    pub fn record_from_value(_span: Span) {}
+}
+
+#[cfg(feature = "metrics")]
+pub mod metrics {
+    use std::{cell::Cell, time::Instant};
+
+    thread_local! {
+        static TO_VALUE: Cell<Phase> = const { Cell::new(Phase::ZERO) };
+        static FROM_VALUE: Cell<Phase> = const { Cell::new(Phase::ZERO) };
+    }
+
+    /// Calls and elapsed nanoseconds of one conversion direction.
+    #[derive(Clone, Copy, Default, Debug)]
+    pub struct Phase {
+        pub calls: u64,
+        pub ns: u64,
+    }
+
+    impl Phase {
+        const ZERO: Self = Self { calls: 0, ns: 0 };
+
+        pub fn mean_ns(&self) -> f64 {
+            if self.calls == 0 {
+                return 0.0;
+            }
+            self.ns as f64 / self.calls as f64
+        }
+    }
+
+    /// A timing span over one conversion.
+    #[derive(Clone, Copy)]
+    pub struct Span(Instant);
+
+    impl Span {
+        #[inline]
+        pub fn start() -> Self {
+            Span(Instant::now())
+        }
+    }
+
+    pub fn record_to_value(span: Span) {
+        add(&TO_VALUE, span);
+    }
+
+    pub fn record_from_value(span: Span) {
+        add(&FROM_VALUE, span);
+    }
+
+    fn add(cell: &'static std::thread::LocalKey<Cell<Phase>>, span: Span) {
+        let ns = span.0.elapsed().as_nanos() as u64;
+        cell.with(|c| {
+            let mut phase = c.get();
+            phase.calls += 1;
+            phase.ns += ns;
+            c.set(phase);
+        });
+    }
+
+    /// Clears both counters on the calling thread.
+    pub fn reset() {
+        TO_VALUE.with(|c| c.set(Phase::ZERO));
+        FROM_VALUE.with(|c| c.set(Phase::ZERO));
+    }
+
+    /// Host-side `to_value` (building an `InvokeResult`) since the last [`reset`].
+    pub fn to_value() -> Phase {
+        TO_VALUE.with(|c| c.get())
+    }
+
+    /// Host-side `from_value` (reading an `InvokeResult`) since the last [`reset`].
+    pub fn from_value() -> Phase {
+        FROM_VALUE.with(|c| c.get())
     }
 }
 

--- a/crates/template_lib/src/args/result.rs
+++ b/crates/template_lib/src/args/result.rs
@@ -2,33 +2,37 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use minicbor::{CborLen, Decode, Encode};
-use tari_bor::{BorError, from_value, to_value};
+use tari_bor::{BorError, RawCbor};
 use tari_template_abi::rust::prelude::*;
 
-/// The result of an instruction invocation, which is either the CBOR encoded result value or a `String` with an error
-/// message
+/// The result of an engine call: either the CBOR encoding of the returned value, or a `String` with
+/// an error message.
+///
+/// A published template carries its own compiled-in decoder for this type, so the bytes must stay
+/// as they are: `#[n(0)] Result<RawCbor, String>` and `#[n(0)] Result<tari_bor::Value, String>`
+/// encode a given response identically, and the tests below hold that.
 #[derive(Clone, Debug, Encode, Decode, CborLen)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct InvokeResult(#[n(0)] Result<tari_bor::Value, String>);
+pub struct InvokeResult(#[n(0)] Result<RawCbor, String>);
 
 impl InvokeResult {
-    pub fn from_value(value: tari_bor::Value) -> Self {
-        Self(Ok(value))
+    pub fn from_value(value: tari_bor::Value) -> Result<Self, BorError> {
+        Ok(Self(Ok(RawCbor::from_value(&value)?)))
     }
 
     pub fn encode<T: Encode<()> + ?Sized>(output: &T) -> Result<Self, BorError> {
         let span = metrics::Span::start();
-        let value = to_value(output)?;
-        metrics::record_to_value(span);
-        Ok(Self(Ok(value)))
+        let raw = RawCbor::from_encodable(output)?;
+        metrics::record_encode(span);
+        Ok(Self(Ok(raw)))
     }
 
     pub fn decode<T: for<'b> Decode<'b, ()>>(self) -> Result<T, BorError> {
         match self.0 {
             Ok(output) => {
                 let span = metrics::Span::start();
-                let decoded = from_value(&output);
-                metrics::record_from_value(span);
+                let decoded = output.decode();
+                metrics::record_decode(span);
                 decoded
             },
             Err(err) => Err(BorError::new(err)),
@@ -36,16 +40,16 @@ impl InvokeResult {
     }
 
     pub fn into_value(self) -> Result<tari_bor::Value, BorError> {
-        self.0.map_err(BorError::new)
+        self.0.map_err(BorError::new)?.to_value()
     }
 
     pub fn unit() -> Self {
-        Self(Ok(tari_bor::Value::Array(Vec::new())))
+        Self(Ok(RawCbor::from_encodable(&()).expect("unit always encodes")))
     }
 }
 
-/// Timing of the `tari_bor::Value` conversions on either side of an [`InvokeResult`], compiled out
-/// unless the `metrics` feature is on. See `tari_engine::abi_metrics`.
+/// Timing of the encode and decode on either side of an [`InvokeResult`], compiled out unless the
+/// `metrics` feature is on. See `tari_engine::abi_metrics`.
 #[cfg(not(feature = "metrics"))]
 pub mod metrics {
     /// A timing span. Without the `metrics` feature it holds nothing and measures nothing.
@@ -60,10 +64,10 @@ pub mod metrics {
     }
 
     #[inline]
-    pub fn record_to_value(_span: Span) {}
+    pub fn record_encode(_span: Span) {}
 
     #[inline]
-    pub fn record_from_value(_span: Span) {}
+    pub fn record_decode(_span: Span) {}
 }
 
 #[cfg(feature = "metrics")]
@@ -71,8 +75,8 @@ pub mod metrics {
     use std::{cell::Cell, time::Instant};
 
     thread_local! {
-        static TO_VALUE: Cell<Phase> = const { Cell::new(Phase::ZERO) };
-        static FROM_VALUE: Cell<Phase> = const { Cell::new(Phase::ZERO) };
+        static ENCODE: Cell<Phase> = const { Cell::new(Phase::ZERO) };
+        static DECODE: Cell<Phase> = const { Cell::new(Phase::ZERO) };
     }
 
     /// Calls and elapsed nanoseconds of one conversion direction.
@@ -104,12 +108,12 @@ pub mod metrics {
         }
     }
 
-    pub fn record_to_value(span: Span) {
-        add(&TO_VALUE, span);
+    pub fn record_encode(span: Span) {
+        add(&ENCODE, span);
     }
 
-    pub fn record_from_value(span: Span) {
-        add(&FROM_VALUE, span);
+    pub fn record_decode(span: Span) {
+        add(&DECODE, span);
     }
 
     fn add(cell: &'static std::thread::LocalKey<Cell<Phase>>, span: Span) {
@@ -124,18 +128,18 @@ pub mod metrics {
 
     /// Clears both counters on the calling thread.
     pub fn reset() {
-        TO_VALUE.with(|c| c.set(Phase::ZERO));
-        FROM_VALUE.with(|c| c.set(Phase::ZERO));
+        ENCODE.with(|c| c.set(Phase::ZERO));
+        DECODE.with(|c| c.set(Phase::ZERO));
     }
 
-    /// Host-side `to_value` (building an `InvokeResult`) since the last [`reset`].
-    pub fn to_value() -> Phase {
-        TO_VALUE.with(|c| c.get())
+    /// Building an `InvokeResult` from a response value, since the last [`reset`].
+    pub fn encode() -> Phase {
+        ENCODE.with(|c| c.get())
     }
 
-    /// Host-side `from_value` (reading an `InvokeResult`) since the last [`reset`].
-    pub fn from_value() -> Phase {
-        FROM_VALUE.with(|c| c.get())
+    /// Reading a response out of an `InvokeResult`, since the last [`reset`].
+    pub fn decode() -> Phase {
+        DECODE.with(|c| c.get())
     }
 }
 
@@ -145,6 +149,63 @@ mod tests {
 
     #[test]
     fn unit_decode() {
-        from_value::<()>(&InvokeResult::unit().0.unwrap()).unwrap();
+        InvokeResult::unit().decode::<()>().unwrap();
+    }
+
+    /// The shape a published template decodes engine responses with. What the engine writes must
+    /// encode identically to this.
+    #[derive(Encode, Decode, CborLen)]
+    struct ValueBackedInvokeResult(#[n(0)] Result<tari_bor::Value, String>);
+
+    fn assert_same_wire_form(value: tari_bor::Value) {
+        let legacy = tari_bor::encode(&ValueBackedInvokeResult(Ok(value.clone()))).unwrap();
+        let current = tari_bor::encode(&InvokeResult::from_value(value).unwrap()).unwrap();
+        assert_eq!(current, legacy);
+    }
+
+    #[test]
+    fn responses_keep_the_wire_form_published_templates_decode() {
+        assert_same_wire_form(tari_bor::Value::Array(Vec::new()));
+        assert_same_wire_form(tari_bor::Value::Null);
+        assert_same_wire_form(tari_bor::Value::Bool(true));
+        assert_same_wire_form(tari_bor::Value::Integer(i128::from(u64::MAX)));
+        assert_same_wire_form(tari_bor::Value::Integer(i128::from(i64::MIN)));
+        assert_same_wire_form(tari_bor::Value::Bytes(vec![0x5A; 300]));
+        assert_same_wire_form(tari_bor::Value::Text("a string".to_string()));
+        assert_same_wire_form(tari_bor::Value::Array(vec![
+            tari_bor::Value::Integer(1),
+            tari_bor::Value::Text("two".to_string()),
+        ]));
+        assert_same_wire_form(tari_bor::Value::Map(vec![(
+            tari_bor::Value::Text("key".to_string()),
+            tari_bor::Value::Bytes(vec![1, 2, 3]),
+        )]));
+        assert_same_wire_form(tari_bor::Value::Tag(42, Box::new(tari_bor::Value::Integer(7))));
+    }
+
+    #[test]
+    fn errors_keep_the_wire_form_published_templates_decode() {
+        let legacy = tari_bor::encode(&ValueBackedInvokeResult(Err("boom".to_string()))).unwrap();
+        let current = tari_bor::encode(&InvokeResult(Err("boom".to_string()))).unwrap();
+        assert_eq!(current, legacy);
+    }
+
+    /// A unit response encodes as the empty array a published template decodes.
+    #[test]
+    fn unit_keeps_its_wire_form() {
+        let legacy = tari_bor::encode(&tari_bor::Value::Array(Vec::new())).unwrap();
+        assert_eq!(InvokeResult::unit().0.unwrap().as_bytes(), legacy.as_slice());
+    }
+
+    /// A typed response and the same response routed through a `Value` put the same bytes on the
+    /// wire.
+    #[test]
+    fn typed_and_value_responses_agree() {
+        let typed = tari_bor::encode(&InvokeResult::encode(&(1u32, "two", vec![3u8])).unwrap()).unwrap();
+        let value = tari_bor::encode(
+            &InvokeResult::from_value(tari_bor::to_value(&(1u32, "two", vec![3u8])).unwrap()).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(typed, value);
     }
 }

--- a/crates/template_lib/src/component/manager.rs
+++ b/crates/template_lib/src/component/manager.rs
@@ -20,7 +20,6 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 use minicbor::{CborLen, Decode, Encode};
-use tari_bor::to_value;
 use tari_template_abi::{EngineOp, call_engine, rust::prelude::*};
 use tari_template_lib_types::{ComponentAddress, TemplateAddress, access_rules::ComponentAccessRules, bytes::Bytes};
 
@@ -98,7 +97,6 @@ impl ComponentManager {
 
     /// Update the component state
     pub fn set_state<T: Encode<()>>(&self, state: T) {
-        let state = to_value(&state).expect("Failed to encode component state");
         let _result = call_engine::<_, InvokeResult>(EngineOp::ComponentInvoke, &ComponentInvokeArg {
             component_ref: ComponentRef::Ref(self.0),
             action: ComponentAction::SetState,


### PR DESCRIPTION
## What

An engine call's response crossed the WASM ABI as `InvokeResult(Result<tari_bor::Value, String>)`. The host built that tree with `to_value`, which is an encode followed by a decode; the guest tore it down with `from_value`, which is an encode followed by another decode. Neither side wanted the tree, and on the guest it is metered.

`tari_bor::RawCbor` holds one CBOR item as its own encoding — decoding captures the item's bytes without interpreting them, encoding writes them back verbatim — so `InvokeResult` now carries the response's encoding. The host encodes once, the guest decodes once. `ComponentManager::set_state` stopped routing state through a `Value` first, for the same reason.

## Results

Measured on this head against the branch point, by `cargo run -p tari_engine --example abi_measure --release --features abi-metrics`. Guest metering points are deterministic, so the first two tables are exact; host times vary between runs and are indicative.

**Per transaction, guest metering points.** These run the real account, faucet and tariswap templates, unchanged between the two runs, so it is a clean comparison.

| Workload | Before | After | Change |
|---|---|---|---|
| Account create + fund | 91,155 | 70,049 | −21,106 (−23%) |
| Tariswap swap | 218,319 | 102,563 | −115,756 (−53%) |
| Account balance read | 34,496 | 17,544 | −16,952 (−49%) |

**Per operation, guest metering points.** Good to about 1%: the probe template gained functions between the runs, which shifts code layout slightly.

| Operation | Before | After | Change |
|---|---|---|---|
| Engine call round trip, 32 B response | 4,140 | 3,110 | −25% |
| `GetState`, state ≥ 1 KiB | 6,600 | 4,323 | −34% |
| `SetState`, state ≥ 1 KiB | 8,093 | 4,942 | −39% |
| `&mut self` method, both halves | 14,693 | 9,265 | −37% |
| Empty invocation, no engine call | 786 | 798 | unchanged |

The last row is the control. An invocation that makes no engine call is untouched, which is what the change predicts, since it only affects how a response crosses back.

**Host serialisation time per transaction.** Two after-runs are shown because the account workload's wall time swings by around 40% between runs; the other two are stable.

| Workload | Before | After, run 1 | After, run 2 |
|---|---|---|---|
| Account create + fund | 15.3 µs | 13.0 µs | 18.6 µs |
| Tariswap swap | 19.0 µs | 14.7 µs | 14.6 µs |
| Account balance read | 4.5 µs | 3.1 µs | 3.2 µs |

Points are user fees, so the first two tables are a direct cost reduction for anyone transacting.

## The wire does not move

`to_value(&T)` already produces the bytes `encode(&T)` would, so a `RawCbor` field and a `Value` field encode identically. **A published template decodes responses with its own compiled-in `Result<Value, String>` and keeps working unchanged**; only a template recompiled against this gets the saving.

Two cases in `tari_bor::Value` are lossy and would move the wire if they arose: `f16`/`f32` widen to `f64`, and indefinite-length items collapse to definite. Neither can occur — there is no float field anywhere in `tari_template_lib` or `tari_template_lib_types`, and minicbor's derive never emits indefinite-length items.

Tests in `args/result.rs` pin byte identity against the exact shape templates were published with, across null, both integer extremes, bytes, text, arrays, maps, tags and the error variant. Note what that does **not** cover: every `Value` variant survives the round trip by construction, so adding an `f32` to a response type would fail no test. `raw.rs` documents that boundary directly instead — `a_float_is_the_one_shape_a_value_does_not_reproduce` asserts the widening, so the constraint is written down and pinned, but keeping response types float-free is a convention, not something the build enforces. The practical exposure is nil either way: a published template decodes an `f32` item into `Value::Float(f64)` with the same numeric value it got before.

## How this was decided

The first commit is measurement only: an `abi-metrics` feature on `tari_engine` recording per-op host timing and wire bytes, a `metrics` feature on `tari_template_lib`, an `abi_probe` template that pairs each ABI hop with a twin doing identical work minus the boundary crossing, and `abi_measure` to drive them. Both features compile to empty inline functions when off, so a validator build carries none of it.

That measurement is what rejected the original plan. A zero-copy codec (rkyv) targets per-byte marshalling, and per-byte turned out to be near free in metering points: `memory.copy` is charged a flat 2 points whatever its length. The cost was per call and structural, which is what this PR removes instead.

Two things it also says no to:

- **Replacing the guest's `encoded_len` pre-pass with a fixed reserve.** Wins ~70 points/call in the probe, wins nothing across real transactions: 191,048 points with the pre-pass against 191,058 with a 1 KiB reserve, and a 4 KiB reserve gives byte-identical counts to the 1 KiB one. A guest heap busy with the template's own allocations does not behave like the probe's quiet one. The pre-pass stays; the probe stays with it so the trade can be re-tested.
- **Removing the `GetState`/`SetState` round trips entirely** by carrying state in the `CallInfo`. That is where the remaining ~9,400 points per `&mut self` method live, but it changes hop 1's framing and needs a template ABI version the engine switches on — a migration, not a refactor. Not attempted here.

## Separate finding, not addressed here

Metering charges `memory.copy` a flat 2 points regardless of length, which prices copying about 10,000x cheaper per microsecond of validator time than arithmetic. The 250M point per-transaction cap buys ~30 ms of arithmetic but ~336 s of copying at the 4.2 GB/s the copies run at. Reproducible with the `bulk_copy` and `spin` probes. This wants its own issue.

## Versions

`tari_bor` 0.15.0 → 0.15.1: the one crate here whose released and working versions matched. `RawCbor` is additive, which `scripts/crate_versioning.py impact` prices as a patch, and the workspace pin moves with it so a published `tari_template_lib` cannot resolve a `tari_bor` predating the type it compiles against. `tari_template_abi`, `tari_template_lib`, `tari_engine` and the tier-3 rollup already sit ahead of their released versions, so the breaking `InvokeResult::from_value` signature rides the bump they carry.

## Testing

`tari_bor` and `tari_template_lib` unit tests, and the `tari_engine` suites: `test`, `tariswap`, `account`, `fees`, `resource`, `fungible`, `events`, `cross_template`, `access_rules`, `caller_context`, `recall`, `freeze`, `intrinsics`, `limits`, `metering_budget`, `compute_fee_budget`, `validator_fees`, `complex_fee_payment`. Clippy and fmt clean.

