### PR TITLE
fix(swarm): stop the log view blanking and attribute logs to the right instance

### DIFF
--- a/applications/tari_swarm_daemon/src/webserver/rpc/logs.rs
+++ b/applications/tari_swarm_daemon/src/webserver/rpc/logs.rs
@@ -10,7 +10,12 @@ use std::{
 use axum_jrpc::error::{JsonRpcError, JsonRpcErrorReason};
 use serde::{Deserialize, Serialize};
 
-use crate::{config::InstanceType, logfile, process_manager::InstanceInfo, webserver::context::HandlerContext};
+use crate::{
+    config::InstanceType,
+    logfile,
+    process_manager::{InstanceId, InstanceInfo},
+    webserver::context::HandlerContext,
+};
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct ListLogFilesRequest {
@@ -19,8 +24,11 @@ pub struct ListLogFilesRequest {
     pub index: Option<usize>,
 }
 
-/// (full path, name, path without extension)
-pub type ListValidatorNodesResponse = Vec<(String, String, String)>;
+/// (full path, instance name, path without extension, instance id)
+///
+/// The id is what identifies the owning instance: two instances can share a base path - the wallet daemon and
+/// the key-creating run that seeds it both point at `wallet-daemon-00` - so a path alone is ambiguous.
+pub type ListValidatorNodesResponse = Vec<(String, String, String, InstanceId)>;
 
 pub async fn list_log_files(
     context: &HandlerContext,
@@ -41,12 +49,12 @@ pub async fn list_log_files(
             )
         })?;
         visit_dirs(&instance.base_path.join("log"), &mut |dir| {
-            collect_current_log(dir, &instance.name, &mut log_files);
+            collect_current_log(dir, instance, &mut log_files);
         })?;
     } else {
-        for instance in instances {
+        for instance in &instances {
             visit_dirs(&instance.base_path.join("log"), &mut |dir| {
-                collect_current_log(dir, &instance.name, &mut log_files);
+                collect_current_log(dir, instance, &mut log_files);
             })?;
         }
     }
@@ -54,7 +62,7 @@ pub async fn list_log_files(
     Ok(log_files)
 }
 
-fn collect_current_log(entry: &DirEntry, instance_name: &str, log_files: &mut ListValidatorNodesResponse) {
+fn collect_current_log(entry: &DirEntry, instance: &InstanceInfo, log_files: &mut ListValidatorNodesResponse) {
     let path = entry.path();
     if path.extension() != Some("log".as_ref()) || is_rotated(&path) {
         return;
@@ -62,8 +70,9 @@ fn collect_current_log(entry: &DirEntry, instance_name: &str, log_files: &mut Li
     let path_without_ext = path.with_extension("");
     log_files.push((
         path.to_string_lossy().to_string(),
-        instance_name.to_string(),
+        instance.name.clone(),
         path_without_ext.to_string_lossy().to_string(),
+        instance.id,
     ));
 }
 
@@ -91,8 +100,8 @@ fn visit_dirs<F: FnMut(&DirEntry)>(dir: &Path, cb: &mut F) -> io::Result<()> {
 
 pub type ListStdoutLogsRequest = ListLogFilesRequest;
 
-/// (full path, name)
-pub type ListStdoutLogsResponse = Vec<(String, &'static str)>;
+/// (full path, stream name, instance id)
+pub type ListStdoutLogsResponse = Vec<(String, &'static str, InstanceId)>;
 pub async fn list_stdout_files(
     context: &HandlerContext,
     req: ListStdoutLogsRequest,
@@ -129,7 +138,7 @@ fn collect_captured_output(instance: &InstanceInfo, log_files: &mut ListStdoutLo
         (&instance.stderr_log_path, "stderr"),
     ] {
         if path.exists() {
-            log_files.push((path.to_string_lossy().to_string(), name));
+            log_files.push((path.to_string_lossy().to_string(), name, instance.id));
         }
     }
 }

--- a/applications/tari_swarm_daemon/webui/src/routes/LogView.tsx
+++ b/applications/tari_swarm_daemon/webui/src/routes/LogView.tsx
@@ -14,23 +14,17 @@ import {
 import { useNavigate, useParams } from "react-router-dom";
 import { describeError, swarmRpc } from "../api/rpc";
 import { LEVELS, Level, Line, TARGET_RE, TIME_RE, parse, toEntries } from "./logFormat";
+import {
+  CHUNK_BYTES,
+  Chunk,
+  MAX_SCAN_CHUNKS,
+  formatBytes,
+  trimBuffer,
+} from "./logBuffer";
 
-/** Bytes fetched per request. The daemon trims each window to whole lines. */
-const CHUNK_BYTES = 256 * 1024;
-/**
- * Chunks held at once. Paging further back drops the newest ones, so however long a session runs the buffer stays
- * bounded and the tab stays responsive.
- */
-const MAX_CHUNKS = 6;
 const FOLLOW_MS = 2000;
 /** Distance from the older end of the view at which the next chunk starts loading. */
 const LOAD_MARGIN_PX = 400;
-
-interface Chunk {
-  start: number;
-  end: number;
-  lines: Line[];
-}
 
 interface ChunkResponse {
   contents: string;
@@ -88,7 +82,8 @@ function renderText(text: string, needle: string): ReactNode {
 
 async function fetchChunk(path: string, end: number | null): Promise<Chunk> {
   const res: ChunkResponse = await swarmRpc("get_file", { path, end, max_bytes: CHUNK_BYTES });
-  return { start: res.start, end: res.end, lines: parse(res.contents, res.start) };
+  const lines = parse(res.contents, res.start);
+  return { start: res.start, end: res.end, lines, entries: toEntries(lines) };
 }
 
 export default function LogView() {
@@ -155,6 +150,25 @@ export default function LogView() {
     };
   }, [path, follow]);
 
+  // An entry's level is its opening line's - a continuation carries none of its own, and hiding a record has
+  // to take its continuations with it.
+  const matches = useCallback(
+    (entry: Line[]) => {
+      const lowerNeedle = needle.trim().toLowerCase();
+      return (
+        !(entry[0].level && hidden.has(entry[0].level)) &&
+        (!lowerNeedle || entry.some((line) => line.text.toLowerCase().includes(lowerNeedle)))
+      );
+    },
+    [hidden, needle],
+  );
+
+  const countVisible = useCallback(
+    (candidates: Chunk[]) =>
+      candidates.reduce((total, chunk) => total + chunk.entries.filter(matches).length, 0),
+    [matches],
+  );
+
   const loadOlder = useCallback(async () => {
     const oldest = chunks?.[chunks.length - 1];
     if (!path || !oldest || loadingRef.current || oldest.start === 0) {
@@ -179,7 +193,7 @@ export default function LogView() {
         if (!current || current[current.length - 1]?.start !== oldest.start) {
           return current;
         }
-        return [...current, chunk].slice(-MAX_CHUNKS);
+        return trimBuffer([...current, chunk], countVisible);
       });
       setFetchError(null);
     } catch (err) {
@@ -188,7 +202,7 @@ export default function LogView() {
       loadingRef.current = false;
       setLoadingOlder(false);
     }
-  }, [path, chunks]);
+  }, [path, chunks, countVisible]);
 
   // Newest lines sit at the top, so scrolling down walks backwards through the file.
   const onScroll = () => {
@@ -209,25 +223,14 @@ export default function LogView() {
 
   // Newest entry first, but the lines inside each entry stay in the order they were written.
   const entries = useMemo(
-    () => (chunks === null ? null : chunks.flatMap((chunk) => toEntries(chunk.lines).reverse())),
+    () => (chunks === null ? null : chunks.flatMap((chunk) => chunk.entries.slice().reverse())),
     [chunks],
   );
 
-  const visible = useMemo(() => {
-    if (entries === null) {
-      return [];
-    }
-    const lowerNeedle = needle.trim().toLowerCase();
-    // An entry's level is its opening line's - a continuation carries none of its own, and hiding a record has
-    // to take its continuations with it.
-    return entries
-      .filter(
-        (entry) =>
-          !(entry[0].level && hidden.has(entry[0].level)) &&
-          (!lowerNeedle || entry.some((line) => line.text.toLowerCase().includes(lowerNeedle))),
-      )
-      .flat();
-  }, [entries, hidden, needle]);
+  const visible = useMemo(
+    () => (entries === null ? [] : entries.filter(matches).flat()),
+    [entries, matches],
+  );
 
   useLayoutEffect(() => {
     const el = view.current;
@@ -247,13 +250,27 @@ export default function LogView() {
     }
   }, [visible, follow, chunks]);
 
+  /** True once the buffer has scanned as far back as it will go without finding a line to render. */
+  const scanExhausted = (chunks?.length ?? 0) >= MAX_SCAN_CHUNKS;
+
   // Level filters can leave too few lines to fill the view, which would strand it with nothing to scroll.
   useEffect(() => {
     const el = view.current;
-    if (el && !follow && !loadingOlder && !atStartOfFile && el.scrollHeight <= el.clientHeight) {
+    if (
+      el &&
+      !follow &&
+      !loadingOlder &&
+      !atStartOfFile &&
+      !scanExhausted &&
+      el.scrollHeight <= el.clientHeight
+    ) {
       void loadOlder();
     }
-  }, [visible, follow, loadingOlder, atStartOfFile, loadOlder]);
+  }, [visible, follow, loadingOlder, atStartOfFile, scanExhausted, loadOlder]);
+
+  /** Bytes the buffer currently spans, which is what the filters have been applied to. */
+  const scannedBytes =
+    chunks && chunks.length ? chunks[0].end - chunks[chunks.length - 1].start : 0;
 
   const counts = useMemo(() => {
     const tally: Record<string, number> = {};
@@ -324,7 +341,13 @@ export default function LogView() {
         {error && <p className="empty">{error}</p>}
         {!error && entries === null && <p className="empty">Loading…</p>}
         {!error && entries !== null && !visible.length && (
-          <p className="empty">{entries.length ? "No lines match the filters." : "This file is empty."}</p>
+          <p className="empty">
+            {!entries.length
+              ? "This file is empty."
+              : `No lines match the filters in the ${formatBytes(scannedBytes)} scanned${
+                  atStartOfFile ? " (the whole file)" : scanExhausted ? ", and the search stopped there" : ""
+                }. ${entries.length.toLocaleString()} entries hidden — show a level, or clear the search.`}
+          </p>
         )}
         {/* Paging back trims the newest chunks, so the head of the file is only reachable through Follow. */}
         {!error && !follow && visible.length > 0 && (

--- a/applications/tari_swarm_daemon/webui/src/routes/logBuffer.ts
+++ b/applications/tari_swarm_daemon/webui/src/routes/logBuffer.ts
@@ -1,0 +1,48 @@
+//  Copyright 2024 The Tari Project
+//  SPDX-License-Identifier: BSD-3-Clause
+
+import { Line } from "./logFormat";
+
+/** Bytes fetched per request. The daemon trims each window to whole lines. */
+export const CHUNK_BYTES = 256 * 1024;
+/** Chunks held at once, which bounds the rendered DOM once the level filters are letting lines through. */
+export const MAX_CHUNKS = 6;
+/**
+ * Chunks the buffer may grow to while nothing in it passes the filters.
+ *
+ * A node log can run for megabytes without a single line above DEBUG. Every one of those chunks renders nothing,
+ * so `MAX_CHUNKS` cannot evict against them - it would throw away the one chunk the reader can see - and the
+ * search for a matching line has to stop somewhere instead of walking the whole file.
+ */
+export const MAX_SCAN_CHUNKS = 32;
+
+/** Newest chunk first, matching the rendered order. */
+export interface Chunk {
+  start: number;
+  end: number;
+  lines: Line[];
+  /** Grouped once on arrival: the trim policy counts rendered entries on every load. */
+  entries: Line[][];
+}
+
+/**
+ * Bounds the buffer without emptying the view.
+ *
+ * Chunks are dropped newest-first as the reader pages backwards, but never past the point where nothing would be
+ * left to render: a run of chunks that the filters hide entirely contributes no rendered lines, so evicting
+ * against it would blank the screen and strand the reader on a file they were reading a moment ago.
+ */
+export function trimBuffer(chunks: Chunk[], countVisible: (chunks: Chunk[]) => number): Chunk[] {
+  let out = chunks;
+  while (out.length > MAX_CHUNKS && countVisible(out.slice(1)) > 0) {
+    out = out.slice(1);
+  }
+  return out;
+}
+
+export function formatBytes(bytes: number): string {
+  if (bytes >= 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+  return `${Math.max(1, Math.round(bytes / 1024))} KB`;
+}

--- a/applications/tari_swarm_daemon/webui/src/state/SwarmProvider.tsx
+++ b/applications/tari_swarm_daemon/webui/src/state/SwarmProvider.tsx
@@ -37,29 +37,24 @@ async function settle<T>(work: Promise<T>, fallback: T): Promise<T> {
 }
 
 /** Groups log files by the instance whose base path contains them. */
+/**
+ * Buckets log files by the instance id the daemon reported for each one.
+ *
+ * Instances do not have distinct directories: the wallet daemon and the key-creating run that seeds it share
+ * `wallet-daemon-00`, so deducing the owner from the path handed both instances' files to whichever matched
+ * first and left the other showing nothing.
+ */
 function assignToInstances(
-  instances: Instance[],
   logFiles: LogFile[],
   stdoutFiles: StdoutFile[],
 ): Record<number, InstanceLogs> {
   const byInstance: Record<number, InstanceLogs> = {};
-  // Longest base path first so a nested instance directory wins over its parent.
-  const ordered = [...instances].sort((a, b) => b.base_path.length - a.base_path.length);
-  const owner = (path: string) => ordered.find((i) => path.startsWith(i.base_path));
 
   for (const file of logFiles) {
-    const instance = owner(file[0]);
-    if (!instance) {
-      continue;
-    }
-    (byInstance[instance.id] ??= { logs: [], stdout: [] }).logs.push(file);
+    (byInstance[file[3]] ??= { logs: [], stdout: [] }).logs.push(file);
   }
   for (const file of stdoutFiles) {
-    const instance = owner(file[0]);
-    if (!instance) {
-      continue;
-    }
-    (byInstance[instance.id] ??= { logs: [], stdout: [] }).stdout.push(file);
+    (byInstance[file[2]] ??= { logs: [], stdout: [] }).stdout.push(file);
   }
   return byInstance;
 }
@@ -176,7 +171,6 @@ export function SwarmProvider({ children }: { children: ReactNode }) {
     );
     setLogs(
       assignToInstances(
-        allInstances.instances,
         logResults.flatMap(([l]) => l),
         logResults.flatMap(([, s]) => s),
       ),

--- a/applications/tari_swarm_daemon/webui/src/types.ts
+++ b/applications/tari_swarm_daemon/webui/src/types.ts
@@ -48,9 +48,11 @@ export interface Indexer {
 }
 
 /** (full path, instance name, path without extension) */
-export type LogFile = [string, string, string];
+/** [full path, instance name, path without extension, instance id] */
+export type LogFile = [string, string, string, number];
 /** (full path, "stdout") */
-export type StdoutFile = [string, string];
+/** [full path, stream name, instance id] */
+export type StdoutFile = [string, string, number];
 
 export interface ShardGroup {
   start: number;


### PR DESCRIPTION
Two problems reported against the log view merged in #2542.

## 1. "No log files yet" on an instance that has logs

`Wallet Daemon-#00` showed no logs while `ootle.log` and `json_rpc.log` were sitting in its directory. The RPC was returning them correctly — the UI was losing them.

`assignToInstances` worked out the owner of each file by longest-matching `base_path` prefix. That assumes instances have distinct directories, and two of them do not:

```
id  0  Wallet Daemon Create Key-#00  →  …/processes/wallet-daemon-00/localnet
id 11  Wallet Daemon-#00             →  …/processes/wallet-daemon-00/localnet
```

The key-creating run is pointed at the wallet daemon's own directory by `with_base_path_override("wallet-daemon-00")`. Equal-length prefixes, stable sort, so the create-key instance matched first and took all six files; the real card got none. This predates #2542 for `get_logs`, but that PR made `get_stdout` return files for the first time, so it now affects those too.

Fixed at the source: `get_logs` and `get_stdout` report the owning `InstanceId` with each file, and the UI buckets on the id instead of guessing from the path.

## 2. Scrolling down empties the view

The buffer was capped with `chunks.slice(-MAX_CHUNKS)` — drop the newest chunks as you page backwards. That assumes every chunk contributes something to render. It often does not: `DEBUG` and `TRACE` are hidden by default, and a node log can run for megabytes without a line above `DEBUG`.

Probing the reported file through the daemon, every single 256 KB window is 100% `DEBUG`:

```
chunk 0: [8900451, 9162583) of 9162583 | 1435 lines | visible with default filters: 0
chunk 1: [8638325, 8900451) of 9162583 | 1435 lines | visible with default filters: 0
…nine more, all identical
```

So nothing renders, the effect that loads more when the view is too short to scroll fires again, and each load evicts a newer chunk — until the one chunk the reader could actually see has been thrown away and the view is blank, with the scan continuing to the start of the file.

Two changes:

- `trimBuffer` drops newest-first as before, but stops before it would leave nothing rendered. A run of fully-hidden chunks no longer evicts the chunk the reader is looking at.
- The scan gives up after `MAX_SCAN_CHUNKS` (8 MB) rather than walking the whole file, and the empty state now says how much was scanned and how many entries the filters are hiding, so a blank view explains itself instead of just being blank.

`trimBuffer`, the chunk type and the size constants moved to `logBuffer.ts` — LogView.tsx was carrying policy that is worth testing on its own.

## Verification

Replayed the load/trim loop against the reported 9 MB log through the running daemon, default filters, old policy vs new:

```
BEFORE (slice(-MAX_CHUNKS))
  loads=36 chunks=6 visibleEntries=0 renderedLines=0
  went blank after having content: yes, at load 32
AFTER  (trimBuffer)
  loads=36 chunks=11 visibleEntries=56 renderedLines=56
  went blank after having content: no
```

Instance attribution checked against the live daemon: `get_logs` for `TariWalletDaemon` returns six files across ids 11/12/13, which now land on the three wallet daemon cards rather than collapsing onto id 0.

21 Rust unit tests pass; `cargo lints clippy --all-targets --all-features`, `tsc --noEmit`, `eslint --max-warnings 0` and `vite build` are all clean.

Not exercised in a browser — no extension connected here — so the scroll behaviour is worth a quick manual pass.

