### PR TITLE
refactor(bor)!: make encoded_len infallible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11205,7 +11205,7 @@ dependencies = [
 
 [[package]]
 name = "tari_bor"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "borsh",
  "indexmap 2.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,7 +145,7 @@ tari_template_lib = { version = "0.32", path = "crates/template_lib" }
 tari_template_lib_types = { version = "0.32", path = "crates/template_lib_types", default-features = false }
 tari_template_abi = { version = "0.20", path = "crates/template_abi", default-features = false }
 tari_template_macros = { version = "0.23", path = "crates/template_macros" }
-tari_bor = { version = "0.15.1", path = "crates/tari_bor", default-features = false }
+tari_bor = { version = "0.16.0", path = "crates/tari_bor", default-features = false }
 
 ootle_byte_type = { path = "crates/ootle_byte_type", version = "0.13" }
 ootle_serde = { path = "crates/ootle_serde", version = "0.5", default-features = false }

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -248,7 +248,7 @@ impl<TStore: StateReader> WorkingState<TStore> {
         if value.published_template().is_some() {
             return Ok(());
         }
-        let size = encoded_len(value)?;
+        let size = encoded_len(value);
         if size > limits::ENGINE_LIMITS.max_substate_size {
             return Err(LimitError::SubstateSizeExceeded { size }.into());
         }

--- a/crates/engine/src/wasm/process.rs
+++ b/crates/engine/src/wasm/process.rs
@@ -419,7 +419,7 @@ impl WasmProcess {
         sample.handler_ns = span.finish();
 
         let span = abi_metrics::Span::start();
-        let len = encoded_len(&resp)?;
+        let len = encoded_len(&resp);
         sample.encode_ns = span.finish();
         sample.resp_bytes = len;
 

--- a/crates/engine/tests/templates/abi_probe/src/lib.rs
+++ b/crates/engine/tests/templates/abi_probe/src/lib.rs
@@ -94,7 +94,7 @@ mod abi_probe {
             match strategy {
                 0 => {
                     for _ in 0..n {
-                        let len = tari_bor::encoded_len(&arg).unwrap();
+                        let len = tari_bor::encoded_len(&arg);
                         let mut buf = Vec::with_capacity(len);
                         tari_bor::encode_into_writer(&arg, &mut buf).unwrap();
                         acc = acc.wrapping_add(core::hint::black_box(&buf).len() as u32);

--- a/crates/tari_bor/Cargo.toml
+++ b/crates/tari_bor/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_bor"
 description = "The binary object representation (BOR) crate provides a binary encoding for template/engine data types"
-version = "0.15.1"
+version = "0.16.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/tari_bor/src/lib.rs
+++ b/crates/tari_bor/src/lib.rs
@@ -93,15 +93,16 @@ where
 /// the type structure. The fallback path through [`ByteCounter`] is still available for
 /// types that haven't derived `CborLen` yet (see [`encoded_len_via_writer`]).
 ///
-/// The `Result` return type is preserved for API compatibility — this function cannot
-/// actually fail today.
-pub fn encoded_len<T: CborLen<()> + ?Sized>(val: &T) -> Result<usize, BorError> {
+/// Infallible: the length follows from the type structure, so there is nothing to fail and no
+/// failure is invented. That matters because callers size allocations from this — a stand-in value
+/// for "unknown length" is either small enough to truncate or large enough to abort.
+pub fn encoded_len<T: CborLen<()> + ?Sized>(val: &T) -> usize {
     encoded_len_with(val, &mut ())
 }
 
 /// Pre-calculate the encoded length in bytes via [`minicbor::CborLen`] using a user-provided context.
-pub fn encoded_len_with<C, T: CborLen<C> + ?Sized>(val: &T, ctx: &mut C) -> Result<usize, BorError> {
-    Ok(minicbor::len_with(val, ctx))
+pub fn encoded_len_with<C, T: CborLen<C> + ?Sized>(val: &T, ctx: &mut C) -> usize {
+    minicbor::len_with(val, ctx)
 }
 
 /// Pre-calculate the encoded length in bytes (unit context), returning an error if it exceeds `limit`.

--- a/crates/tari_bor/src/raw.rs
+++ b/crates/tari_bor/src/raw.rs
@@ -210,6 +210,6 @@ mod tests {
     #[test]
     fn cbor_len_matches_the_encoding() {
         let raw = RawCbor::from_encodable(&vec![0u8; 300]).unwrap();
-        assert_eq!(crate::encoded_len(&raw).unwrap(), raw.as_bytes().len());
+        assert_eq!(crate::encoded_len(&raw), raw.as_bytes().len());
     }
 }

--- a/crates/template_abi/src/abi/mod.rs
+++ b/crates/template_abi/src/abi/mod.rs
@@ -59,7 +59,7 @@ where
     T: Encode<()> + CborLen<()> + ?Sized,
     U: for<'b> Decode<'b, ()>,
 {
-    let len = encoded_len(&input).unwrap();
+    let len = encoded_len(&input);
     let mut encoded_input = Vec::with_capacity(len);
     encode_into_writer(input, &mut encoded_input).unwrap();
     let len = encoded_input.len();
@@ -122,7 +122,7 @@ impl OwnedData {
 /// Allocates a length-prefixed block of memory containing the encoded value and returns a pointer to that value.
 /// This memory should be freed using `tari_free`.
 pub fn alloc_and_encode<T: Encode<()> + CborLen<()> + ?Sized>(val: &T) -> *mut u8 {
-    let len = encoded_len(val).expect("ENCDLENFAIL");
+    let len = encoded_len(val);
     let ptr = internal_alloc(len);
     let mut buf = unsafe { Vec::from_raw_parts(ptr, 0, len) };
     encode_into_writer(val, &mut buf).expect("ENCDFAIL");

--- a/crates/template_abi/src/call_info.rs
+++ b/crates/template_abi/src/call_info.rs
@@ -36,10 +36,7 @@ pub struct CallInfo;
 impl CallInfo {
     #[cfg(feature = "std")]
     pub fn encode_v1_packed_size(args: &[tari_bor::Value]) -> Result<usize, tari_bor::BorError> {
-        let total_args_len = args
-            .iter()
-            .map(|a| tari_bor::encoded_len(&a))
-            .sum::<Result<usize, tari_bor::BorError>>()?;
+        let total_args_len = args.iter().map(|a| tari_bor::encoded_len(&a)).sum::<usize>();
         let total_len = CallHeader::SIZE + total_args_len + args.len() * size_of::<u32>();
         Ok(total_len)
     }
@@ -61,7 +58,6 @@ impl CallInfo {
         let args_lens = args.iter().map(|a| tari_bor::encoded_len(&a));
         // Args
         for (arg, len) in args.iter().zip(args_lens) {
-            let len = len?;
             let arg_len =
                 u32::try_from(len).map_err(|_| tari_bor::BorError::new("Argument length exceeds u32".to_string()))?;
             writer

--- a/crates/template_abi/src/template_def.rs
+++ b/crates/template_abi/src/template_def.rs
@@ -53,7 +53,7 @@ impl TemplateDef {
         use tari_bor::{encode_into_writer, encoded_len};
 
         use crate::WASM_PTR_SIZE;
-        let data_len = encoded_len(self)?;
+        let data_len = encoded_len(self);
         // for the length prefix
         let mut buf = Vec::with_capacity(data_len + WASM_PTR_SIZE);
         let full_len = data_len + WASM_PTR_SIZE;

--- a/crates/transaction/src/transaction.rs
+++ b/crates/transaction/src/transaction.rs
@@ -97,11 +97,7 @@ impl Transaction {
     ///
     /// Computed from the derived `CborLen` rather than by encoding, so nothing is allocated.
     pub fn encoded_size(&self) -> usize {
-        // `encoded_len`'s `Result` is vestigial — it cannot fail for a type deriving `CborLen`. The
-        // fallback is therefore unreachable, which makes its direction free: this figure is read to
-        // decide whether a transaction is under a size cap, so an unknown size must be one that
-        // fails the check rather than one that passes it.
-        tari_bor::encoded_len(self).unwrap_or(usize::MAX)
+        tari_bor::encoded_len(self)
     }
 
     pub fn is_dry_run(&self) -> bool {

--- a/crates/transaction/src/v1/transaction.rs
+++ b/crates/transaction/src/v1/transaction.rs
@@ -375,7 +375,7 @@ fn calc_stealth_statement_weight(statement: &StealthTransferStatement) -> u64 {
         .inputs_statement
         .inputs
         .iter()
-        .map(|i| tari_bor::encoded_len(&i.witness).unwrap_or(0) as u64)
+        .map(|i| tari_bor::encoded_len(&i.witness) as u64)
         .sum();
 
     // Fixed cost of a transfer (resource lock, balance-proof verification, basic validation).


### PR DESCRIPTION
Follow-up to #2540, on a point Stan raised after merge.

## The problem

`Transaction::encoded_size` resolved an unmeasurable size to `usize::MAX`, chosen so a size cap would reject rather than admit it. That only holds while every caller is a comparison — a caller sizing an allocation from the same value aborts the process. The opposite sentinel (`0`) silently passes the cap instead. No number is right for both.

That is a symptom. The cause is `tari_bor::encoded_len`, whose signature says it can fail when it cannot:

```rust
pub fn encoded_len_with<C, T: CborLen<C> + ?Sized>(val: &T, ctx: &mut C) -> Result<usize, BorError> {
    Ok(minicbor::len_with(val, ctx))   // unconditionally Ok
}
```

The `CborLen` bound is already enforced at compile time, so the length always exists. The `Result` was kept for API compatibility and against minicbor changing.

## Why it is worth the breaking change

Every call site resolves the impossible branch its own way — `?`, `unwrap`, `expect("ENCDLENFAIL")`, `unwrap_or(0)` — and `fee_estimate.rs:171` gave up and defined a private infallible shadow with the same name. Two of them size allocations from it:

```rust
let len = encoded_len(val).expect("ENCDLENFAIL");   // template_abi/src/abi/mod.rs:125
let ptr = internal_alloc(len);
let len = encoded_len(&input).unwrap();             // template_abi/src/abi/mod.rs:62
let mut encoded_input = Vec::with_capacity(len);
```

So the hazard behind the original review comment is real and already present in the codebase — it just has not fired, because the branch cannot be taken.

It also removes a **fail-open**: `calc_stealth_statement_weight` summed `encoded_len(..).unwrap_or(0)` over witness bytes, so an error there would have undercharged a transaction's weight at ingress rather than rejecting it. Same class of bug as the one that started this, in the opposite direction.

## What changed

`encoded_len` and `encoded_len_with` return `usize`. Callers lose a `?`, an `unwrap`, an `expect` or an `unwrap_or` each. **Behaviour is unchanged** — the branch that is gone could not be taken.

Kept fallible, because they genuinely are:
- `encoded_len_with_limit*` — errors when the length exceeds its limit
- `encoded_len_via_writer` — drives a real encoder

`Transaction::encoded_size` is back to returning `usize`, with no sentinel and no unwrap.

## Versioning

`tari_bor` 0.15.1 → 0.16.0, and the workspace pin with it. The rest of the cascade from `scripts/crate_versioning.py impact tari_bor --breaking` — workspace rollup to 0.42.0 plus 18 dependent bumps — is a release step and deliberately **not** in this PR: it touches every crate's version and would collide with anything else in flight. Worth doing before the next publish, not before this merge.

## Verification

```
cargo lints clippy -p tari_bor -p tari_template_abi -p tari_ootle_transaction -p tari_engine \
  -p tari_engine_types -p tari_ootle_transaction_validation -p tari_consensus -p tari_template_lib \
  -p tari_validator_node -p tari_indexer -p tari_ootle_walletd -p ootle_serde \
  -p tari_ootle_wallet_sdk -p tari_ootle_template_metadata -p tari_template_lib_types \
  -p tari_indexer_client --all-targets      # clean
cargo test -p tari_bor -p tari_template_abi -p tari_ootle_transaction \
  -p tari_ootle_transaction_validation -p tari_consensus --lib     # 58 + 17 + 20 + 43 + 63 pass
```

Not verified: the WASM guest side. `template_abi` is compiled into templates, and while the change is signature-only, nothing here has run a template end-to-end — `abi_probe`'s call site is migrated but the integration suite is CI's.