### PR TITLE
fix(state_sync): serve state from the current committee, validate against the previous

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12533,6 +12533,7 @@ dependencies = [
  "futures 0.3.31",
  "log",
  "ootle-network",
+ "rand 0.10.1",
  "tari_consensus",
  "tari_consensus_types",
  "tari_epoch_manager",

--- a/applications/tari_indexer/src/network_state_sync/worker.rs
+++ b/applications/tari_indexer/src/network_state_sync/worker.rs
@@ -352,6 +352,7 @@ impl NetworkWideStateSync {
                         .get_checkpoints(rpc::GetCheckpointsRequest {
                             from_epoch: Some(from_epoch.into()),
                             num_to_return: 100,
+                            shard_group: None,
                         })
                         .await?;
 

--- a/applications/tari_validator_node/src/p2p/rpc/rpc_impl.rs
+++ b/applications/tari_validator_node/src/p2p/rpc/rpc_impl.rs
@@ -567,6 +567,24 @@ impl<TStateStore: StateStore + Clone + Send + Sync + 'static> ValidatorNodeRpcSe
             )));
         }
 
+        if let Some(shard_group) = msg.shard_group {
+            let shard_group = ShardGroup::decode_from_u32(shard_group)
+                .ok_or_else(|| RpcStatus::bad_request(format!("Invalid shard group {shard_group}")))?;
+            let checkpoint = self
+                .state_store
+                .with_read_tx(|tx| EpochCheckpoint::get_by_shard_group(tx, from_epoch, shard_group))
+                .optional()
+                .map_err(RpcStatus::log_internal_error(LOG_TARGET))?
+                .ok_or_else(|| {
+                    RpcStatus::not_found(format!(
+                        "No checkpoint for epoch {from_epoch} shard group {shard_group}"
+                    ))
+                })?;
+            return Ok(Response::new(GetCheckpointsResponse {
+                checkpoints: vec![checkpoint.into()],
+            }));
+        }
+
         if msg.num_to_return > 100 {
             return Err(RpcStatus::bad_request("num_to_return must be less than 100"));
         }

--- a/crates/p2p/proto/rpc.proto
+++ b/crates/p2p/proto/rpc.proto
@@ -213,6 +213,8 @@ message QuorumCertificates {
 message GetCheckpointsRequest {
   tari.ootle.common.Epoch from_epoch = 1;
   uint32 num_to_return = 2;
+  // When set, returns only the checkpoint for this shard group at from_epoch.
+  optional uint32 shard_group = 3;
 }
 
 message GetCheckpointsResponse {

--- a/crates/rpc_state_sync/Cargo.toml
+++ b/crates/rpc_state_sync/Cargo.toml
@@ -23,4 +23,5 @@ tari_validator_node_rpc = { workspace = true }
 anyhow = { workspace = true }
 futures = { workspace = true }
 log = { workspace = true }
+rand = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/rpc_state_sync/src/error.rs
+++ b/crates/rpc_state_sync/src/error.rs
@@ -26,8 +26,8 @@ pub enum RpcStateSyncError {
     InvalidResponse(anyhow::Error),
     #[error("Block {block_id} failed SafeNode predicate")]
     BlockNotSafe { block_id: BlockId },
-    #[error("Failed to sync from all peers. The committee size is {committee_size}")]
-    SyncFailedAllPeers { committee_size: usize },
+    #[error("Failed to sync from all {num_peers} peer(s)")]
+    SyncFailedAllPeers { num_peers: usize },
     #[error("Proposal validation error: {0}")]
     ProposalValidationError(#[from] ProposalValidationError),
     #[error("State tree error: {0}")]

--- a/crates/rpc_state_sync/src/state_sync.rs
+++ b/crates/rpc_state_sync/src/state_sync.rs
@@ -147,8 +147,8 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
         };
 
         let num_returned = checkpoints.len();
-        // Most of the batch is checkpoints we did not ask for, so a malformed entry only disqualifies itself;
-        // the one we select is still checked against the signing committee's quorum.
+        // The batch can include checkpoints for other shard groups and later epochs, so a malformed entry
+        // only disqualifies itself; the one we select is still checked against the signing committee's quorum.
         for checkpoint in checkpoints {
             let checkpoint = match EpochCheckpoint::try_from(checkpoint) {
                 Ok(cp) => cp,

--- a/crates/rpc_state_sync/src/state_sync.rs
+++ b/crates/rpc_state_sync/src/state_sync.rs
@@ -21,7 +21,7 @@ use tari_ootle_common_types::{
     ShardGroup,
     VersionedSubstateId,
     VotePower,
-    committee::Committee,
+    committee::{Committee, CommitteeMember},
     optional::Optional,
     shard::Shard,
 };
@@ -448,11 +448,11 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
         Ok(())
     }
 
-    async fn get_sync_committees(
+    async fn get_sync_sources(
         &self,
         local_shard_group: ShardGroup,
         current_epoch: Epoch,
-    ) -> Result<HashMap<ShardGroup, Committee<PeerAddress>>, RpcStateSyncError> {
+    ) -> Result<HashMap<ShardGroup, SyncSource>, RpcStateSyncError> {
         // We are behind at least one epoch.
         // We get the current substate range, and we ask committees from previous epoch in this range to give us
         // data.
@@ -461,18 +461,27 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
             .ok_or_else(|| RpcStateSyncError::NoCommittees(Epoch::zero()))?;
         info!(target: LOG_TARGET,"Previous epoch is {}", prev_epoch);
         // We want to get any committees from the previous epoch that overlap with our shard group in this epoch
-        let committees = self
+        let prev_committees = self
             .epoch_manager
             .get_committees_overlapping_shard_group(prev_epoch, local_shard_group)
             .await?;
 
-        if committees.is_empty() {
+        if prev_committees.is_empty() {
             return Err(RpcStateSyncError::NoCommittees(prev_epoch));
         }
 
-        let committees = committees.into_iter().collect::<HashMap<_, _>>();
-        info!(target: LOG_TARGET, "🛜 Querying {} committee(s) from epoch {}", committees.len(), prev_epoch);
-        Ok(committees)
+        let mut sources = HashMap::with_capacity(prev_committees.len());
+        for (shard_group, signing_committee) in prev_committees {
+            let current_members = self
+                .epoch_manager
+                .get_committees_overlapping_shard_group(current_epoch, shard_group)
+                .await?
+                .into_values()
+                .collect::<Committee<_>>();
+            sources.insert(shard_group, SyncSource::new(signing_committee, &current_members));
+        }
+        info!(target: LOG_TARGET, "🛜 Querying {} committee(s) from epoch {}", sources.len(), prev_epoch);
+        Ok(sources)
     }
 
     fn validate_checkpoint(
@@ -521,7 +530,7 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
         shard: Shard,
         shard_group: ShardGroup,
         epoch: Epoch,
-        prev_committee: &Committee<PeerAddress>,
+        source: &SyncSource,
         our_vn_addr: &PeerAddress,
     ) -> Result<Option<Version>, RpcStateSyncError> {
         let prev_epoch = epoch
@@ -532,7 +541,7 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
         let mut last_hard_error = None;
         let mut saw_unavailable_checkpoint = false;
 
-        for member in prev_committee.shuffled() {
+        for member in &source.serving_peers {
             if *our_vn_addr == member.address {
                 continue;
             }
@@ -550,7 +559,7 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
 
             // fetch checkpoint
             let checkpoint = match self
-                .get_or_fetch_valid_epoch_checkpoint(&mut client, shard_group, prev_committee, prev_epoch)
+                .get_or_fetch_valid_epoch_checkpoint(&mut client, shard_group, &source.signing_committee, prev_epoch)
                 .await
             {
                 Ok(Some(cp)) => cp,
@@ -614,7 +623,7 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
         }
 
         Err(RpcStateSyncError::SyncFailedAllPeers {
-            committee_size: prev_committee.len(),
+            committee_size: source.serving_peers.len(),
         })
     }
 
@@ -622,23 +631,17 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
         &mut self,
         current_epoch: Epoch,
         shard_group: ShardGroup,
-        prev_committees: &HashMap<ShardGroup, Committee<PeerAddress>>,
+        sources: &HashMap<ShardGroup, SyncSource>,
         our_vn_address: &PeerAddress,
     ) -> Result<Option<Version>, RpcStateSyncError> {
         let mut last_error = None;
 
-        for (sg, prev_committee) in prev_committees {
+        for (sg, source) in sources {
             // TODO: any checkpoint for the previous epoch will justify the global shard sync.
             //       Currently we'll fetch the checkpoint again even if we already have it if there are more than one
             // shard groups.
             let result = self
-                .sync_shard(
-                    Shard::global(),
-                    shard_group,
-                    current_epoch,
-                    prev_committee,
-                    our_vn_address,
-                )
+                .sync_shard(Shard::global(), shard_group, current_epoch, source, our_vn_address)
                 .await;
             match result {
                 Ok(maybe_version) => {
@@ -664,7 +667,7 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
         }
 
         Err(RpcStateSyncError::SyncFailedAllPeers {
-            committee_size: prev_committees.len(),
+            committee_size: sources.len(),
         })
     }
 
@@ -684,8 +687,8 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
         };
         let our_vn = self.epoch_manager.get_our_validator_node(current_epoch).await?;
         let local_info = self.epoch_manager.get_local_committee_info(current_epoch).await?;
-        let prev_epoch_committees = match self.get_sync_committees(local_info.shard_group(), current_epoch).await {
-            Ok(committees) => committees,
+        let sync_sources = match self.get_sync_sources(local_info.shard_group(), current_epoch).await {
+            Ok(sources) => sources,
             Err(RpcStateSyncError::NoCommittees(prev_epoch)) => {
                 info!(target: LOG_TARGET, "No committees for the previous epoch {prev_epoch}. This is the first committee.");
                 return Ok(());
@@ -694,9 +697,13 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
         };
 
         // Edge case: we're the only VN in a previous committee
-        if prev_epoch_committees.len() == 1 &&
-            prev_epoch_committees.values().all(|committee| {
-                committee.len() == 1 && committee.address_iter().all(|addr| *addr == our_vn.address)
+        if sync_sources.len() == 1 &&
+            sync_sources.values().all(|source| {
+                source.signing_committee.len() == 1 &&
+                    source
+                        .signing_committee
+                        .address_iter()
+                        .all(|addr| *addr == our_vn.address)
             })
         {
             info!(target: LOG_TARGET, "This node is the only Validator in the previous committee - no need to sync.");
@@ -708,14 +715,14 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
         self.sync_global_shard(
             current_epoch,
             ShardGroup::all_shards(local_info.num_preshards()),
-            &prev_epoch_committees,
+            &sync_sources,
             &our_vn.address,
         )
         .await?;
 
         // Sync data from each committee in range of the committee we're joining.
         // NOTE: we don't have to worry about substates in address range because shard boundaries are fixed.
-        for (shard_group, committee) in prev_epoch_committees {
+        for (shard_group, source) in sync_sources {
             let Some(intersect_shard_group) = shard_group.intersection(&local_shard_group) else {
                 warn!(
                     target: LOG_TARGET,
@@ -724,13 +731,57 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
                 continue;
             };
             for shard in intersect_shard_group.shard_iter() {
-                self.sync_shard(shard, shard_group, current_epoch, &committee, &our_vn.address)
+                self.sync_shard(shard, shard_group, current_epoch, &source, &our_vn.address)
                     .await?;
             }
         }
 
         self.stats.total_time = timer.elapsed();
         Ok(())
+    }
+}
+
+/// Where to sync one shard group's state from. Checkpoint validity depends only on the quorum signatures of
+/// the committee that produced it, so who serves the bytes is chosen for availability rather than trust.
+struct SyncSource {
+    /// The previous epoch's committee for the shard group. Its quorum threshold and voting powers are the
+    /// only thing a fetched checkpoint is validated against.
+    signing_committee: Committee<PeerAddress>,
+    /// Peers to request the checkpoint and state from, in order of preference. Current-epoch members are
+    /// running consensus and hold the previous epoch's state (either as continuing members or because
+    /// they synced it from the same checkpoint), so they come first; members that left at the epoch
+    /// boundary are the fallback.
+    serving_peers: Vec<CommitteeMember<PeerAddress>>,
+}
+
+impl SyncSource {
+    fn new(signing_committee: Committee<PeerAddress>, current_members: &Committee<PeerAddress>) -> Self {
+        let continuing = current_members
+            .iter()
+            .filter(|m| signing_committee.contains(&m.address))
+            .cloned()
+            .collect::<Committee<_>>();
+        let joined = current_members
+            .iter()
+            .filter(|m| !signing_committee.contains(&m.address))
+            .cloned()
+            .collect::<Committee<_>>();
+        let departed = signing_committee
+            .iter()
+            .filter(|m| !current_members.contains(&m.address))
+            .cloned()
+            .collect::<Committee<_>>();
+
+        // Shuffling within each tier spreads load across equally preferred peers.
+        let serving_peers = [continuing, joined, departed]
+            .iter()
+            .flat_map(|tier| tier.shuffled().cloned().collect::<Vec<_>>())
+            .collect();
+
+        Self {
+            signing_committee,
+            serving_peers,
+        }
     }
 }
 

--- a/crates/rpc_state_sync/src/state_sync.rs
+++ b/crates/rpc_state_sync/src/state_sync.rs
@@ -146,14 +146,28 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
             Err(err) => return Err(err.into()),
         };
 
+        let num_returned = checkpoints.len();
+        // Most of the batch is checkpoints we did not ask for, so a malformed entry only disqualifies itself;
+        // the one we select is still checked against the signing committee's quorum.
         for checkpoint in checkpoints {
-            let checkpoint = EpochCheckpoint::try_from(checkpoint).map_err(RpcStateSyncError::InvalidResponse)?;
-            let shard_group = checkpoint.checked_shard_group().map_err(|err| {
-                RpcStateSyncError::InvalidResponse(anyhow!(
-                    "Fetched checkpoint for epoch {} has invalid shard group: {err}",
-                    checkpoint.epoch()
-                ))
-            })?;
+            let checkpoint = match EpochCheckpoint::try_from(checkpoint) {
+                Ok(cp) => cp,
+                Err(err) => {
+                    warn!(target: LOG_TARGET, "Skipping undecodable checkpoint in batch: {err}");
+                    continue;
+                },
+            };
+            let shard_group = match checkpoint.checked_shard_group() {
+                Ok(sg) => sg,
+                Err(err) => {
+                    warn!(
+                        target: LOG_TARGET,
+                        "Skipping checkpoint for epoch {} with invalid shard group: {err}",
+                        checkpoint.epoch()
+                    );
+                    continue;
+                },
+            };
             if checkpoint.epoch() != prev_epoch || shard_group != for_shard_group {
                 continue;
             }
@@ -161,6 +175,14 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
             self.validate_checkpoint(&checkpoint, prev_committee, prev_epoch)?;
             self.state_store.with_write_tx(|tx| checkpoint.save(tx))?;
             return Ok(Some(checkpoint));
+        }
+
+        if num_returned >= MAX_CHECKPOINTS_PER_REQUEST as usize {
+            warn!(
+                target: LOG_TARGET,
+                "Peer returned {num_returned} checkpoints without one for epoch {prev_epoch} shard group \
+                 {for_shard_group}; the batch may have been truncated at MAX_CHECKPOINTS_PER_REQUEST"
+            );
         }
 
         Ok(None)

--- a/crates/rpc_state_sync/src/state_sync.rs
+++ b/crates/rpc_state_sync/src/state_sync.rs
@@ -10,6 +10,7 @@ use anyhow::anyhow;
 use futures::StreamExt;
 use log::*;
 use ootle_network::Network;
+use rand::seq::SliceRandom;
 use tari_consensus::{
     check_quorum_certificate_signatures,
     traits::{ConsensusSpec, SyncManager, SyncStatus},
@@ -64,6 +65,10 @@ use tari_validator_node_rpc::{
 
 use crate::{error::RpcStateSyncError, stats::StateSyncStats};
 
+/// Upper bound on checkpoints requested per peer. A peer stores one checkpoint per shard group it synced from
+/// in an epoch, so this only needs to cover the previous epoch's committee count.
+const MAX_CHECKPOINTS_PER_REQUEST: u32 = 32;
+
 const LOG_TARGET: &str = "tari::ootle::rpc_state_sync";
 
 pub struct RpcStateSyncClientProtocol<TConsensusSpec: ConsensusSpec> {
@@ -72,7 +77,6 @@ pub struct RpcStateSyncClientProtocol<TConsensusSpec: ConsensusSpec> {
     state_store: TConsensusSpec::StateStore,
     client_factory: TariValidatorNodeRpcClientFactory,
     signer_service: TConsensusSpec::SignerService,
-    valid_checkpoints: HashMap<ShardGroup, EpochCheckpoint>,
     stats: StateSyncStats,
     skip_sync: bool,
 }
@@ -93,7 +97,6 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
             state_store,
             client_factory,
             signer_service,
-            valid_checkpoints: HashMap::new(),
             stats: StateSyncStats::default(),
             skip_sync: false,
         }
@@ -129,35 +132,38 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
 
         self.stats.total_requests += 1;
 
-        match client
+        // A peer holds one checkpoint per shard group it synced from at prev_epoch, and the request has no
+        // shard-group selector, so fetch a batch and pick the one for the requested group.
+        let checkpoints = match client
             .get_checkpoints(GetCheckpointsRequest {
                 from_epoch: Some(prev_epoch.into()),
-                num_to_return: 1,
+                num_to_return: MAX_CHECKPOINTS_PER_REQUEST,
             })
             .await
         {
-            Ok(GetCheckpointsResponse { checkpoints }) if checkpoints.is_empty() => Ok(None),
-            Ok(GetCheckpointsResponse { mut checkpoints }) => {
-                match EpochCheckpoint::try_from(checkpoints.pop().expect("checked is_empty")) {
-                    Ok(checkpoint) => {
-                        checkpoint.checked_shard_group().map_err(|err| {
-                            RpcStateSyncError::InvalidResponse(anyhow!(
-                                "Fetched checkpoint for epoch {} has invalid shard group: {err}",
-                                checkpoint.epoch()
-                            ))
-                        })?;
-                        info!(target: LOG_TARGET, "🛜 Checkpoint: {checkpoint}");
-                        self.validate_checkpoint(&checkpoint, prev_committee, prev_epoch)?;
-                        self.state_store.with_write_tx(|tx| checkpoint.save(tx))?;
-                        self.valid_checkpoints.insert(for_shard_group, checkpoint.clone());
-                        Ok(Some(checkpoint))
-                    },
-                    Err(err) => Err(RpcStateSyncError::InvalidResponse(err)),
-                }
-            },
-            Err(RpcError::RequestFailed(err)) if err.is_not_found() => Ok(None),
-            Err(err) => Err(err.into()),
+            Ok(GetCheckpointsResponse { checkpoints }) => checkpoints,
+            Err(RpcError::RequestFailed(err)) if err.is_not_found() => return Ok(None),
+            Err(err) => return Err(err.into()),
+        };
+
+        for checkpoint in checkpoints {
+            let checkpoint = EpochCheckpoint::try_from(checkpoint).map_err(RpcStateSyncError::InvalidResponse)?;
+            let shard_group = checkpoint.checked_shard_group().map_err(|err| {
+                RpcStateSyncError::InvalidResponse(anyhow!(
+                    "Fetched checkpoint for epoch {} has invalid shard group: {err}",
+                    checkpoint.epoch()
+                ))
+            })?;
+            if checkpoint.epoch() != prev_epoch || shard_group != for_shard_group {
+                continue;
+            }
+            info!(target: LOG_TARGET, "🛜 Checkpoint: {checkpoint}");
+            self.validate_checkpoint(&checkpoint, prev_committee, prev_epoch)?;
+            self.state_store.with_write_tx(|tx| checkpoint.save(tx))?;
+            return Ok(Some(checkpoint));
         }
+
+        Ok(None)
     }
 
     #[allow(clippy::too_many_lines)]
@@ -452,6 +458,7 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
         &self,
         local_shard_group: ShardGroup,
         current_epoch: Epoch,
+        our_vn_addr: &PeerAddress,
     ) -> Result<HashMap<ShardGroup, SyncSource>, RpcStateSyncError> {
         // We are behind at least one epoch.
         // We get the current substate range, and we ask committees from previous epoch in this range to give us
@@ -470,16 +477,19 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
             return Err(RpcStateSyncError::NoCommittees(prev_epoch));
         }
 
-        let mut sources = HashMap::with_capacity(prev_committees.len());
-        for (shard_group, signing_committee) in prev_committees {
-            let current_members = self
-                .epoch_manager
-                .get_committees_overlapping_shard_group(current_epoch, shard_group)
-                .await?
-                .into_values()
-                .collect::<Committee<_>>();
-            sources.insert(shard_group, SyncSource::new(signing_committee, &current_members));
-        }
+        // Every shard this sync requests lies in local_shard_group, and every member of our current committee
+        // holds the previous epoch's state for exactly that range. After a split, members of other current
+        // committees hold only their own sub-range of the previous shard group.
+        let local_committee = self.epoch_manager.get_local_committee(current_epoch).await?;
+        let sources = prev_committees
+            .into_iter()
+            .map(|(shard_group, signing_committee)| {
+                (
+                    shard_group,
+                    SyncSource::new(signing_committee, &local_committee, our_vn_addr),
+                )
+            })
+            .collect::<HashMap<_, _>>();
         info!(target: LOG_TARGET, "🛜 Querying {} committee(s) from epoch {}", sources.len(), prev_epoch);
         Ok(sources)
     }
@@ -531,7 +541,6 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
         shard_group: ShardGroup,
         epoch: Epoch,
         source: &SyncSource,
-        our_vn_addr: &PeerAddress,
     ) -> Result<Option<Version>, RpcStateSyncError> {
         let prev_epoch = epoch
             .checked_sub(Epoch(1))
@@ -542,9 +551,6 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
         let mut saw_unavailable_checkpoint = false;
 
         for member in &source.serving_peers {
-            if *our_vn_addr == member.address {
-                continue;
-            }
             let mut client = match self.establish_rpc_session(&member.address).await {
                 Ok(c) => c,
                 Err(err) => {
@@ -623,26 +629,21 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
         }
 
         Err(RpcStateSyncError::SyncFailedAllPeers {
-            committee_size: source.serving_peers.len(),
+            num_peers: source.serving_peers.len(),
         })
     }
 
     async fn sync_global_shard(
         &mut self,
         current_epoch: Epoch,
-        shard_group: ShardGroup,
         sources: &HashMap<ShardGroup, SyncSource>,
-        our_vn_address: &PeerAddress,
     ) -> Result<Option<Version>, RpcStateSyncError> {
         let mut last_error = None;
 
         for (sg, source) in sources {
-            // TODO: any checkpoint for the previous epoch will justify the global shard sync.
-            //       Currently we'll fetch the checkpoint again even if we already have it if there are more than one
-            // shard groups.
-            let result = self
-                .sync_shard(Shard::global(), shard_group, current_epoch, source, our_vn_address)
-                .await;
+            // Any previous-epoch checkpoint carries the global shard root, so the first shard group to succeed
+            // justifies the whole global shard sync.
+            let result = self.sync_shard(Shard::global(), *sg, current_epoch, source).await;
             match result {
                 Ok(maybe_version) => {
                     let Some(version) = maybe_version else {
@@ -667,7 +668,7 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
         }
 
         Err(RpcStateSyncError::SyncFailedAllPeers {
-            committee_size: sources.len(),
+            num_peers: sources.values().map(|s| s.serving_peers.len()).sum(),
         })
     }
 
@@ -687,7 +688,10 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
         };
         let our_vn = self.epoch_manager.get_our_validator_node(current_epoch).await?;
         let local_info = self.epoch_manager.get_local_committee_info(current_epoch).await?;
-        let sync_sources = match self.get_sync_sources(local_info.shard_group(), current_epoch).await {
+        let sync_sources = match self
+            .get_sync_sources(local_info.shard_group(), current_epoch, &our_vn.address)
+            .await
+        {
             Ok(sources) => sources,
             Err(RpcStateSyncError::NoCommittees(prev_epoch)) => {
                 info!(target: LOG_TARGET, "No committees for the previous epoch {prev_epoch}. This is the first committee.");
@@ -712,13 +716,7 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
 
         let local_shard_group = local_info.shard_group();
 
-        self.sync_global_shard(
-            current_epoch,
-            ShardGroup::all_shards(local_info.num_preshards()),
-            &sync_sources,
-            &our_vn.address,
-        )
-        .await?;
+        self.sync_global_shard(current_epoch, &sync_sources).await?;
 
         // Sync data from each committee in range of the committee we're joining.
         // NOTE: we don't have to worry about substates in address range because shard boundaries are fixed.
@@ -731,8 +729,7 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
                 continue;
             };
             for shard in intersect_shard_group.shard_iter() {
-                self.sync_shard(shard, shard_group, current_epoch, &source, &our_vn.address)
-                    .await?;
+                self.sync_shard(shard, shard_group, current_epoch, &source).await?;
             }
         }
 
@@ -747,35 +744,45 @@ struct SyncSource {
     /// The previous epoch's committee for the shard group. Its quorum threshold and voting powers are the
     /// only thing a fetched checkpoint is validated against.
     signing_committee: Committee<PeerAddress>,
-    /// Peers to request the checkpoint and state from, in order of preference. Current-epoch members are
-    /// running consensus and hold the previous epoch's state (either as continuing members or because
-    /// they synced it from the same checkpoint), so they come first; members that left at the epoch
-    /// boundary are the fallback.
+    /// Peers to request the checkpoint and state from, in order of preference, excluding this node.
+    /// Members of our current committee are running consensus and hold the previous epoch's state for our
+    /// whole shard group (either as continuing members or because they synced it from the same checkpoint),
+    /// so they come first; signing-committee members that left at the epoch boundary are the fallback.
     serving_peers: Vec<CommitteeMember<PeerAddress>>,
 }
 
 impl SyncSource {
-    fn new(signing_committee: Committee<PeerAddress>, current_members: &Committee<PeerAddress>) -> Self {
-        let continuing = current_members
-            .iter()
-            .filter(|m| signing_committee.contains(&m.address))
-            .cloned()
-            .collect::<Committee<_>>();
-        let joined = current_members
-            .iter()
-            .filter(|m| !signing_committee.contains(&m.address))
-            .cloned()
-            .collect::<Committee<_>>();
+    fn new(
+        signing_committee: Committee<PeerAddress>,
+        local_committee: &Committee<PeerAddress>,
+        our_vn_addr: &PeerAddress,
+    ) -> Self {
+        let signing_addrs = signing_committee.address_iter().collect::<HashSet<_>>();
+        let local_addrs = local_committee.address_iter().collect::<HashSet<_>>();
+
+        let mut continuing = Vec::new();
+        let mut joined = Vec::new();
+        for member in local_committee.iter().filter(|m| m.address != *our_vn_addr) {
+            if signing_addrs.contains(&member.address) {
+                continuing.push(member.clone());
+            } else {
+                joined.push(member.clone());
+            }
+        }
         let departed = signing_committee
             .iter()
-            .filter(|m| !current_members.contains(&m.address))
+            .filter(|m| m.address != *our_vn_addr && !local_addrs.contains(&m.address))
             .cloned()
-            .collect::<Committee<_>>();
+            .collect::<Vec<_>>();
 
         // Shuffling within each tier spreads load across equally preferred peers.
+        let mut rng = rand::rng();
         let serving_peers = [continuing, joined, departed]
-            .iter()
-            .flat_map(|tier| tier.shuffled().cloned().collect::<Vec<_>>())
+            .into_iter()
+            .flat_map(|mut tier| {
+                tier.shuffle(&mut rng);
+                tier
+            })
             .collect();
 
         Self {
@@ -1118,16 +1125,12 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress> + Send + Sync + 'static
     async fn sync(&mut self, target_epoch: Option<Epoch>) -> Result<(), Self::Error> {
         if let Err(err) = self.sync_inner(target_epoch).await {
             warn!(target: LOG_TARGET, "🛜State sync failed: {err} (stats: {})", self.stats);
-            // Clear the valid checkpoints cache
-            self.valid_checkpoints = HashMap::new();
             self.stats = StateSyncStats::default();
             return Err(err);
         }
 
         info!(target: LOG_TARGET, "🛜State sync completed successfully: {}", self.stats);
 
-        // Clear the valid checkpoints cache
-        self.valid_checkpoints = HashMap::new();
         self.stats = StateSyncStats::default();
         Ok(())
     }

--- a/crates/rpc_state_sync/src/state_sync.rs
+++ b/crates/rpc_state_sync/src/state_sync.rs
@@ -65,10 +65,6 @@ use tari_validator_node_rpc::{
 
 use crate::{error::RpcStateSyncError, stats::StateSyncStats};
 
-/// Upper bound on checkpoints requested per peer. A peer stores one checkpoint per shard group it synced from
-/// in an epoch, so this only needs to cover the previous epoch's committee count.
-const MAX_CHECKPOINTS_PER_REQUEST: u32 = 32;
-
 const LOG_TARGET: &str = "tari::ootle::rpc_state_sync";
 
 pub struct RpcStateSyncClientProtocol<TConsensusSpec: ConsensusSpec> {
@@ -132,12 +128,11 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
 
         self.stats.total_requests += 1;
 
-        // A peer holds one checkpoint per shard group it synced from at prev_epoch, and the request has no
-        // shard-group selector, so fetch a batch and pick the one for the requested group.
-        let checkpoints = match client
+        let mut checkpoints = match client
             .get_checkpoints(GetCheckpointsRequest {
                 from_epoch: Some(prev_epoch.into()),
-                num_to_return: MAX_CHECKPOINTS_PER_REQUEST,
+                num_to_return: 1,
+                shard_group: Some(for_shard_group.encode_as_u32()),
             })
             .await
         {
@@ -146,46 +141,27 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
             Err(err) => return Err(err.into()),
         };
 
-        let num_returned = checkpoints.len();
-        // The batch can include checkpoints for other shard groups and later epochs, so a malformed entry
-        // only disqualifies itself; the one we select is still checked against the signing committee's quorum.
-        for checkpoint in checkpoints {
-            let checkpoint = match EpochCheckpoint::try_from(checkpoint) {
-                Ok(cp) => cp,
-                Err(err) => {
-                    warn!(target: LOG_TARGET, "Skipping undecodable checkpoint in batch: {err}");
-                    continue;
-                },
-            };
-            let shard_group = match checkpoint.checked_shard_group() {
-                Ok(sg) => sg,
-                Err(err) => {
-                    warn!(
-                        target: LOG_TARGET,
-                        "Skipping checkpoint for epoch {} with invalid shard group: {err}",
-                        checkpoint.epoch()
-                    );
-                    continue;
-                },
-            };
-            if checkpoint.epoch() != prev_epoch || shard_group != for_shard_group {
-                continue;
-            }
-            info!(target: LOG_TARGET, "🛜 Checkpoint: {checkpoint}");
-            self.validate_checkpoint(&checkpoint, prev_committee, prev_epoch)?;
-            self.state_store.with_write_tx(|tx| checkpoint.save(tx))?;
-            return Ok(Some(checkpoint));
+        let Some(checkpoint) = checkpoints.pop() else {
+            return Ok(None);
+        };
+        let checkpoint = EpochCheckpoint::try_from(checkpoint).map_err(RpcStateSyncError::InvalidResponse)?;
+        let shard_group = checkpoint.checked_shard_group().map_err(|err| {
+            RpcStateSyncError::InvalidResponse(anyhow!(
+                "Fetched checkpoint for epoch {} has invalid shard group: {err}",
+                checkpoint.epoch()
+            ))
+        })?;
+        if checkpoint.epoch() != prev_epoch || shard_group != for_shard_group {
+            return Err(RpcStateSyncError::InvalidResponse(anyhow!(
+                "Requested checkpoint for epoch {prev_epoch} shard group {for_shard_group} but peer returned epoch {} \
+                 shard group {shard_group}",
+                checkpoint.epoch()
+            )));
         }
-
-        if num_returned >= MAX_CHECKPOINTS_PER_REQUEST as usize {
-            warn!(
-                target: LOG_TARGET,
-                "Peer returned {num_returned} checkpoints without one for epoch {prev_epoch} shard group \
-                 {for_shard_group}; the batch may have been truncated at MAX_CHECKPOINTS_PER_REQUEST"
-            );
-        }
-
-        Ok(None)
+        info!(target: LOG_TARGET, "🛜 Checkpoint: {checkpoint}");
+        self.validate_checkpoint(&checkpoint, prev_committee, prev_epoch)?;
+        self.state_store.with_write_tx(|tx| checkpoint.save(tx))?;
+        Ok(Some(checkpoint))
     }
 
     #[allow(clippy::too_many_lines)]


### PR DESCRIPTION
## Description

State sync used the previous epoch's committee for two unrelated jobs: the quorum that makes an `EpochCheckpoint` valid, and the set of peers asked to hand over the bytes. Only the first needs to be the previous committee. Using it for the second preferentially targets validators that may have left the register (`Idle`) or shut down, while continuing members of the same shard group are `Running` and hold identical state.

This introduces `SyncSource`, pairing the signing committee (prev epoch, used only by `validate_checkpoint`) with an ordered serving-peer list drawn from the current epoch's committees overlapping the target shard group:

1. continuing members
2. members that joined at this epoch (they synced from the same checkpoint)
3. departed prev-only members, as the fallback for full committee turnover

Each tier is shuffled so load still spreads. `sync_shard`'s retry pool is the serving list.

Unchanged: epoch-0 `NoCommittees(Epoch::zero())`, first-committee and sole-VN early-outs, and the literal error-string retry classification (converting that to a typed RPC error is a separate improvement).

## How Has This Been Tested?

`cargo lints clippy -p tari_rpc_state_sync --all-targets`. Integration tests via CI.

## Breaking Changes

- [x] None
