### PR TITLE
chore: bump ootle_serde for the tari_bor cascade, and make the versioning script check crates.io

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,13 +77,18 @@ Two scripts in `scripts/` cover publishing to crates.io and reasoning about vers
   - Default (no flags) is a dry-run summary. `--dry-run` runs `cargo publish --dry-run` per crate. `--execute` publishes.
   - `--from <crate>` resumes after a failure.
 - `scripts/crate_versioning.py` — answers "who needs to bump if X bumps?".
-  - `list` — same publish set with versions/tiers.
+  - `list` — same publish set with versions/tiers, plus whether each version is already on crates.io (`released`) or
+    still unpublished (`pending`).
   - `deps <crate>` / `dependents <crate> [--transitive]` — graph queries.
   - `impact <crate> [--breaking]` — for a non-breaking change, prints just a patch bump. For `--breaking`, prints the
     tier-3 workspace rollup (every tier-3 crate moves with `workspace.package.version`) plus the tier-1/2 crates that
     need pin updates + their republish guidance (patch min, minor if their public API re-exposes the changed types).
+  - Both commands query crates.io and ask only for bumps that are still outstanding. A crate whose in-tree version is
+    an unreleased minor ahead of crates.io needs nothing — the pending release already carries the change, because a
+    `^0.y` pin cannot exist on a version that was never published. `--offline` skips the check and lists the whole
+    cascade instead.
 
 When asked to bump a crate or prepare a release, run `impact <crate> --breaking` (or without `--breaking` for a patch)
-first, then follow its workflow checklist. Both scripts share their crate list — `publish_crates.py::CRATES` is the
-source of truth, so adding/removing a published crate there automatically updates `crate_versioning.py`. Detailed
-reference: `scripts/README.md`.
+first, then follow its workflow checklist — and apply only the bumps it asks for, not the ones it lists as already
+covered. Both scripts share their crate list — `publish_crates.py::CRATES` is the source of truth, so adding/removing a
+published crate there automatically updates `crate_versioning.py`. Detailed reference: `scripts/README.md`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8041,7 +8041,7 @@ dependencies = [
 
 [[package]]
 name = "ootle_serde"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "base64 0.22.1",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,7 @@ tari_template_macros = { version = "0.23", path = "crates/template_macros" }
 tari_bor = { version = "0.16.0", path = "crates/tari_bor", default-features = false }
 
 ootle_byte_type = { path = "crates/ootle_byte_type", version = "0.13" }
-ootle_serde = { path = "crates/ootle_serde", version = "0.5", default-features = false }
+ootle_serde = { path = "crates/ootle_serde", version = "0.6", default-features = false }
 ootle-wasm-core = { path = "crates/ootle_wasm/core", version = "0.41" }
 ootle_sdk_core = { path = "crates/ootle_sdk_core", version = "0.41" }
 

--- a/crates/ootle_serde/Cargo.toml
+++ b/crates/ootle_serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ootle_serde"
-version = "0.5.0"
+version = "0.6.0"
 description = "serde utilities for Tari Ootle"
 edition.workspace = true
 authors.workspace = true

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,12 +13,16 @@ versioning rules below.
 ## TL;DR — the two scripts
 
 ```sh
-# What's in the publish set, in publish order, with current versions + tiers
+# What's in the publish set, in publish order, with current versions + tiers,
+# and whether each version is already on crates.io or still pending release
 ./scripts/crate_versioning.py list
 
 # I bumped crate X. Who else needs to bump, and how?
 ./scripts/crate_versioning.py impact <crate>              # non-breaking (patch)
 ./scripts/crate_versioning.py impact <crate> --breaking   # breaking (minor)
+
+# Both consult crates.io. Add --offline to skip it (see "Pending releases" below)
+./scripts/crate_versioning.py impact <crate> --breaking --offline
 
 # Once versions are set, publish to crates.io
 ./scripts/publish_crates.py                  # what would publish (read-only)
@@ -57,6 +61,43 @@ actually depend on something that moved.
 
 ---
 
+## Pending releases (the second must-read)
+
+The tiers above answer *who a change is breaking for*. That is not the same
+question as *who still needs a version edit*, and the two come apart whenever a
+release is pending.
+
+A version that was never published to crates.io carries no `^0.y` pins. Nobody
+depends on it, so nothing can be broken by changing what goes into it. If a
+crate's working-tree version is already an unreleased minor ahead of crates.io,
+its bump is **already made** — the pending release ships the change under a
+number that announces it, and bumping again just burns a version.
+
+This is easy to get wrong, because a whole cohort can sit on unreleased bumps
+for weeks. After `tari_bor` 0.15.1 → 0.16.0, `impact tari_bor --breaking` named
+18 crates; 17 of them were already on unreleased minors and the real cascade was
+one crate.
+
+So `list` and `impact` both query the crates.io sparse index and classify every
+crate:
+
+| State | Meaning | Action |
+|---|---|---|
+| `pending` | the tree's version is not on crates.io **and** breaks a pin on the latest that is | none — the pending release covers it |
+| `released` | the tree's version is already on crates.io | must move; the number is spent |
+| *short* | a bump is pending, but too small to break the pin it needs to (e.g. `0.15.1` against a published `0.15.0`) | promote it to a minor |
+
+A crate that has never been published is `pending` — its first release announces
+everything.
+
+`--offline` skips the lookup. The output then lists the entire cascade whether
+or not each bump has already been made, which is the pre-registry behaviour;
+useful with no network, misleading otherwise. A failed lookup for an individual
+crate is treated as `released`, so the script asks for a bump it may not need
+rather than skipping one it does.
+
+---
+
 ## `crate_versioning.py` — bump impact analysis
 
 Subcommands:
@@ -64,11 +105,20 @@ Subcommands:
 ### `list`
 
 ```sh
-./scripts/crate_versioning.py list
+./scripts/crate_versioning.py list [--offline]
 ```
 
-Prints the publish set in topological order with current version + tier + path.
-Sourced from `cargo metadata` (versions) and `publish_crates.py` (order/tier).
+Prints the publish set in topological order with current version + tier +
+release state + path. Sourced from `cargo metadata` (versions),
+`publish_crates.py` (order/tier) and the crates.io sparse index (release state):
+
+```
+tari_bor          0.16.0  [stable  ]  pending (crates.io: 0.15.0)  crates/tari_bor
+ootle-network      0.2.0  [stable  ]  released                     crates/ootle_network
+```
+
+The `pending` column doubles as a release checklist: it is exactly the set of
+crates the next `publish_crates.py --execute` will push.
 
 ### `deps <crate>`
 
@@ -101,21 +151,29 @@ the full bump plan.
 
 For a **breaking** bump, output is structured as:
 
-1. **Tier 3 (core) cohort** — every tier-3 crate's new version (because the workspace
-   `[workspace.package].version` moves), plus the exact `version = "0.31" →
-   "0.32"` pin updates required in `[workspace.dependencies]`.
-2. **Independent (non-core) minor bumps** — the crate itself (and any other
-   independently-versioned crate that ends up minor-bumped in this round).
+1. **Tier 3 (core) cohort** — either the exact `[workspace.package].version` and
+   `[workspace.dependencies]` pin updates (`"0.31" → "0.32"`), or a note that the
+   workspace version is already an unreleased breaking bump and no rollup is
+   needed. The cohort shares one version, so it moves as soon as any single
+   member still owes a bump.
+2. **Independent (non-core) minor bumps** — independently-versioned crates whose
+   published version is spent and so must move, each with the reason (which dep
+   it re-exposes) and its registry state.
 3. **Independent (non-core) pin updates** — independently-versioned crates that
    don't minor-bump themselves but still need to update pins and republish at least
    a patch. The output lists which pin(s) to bump and a *patch vs minor*
    recommendation (patch is safe; minor is required only if the crate's own
    public API re-exposes the upstream's changed types).
-4. **Dev-only callouts** — informational; dev-only edges never force a bump.
-5. **Suggested workflow** — numbered checklist for the bump → format → publish loop.
+4. **Already covered** — crates the change breaks for whose bump is already made
+   and unreleased. Listed for the audit trail; no action.
+5. **Dev-only callouts** — informational; dev-only edges never force a bump.
+6. **Suggested workflow** — numbered checklist for the bump → format → publish
+   loop, covering only the crates that actually need to move. When nothing does,
+   it says `No version changes required.` instead.
 
 Without `--breaking`, the output is a single line: it's a patch bump,
-dependents auto-pick-up via `^0.y` and nobody else republishes.
+dependents auto-pick-up via `^0.y` and nobody else republishes — or, if the
+crate's version is already pending release, that no edit is needed at all.
 
 ---
 
@@ -166,11 +224,17 @@ When asked to bump a crate / cut a release:
    ```sh
    ./scripts/crate_versioning.py impact <crate> [--breaking]
    ```
-3. **Apply the bumps the script printed:**
+3. **Apply the bumps the script printed** — and only those. Crates under
+   "already covered by an unreleased bump" need nothing; bumping them anyway
+   burns a version for no one's benefit. If the script says `No version changes
+   required.`, skip to step 4.
    - If a tier-3 crate moved, update `[workspace.package].version` and every
      `version = "<old>"` pin in `[workspace.dependencies]` for tier-3 crates.
    - For each independent (non-core) crate the script listed, update its own
      `Cargo.toml` `version` (patch or minor as advised) and any pin(s) on the bumped deps.
+   - A few pins live outside the root manifest (`ootle_ledger_client` in
+     `crates/wallet/ootle-rs`, `ootle-wasm-core` in `crates/ootle_wasm/wasm`).
+     `cargo metadata` fails loudly if one is left behind, so run it after editing.
 4. **Format:**
    ```sh
    cargo +nightly-2025-12-05 fmt --all
@@ -200,3 +264,14 @@ crates skip themselves automatically, but it's wasted CI time.
 3. Run `./scripts/crate_versioning.py list` to confirm the new crate shows up
    with the expected version and tier.
 4. Run `./scripts/publish_crates.py --dry-run` to confirm the build works.
+
+---
+
+## Tests
+
+The version arithmetic behind the registry check — is this version spent, does
+this bump break that pin — has its own tests. No network, no cargo, no pytest:
+
+```sh
+python3 scripts/test_crate_versioning.py
+```

--- a/scripts/crate_versioning.py
+++ b/scripts/crate_versioning.py
@@ -8,10 +8,10 @@ by hand. When a crate is added/removed in `publish_crates.py`, this
 script automatically picks it up.
 
 Usage:
-    ./scripts/crate_versioning.py list
+    ./scripts/crate_versioning.py list [--offline]
     ./scripts/crate_versioning.py deps <crate>
     ./scripts/crate_versioning.py dependents <crate> [--transitive]
-    ./scripts/crate_versioning.py impact <crate> [--breaking]
+    ./scripts/crate_versioning.py impact <crate> [--breaking] [--offline]
 
 Tier semantics (mirrors publish_crates.py). Tier 3 is the only workspace-versioned
 cohort; every other tier is independently versioned:
@@ -31,17 +31,36 @@ crate, so it must bump minor too (and that, in turn, can promote its own public
 dependents). Deps are treated as public by default — the safe, never-under-bump
 assumption. IMPL_DETAIL_DEPS records audited exceptions that are
 implementation-detail only and so need just a patch + pin update.
+
+That cascade says which crates a change is breaking FOR. It does not say which
+ones still need a version edit, and the two differ whenever a release is
+pending: a version that was never published carries no ^0.y pins, so nothing can
+be broken by changing what it contains. A crate whose working-tree version is
+already an unreleased minor ahead of crates.io therefore needs nothing — its
+pending release absorbs the change and already announces it.
+
+So every bump is checked against the crates.io sparse index before it is
+printed, and a crate is only asked to move when its working-tree version is
+genuinely taken (or its pending bump is too small to break the pin it needs to).
+Pass --offline to skip the lookup; the output then falls back to listing the
+whole cascade, bumps already made included.
 """
 
 import argparse
 import json
 import subprocess
 import sys
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
 from pathlib import Path
 
 # Reuse the publish list as the single source of truth.
 sys.path.insert(0, str(Path(__file__).parent))
-from publish_crates import CRATES, TIER_LABELS  # type: ignore[import-not-found]
+from publish_crates import (  # type: ignore[import-not-found]
+    CRATES,
+    TIER_LABELS,
+    published_versions,
+)
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 PUBLISH_SET = {name for name, _, _ in CRATES}
@@ -86,6 +105,119 @@ IMPL_DETAIL_DEPS = {}
 def is_public_dep(crate, dep):
     """True unless the (crate -> dep) edge is an audited implementation-detail."""
     return dep not in IMPL_DETAIL_DEPS.get(crate, set())
+
+
+# ---------------------------------------------------------------------------
+# Registry state — what is actually published, vs what the tree says.
+# ---------------------------------------------------------------------------
+
+REGISTRY_WORKERS = 8
+
+
+def vkey(version: str):
+    """Sortable key for a version, ignoring any pre-release/build suffix."""
+    core = version.split("-", 1)[0].split("+", 1)[0]
+    parts = []
+    for part in core.split("."):
+        parts.append(int(part) if part.isdigit() else 0)
+    while len(parts) < 3:
+        parts.append(0)
+    return tuple(parts[:3])
+
+
+def breaks_pin(newer: str, older: str) -> bool:
+    """True if `newer` falls outside a caret pin on `older`.
+
+    Cargo's caret rules make the leftmost non-zero component the compatibility
+    one: ^1.2 admits 1.3, ^0.2 admits 0.2.9 but not 0.3, ^0.0.2 admits nothing
+    but 0.0.2.
+    """
+    a, b = vkey(newer), vkey(older)
+    if a[0] != b[0]:
+        return True
+    if a[0] == 0 and a[1] != b[1]:
+        return True
+    if a[0] == 0 and a[1] == 0 and a[2] != b[2]:
+        return True
+    return False
+
+
+@dataclass
+class Release:
+    """A crate's working-tree version set against what crates.io holds."""
+
+    name: str
+    local: str
+    # [(version, yanked), ...] — or None when the lookup failed or was skipped.
+    published: "list | None"
+
+    @property
+    def known(self) -> bool:
+        return self.published is not None
+
+    @property
+    def latest(self):
+        """Highest non-yanked published version, or None if there is none.
+
+        Yanked versions are excluded because this is the version dependents
+        resolve to; `taken` keeps them because their numbers stay spent.
+        """
+        live = [v for v, yanked in self.published or () if not yanked]
+        return max(live, key=vkey, default=None)
+
+    @property
+    def taken(self) -> bool:
+        """The tree's own version is spent — a release must carry a new number."""
+        return any(v == self.local for v, _ in self.published or ())
+
+    def carries(self, kind: str) -> bool:
+        """Is a `kind`-sized bump already made but unreleased?
+
+        A version nobody could depend on cannot break anybody, so an unpublished
+        local version that is far enough ahead of crates.io has already done the
+        job: the pending release ships the change under a number that announces
+        it. Unknown registry state answers False, so the caller asks for the bump
+        rather than skipping one that is needed.
+        """
+        if not self.known or self.taken:
+            return False
+        if self.latest is None:
+            return True  # never published — the first release announces everything
+        if vkey(self.local) <= vkey(self.latest):
+            return False  # tree is level with or behind the registry
+        return breaks_pin(self.local, self.latest) if kind == "minor" else True
+
+    def describe(self) -> str:
+        if not self.known:
+            return "registry unknown"
+        if self.taken:
+            return f"{self.local} is on crates.io"
+        if self.latest is None:
+            return "never published"
+        return f"{self.local} pending, crates.io has {self.latest}"
+
+
+def fetch_releases(versions: dict, offline: bool = False) -> dict:
+    """Look up every crate's published versions, concurrently."""
+    if offline:
+        return {n: Release(n, v, None) for n, v in versions.items()}
+    names = list(versions)
+    with ThreadPoolExecutor(max_workers=REGISTRY_WORKERS) as pool:
+        found = dict(zip(names, pool.map(published_versions, names)))
+    return {n: Release(n, versions[n], found[n]) for n in names}
+
+
+def registry_caveat(releases: dict, offline: bool) -> str:
+    """A warning line when the bumps below are not registry-checked, else ''."""
+    if offline:
+        return (f"{YELLOW}Registry check skipped (--offline) — bumps already made "
+                f"but unreleased are listed as if still needed.{NC}")
+    unknown = sorted(n for n, r in releases.items() if not r.known)
+    if not unknown:
+        return ""
+    shown = ", ".join(unknown[:3]) + (f", +{len(unknown) - 3} more" if len(unknown) > 3 else "")
+    return (f"{YELLOW}crates.io lookup failed for {len(unknown)} crate(s) ({shown}) — "
+            f"treating them as published, so their bumps are listed.{NC}")
 
 
 def cargo_metadata():
@@ -146,12 +278,26 @@ def transitive_dependents(seed: str, rev_deps):
     return seen
 
 
-def cmd_list(_args):
+def cmd_list(args):
     versions, _, _ = build_graph()
+    releases = fetch_releases(versions, args.offline)
     print(f"{BOLD}Publish order (from publish_crates.py):{NC}")
     for name, crate_dir, tier in CRATES:
         ver = versions[name]
-        print(f"  {name:38} {ver:8}  [{TIER_LABELS[tier]:11}]  {crate_dir}")
+        r = releases[name]
+        if not r.known:
+            plain, colour = "", ""
+        elif r.taken:
+            plain, colour = "released", GREEN
+        else:
+            plain, colour = f"pending (crates.io: {r.latest or 'never'})", YELLOW
+        # Pad on the visible text: the colour escapes would otherwise count
+        # toward the field width and stagger the column.
+        status = f"{colour}{plain}{NC}" + " " * max(0, 34 - len(plain))
+        print(f"  {name:38} {ver:8}  [{TIER_LABELS[tier]:11}]  {status}{crate_dir}")
+    caveat = registry_caveat(releases, args.offline)
+    if caveat:
+        print(caveat)
 
 
 def cmd_deps(args):
@@ -191,6 +337,21 @@ def cmd_dependents(args):
             print(f"  <~ {d} {versions[d]} [{TIER_LABELS[TIER_OF[d]]}]")
 
 
+def classify(name: str, kind: str, releases: dict) -> str:
+    """How much of a `kind` bump is still outstanding for this crate.
+
+      covered — the bump is already made and unreleased; nothing to do.
+      short   — a bump is pending but too small to break the pin it must break.
+      needed  — the tree's version is spent (or unknown); it has to move.
+    """
+    r = releases[name]
+    if r.carries(kind):
+        return "covered"
+    if r.known and not r.taken and r.latest and vkey(r.local) > vkey(r.latest):
+        return "short"
+    return "needed"
+
+
 def cmd_impact(args):
     versions, deps, dev_deps = build_graph()
     target = args.crate
@@ -202,15 +363,29 @@ def cmd_impact(args):
     target_tier = TIER_OF[target]
 
     print(f"{BOLD}Impact analysis: {target} {cur_ver} [{TIER_LABELS[target_tier]}]{NC}")
+
     if not args.breaking:
-        print(f"{GREEN}Non-breaking (patch) bump.{NC}")
-        print(f"  {target}: {cur_ver} -> {bump(cur_ver, 'patch')}")
+        rel = fetch_releases({target: cur_ver}, args.offline)[target]
+        if rel.carries("patch"):
+            print(f"{GREEN}Non-breaking (patch) change — no version edit needed.{NC}")
+            print(f"  {target} {rel.describe()}, so the pending release carries it.")
+        else:
+            print(f"{GREEN}Non-breaking (patch) bump.{NC}")
+            print(f"  {target}: {cur_ver} -> {bump(cur_ver, 'patch')}")
         print(f"  Dependents auto-pick-up via ^0.y constraints — no republish needed")
         print(f"  unless a dependent wants to ship the fix.")
         return
 
-    new_ver = bump(cur_ver, "minor")
-    print(f"{YELLOW}Breaking (minor) bump: {cur_ver} -> {new_ver}{NC}")
+    releases = fetch_releases(versions, args.offline)
+    target_state = classify(target, "minor", releases)
+    if target_state == "covered":
+        print(f"{GREEN}Breaking (minor) change — {target} {releases[target].describe()}, "
+              f"so its own bump is already made.{NC}")
+    else:
+        print(f"{YELLOW}Breaking (minor) bump: {cur_ver} -> {bump(cur_ver, 'minor')}{NC}")
+    caveat = registry_caveat(releases, args.offline)
+    if caveat:
+        print(caveat)
     print()
 
     tier3_crates = {n for n, t in TIER_OF.items() if t == 3}
@@ -224,6 +399,10 @@ def cmd_impact(args):
     #     change (the changed types reach its public API) and joins the set. This
     #     cascades: a crate promoted to minor can in turn promote its own public
     #     dependents.
+    #
+    # This set is who the change is breaking FOR. Whether each of them still needs
+    # a version edit is a separate question, answered against the registry below —
+    # a crate already sitting on an unreleased minor has nothing left to do.
     minor_set = {target}
     while True:
         changed = False
@@ -251,22 +430,43 @@ def cmd_impact(args):
         if c not in minor_set and TIER_OF[c] != 3 and ds & minor_set
     }
 
-    # Render tier-3 cohort.
-    if minor_set & tier3_crates:
-        print(f"{BOLD}Tier 3 (core) — all republish at the new workspace version:{NC}")
+    state = {c: classify(c, "minor", releases) for c in minor_set}
+    state.update({c: classify(c, "patch", releases) for c in pin_update_set})
+    # Tier-3 members are reported by the cohort block below, which owns their
+    # shared version; listing them again as individually covered double-counts.
+    covered = sorted(c for c, st in state.items()
+                     if st == "covered" and TIER_OF[c] != 3)
+
+    # Render tier-3 cohort. The cohort shares one version, so it moves as soon as
+    # any single member still owes a bump.
+    t3_in_play = sorted(minor_set & tier3_crates)
+    t3_moving = [c for c in t3_in_play if state[c] != "covered"]
+    if t3_in_play:
         ws_ver = workspace_version()
-        new_ws = bump(ws_ver, "minor")
-        print(f"  Set [workspace.package].version = \"{new_ws}\" in root Cargo.toml.")
-        print(f"  Update every tier-3 pin in [workspace.dependencies] "
-              f"from \"{trim(ws_ver)}\" -> \"{trim(new_ws)}\".")
-        for c in sorted(tier3_crates):
-            marker = "*" if c == target else " "
-            print(f"  {marker} {c} {versions[c]} -> {new_ws}")
+        print(f"{BOLD}Tier 3 (core) — the workspace cohort:{NC}")
+        if not t3_moving:
+            print(f"  {GREEN}No rollup needed{NC} — [workspace.package].version {ws_ver} is "
+                  f"already an unreleased breaking bump ahead of crates.io.")
+            for c in t3_in_play:
+                print(f"    {c:38} {releases[c].describe()}")
+        else:
+            new_ws = bump(ws_ver, "minor")
+            print(f"  Set [workspace.package].version = \"{new_ws}\" in root Cargo.toml.")
+            print(f"  Update every tier-3 pin in [workspace.dependencies] "
+                  f"from \"{trim(ws_ver)}\" -> \"{trim(new_ws)}\".")
+            if 0 < len(t3_moving) < len(t3_in_play):
+                print(f"  The whole cohort moves because {len(t3_moving)} member(s) "
+                      f"still owe a bump:")
+                for c in t3_moving:
+                    print(f"    {c:38} ({releases[c].describe()})")
+            for c in sorted(tier3_crates):
+                marker = "*" if c == target else " "
+                print(f"  {marker} {c} {versions[c]} -> {new_ws}")
         print()
 
-    # Render independent (non-core) minor bumps (target if independent, plus any
-    # other independent crate elevated to minor — typically none unless target is).
-    non_t3_minor = sorted(c for c in minor_set if TIER_OF[c] != 3)
+    # Render independent (non-core) minor bumps that are still outstanding.
+    non_t3_minor = sorted(c for c in minor_set
+                          if TIER_OF[c] != 3 and state[c] != "covered")
     if non_t3_minor:
         print(f"{BOLD}Independent (non-core) — minor (breaking) bump required:{NC}")
         for c in non_t3_minor:
@@ -277,10 +477,16 @@ def cmd_impact(args):
             else:
                 causes = sorted(d for d in deps[c] & minor_set if is_public_dep(c, d))
                 print(f"{line}  (re-exposes {', '.join(causes)} in public API)")
+            if state[c] == "short":
+                print(f"      {YELLOW}{versions[c]} is pending but does not break "
+                      f"^{releases[c].latest} — promote it.{NC}")
+            elif releases[c].known:
+                print(f"      {releases[c].describe()}")
         print()
 
     # Render pin-update set (independent crates that must republish).
-    pin_independent = sorted(c for c in pin_update_set if TIER_OF[c] != 3)
+    pin_independent = sorted(c for c in pin_update_set
+                             if TIER_OF[c] != 3 and state[c] != "covered")
     if pin_independent:
         print(f"{BOLD}Independent (non-core) — recompile & republish a PATCH "
               f"(deps are impl-detail, not re-exposed):{NC}")
@@ -296,6 +502,18 @@ def cmd_impact(args):
             print(f"    pins:  {pin_hint}")
         print()
 
+    # Crates the change breaks for, whose bump is already made and unreleased.
+    if covered:
+        print(f"{GREEN}Already covered by an unreleased bump ({len(covered)}) — "
+              f"no action:{NC}")
+        for c in covered:
+            tag = " [tier-3 cohort]" if TIER_OF[c] == 3 else ""
+            print(f"  {c:38} {releases[c].describe()}{tag}")
+        print(f"  A ^0.y pin cannot exist on a version that was never published, so "
+              f"the pending")
+        print(f"  release absorbs the change under a number that already announces it.")
+        print()
+
     # Dev-only callouts on the target (informational).
     direct_dev_dependents = sorted(rev_dev.get(target, ()))
     if direct_dev_dependents:
@@ -306,15 +524,23 @@ def cmd_impact(args):
         print()
 
     # Suggested workflow.
+    if not t3_moving and not non_t3_minor and not pin_independent:
+        print(f"{BOLD}{GREEN}No version changes required.{NC}")
+        print(f"  Every crate this change breaks is already on an unreleased bump.")
+        if args.offline:
+            print(f"  (…as far as --offline can tell; re-run without it to confirm.)")
+        return
+
     print(f"{BOLD}Suggested workflow:{NC}")
     step = 1
-    if minor_set & tier3_crates:
+    if t3_moving:
         print(f"  {step}. Bump workspace.package.version in root Cargo.toml.")
         step += 1
         print(f"  {step}. Update tier-3 pins in [workspace.dependencies].")
         step += 1
     if non_t3_minor:
-        print(f"  {step}. Minor-bump these independent crates in their own Cargo.toml:")
+        print(f"  {step}. Minor-bump these independent crates in their own Cargo.toml,")
+        print(f"     and update each one's pin in [workspace.dependencies]:")
         for c in non_t3_minor:
             print(f"       {c} -> {bump(versions[c], 'minor')}")
         step += 1
@@ -363,7 +589,12 @@ def main():
     p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     sp = p.add_subparsers(dest="cmd", required=True)
 
-    sp.add_parser("list", help="Show the publish set with versions and tiers.").set_defaults(func=cmd_list)
+    OFFLINE_HELP = ("Skip the crates.io lookup. Bumps already made but not yet "
+                    "released can then no longer be told apart from ones still owed.")
+
+    pl = sp.add_parser("list", help="Show the publish set with versions and tiers.")
+    pl.add_argument("--offline", action="store_true", help=OFFLINE_HELP)
+    pl.set_defaults(func=cmd_list)
 
     pd = sp.add_parser("deps", help="What does this crate depend on (in the publish set)?")
     pd.add_argument("crate")
@@ -378,6 +609,7 @@ def main():
     pi.add_argument("crate")
     pi.add_argument("--breaking", action="store_true",
                     help="Treat the change as a breaking (minor) bump rather than a patch.")
+    pi.add_argument("--offline", action="store_true", help=OFFLINE_HELP)
     pi.set_defaults(func=cmd_impact)
 
     args = p.parse_args()

--- a/scripts/publish_crates.py
+++ b/scripts/publish_crates.py
@@ -135,23 +135,44 @@ def crate_index_path(name: str) -> str:
         return f"{name[:2]}/{name[2:4]}/{name}"
 
 
-def is_published(crate_name: str, version: str) -> bool:
-    """Check if a specific version of a crate exists on crates.io."""
+def published_versions(crate_name: str):
+    """Every version of a crate on crates.io, as [(version, yanked), ...].
+
+    Returns [] for a crate that has never been published, and None when the
+    lookup itself failed — callers must distinguish the two, since "no versions"
+    and "we could not find out" lead to opposite advice.
+
+    Reads the sparse index rather than the JSON API: one unauthenticated request
+    against the same source cargo resolves from.
+    """
     url = f"https://index.crates.io/{crate_index_path(crate_name)}"
     try:
         req = urllib.request.Request(url)
         with urllib.request.urlopen(req, timeout=10) as resp:
-            # Each line is a JSON object for one version
-            for line in resp.read().decode().splitlines():
-                try:
-                    entry = json.loads(line)
-                    if entry.get("vers") == version:
-                        return True
-                except json.JSONDecodeError:
-                    continue
-    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError):
-        pass
-    return False
+            body = resp.read().decode()
+    except urllib.error.HTTPError as e:
+        return [] if e.code == 404 else None
+    except (urllib.error.URLError, TimeoutError):
+        return None
+
+    versions = []
+    for line in body.splitlines():
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if entry.get("vers"):
+            versions.append((entry["vers"], bool(entry.get("yanked"))))
+    return versions
+
+
+def is_published(crate_name: str, version: str) -> bool:
+    """Check if a specific version of a crate exists on crates.io.
+
+    A failed lookup answers False so a publish is attempted rather than skipped;
+    cargo rejects a duplicate version itself.
+    """
+    return any(v == version for v, _ in published_versions(crate_name) or ())
 
 
 def cargo_publish(crate_name: str, dry_run: bool = False) -> bool:

--- a/scripts/test_crate_versioning.py
+++ b/scripts/test_crate_versioning.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+Tests for the version arithmetic in crate_versioning.py.
+
+No network, no cargo, no pytest — run it directly:
+
+    python3 scripts/test_crate_versioning.py
+
+The logic under test decides whether a release still owes a version bump. Getting
+it wrong in the permissive direction ships a breaking change under a number that
+^0.y pins accept, which is silent breakage for every downstream consumer, so the
+cases below pin down each branch.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from crate_versioning import Release, breaks_pin, classify, vkey  # noqa: E402
+
+
+def rel(local, published):
+    """A Release whose published list is written as ["0.1.0", "0.2.0!"] — ! = yanked."""
+    if published is None:
+        return Release("crate", local, None)
+    return Release("crate", local, [(v.rstrip("!"), v.endswith("!")) for v in published])
+
+
+def test_vkey():
+    assert vkey("0.16.0") == (0, 16, 0)
+    assert vkey("1.2") == (1, 2, 0)
+    assert vkey("0.5.1-rc.1") == (0, 5, 1)
+    assert vkey("0.5.1+build") == (0, 5, 1)
+    assert vkey("0.9.0") < vkey("0.10.0"), "must compare numerically, not as strings"
+
+
+def test_breaks_pin():
+    # Pre-1.0: the minor is the compatibility component.
+    assert breaks_pin("0.16.0", "0.15.0")
+    assert not breaks_pin("0.15.1", "0.15.0")
+    # Post-1.0: the major is.
+    assert breaks_pin("2.0.0", "1.9.0")
+    assert not breaks_pin("1.9.0", "1.2.0")
+    # 0.0.z: ^0.0.z admits nothing else at all.
+    assert breaks_pin("0.0.2", "0.0.1")
+
+
+def test_latest_skips_yanked():
+    # Yanked versions are not what dependents resolve to.
+    assert rel("0.4.0", ["0.1.0", "0.3.0", "0.3.1!"]).latest == "0.3.0"
+    assert rel("0.4.0", []).latest is None
+
+
+def test_taken_counts_yanked():
+    # A yanked number is spent — crates.io will not accept it again.
+    assert rel("0.3.1", ["0.3.0", "0.3.1!"]).taken
+    assert not rel("0.3.2", ["0.3.0", "0.3.1!"]).taken
+
+
+def test_carries_pending_minor():
+    # The whole point: an unreleased minor already announces the break.
+    r = rel("0.16.0", ["0.15.0"])
+    assert r.carries("minor")
+    assert r.carries("patch")
+
+
+def test_carries_pending_patch_is_not_enough_for_minor():
+    # 0.15.1 is unreleased, but ^0.15.0 still accepts it — the break would be silent.
+    r = rel("0.15.1", ["0.15.0"])
+    assert not r.carries("minor")
+    assert r.carries("patch")
+
+
+def test_carries_released_version():
+    # The tree's version is on crates.io, so any change needs a new number.
+    r = rel("0.15.0", ["0.15.0"])
+    assert not r.carries("minor")
+    assert not r.carries("patch")
+
+
+def test_carries_never_published():
+    # Nothing can pin what has never been released.
+    r = rel("0.1.0", [])
+    assert r.carries("minor")
+    assert r.carries("patch")
+
+
+def test_carries_unknown_registry():
+    # A failed lookup must ask for the bump, never skip one that is needed.
+    r = rel("0.16.0", None)
+    assert not r.carries("minor")
+    assert not r.carries("patch")
+
+
+def test_carries_tree_behind_registry():
+    # Someone published past the tree; the local version proves nothing.
+    r = rel("0.14.0", ["0.15.0"])
+    assert not r.carries("minor")
+    assert not r.carries("patch")
+
+
+def test_classify():
+    releases = {
+        "covered": rel("0.16.0", ["0.15.0"]),
+        "short": rel("0.15.1", ["0.15.0"]),
+        "needed": rel("0.15.0", ["0.15.0"]),
+        "fresh": rel("0.1.0", []),
+        "unknown": rel("0.16.0", None),
+    }
+    assert classify("covered", "minor", releases) == "covered"
+    assert classify("short", "minor", releases) == "short"
+    assert classify("needed", "minor", releases) == "needed"
+    assert classify("fresh", "minor", releases) == "covered"
+    # An unknown registry is never reported as "short": there is no latest to
+    # promote from, and "needed" is the safe answer.
+    assert classify("unknown", "minor", releases) == "needed"
+    # A pending patch is enough when only a patch is owed.
+    assert classify("short", "patch", releases) == "covered"
+
+
+def test_describe():
+    assert rel("0.15.0", ["0.15.0"]).describe() == "0.15.0 is on crates.io"
+    assert rel("0.16.0", ["0.15.0"]).describe() == "0.16.0 pending, crates.io has 0.15.0"
+    assert rel("0.1.0", []).describe() == "never published"
+    assert rel("0.1.0", None).describe() == "registry unknown"
+
+
+def main():
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for t in tests:
+        t()
+    print(f"{len(tests)} tests passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

Follow-up to #2546, which moved `tari_bor` 0.15.1 → 0.16.0 and deferred "the rest of the cascade — workspace rollup to 0.42.0 plus 18 dependent bumps".

**That cascade is one crate, not 18** — and the reason the script said otherwise is the second commit.

### 1. `ootle_serde` 0.5.0 → 0.6.0

`crate_versioning.py impact` computes which crates a breaking change is breaking *for*. That is not the same question as which crates still need a version edit, and the two come apart whenever a release is pending: a version that was never published carries no `^0.y` pins, so nothing can be broken by changing what goes into it.

Checking each crate in the impact list against crates.io:

| crate | in tree | on crates.io | |
|---|---|---|---|
| tier-3 cohort (`tari_engine_types`, `tari_ootle_common_types`, `tari_ootle_transaction`, `tari_transaction_manifest`, `tari_engine`, `tari_consensus_types`, `ootle-wasm-core`, `ootle-wasm`, `tari_template_test_tooling`) | 0.41.0 | 0.40.0 | pending |
| `tari_bor` | 0.16.0 | 0.15.0 | pending |
| `tari_template_abi` | 0.20.0 | 0.19.1 | pending |
| `tari_template_lib_types` | 0.32.0 | 0.31.0 | pending |
| `tari_template_lib` | 0.32.0 | 0.31.1 | pending |
| `tari_template_macros` | 0.23.0 | 0.22.1 | pending |
| `tari_template_builtin` | 0.41.0 | 0.40.0 | pending |
| `ootle_byte_type` | 0.13.0 | 0.12.0 | pending |
| `tari_ootle_template_metadata` | 0.12.0 | 0.11.0 | pending |
| `tari_ootle_template_build` | 0.12.0 | 0.11.0 | pending |
| `tari_ootle_address` | 0.11.0 | 0.10.0 | pending |
| `tari_indexer_client` | 0.42.0 | 0.41.0 | pending |
| `ootle_ledger_client` | 0.7.0 | 0.6.0 | pending |
| `ootle-rs` | 0.23.0 | 0.22.0 | pending |
| `tari_ootle_wallet_crypto` | 0.43.0 | 0.42.0 | pending |
| `tari_ootle_wallet_sdk` | 0.43.0 | 0.42.0 | pending |
| `tari_ootle_wallet_storage_sqlite` | 0.43.0 | 0.42.0 | pending |
| `tari_ootle_walletd_client` | 0.43.0 | 0.42.0 | pending |
| **`ootle_serde`** | **0.5.0** | **0.5.0** | **released** |

Every one of them except `ootle_serde` already sits on a pending **minor** bump that has not shipped. Those pending releases absorb the `tari_bor` change and already announce it with the number they carry. Rolling the workspace to 0.42.0 would burn a minor version to fix nothing.

`ootle_serde` 0.5.0 **is** on crates.io, published against `tari_bor = "^0.15.0"`:

```
$ curl -s https://index.crates.io/oo/tl/ootle_serde | jq -r 'select(.vers=="0.5.0").deps[]|select(.name=="tari_bor")|.req'
^0.15.0
```

so its next release needs a new number, and a breaking one — it re-exposes `tari_bor` in its public API. Hence 0.5.0 → 0.6.0 and the `[workspace.dependencies]` pin with it.

The other two crates whose in-tree version is already published, `ootle-network` and `ootle_ledger_common` (both 0.2.0), have no publish-set dependencies at all, so they are unaffected.

### 2. Teaching the script the difference

Left alone, `impact` prints the same phantom cascade after every release-pending window, so `list` and `impact` now read the crates.io sparse index and classify each crate:

| state | meaning | action |
|---|---|---|
| `pending` | not on crates.io, and breaks a pin on the latest that is | none — the pending release covers it |
| `released` | the tree's version is spent | must move |
| *short* | a bump is pending but too small to break the pin it must break (`0.15.1` against a published `0.15.0`) | promote to a minor |

Only outstanding bumps reach the suggested workflow. The rest are listed under "already covered" for the audit trail, and when nothing is owed the answer is `No version changes required.`

Run against the tree as it stood **before** commit 1, it produces exactly this PR:

```
Impact analysis: tari_bor 0.16.0 [stable]
Breaking (minor) change — tari_bor 0.16.0 pending, crates.io has 0.15.0, so its own bump is already made.

Tier 3 (core) — the workspace cohort:
  No rollup needed — [workspace.package].version 0.41.0 is already an unreleased breaking bump ahead of crates.io.
    ...

Independent (non-core) — minor (breaking) bump required:
    ootle_serde 0.5.0 -> 0.6.0  (re-exposes tari_bor in public API)
      0.5.0 is on crates.io

Already covered by an unreleased bump (17) — no action:
    ...
  A ^0.y pin cannot exist on a version that was never published, so the pending
  release absorbs the change under a number that already announces it.

Suggested workflow:
  1. Minor-bump these independent crates in their own Cargo.toml,
     and update each one's pin in [workspace.dependencies]:
       ootle_serde -> 0.6.0
  2. cargo +nightly-2025-12-05 fmt --all, then ./scripts/publish_crates.py --dry-run, then --execute.
```

`list` gained the same column, which doubles as a release checklist — the `pending` rows are exactly what the next `--execute` will push:

```
tari_bor        0.16.0  [stable  ]  pending (crates.io: 0.15.0)   crates/tari_bor
ootle-network    0.2.0  [stable  ]  released                      crates/ootle_network
```

**Failure modes.** `--offline` skips the lookup and restores the old exhaustive listing (verified byte-identical to the previous output for this case). A lookup that fails for an individual crate is treated as `released`, so the script over-asks rather than skipping a bump that is needed — the under-bump is the hazard, the same reasoning as the existing `IMPL_DETAIL_DEPS` default. Both are called out in the output rather than left silent.

`published_versions()` in `publish_crates.py` backs both scripts and `is_published()` now reads through it, so there is one code path to the registry. It distinguishes "never published" from "lookup failed", which the old `is_published` collapsed, and excludes yanked versions from *latest* while still counting them as *taken* — a yanked number cannot be republished.

## Verification

```
python3 scripts/test_crate_versioning.py     # 12 tests, no network/cargo/pytest
cargo metadata --offline                     # workspace resolves clean
./scripts/publish_crates.py                  # read-only: skips ootle-network + ootle_ledger_common, matches `list`
./scripts/crate_versioning.py impact tari_bor --breaking            # No version changes required
./scripts/crate_versioning.py impact tari_bor --breaking --offline  # full cascade, unchanged from before
```

Each branch was exercised against the real registry: target already bumped, target released, a synthetic *short* bump (`ootle_serde` at 0.5.1 → correctly asks for 0.6.0), the non-breaking path in both states, and `--offline`.

`cargo metadata` is the check that the pin edit is right: cargo rejects a `path` + `version` dependency whose pin does not admit the path crate's own version.

## Breaking Changes

- [ ] None
- [ ] Requires data directory to be deleted
- [x] Other - Please specify

`ootle_serde` 0.6.0 breaks `^0.5` pins, which is the point — it is the release that carries the `tari_bor` 0.16.0 signature change to crates.io consumers. No behaviour change in either commit; the breakage those versions announce landed in #2546.
