### PR TITLE
fix(engine)!: hash a receipt's exhaust_burn only from protocol version 1

### DIFF
--- a/crates/engine_types/src/fees.rs
+++ b/crates/engine_types/src/fees.rs
@@ -214,7 +214,7 @@ impl FeeReceipt {
 
     /// Writes the receipt as a protocol version 0 substate hash preimage: every field but
     /// `exhaust_burn`, which version 0 receipts do not carry.
-    pub fn borsh_serialize_v0<W: borsh::io::Write>(&self, writer: &mut W) -> borsh::io::Result<()> {
+    pub(crate) fn borsh_serialize_v0<W: borsh::io::Write>(&self, writer: &mut W) -> borsh::io::Result<()> {
         borsh::BorshSerialize::serialize(&self.total_fee_payment, writer)?;
         borsh::BorshSerialize::serialize(&self.total_fees_paid, writer)?;
         borsh::BorshSerialize::serialize(&self.total_fee_overcharge, writer)?;

--- a/crates/engine_types/src/fees.rs
+++ b/crates/engine_types/src/fees.rs
@@ -212,6 +212,15 @@ impl FeeReceipt {
         }
     }
 
+    /// Writes the receipt as a protocol version 0 substate hash preimage: every field but
+    /// `exhaust_burn`, which version 0 receipts do not carry.
+    pub fn borsh_serialize_v0<W: borsh::io::Write>(&self, writer: &mut W) -> borsh::io::Result<()> {
+        borsh::BorshSerialize::serialize(&self.total_fee_payment, writer)?;
+        borsh::BorshSerialize::serialize(&self.total_fees_paid, writer)?;
+        borsh::BorshSerialize::serialize(&self.total_fee_overcharge, writer)?;
+        borsh::BorshSerialize::serialize(&self.cost_breakdown, writer)
+    }
+
     pub fn to_cost_breakdown(&self) -> FeeCostBreakdown {
         FeeCostBreakdown {
             total_fees_charged: self.total_fees_charged(),

--- a/crates/engine_types/src/protocol_version.rs
+++ b/crates/engine_types/src/protocol_version.rs
@@ -21,8 +21,10 @@ pub enum ProtocolVersion {
     /// under.
     #[default]
     V0 = 0,
-    /// Block headers commit to their own protocol version. No network schedules this version in
-    /// [`Self::activations`]; scheduling it is a deliberate per-network deployment decision.
+    /// Block headers commit to their own protocol version, and a transaction receipt's substate hash
+    /// covers `FeeReceipt::exhaust_burn`. Networks without history launch at this version; a network
+    /// with V0 history reaches it through a scheduled activation in [`Self::activations`], a
+    /// deliberate per-network deployment decision.
     V1 = 1,
 }
 

--- a/crates/engine_types/src/substate_hasher.rs
+++ b/crates/engine_types/src/substate_hasher.rs
@@ -36,54 +36,29 @@ impl<'a> SubstateHashMessage<'a> {
     }
 }
 
+pub type SubstateValueHashMessageV0<'a> = SubstateValueHashMessage<'a, TransactionReceiptHashMessageV0<'a>>;
+
+/// Version 1 changes the transaction receipt's preimage, which covers `FeeReceipt::exhaust_burn`,
+/// and - through the leading `SubstateHashMessage` tag - the preimage of every substate.
+pub type SubstateValueHashMessageV1<'a> = SubstateValueHashMessage<'a, TransactionReceiptHashMessageV1<'a>>;
+
+/// The per-type preimage, shared by every protocol version so that the borsh tag of each variant is
+/// the same under all of them. Variant order is consensus-bound: a new variant goes at the end.
 #[derive(Debug, Clone, Copy, borsh::BorshSerialize)]
-pub enum SubstateValueHashMessageV0<'a> {
+pub enum SubstateValueHashMessage<'a, R> {
     Component(ComponentHashMessage<'a>),
     Resource(ResourceHashMessage<'a>),
     Vault(VaultHashMessage<'a>),
     NonFungible(NonFungibleContainerHashMessage<'a>),
     ClaimedOutputTombstone(ClaimedOutputTombstoneHashMessage<'a>),
-    TransactionReceipt(TransactionReceiptHashMessageV0<'a>),
+    TransactionReceipt(R),
     Template(PublishedTemplateHashMessage<'a>),
     ValidatorFeePool(ValidatorFeePoolHashMessage<'a>),
     Utxo(UtxoHashMessage<'a>),
     ConfidentialOutput(ConfidentialOutputHashMessage<'a>),
 }
 
-impl<'a> From<&'a SubstateValue> for SubstateValueHashMessageV0<'a> {
-    fn from(value: &'a SubstateValue) -> Self {
-        match value {
-            SubstateValue::Component(component) => Self::Component(component.into()),
-            SubstateValue::Resource(resource) => Self::Resource(resource.as_ref().into()),
-            SubstateValue::Vault(vault) => Self::Vault(vault.into()),
-            SubstateValue::NonFungible(nf) => Self::NonFungible(nf.into()),
-            SubstateValue::ClaimedOutputTombstone(tombstone) => Self::ClaimedOutputTombstone(tombstone.into()),
-            SubstateValue::TransactionReceipt(receipt) => Self::TransactionReceipt(receipt.into()),
-            SubstateValue::Template(template) => Self::Template(template.into()),
-            SubstateValue::ValidatorFeePool(pool) => Self::ValidatorFeePool(pool.into()),
-            SubstateValue::Utxo(utxo) => Self::Utxo(utxo.into()),
-            SubstateValue::ConfidentialOutput(output) => Self::ConfidentialOutput(output.into()),
-        }
-    }
-}
-
-/// Version 1 differs from version 0 in the transaction receipt alone: its preimage covers
-/// `FeeReceipt::exhaust_burn`.
-#[derive(Debug, Clone, Copy, borsh::BorshSerialize)]
-pub enum SubstateValueHashMessageV1<'a> {
-    Component(ComponentHashMessage<'a>),
-    Resource(ResourceHashMessage<'a>),
-    Vault(VaultHashMessage<'a>),
-    NonFungible(NonFungibleContainerHashMessage<'a>),
-    ClaimedOutputTombstone(ClaimedOutputTombstoneHashMessage<'a>),
-    TransactionReceipt(TransactionReceiptHashMessageV1<'a>),
-    Template(PublishedTemplateHashMessage<'a>),
-    ValidatorFeePool(ValidatorFeePoolHashMessage<'a>),
-    Utxo(UtxoHashMessage<'a>),
-    ConfidentialOutput(ConfidentialOutputHashMessage<'a>),
-}
-
-impl<'a> From<&'a SubstateValue> for SubstateValueHashMessageV1<'a> {
+impl<'a, R: From<&'a TransactionReceipt>> From<&'a SubstateValue> for SubstateValueHashMessage<'a, R> {
     fn from(value: &'a SubstateValue) -> Self {
         match value {
             SubstateValue::Component(component) => Self::Component(component.into()),
@@ -273,12 +248,16 @@ fn hash<T: borsh::BorshSerialize>(value: &T) -> Hash32 {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
+
     use ootle_network::Network;
+    use tari_template_lib::types::{ObjectKey, ResourceAddress, crypto::RistrettoPublicKeyBytes};
 
     use super::*;
     use crate::{
         Epoch,
         fees::{FeeBreakdown, FeeSource},
+        resource_container::ResourceContainer,
         substate::hash_substate,
         transaction_receipt::{DiffSummary, FinalizeOutcome},
     };
@@ -314,17 +293,34 @@ mod tests {
             .result()
     }
 
+    fn hex(hash: Hash32) -> String {
+        hex::encode(hash.as_ref() as &[u8])
+    }
+
     /// The hash a binary that predates `FeeReceipt::exhaust_burn` produced for this receipt (captured
     /// from `hash_substate` at 2cc729b95). Version 0 must keep producing it, or no node can re-derive
-    /// the state roots that committed such receipts. Esmeralda is the network whose genesis is V0.
+    /// the state roots that committed such receipts.
     #[test]
     fn version_0_reproduces_the_pre_exhaust_burn_hash() {
-        let hash = hash_substate(Network::Esmeralda, &receipt(0), 0, Epoch(3));
         assert_eq!(
-            hex::encode(hash.as_ref() as &[u8]),
+            hex(hash_at(ProtocolVersion::V0, &receipt(0))),
             "061d838f149c767043152d6362afd71f18d58ac41c1c7b0a7f130066e9e1efcb"
         );
-        assert_eq!(hash, hash_at(ProtocolVersion::V0, &receipt(0)));
+        // Esmeralda is the network whose history was hashed under version 0.
+        assert_eq!(ProtocolVersion::at(Network::Esmeralda, Epoch(3)), ProtocolVersion::V0);
+        assert_eq!(
+            hash_substate(Network::Esmeralda, &receipt(0), 0, Epoch(3)),
+            hash_at(ProtocolVersion::V0, &receipt(0))
+        );
+    }
+
+    /// Networks launched at version 1 commit to this from their first block.
+    #[test]
+    fn version_1_hash_is_pinned() {
+        assert_eq!(
+            hex(hash_at(ProtocolVersion::V1, &receipt(123))),
+            "78a85877d39682b55d299b5c3fad89b4261603bc2e261f5af728caa876fbbc78"
+        );
     }
 
     #[test]
@@ -345,5 +341,47 @@ mod tests {
             hash_at(ProtocolVersion::V0, &receipt(0)),
             hash_at(ProtocolVersion::V1, &receipt(0))
         );
+    }
+
+    /// Pins the borsh tag of every variant with a cheaply constructed value, so a variant inserted
+    /// ahead of any of them fails here rather than moving consensus-bound tags silently. The two
+    /// leading bytes are the `SubstateHashMessage` version tag and the value tag.
+    #[test]
+    fn value_tags_are_stable_and_shared_by_both_versions() {
+        let values: Vec<(u8, SubstateValue)> = vec![
+            (
+                2,
+                SubstateValue::Vault(Vault::new(ResourceContainer::non_fungible(
+                    ResourceAddress::new(ObjectKey::from_array([1u8; ObjectKey::LENGTH])),
+                    BTreeSet::new(),
+                ))),
+            ),
+            (
+                3,
+                SubstateValue::NonFungible(NonFungibleContainer::new(tari_bor::Value::Null, tari_bor::Value::Null)),
+            ),
+            (
+                4,
+                SubstateValue::ClaimedOutputTombstone(ClaimedOutputTombstone { value: 1 }),
+            ),
+            (5, receipt(0)),
+            (
+                7,
+                SubstateValue::ValidatorFeePool(ValidatorFeePool::new(RistrettoPublicKeyBytes::default(), 5)),
+            ),
+        ];
+        for (tag, value) in &values {
+            let v0 = borsh::to_vec(&SubstateHashMessage::new(ProtocolVersion::V0, value)).unwrap();
+            let v1 = borsh::to_vec(&SubstateHashMessage::new(ProtocolVersion::V1, value)).unwrap();
+            assert_eq!(&v0[..2], &[0, *tag], "V0 tag for {value:?}");
+            assert_eq!(&v1[..2], &[1, *tag], "V1 tag for {value:?}");
+            if value.as_transaction_receipt().is_none() {
+                assert_eq!(
+                    v0[1..],
+                    v1[1..],
+                    "V1 must differ from V0 only in the version tag for {value:?}"
+                );
+            }
+        }
     }
 }

--- a/crates/engine_types/src/substate_hasher.rs
+++ b/crates/engine_types/src/substate_hasher.rs
@@ -343,9 +343,10 @@ mod tests {
         );
     }
 
-    /// Pins the borsh tag of every variant with a cheaply constructed value, so a variant inserted
-    /// ahead of any of them fails here rather than moving consensus-bound tags silently. The two
-    /// leading bytes are the `SubstateHashMessage` version tag and the value tag.
+    /// Pins the borsh tag of every cheaply constructed variant, which pins the rest transitively: a
+    /// variant inserted anywhere but after `Utxo` shifts one of these tags. `ConfidentialOutput` is
+    /// last, where an append is the only move and is safe. The two leading bytes are the
+    /// `SubstateHashMessage` version tag and the value tag.
     #[test]
     fn value_tags_are_stable_and_shared_by_both_versions() {
         let values: Vec<(u8, SubstateValue)> = vec![
@@ -368,6 +369,13 @@ mod tests {
             (
                 7,
                 SubstateValue::ValidatorFeePool(ValidatorFeePool::new(RistrettoPublicKeyBytes::default(), 5)),
+            ),
+            (
+                8,
+                SubstateValue::Utxo(Utxo {
+                    output: None,
+                    is_frozen: false,
+                }),
             ),
         ];
         for (tag, value) in &values {

--- a/crates/engine_types/src/substate_hasher.rs
+++ b/crates/engine_types/src/substate_hasher.rs
@@ -9,6 +9,7 @@ use crate::{
     component::Component,
     confidential::ClaimedOutputTombstone,
     confidential_output::ConfidentialOutput,
+    fees::FeeReceipt,
     hashing::{EngineHashDomainLabel, hasher32},
     non_fungible::NonFungibleContainer,
     published_template::PublishedTemplate,
@@ -23,13 +24,14 @@ use crate::{
 #[derive(Debug, Clone, Copy, borsh::BorshSerialize)]
 pub enum SubstateHashMessage<'a> {
     V0(SubstateValueHashMessageV0<'a>),
+    V1(SubstateValueHashMessageV1<'a>),
 }
 
 impl<'a> SubstateHashMessage<'a> {
     pub fn new(protocol_version: ProtocolVersion, value: &'a SubstateValue) -> Self {
         match protocol_version {
-            // V1 changes the block header preimage only, so substates keep the V0 schema.
-            ProtocolVersion::V0 | ProtocolVersion::V1 => Self::V0(value.into()),
+            ProtocolVersion::V0 => Self::V0(value.into()),
+            ProtocolVersion::V1 => Self::V1(value.into()),
         }
     }
 }
@@ -41,7 +43,7 @@ pub enum SubstateValueHashMessageV0<'a> {
     Vault(VaultHashMessage<'a>),
     NonFungible(NonFungibleContainerHashMessage<'a>),
     ClaimedOutputTombstone(ClaimedOutputTombstoneHashMessage<'a>),
-    TransactionReceipt(TransactionReceiptHashMessage<'a>),
+    TransactionReceipt(TransactionReceiptHashMessageV0<'a>),
     Template(PublishedTemplateHashMessage<'a>),
     ValidatorFeePool(ValidatorFeePoolHashMessage<'a>),
     Utxo(UtxoHashMessage<'a>),
@@ -49,6 +51,39 @@ pub enum SubstateValueHashMessageV0<'a> {
 }
 
 impl<'a> From<&'a SubstateValue> for SubstateValueHashMessageV0<'a> {
+    fn from(value: &'a SubstateValue) -> Self {
+        match value {
+            SubstateValue::Component(component) => Self::Component(component.into()),
+            SubstateValue::Resource(resource) => Self::Resource(resource.as_ref().into()),
+            SubstateValue::Vault(vault) => Self::Vault(vault.into()),
+            SubstateValue::NonFungible(nf) => Self::NonFungible(nf.into()),
+            SubstateValue::ClaimedOutputTombstone(tombstone) => Self::ClaimedOutputTombstone(tombstone.into()),
+            SubstateValue::TransactionReceipt(receipt) => Self::TransactionReceipt(receipt.into()),
+            SubstateValue::Template(template) => Self::Template(template.into()),
+            SubstateValue::ValidatorFeePool(pool) => Self::ValidatorFeePool(pool.into()),
+            SubstateValue::Utxo(utxo) => Self::Utxo(utxo.into()),
+            SubstateValue::ConfidentialOutput(output) => Self::ConfidentialOutput(output.into()),
+        }
+    }
+}
+
+/// Version 1 differs from version 0 in the transaction receipt alone: its preimage covers
+/// `FeeReceipt::exhaust_burn`.
+#[derive(Debug, Clone, Copy, borsh::BorshSerialize)]
+pub enum SubstateValueHashMessageV1<'a> {
+    Component(ComponentHashMessage<'a>),
+    Resource(ResourceHashMessage<'a>),
+    Vault(VaultHashMessage<'a>),
+    NonFungible(NonFungibleContainerHashMessage<'a>),
+    ClaimedOutputTombstone(ClaimedOutputTombstoneHashMessage<'a>),
+    TransactionReceipt(TransactionReceiptHashMessageV1<'a>),
+    Template(PublishedTemplateHashMessage<'a>),
+    ValidatorFeePool(ValidatorFeePoolHashMessage<'a>),
+    Utxo(UtxoHashMessage<'a>),
+    ConfidentialOutput(ConfidentialOutputHashMessage<'a>),
+}
+
+impl<'a> From<&'a SubstateValue> for SubstateValueHashMessageV1<'a> {
     fn from(value: &'a SubstateValue) -> Self {
         match value {
             SubstateValue::Component(component) => Self::Component(component.into()),
@@ -121,30 +156,62 @@ impl<'a> From<&'a ClaimedOutputTombstone> for ClaimedOutputTombstoneHashMessage<
     }
 }
 
+/// The receipt preimage under protocol version 0. `FeeReceipt` is written without `exhaust_burn`,
+/// the shape every version 0 receipt was hashed with.
 #[derive(Debug, Clone, Copy)]
-pub struct TransactionReceiptHashMessage<'a> {
+pub struct TransactionReceiptHashMessageV0<'a> {
     pub receipt: &'a TransactionReceipt,
 }
 
-impl<'a> From<&'a TransactionReceipt> for TransactionReceiptHashMessage<'a> {
+impl<'a> From<&'a TransactionReceipt> for TransactionReceiptHashMessageV0<'a> {
     fn from(receipt: &'a TransactionReceipt) -> Self {
         Self { receipt }
     }
 }
 
-impl borsh::BorshSerialize for TransactionReceiptHashMessage<'_> {
+impl borsh::BorshSerialize for TransactionReceiptHashMessageV0<'_> {
     fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
-        BorshSerialize::serialize(&self.receipt.outcome, writer)?;
-        BorshSerialize::serialize(&self.receipt.diff_summary, writer)?;
-        BorshSerialize::serialize(&self.receipt.fee_withdrawals, writer)?;
-        let events = hash(&self.receipt.events);
-        BorshSerialize::serialize(&events, writer)?;
-        BorshSerialize::serialize(&self.receipt.fee_receipt, writer)?;
-        BorshSerialize::serialize(&self.receipt.epoch, writer)?;
-        // Serialized in full: the commitment is already 32 bytes, so part-hashing it saves nothing.
-        BorshSerialize::serialize(&self.receipt.intent_commitment, writer)?;
-        Ok(())
+        serialize_receipt(self.receipt, writer, |fee_receipt, writer| {
+            fee_receipt.borsh_serialize_v0(writer)
+        })
     }
+}
+
+/// The receipt preimage from protocol version 1: the whole `FeeReceipt`, `exhaust_burn` included.
+#[derive(Debug, Clone, Copy)]
+pub struct TransactionReceiptHashMessageV1<'a> {
+    pub receipt: &'a TransactionReceipt,
+}
+
+impl<'a> From<&'a TransactionReceipt> for TransactionReceiptHashMessageV1<'a> {
+    fn from(receipt: &'a TransactionReceipt) -> Self {
+        Self { receipt }
+    }
+}
+
+impl borsh::BorshSerialize for TransactionReceiptHashMessageV1<'_> {
+    fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
+        serialize_receipt(self.receipt, writer, |fee_receipt, writer| {
+            BorshSerialize::serialize(fee_receipt, writer)
+        })
+    }
+}
+
+fn serialize_receipt<W: io::Write>(
+    receipt: &TransactionReceipt,
+    writer: &mut W,
+    serialize_fee_receipt: impl FnOnce(&FeeReceipt, &mut W) -> io::Result<()>,
+) -> io::Result<()> {
+    BorshSerialize::serialize(&receipt.outcome, writer)?;
+    BorshSerialize::serialize(&receipt.diff_summary, writer)?;
+    BorshSerialize::serialize(&receipt.fee_withdrawals, writer)?;
+    let events = hash(&receipt.events);
+    BorshSerialize::serialize(&events, writer)?;
+    serialize_fee_receipt(&receipt.fee_receipt, writer)?;
+    BorshSerialize::serialize(&receipt.epoch, writer)?;
+    // Serialized in full: the commitment is already 32 bytes, so part-hashing it saves nothing.
+    BorshSerialize::serialize(&receipt.intent_commitment, writer)?;
+    Ok(())
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -202,4 +269,81 @@ fn hash<T: borsh::BorshSerialize>(value: &T) -> Hash32 {
     hasher32(EngineHashDomainLabel::SubstateValuePart)
         .chain(&value)
         .result()
+}
+
+#[cfg(test)]
+mod tests {
+    use ootle_network::Network;
+
+    use super::*;
+    use crate::{
+        Epoch,
+        fees::{FeeBreakdown, FeeSource},
+        substate::hash_substate,
+        transaction_receipt::{DiffSummary, FinalizeOutcome},
+    };
+
+    fn receipt(exhaust_burn: u64) -> SubstateValue {
+        let mut breakdown = FeeBreakdown::default();
+        breakdown.add(FeeSource::Initial, 10);
+        breakdown.add(FeeSource::Storage, 30);
+        breakdown.add(FeeSource::WasmExecution, 20);
+        let fee_receipt = FeeReceipt::builder()
+            .with_total_fee_payment(1000)
+            .with_total_fees_paid(60)
+            .with_total_fee_overcharge(0)
+            .with_cost_breakdown(breakdown)
+            .with_exhaust_burn(exhaust_burn)
+            .build();
+        SubstateValue::TransactionReceipt(TransactionReceipt {
+            outcome: FinalizeOutcome::Commit,
+            diff_summary: DiffSummary { upped: Box::new([]) },
+            fee_withdrawals: Box::new([]),
+            events: Box::new([]),
+            fee_receipt,
+            epoch: Epoch(3),
+            intent_commitment: Hash32::from_array([7u8; 32]),
+        })
+    }
+
+    fn hash_at(version: ProtocolVersion, value: &SubstateValue) -> Hash32 {
+        hasher32(EngineHashDomainLabel::SubstateValue)
+            .chain(&SubstateHashMessage::new(version, value))
+            .chain(&0u32)
+            .chain(&Epoch(3))
+            .result()
+    }
+
+    /// The hash a binary that predates `FeeReceipt::exhaust_burn` produced for this receipt (captured
+    /// from `hash_substate` at 2cc729b95). Version 0 must keep producing it, or no node can re-derive
+    /// the state roots that committed such receipts. Esmeralda is the network whose genesis is V0.
+    #[test]
+    fn version_0_reproduces_the_pre_exhaust_burn_hash() {
+        let hash = hash_substate(Network::Esmeralda, &receipt(0), 0, Epoch(3));
+        assert_eq!(
+            hex::encode(hash.as_ref() as &[u8]),
+            "061d838f149c767043152d6362afd71f18d58ac41c1c7b0a7f130066e9e1efcb"
+        );
+        assert_eq!(hash, hash_at(ProtocolVersion::V0, &receipt(0)));
+    }
+
+    #[test]
+    fn version_0_does_not_cover_exhaust_burn() {
+        assert_eq!(
+            hash_at(ProtocolVersion::V0, &receipt(0)),
+            hash_at(ProtocolVersion::V0, &receipt(123))
+        );
+    }
+
+    #[test]
+    fn version_1_covers_exhaust_burn() {
+        assert_ne!(
+            hash_at(ProtocolVersion::V1, &receipt(0)),
+            hash_at(ProtocolVersion::V1, &receipt(123))
+        );
+        assert_ne!(
+            hash_at(ProtocolVersion::V0, &receipt(0)),
+            hash_at(ProtocolVersion::V1, &receipt(0))
+        );
+    }
 }


### PR DESCRIPTION
## Description

`SubstateHashMessage` now has a V1 shape. V0 writes `FeeReceipt` without `exhaust_burn`, V1 writes the whole struct. The per-type enum `SubstateValueHashMessage<R>` is shared by both versions (generic over the receipt message), so their variant tags cannot drift apart. Note that at the byte level V1 changes every substate's preimage, not only receipts: `SubstateHashMessage` is a borsh enum, so V1 writes a leading tag of `1` where V0 writes `0`. No leaf moves because the schema is selected from the substate's creation epoch, but at an activation epoch every substate created from then on hashes under the new tag. `ProtocolVersion::V1`'s doc names both things it changes.

## Motivation and Context

#2520 added `FeeReceipt::exhaust_burn` with `#[cbor(default)]` so receipts committed before it still decode. The substate hash preimage is borsh, and the derive writes every field, so a pre-#2520 receipt now re-hashes with an extra `0` that the committing node never covered. Any node that derives a receipt's hash from its value disagrees with the quorum-signed state roots: a validator or indexer syncing from scratch, and substate proof verification.

Found by resyncing a validator on a localnet swarm that had crossed the upgrade. Shard 0 matched; shard 1 mismatched at the first checkpoint after the first receipt. Walking both JMTs: 179 of 380 receipt leaves hashed differently, every other substate type identical, and the split fell exactly on the epoch the swarm was upgraded. A fresh validator could not sync at all.

Version 0 now writes the exact preimage the pre-#2520 binary produced, pinned by a golden hash captured by running `hash_substate` at `2cc729b95` (the parent of #2520) on the same synthetic receipt.

## Scope

This prevents the next occurrence; it cannot repair a network that already committed receipts under a post-#2520 binary while on V0. Those receipts were hashed with the field, and an epoch-granular activation cannot describe a mid-epoch cutover. Such a network needs a reset. Esmeralda has not run a post-#2520 binary, so it is covered as long as its V1 activation is scheduled at or after the epoch that binary is deployed.

The gap while esmeralda runs a post-#2520 binary on V0 is narrower than "an uncommitted consensus value": the burn is committed through `BlockHeader::total_accumulated_exhaust_burn`, which every voter re-derives (`on_ready_to_vote_on_local_block.rs`), so a node computing a different burn refuses to vote rather than forking. What V0 leaves out is only the per-receipt field in the state root.

## How Has This Been Tested?

`cargo test -p tari_engine_types` (85 tests) and `cargo lints clippy -p tari_engine_types --all-targets` clean.

- `version_0_reproduces_the_pre_exhaust_burn_hash` — the golden above, asserted through `ProtocolVersion::V0` directly, with esmeralda's V0 genesis stated as its own assertion. This is the whole guarantee.
- `version_1_hash_is_pinned` — a V1 golden; five networks launch at V1, so it is consensus-bound from their first block.
- `version_0_does_not_cover_exhaust_burn` / `version_1_covers_exhaust_burn`.
- `value_tags_are_stable_and_shared_by_both_versions` — pins the borsh tags 2,3,4,5,7,8 (vault, non-fungible, tombstone, receipt, fee pool, utxo) under both versions, and that V1 differs from V0 only in the leading version tag outside the receipt. That pins the rest transitively: any insertion except after `Utxo` shifts a pinned tag, and after `Utxo` only the final variant follows, where an append is the only move.

## What process can a PR reviewer use to test or verify this change?

Run the tests. To re-derive the golden independently: check out `2cc729b95`, build the receipt in `substate_hasher::tests::receipt` (no `with_exhaust_burn`, which does not exist there) and print `hash_substate(Network::LocalNet, &value, 0, Epoch(3))` — LocalNet was V0-genesis at that commit.

## Breaking Changes

- [ ] None
- [ ] Requires data directory to be deleted
- [ ] Requires hard fork
- [x] Other - Please specify

`SubstateHashMessage` gains a `V1` variant and `TransactionReceiptHashMessage` becomes `TransactionReceiptHashMessageV0`/`V1`. Networks launched at V1 hash receipts with `exhaust_burn`; V0 hashes are byte-identical to before.


