### PR TITLE
feat(engine)!: allow a resource's auth hook to be replaced or removed

### DIFF
--- a/bindings/src/types/ResourceAccessRules.ts
+++ b/bindings/src/types/ResourceAccessRules.ts
@@ -22,4 +22,14 @@ export type ResourceAccessRules = {
   freeze_updater: UpdateRule;
   update_metadata: AccessRule;
   metadata_updater: UpdateRule;
+  /**
+   * Who may replace or remove the resource's [`AuthHook`](crate::AuthHook). The hook itself is not an
+   * [`AccessRule`], so this updater stands alone rather than pairing with one.
+   *
+   * A hook runs on nearly every resource action, so one that panics or denies unconditionally takes the
+   * resource offline and strands the balances in its vaults. `Locked` — the default — keeps a hook binding
+   * for the life of the resource; anything else lets the hook be repaired or retired, at the cost of letting
+   * whoever satisfies the updater change the rules that existing holders are relying on.
+   */
+  auth_hook_updater: UpdateRule;
 };

--- a/bindings/src/types/ResourceAccessRules.ts
+++ b/bindings/src/types/ResourceAccessRules.ts
@@ -23,13 +23,14 @@ export type ResourceAccessRules = {
   update_metadata: AccessRule;
   metadata_updater: UpdateRule;
   /**
-   * Who may replace or remove the resource's [`AuthHook`](crate::AuthHook). The hook itself is not an
-   * [`AccessRule`], so this updater stands alone rather than pairing with one.
+   * Who may install, replace or remove the resource's [`AuthHook`](crate::AuthHook). The hook itself is not
+   * an [`AccessRule`], so this updater stands alone rather than pairing with one.
    *
    * A hook runs on nearly every resource action, so one that panics or denies unconditionally takes the
    * resource offline and strands the balances in its vaults. `Locked` — the default — keeps a hook binding
    * for the life of the resource; anything else lets the hook be repaired or retired, at the cost of letting
-   * whoever satisfies the updater change the rules that existing holders are relying on.
+   * whoever satisfies the updater change the rules that existing holders are relying on — up to and
+   * including giving a hook-free resource a hook.
    */
   auth_hook_updater: UpdateRule;
 };

--- a/crates/engine/src/runtime/actions.rs
+++ b/crates/engine/src/runtime/actions.rs
@@ -64,6 +64,7 @@ pub enum NativeAction {
     StealthUtxoSpend,
     UpdateComponentTemplate,
     UpdateResourceAccessRule(ResourceAuthAction),
+    UpdateResourceAuthHook,
 }
 
 impl Display for NativeAction {
@@ -76,6 +77,7 @@ impl Display for NativeAction {
             Self::StealthUtxoSpend => write!(f, "stealth_utxo.spend"),
             Self::UpdateComponentTemplate => write!(f, "component.update_template"),
             Self::UpdateResourceAccessRule(action) => write!(f, "resource.update_access_rule.{:?}", action),
+            Self::UpdateResourceAuthHook => write!(f, "resource.update_auth_hook"),
         }
     }
 }

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -101,6 +101,7 @@ use tari_template_lib::{
         SpendContextAction,
         StealthTransferResourceArg,
         UpdateAccessRuleArg,
+        UpdateAuthHookArg,
         VaultAction,
         VaultCreateProofByFungibleAmountArg,
         VaultCreateProofByNonFungiblesArg,
@@ -578,7 +579,9 @@ impl<TStore: StateReader + Clone + 'static, TTemplateProvider: TemplateProvider<
         Ok(())
     }
 
-    fn check_resource_auth_hook(&mut self, hook: &AuthHook) -> Result<(), RuntimeError> {
+    /// Validates that `hook` names a method with an authorization hook's signature. `argument` names the engine
+    /// argument the hook arrived in, so that a rejection points at the call the caller actually made.
+    fn check_resource_auth_hook(&mut self, argument: &'static str, hook: &AuthHook) -> Result<(), RuntimeError> {
         let template_address = self
             .tracker
             .write_with(|state| state.get_template_for_component(hook.component_address))?;
@@ -586,26 +589,26 @@ impl<TStore: StateReader + Clone + 'static, TTemplateProvider: TemplateProvider<
         let func = template
             .get_function(&hook.method)
             .ok_or(RuntimeError::InvalidArgument {
-                argument: "CreateResourceArg",
+                argument,
                 reason: format!("Authorize hook '{}' not found", hook),
             })?;
 
         if func.is_mut {
             return Err(RuntimeError::InvalidArgument {
-                argument: "CreateResourceArg",
+                argument,
                 reason: format!("Authorize hook '{}' cannot be mutable", hook),
             });
         }
         if !matches!(func.output, Type::Unit) {
             return Err(RuntimeError::InvalidArgument {
-                argument: "CreateResourceArg",
+                argument,
                 reason: format!("Authorize hook '{}' must return unit", hook),
             });
         }
 
         if func.arguments.len() != 3 {
             return Err(RuntimeError::InvalidArgument {
-                argument: "CreateResourceArg",
+                argument,
                 reason: format!(
                     "Authorize hook '{}' must take 3 arguments (incl &self), but found {}",
                     hook,
@@ -619,7 +622,7 @@ impl<TStore: StateReader + Clone + 'static, TTemplateProvider: TemplateProvider<
             Some("ResourceAuthAction")
         ) {
             return Err(RuntimeError::InvalidArgument {
-                argument: "CreateResourceArg",
+                argument,
                 reason: format!("Authorize hook '{}' must take a ResourceAuthAction as argument 1", hook),
             });
         }
@@ -629,7 +632,7 @@ impl<TStore: StateReader + Clone + 'static, TTemplateProvider: TemplateProvider<
             Some("AuthHookCaller")
         ) {
             return Err(RuntimeError::InvalidArgument {
-                argument: "CreateResourceArg",
+                argument,
                 reason: format!("Authorize hook '{}' must take an AuthHookCaller as argument 2", hook),
             });
         }
@@ -1532,7 +1535,7 @@ where
 
                 // Check that auth hook is valid
                 if let Some(hook) = arg.authorize_hook.as_ref() {
-                    self.check_resource_auth_hook(hook)?;
+                    self.check_resource_auth_hook("CreateResourceArg", hook)?;
                 }
 
                 // Charge the initial mint's native verification cost against the payment-funded
@@ -1896,6 +1899,62 @@ where
                         ("action", format!("{:?}", action)),
                     ]);
                     Self::emit_std_event("resource", "update_access_rule", resource_address, payload, state_mut)?;
+
+                    state_mut.unlock_substate(resource_lock)?;
+
+                    Ok(InvokeResult::unit())
+                })
+            },
+            ResourceAction::UpdateAuthHook => {
+                let resource_address =
+                    resource_ref
+                        .as_resource_address()
+                        .ok_or_else(|| RuntimeError::InvalidArgument {
+                            argument: "resource_ref",
+                            reason: "UpdateAuthHook resource action requires a resource address".to_string(),
+                        })?;
+                let UpdateAuthHookArg { auth_hook } = args.assert_one_arg()?;
+
+                let resource_lock = self.tracker.write_with(|state_mut| {
+                    let resource_lock = state_mut.write_lock_substate(SubstateId::Resource(resource_address))?;
+
+                    let resource = state_mut.get_resource(&resource_lock)?;
+                    let updater = resource.access_rules().auth_hook_updater();
+
+                    let authorized = match updater {
+                        UpdateRule::Locked => false,
+                        UpdateRule::Owner => state_mut
+                            .authorization()
+                            .check_ownership_in_current_frame(resource.as_ownership())?,
+                        UpdateRule::AccessRule(rule) => state_mut.authorization().check_access_rule(rule)?,
+                    };
+
+                    if !authorized {
+                        return Err(RuntimeError::AccessDenied {
+                            action_ident: ActionIdent::Native(NativeAction::UpdateResourceAuthHook),
+                        });
+                    }
+
+                    Ok::<_, RuntimeError>(resource_lock)
+                })?;
+
+                // The hook being replaced is not invoked: a hook that denies or panics is the failure this
+                // action exists to repair, so asking it to approve its own removal would defeat the point.
+                if let Some(hook) = auth_hook.as_ref() {
+                    self.check_resource_auth_hook("UpdateAuthHookArg", hook)?;
+                }
+
+                self.tracker.write_with(|state_mut| {
+                    let resource_mut = state_mut.get_resource_mut(&resource_lock)?;
+                    let payload = Metadata::from_iter([
+                        ("resource_type", resource_mut.resource_type().to_string()),
+                        (
+                            "auth_hook",
+                            auth_hook.as_ref().map_or_else(|| "none".to_string(), |h| h.to_string()),
+                        ),
+                    ]);
+                    resource_mut.set_auth_hook(auth_hook);
+                    Self::emit_std_event("resource", "update_auth_hook", resource_address, payload, state_mut)?;
 
                     state_mut.unlock_substate(resource_lock)?;
 

--- a/crates/engine/tests/access_rules.rs
+++ b/crates/engine/tests/access_rules.rs
@@ -22,6 +22,7 @@ use tari_template_lib::{
             ResourceAuthAction,
             RestrictedAccessRule,
             RuleRequirement,
+            UpdateRule,
         },
         rule,
     },
@@ -1315,6 +1316,217 @@ mod resource_access_rules {
                 reason: "Authorize hook".to_string(),
             });
         })
+    }
+
+    #[test]
+    fn auth_hook_is_locked_by_default() {
+        let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/access_rules"]);
+
+        let (_, owner_proof, owner_key) = test.create_empty_account();
+
+        let access_rules_template = test.get_template_address("AccessRulesTest");
+
+        let result = test.execute_expect_success(
+            Transaction::builder_localnet(Epoch(1))
+                .call_function(access_rules_template, "with_auth_hook", args![true, "valid_auth_hook"])
+                .build_and_seal(&owner_key),
+            vec![owner_proof.clone()],
+        );
+
+        let component_address = result.finalize.execution_results[0]
+            .decode::<ComponentAddress>()
+            .unwrap();
+
+        let reason = test.execute_expect_failure(
+            Transaction::builder_localnet(Epoch(1))
+                .call_method(component_address, "set_auth_hook", args![None::<String>])
+                .build_and_seal(&owner_key),
+            vec![owner_proof],
+        );
+
+        assert_reject_reason(reason, RuntimeError::AccessDenied {
+            action_ident: ActionIdent::Native(NativeAction::UpdateResourceAuthHook),
+        });
+    }
+
+    #[test]
+    fn a_denying_auth_hook_can_be_removed_by_the_owner() {
+        let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/access_rules"]);
+
+        let (owner_account, owner_proof, owner_key) = test.create_empty_account();
+
+        let access_rules_template = test.get_template_address("AccessRulesTest");
+
+        // `allowed = false` makes `valid_auth_hook` panic on every action, which is the failure this action
+        // exists to recover from.
+        let result = test.execute_expect_success(
+            Transaction::builder_localnet(Epoch(1))
+                .call_function(access_rules_template, "with_updatable_auth_hook", args![
+                    false,
+                    "valid_auth_hook",
+                    OWNER
+                ])
+                .build_and_seal(&owner_key),
+            vec![owner_proof.clone()],
+        );
+
+        let component_address = result.finalize.execution_results[0]
+            .decode::<ComponentAddress>()
+            .unwrap();
+
+        let take_and_deposit = || {
+            Transaction::builder_localnet(Epoch(1))
+                .call_method(component_address, "take_tokens", args![10])
+                .put_last_instruction_output_on_workspace("tokens")
+                .call_method(owner_account, "deposit", args![Workspace("tokens")])
+                .build_and_seal(&owner_key)
+        };
+
+        let reason = test.execute_expect_failure(take_and_deposit(), vec![owner_proof.clone()]);
+        assert_reject_reason(reason, RuntimeError::AccessDeniedAuthHook {
+            action_ident: ResourceAuthAction::Deposit.into(),
+            details: "Panic! Access denied for action Deposit".to_string(),
+        });
+
+        test.execute_expect_success(
+            Transaction::builder_localnet(Epoch(1))
+                .call_method(component_address, "set_auth_hook", args![None::<String>])
+                .build_and_seal(&owner_key),
+            vec![owner_proof.clone()],
+        );
+
+        test.execute_expect_success(take_and_deposit(), vec![owner_proof]);
+    }
+
+    #[test]
+    fn a_denying_auth_hook_can_be_replaced_by_the_owner() {
+        let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/access_rules"]);
+
+        let (owner_account, owner_proof, owner_key) = test.create_empty_account();
+
+        let access_rules_template = test.get_template_address("AccessRulesTest");
+
+        let result = test.execute_expect_success(
+            Transaction::builder_localnet(Epoch(1))
+                .call_function(access_rules_template, "with_updatable_auth_hook", args![
+                    false,
+                    "valid_auth_hook",
+                    OWNER
+                ])
+                .build_and_seal(&owner_key),
+            vec![owner_proof.clone()],
+        );
+
+        let component_address = result.finalize.execution_results[0]
+            .decode::<ComponentAddress>()
+            .unwrap();
+
+        // `caller_gated_hook` permits the action regardless of the component's `allowed` flag.
+        test.execute_expect_success(
+            Transaction::builder_localnet(Epoch(1))
+                .call_method(component_address, "set_auth_hook", args![Some("caller_gated_hook")])
+                .build_and_seal(&owner_key),
+            vec![owner_proof.clone()],
+        );
+
+        test.execute_expect_success(
+            Transaction::builder_localnet(Epoch(1))
+                .call_method(component_address, "take_tokens", args![10])
+                .put_last_instruction_output_on_workspace("tokens")
+                .call_method(owner_account, "deposit", args![Workspace("tokens")])
+                .build_and_seal(&owner_key),
+            vec![owner_proof],
+        );
+    }
+
+    #[test]
+    fn a_replacement_auth_hook_must_have_a_hook_signature() {
+        let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/access_rules"]);
+
+        let (_, owner_proof, owner_key) = test.create_empty_account();
+
+        let access_rules_template = test.get_template_address("AccessRulesTest");
+
+        let result = test.execute_expect_success(
+            Transaction::builder_localnet(Epoch(1))
+                .call_function(access_rules_template, "with_updatable_auth_hook", args![
+                    true,
+                    "valid_auth_hook",
+                    OWNER
+                ])
+                .build_and_seal(&owner_key),
+            vec![owner_proof.clone()],
+        );
+
+        let component_address = result.finalize.execution_results[0]
+            .decode::<ComponentAddress>()
+            .unwrap();
+
+        for hook in [
+            "invalid_auth_hook1",
+            "invalid_auth_hook2",
+            "invalid_auth_hook3",
+            "invalid_auth_hook4",
+            "invalid_auth_hook5",
+            "hook_doesnt_exist",
+        ] {
+            let reason = test.execute_expect_failure(
+                Transaction::builder_localnet(Epoch(1))
+                    .call_method(component_address, "set_auth_hook", args![Some(hook)])
+                    .build_and_seal(&owner_key),
+                vec![owner_proof.clone()],
+            );
+
+            assert_reject_reason(reason, RuntimeError::InvalidArgument {
+                argument: "UpdateAuthHookArg",
+                // Partial error text
+                reason: "Authorize hook".to_string(),
+            });
+        }
+    }
+
+    #[test]
+    fn badge_holder_can_update_an_auth_hook_gated_on_their_badge() {
+        let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/access_rules"]);
+
+        let (_, owner_proof, owner_key) = test.create_empty_account();
+        let (user_proof, _, user_key) = test.create_owner_proof();
+
+        let access_rules_template = test.get_template_address("AccessRulesTest");
+
+        let updater: UpdateRule = rule!(non_fungible(user_proof.clone())).into();
+        let result = test.execute_expect_success(
+            Transaction::builder_localnet(Epoch(1))
+                .call_function(access_rules_template, "with_updatable_auth_hook", args![
+                    true,
+                    "valid_auth_hook",
+                    updater
+                ])
+                .build_and_seal(&owner_key),
+            vec![owner_proof.clone()],
+        );
+
+        let component_address = result.finalize.execution_results[0]
+            .decode::<ComponentAddress>()
+            .unwrap();
+
+        // The resource owner does not hold the badge, so they cannot touch the hook.
+        let reason = test.execute_expect_failure(
+            Transaction::builder_localnet(Epoch(1))
+                .call_method(component_address, "set_auth_hook", args![None::<String>])
+                .build_and_seal(&owner_key),
+            vec![owner_proof],
+        );
+        assert_reject_reason(reason, RuntimeError::AccessDenied {
+            action_ident: ActionIdent::Native(NativeAction::UpdateResourceAuthHook),
+        });
+
+        test.execute_expect_success(
+            Transaction::builder_localnet(Epoch(1))
+                .call_method(component_address, "set_auth_hook", args![None::<String>])
+                .build_and_seal(&user_key),
+            vec![user_proof],
+        );
     }
 
     #[test]

--- a/crates/engine/tests/access_rules.rs
+++ b/crates/engine/tests/access_rules.rs
@@ -1399,18 +1399,21 @@ mod resource_access_rules {
     }
 
     #[test]
-    fn a_denying_auth_hook_can_be_replaced_by_the_owner() {
+    fn a_replacement_auth_hook_is_in_force() {
         let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/access_rules"]);
 
         let (owner_account, owner_proof, owner_key) = test.create_empty_account();
 
         let access_rules_template = test.get_template_address("AccessRulesTest");
 
+        // `caller_gated_hook` permits every action, so the resource starts usable. `allowed = false` only
+        // takes effect once `valid_auth_hook` is the hook in force, which is what the swap below installs —
+        // so the denial afterwards can only come from the replacement, not from the hook having been dropped.
         let result = test.execute_expect_success(
             Transaction::builder_localnet(Epoch(1))
                 .call_function(access_rules_template, "with_updatable_auth_hook", args![
                     false,
-                    "valid_auth_hook",
+                    "caller_gated_hook",
                     OWNER
                 ])
                 .build_and_seal(&owner_key),
@@ -1421,22 +1424,28 @@ mod resource_access_rules {
             .decode::<ComponentAddress>()
             .unwrap();
 
-        // `caller_gated_hook` permits the action regardless of the component's `allowed` flag.
-        test.execute_expect_success(
-            Transaction::builder_localnet(Epoch(1))
-                .call_method(component_address, "set_auth_hook", args![Some("caller_gated_hook")])
-                .build_and_seal(&owner_key),
-            vec![owner_proof.clone()],
-        );
-
-        test.execute_expect_success(
+        let take_and_deposit = || {
             Transaction::builder_localnet(Epoch(1))
                 .call_method(component_address, "take_tokens", args![10])
                 .put_last_instruction_output_on_workspace("tokens")
                 .call_method(owner_account, "deposit", args![Workspace("tokens")])
+                .build_and_seal(&owner_key)
+        };
+
+        test.execute_expect_success(take_and_deposit(), vec![owner_proof.clone()]);
+
+        test.execute_expect_success(
+            Transaction::builder_localnet(Epoch(1))
+                .call_method(component_address, "set_auth_hook", args![Some("valid_auth_hook")])
                 .build_and_seal(&owner_key),
-            vec![owner_proof],
+            vec![owner_proof.clone()],
         );
+
+        let reason = test.execute_expect_failure(take_and_deposit(), vec![owner_proof]);
+        assert_reject_reason(reason, RuntimeError::AccessDeniedAuthHook {
+            action_ident: ResourceAuthAction::Deposit.into(),
+            details: "Panic! Access denied for action Deposit".to_string(),
+        });
     }
 
     #[test]

--- a/crates/engine/tests/templates/access_rules/src/lib.rs
+++ b/crates/engine/tests/templates/access_rules/src/lib.rs
@@ -93,6 +93,33 @@ mod access_rules_template {
             .create()
         }
 
+        /// As `with_auth_hook`, but the hook may be replaced or removed by whoever satisfies `updater`.
+        pub fn with_updatable_auth_hook(
+            allowed: bool,
+            hook: FunctionName,
+            updater: UpdateRule,
+        ) -> Component<AccessRulesTest> {
+            let badges = create_badge_resource(rule!(deny_all));
+
+            let address_alloc = CallerContext::allocate_component_address(None);
+
+            let tokens = ResourceBuilder::public_fungible()
+                .with_authorization_hook(address_alloc.get_address(), hook)
+                .with_authorization_hook_updater(updater)
+                .initial_supply(1000u32);
+
+            Component::new(Self {
+                value: 0,
+                tokens: Vault::from_bucket(tokens),
+                badges: Vault::from_bucket(badges),
+                allowed,
+                attack_component: None,
+            })
+            .with_address_allocation(address_alloc)
+            .with_access_rules(ComponentAccessRules::new().default(rule!(allow_all)))
+            .create()
+        }
+
         pub fn with_auth_hook_attack_component(component_address: ComponentAddress) -> Component<AccessRulesTest> {
             let badges = create_badge_resource(rule!(deny_all));
 
@@ -296,6 +323,12 @@ mod access_rules_template {
             // authorize a restricted cross template call. We're really checking the semantics of cross-template calls,
             // not the auth hook.
             ComponentManager::get(self.attack_component.unwrap()).invoke("set", args![123]);
+        }
+
+        /// Points the managed resource's hook at `hook` on this component, or removes it when `hook` is None.
+        pub fn set_auth_hook(&self, hook: Option<FunctionName>) {
+            let hook = hook.map(|method| AuthHook::new(CallerContext::current_component_address(), method));
+            ResourceManager::get(self.tokens.resource_address()).set_auth_hook(hook);
         }
 
         pub fn invalid_auth_hook1(&mut self, _action: ResourceAuthAction, _caller: AuthHookCaller) {}

--- a/crates/engine_types/src/protocol_version.rs
+++ b/crates/engine_types/src/protocol_version.rs
@@ -21,8 +21,9 @@ pub enum ProtocolVersion {
     /// under.
     #[default]
     V0 = 0,
-    /// Block headers commit to their own protocol version, and a transaction receipt's substate hash
-    /// covers `FeeReceipt::exhaust_burn`. Networks without history launch at this version; a network
+    /// Block headers commit to their own protocol version, a transaction receipt's substate hash
+    /// covers `FeeReceipt::exhaust_burn`, and a resource's covers
+    /// `ResourceAccessRules::auth_hook_updater`. Networks without history launch at this version; a network
     /// with V0 history reaches it through a scheduled activation in [`Self::activations`], a
     /// deliberate per-network deployment decision.
     V1 = 1,

--- a/crates/engine_types/src/resource.rs
+++ b/crates/engine_types/src/resource.rs
@@ -153,6 +153,40 @@ impl Resource {
         self.auth_hook.as_ref()
     }
 
+    /// Replaces the resource's authorization hook, or removes it when `auth_hook` is `None`. The caller is
+    /// responsible for authorizing the change against
+    /// [`ResourceAccessRules::auth_hook_updater`](tari_template_lib::types::access_rules::ResourceAccessRules::auth_hook_updater)
+    /// and for validating the hook's signature.
+    pub fn set_auth_hook(&mut self, auth_hook: Option<AuthHook>) {
+        self.auth_hook = auth_hook;
+    }
+
+    /// Writes the resource as a protocol version 0 substate hash preimage: `ResourceAccessRules` without
+    /// `auth_hook_updater`, which version 0 resources do not carry.
+    pub(crate) fn borsh_serialize_v0<W: borsh::io::Write>(&self, writer: &mut W) -> borsh::io::Result<()> {
+        // Destructured so that a field added to the struct fails to compile here rather than being silently
+        // dropped from the version 0 preimage.
+        let Self {
+            resource_type,
+            owner_rule,
+            access_rules,
+            metadata,
+            total_supply,
+            view_key,
+            auth_hook,
+            divisibility,
+        } = self;
+
+        borsh::BorshSerialize::serialize(resource_type, writer)?;
+        borsh::BorshSerialize::serialize(owner_rule, writer)?;
+        access_rules.borsh_serialize_v0(writer)?;
+        borsh::BorshSerialize::serialize(metadata, writer)?;
+        borsh::BorshSerialize::serialize(total_supply, writer)?;
+        borsh::BorshSerialize::serialize(view_key, writer)?;
+        borsh::BorshSerialize::serialize(auth_hook, writer)?;
+        borsh::BorshSerialize::serialize(divisibility, writer)
+    }
+
     pub fn access_rules(&self) -> &ResourceAccessRules {
         &self.access_rules
     }

--- a/crates/engine_types/src/substate_hasher.rs
+++ b/crates/engine_types/src/substate_hasher.rs
@@ -392,10 +392,11 @@ mod tests {
             hash_at(ProtocolVersion::V1, &resource(UpdateRule::Locked)),
             hash_at(ProtocolVersion::V1, &resource(UpdateRule::Owner))
         );
-        assert_ne!(
-            hash_at(ProtocolVersion::V0, &resource(UpdateRule::Locked)),
-            hash_at(ProtocolVersion::V1, &resource(UpdateRule::Locked))
-        );
+        // Past the leading version tag, so that wiring V1 to the version 0 preimage would fail here.
+        let value = resource(UpdateRule::Locked);
+        let v0 = borsh::to_vec(&SubstateHashMessage::new(ProtocolVersion::V0, &value)).unwrap();
+        let v1 = borsh::to_vec(&SubstateHashMessage::new(ProtocolVersion::V1, &value)).unwrap();
+        assert_ne!(v0[1..], v1[1..]);
     }
 
     #[test]

--- a/crates/engine_types/src/substate_hasher.rs
+++ b/crates/engine_types/src/substate_hasher.rs
@@ -36,29 +36,34 @@ impl<'a> SubstateHashMessage<'a> {
     }
 }
 
-pub type SubstateValueHashMessageV0<'a> = SubstateValueHashMessage<'a, TransactionReceiptHashMessageV0<'a>>;
+pub type SubstateValueHashMessageV0<'a> =
+    SubstateValueHashMessage<'a, ResourceHashMessageV0<'a>, TransactionReceiptHashMessageV0<'a>>;
 
-/// Version 1 changes the transaction receipt's preimage, which covers `FeeReceipt::exhaust_burn`,
-/// and - through the leading `SubstateHashMessage` tag - the preimage of every substate.
-pub type SubstateValueHashMessageV1<'a> = SubstateValueHashMessage<'a, TransactionReceiptHashMessageV1<'a>>;
+/// Version 1 changes the transaction receipt's preimage, which covers `FeeReceipt::exhaust_burn`, and the
+/// resource's, which covers `ResourceAccessRules::auth_hook_updater` - and, through the leading
+/// `SubstateHashMessage` tag, the preimage of every substate.
+pub type SubstateValueHashMessageV1<'a> =
+    SubstateValueHashMessage<'a, ResourceHashMessageV1<'a>, TransactionReceiptHashMessageV1<'a>>;
 
 /// The per-type preimage, shared by every protocol version so that the borsh tag of each variant is
 /// the same under all of them. Variant order is consensus-bound: a new variant goes at the end.
 #[derive(Debug, Clone, Copy, borsh::BorshSerialize)]
-pub enum SubstateValueHashMessage<'a, R> {
+pub enum SubstateValueHashMessage<'a, Res, Rec> {
     Component(ComponentHashMessage<'a>),
-    Resource(ResourceHashMessage<'a>),
+    Resource(Res),
     Vault(VaultHashMessage<'a>),
     NonFungible(NonFungibleContainerHashMessage<'a>),
     ClaimedOutputTombstone(ClaimedOutputTombstoneHashMessage<'a>),
-    TransactionReceipt(R),
+    TransactionReceipt(Rec),
     Template(PublishedTemplateHashMessage<'a>),
     ValidatorFeePool(ValidatorFeePoolHashMessage<'a>),
     Utxo(UtxoHashMessage<'a>),
     ConfidentialOutput(ConfidentialOutputHashMessage<'a>),
 }
 
-impl<'a, R: From<&'a TransactionReceipt>> From<&'a SubstateValue> for SubstateValueHashMessage<'a, R> {
+impl<'a, Res: From<&'a Resource>, Rec: From<&'a TransactionReceipt>> From<&'a SubstateValue>
+    for SubstateValueHashMessage<'a, Res, Rec>
+{
     fn from(value: &'a SubstateValue) -> Self {
         match value {
             SubstateValue::Component(component) => Self::Component(component.into()),
@@ -95,10 +100,28 @@ impl borsh::BorshSerialize for ComponentHashMessage<'_> {
     }
 }
 
-#[derive(Debug, Clone, Copy, borsh::BorshSerialize)]
-pub struct ResourceHashMessage<'a>(pub &'a Resource);
+/// The resource preimage under protocol version 0. `ResourceAccessRules` is written without
+/// `auth_hook_updater`, the shape every version 0 resource was hashed with.
+#[derive(Debug, Clone, Copy)]
+pub struct ResourceHashMessageV0<'a>(pub &'a Resource);
 
-impl<'a> From<&'a Resource> for ResourceHashMessage<'a> {
+impl<'a> From<&'a Resource> for ResourceHashMessageV0<'a> {
+    fn from(resource: &'a Resource) -> Self {
+        Self(resource)
+    }
+}
+
+impl borsh::BorshSerialize for ResourceHashMessageV0<'_> {
+    fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
+        self.0.borsh_serialize_v0(writer)
+    }
+}
+
+/// The resource preimage from protocol version 1: the whole `Resource`, `auth_hook_updater` included.
+#[derive(Debug, Clone, Copy, borsh::BorshSerialize)]
+pub struct ResourceHashMessageV1<'a>(pub &'a Resource);
+
+impl<'a> From<&'a Resource> for ResourceHashMessageV1<'a> {
     fn from(resource: &'a Resource) -> Self {
         Self(resource)
     }
@@ -251,7 +274,15 @@ mod tests {
     use std::collections::BTreeSet;
 
     use ootle_network::Network;
-    use tari_template_lib::types::{ObjectKey, ResourceAddress, crypto::RistrettoPublicKeyBytes};
+    use tari_template_lib::types::{
+        Metadata,
+        ObjectKey,
+        ResourceAddress,
+        ResourceType,
+        SubstateOwnerRule,
+        access_rules::{ResourceAccessRules, UpdateRule},
+        crypto::RistrettoPublicKeyBytes,
+    };
 
     use super::*;
     use crate::{
@@ -261,6 +292,19 @@ mod tests {
         substate::hash_substate,
         transaction_receipt::{DiffSummary, FinalizeOutcome},
     };
+
+    fn resource(auth_hook_updater: UpdateRule) -> SubstateValue {
+        SubstateValue::Resource(Box::new(Resource::new(
+            ResourceType::Fungible,
+            SubstateOwnerRule::None,
+            ResourceAccessRules::new().set_auth_hook_updater(auth_hook_updater),
+            Metadata::from_iter([("name", "baseline")]),
+            None,
+            None,
+            6,
+            true,
+        )))
+    }
 
     fn receipt(exhaust_burn: u64) -> SubstateValue {
         let mut breakdown = FeeBreakdown::default();
@@ -323,6 +367,37 @@ mod tests {
         );
     }
 
+    /// The hash a binary that predates `ResourceAccessRules::auth_hook_updater` produced for this
+    /// resource (captured from `hash_substate` at 4da937665). Version 0 must keep producing it, or no
+    /// node can re-derive the state roots that committed such resources.
+    #[test]
+    fn version_0_reproduces_the_pre_auth_hook_updater_hash() {
+        assert_eq!(
+            hex(hash_at(ProtocolVersion::V0, &resource(UpdateRule::Locked))),
+            "e70d065a427a57fb18d8d03ff858411b7c542081863042b0753b2459759ecead"
+        );
+    }
+
+    #[test]
+    fn version_0_does_not_cover_auth_hook_updater() {
+        assert_eq!(
+            hash_at(ProtocolVersion::V0, &resource(UpdateRule::Locked)),
+            hash_at(ProtocolVersion::V0, &resource(UpdateRule::Owner))
+        );
+    }
+
+    #[test]
+    fn version_1_covers_auth_hook_updater() {
+        assert_ne!(
+            hash_at(ProtocolVersion::V1, &resource(UpdateRule::Locked)),
+            hash_at(ProtocolVersion::V1, &resource(UpdateRule::Owner))
+        );
+        assert_ne!(
+            hash_at(ProtocolVersion::V0, &resource(UpdateRule::Locked)),
+            hash_at(ProtocolVersion::V1, &resource(UpdateRule::Locked))
+        );
+    }
+
     #[test]
     fn version_0_does_not_cover_exhaust_burn() {
         assert_eq!(
@@ -365,6 +440,7 @@ mod tests {
                 4,
                 SubstateValue::ClaimedOutputTombstone(ClaimedOutputTombstone { value: 1 }),
             ),
+            (1, resource(UpdateRule::Locked)),
             (5, receipt(0)),
             (
                 7,
@@ -383,7 +459,9 @@ mod tests {
             let v1 = borsh::to_vec(&SubstateHashMessage::new(ProtocolVersion::V1, value)).unwrap();
             assert_eq!(&v0[..2], &[0, *tag], "V0 tag for {value:?}");
             assert_eq!(&v1[..2], &[1, *tag], "V1 tag for {value:?}");
-            if value.as_transaction_receipt().is_none() {
+            // Receipts and resources carry a version-dependent preimage; every other value is written
+            // identically under both versions.
+            if value.as_transaction_receipt().is_none() && value.as_resource().is_none() {
                 assert_eq!(
                     v0[1..],
                     v1[1..],

--- a/crates/template_lib/src/args/types.rs
+++ b/crates/template_lib/src/args/types.rs
@@ -248,6 +248,10 @@ pub enum ResourceAction {
     /// Un/freezes one or more confidential outputs of a resource
     #[n(13)]
     SetConfidentialOutputsFreeze,
+    /// Replace or remove a resource's authorization hook. Authorization is gated by
+    /// [`ResourceAccessRules::auth_hook_updater`](tari_template_lib_types::access_rules::ResourceAccessRules::auth_hook_updater).
+    #[n(14)]
+    UpdateAuthHook,
 }
 
 /// All the possible minting operation types
@@ -362,6 +366,15 @@ pub struct UpdateAccessRuleArg {
     pub action: ResourceAuthAction,
     #[n(1)]
     pub new_rule: AccessRule,
+}
+
+/// An argument used to replace or remove a resource's authorization hook.
+#[derive(Clone, Debug, Encode, Decode, CborLen)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct UpdateAuthHookArg {
+    /// The hook to install, or `None` to remove the resource's hook entirely.
+    #[n(0)]
+    pub auth_hook: Option<AuthHook>,
 }
 
 /// A convenience enum that allows to specify resource types

--- a/crates/template_lib/src/prelude.rs
+++ b/crates/template_lib/src/prelude.rs
@@ -30,6 +30,7 @@ pub use tari_template_lib_types::constants::XTR;
 pub use tari_template_lib_types::fast_hash::{FastMap, PrehashedMap, indexmap_codec};
 pub use tari_template_lib_types::{
     AccessRule,
+    AuthHook,
     AuthHookCaller,
     ComponentAddress,
     Hash32,

--- a/crates/template_lib/src/resource/builder/confidential.rs
+++ b/crates/template_lib/src/resource/builder/confidential.rs
@@ -251,7 +251,21 @@ impl ConfidentialResourceBuilder {
     ///     .with_authorization_hook(*alloc.address(), "my_hook")
     ///     .build();
     /// ```
-    /// Sets up who can replace or remove the resource's authorization hook after creation.
+    pub fn with_authorization_hook<T: TryInto<FunctionName>>(
+        mut self,
+        address: ComponentAddress,
+        auth_callback: T,
+    ) -> Self {
+        self.authorize_hook = Some(AuthHook::new(
+            address,
+            auth_callback
+                .try_into()
+                .unwrap_or_else(|_| panic!("{}", ERR_AUTH_HOOK_FN_NAME_LEN)),
+        ));
+        self
+    }
+
+    /// Sets up who can install, replace or remove the resource's authorization hook after creation.
     ///
     /// A hook is [`LOCKED`](tari_template_lib_types::access_rules::LOCKED) by default: it binds for the life of
     /// the resource, and a hook that panics or denies unconditionally leaves every vault of the resource
@@ -269,20 +283,6 @@ impl ConfidentialResourceBuilder {
     /// ```
     pub fn with_authorization_hook_updater<U: Into<UpdateRule>>(mut self, updater: U) -> Self {
         self.access_rules = self.access_rules.set_auth_hook_updater(updater);
-        self
-    }
-
-    pub fn with_authorization_hook<T: TryInto<FunctionName>>(
-        mut self,
-        address: ComponentAddress,
-        auth_callback: T,
-    ) -> Self {
-        self.authorize_hook = Some(AuthHook::new(
-            address,
-            auth_callback
-                .try_into()
-                .unwrap_or_else(|_| panic!("{}", ERR_AUTH_HOOK_FN_NAME_LEN)),
-        ));
         self
     }
 

--- a/crates/template_lib/src/resource/builder/confidential.rs
+++ b/crates/template_lib/src/resource/builder/confidential.rs
@@ -251,6 +251,27 @@ impl ConfidentialResourceBuilder {
     ///     .with_authorization_hook(*alloc.address(), "my_hook")
     ///     .build();
     /// ```
+    /// Sets up who can replace or remove the resource's authorization hook after creation.
+    ///
+    /// A hook is [`LOCKED`](tari_template_lib_types::access_rules::LOCKED) by default: it binds for the life of
+    /// the resource, and a hook that panics or denies unconditionally leaves every vault of the resource
+    /// unspendable. Setting an updater buys the ability to repair or retire the hook, at the cost of letting
+    /// whoever satisfies the updater change the rules that existing holders are relying on.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use tari_template_lib::{caller_context::CallerContext, prelude::{OWNER, ResourceBuilder}};
+    /// ResourceBuilder::confidential()
+    ///     .with_authorization_hook(CallerContext::current_component_address(), "my_hook")
+    ///     .with_authorization_hook_updater(OWNER)
+    ///     .build();
+    /// ```
+    pub fn with_authorization_hook_updater<U: Into<UpdateRule>>(mut self, updater: U) -> Self {
+        self.access_rules = self.access_rules.set_auth_hook_updater(updater);
+        self
+    }
+
     pub fn with_authorization_hook<T: TryInto<FunctionName>>(
         mut self,
         address: ComponentAddress,

--- a/crates/template_lib/src/resource/builder/fungible.rs
+++ b/crates/template_lib/src/resource/builder/fungible.rs
@@ -448,6 +448,27 @@ impl FungibleResourceBuilder {
     ///     .with_authorization_hook(*alloc.address(), "my_hook")
     ///     .build();
     /// ```
+    /// Sets up who can replace or remove the resource's authorization hook after creation.
+    ///
+    /// A hook is [`LOCKED`](tari_template_lib_types::access_rules::LOCKED) by default: it binds for the life of
+    /// the resource, and a hook that panics or denies unconditionally leaves every vault of the resource
+    /// unspendable. Setting an updater buys the ability to repair or retire the hook, at the cost of letting
+    /// whoever satisfies the updater change the rules that existing holders are relying on.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use tari_template_lib::{caller_context::CallerContext, prelude::{OWNER, ResourceBuilder}};
+    /// ResourceBuilder::public_fungible()
+    ///     .with_authorization_hook(CallerContext::current_component_address(), "my_hook")
+    ///     .with_authorization_hook_updater(OWNER)
+    ///     .build();
+    /// ```
+    pub fn with_authorization_hook_updater<U: Into<UpdateRule>>(mut self, updater: U) -> Self {
+        self.access_rules = self.access_rules.set_auth_hook_updater(updater);
+        self
+    }
+
     pub fn with_authorization_hook<T: TryInto<FunctionName>>(
         mut self,
         address: ComponentAddress,

--- a/crates/template_lib/src/resource/builder/fungible.rs
+++ b/crates/template_lib/src/resource/builder/fungible.rs
@@ -448,7 +448,21 @@ impl FungibleResourceBuilder {
     ///     .with_authorization_hook(*alloc.address(), "my_hook")
     ///     .build();
     /// ```
-    /// Sets up who can replace or remove the resource's authorization hook after creation.
+    pub fn with_authorization_hook<T: TryInto<FunctionName>>(
+        mut self,
+        address: ComponentAddress,
+        auth_callback: T,
+    ) -> Self {
+        self.authorize_hook = Some(AuthHook::new(
+            address,
+            auth_callback
+                .try_into()
+                .unwrap_or_else(|_| panic!("{}", ERR_AUTH_HOOK_FN_NAME_LEN)),
+        ));
+        self
+    }
+
+    /// Sets up who can install, replace or remove the resource's authorization hook after creation.
     ///
     /// A hook is [`LOCKED`](tari_template_lib_types::access_rules::LOCKED) by default: it binds for the life of
     /// the resource, and a hook that panics or denies unconditionally leaves every vault of the resource
@@ -466,20 +480,6 @@ impl FungibleResourceBuilder {
     /// ```
     pub fn with_authorization_hook_updater<U: Into<UpdateRule>>(mut self, updater: U) -> Self {
         self.access_rules = self.access_rules.set_auth_hook_updater(updater);
-        self
-    }
-
-    pub fn with_authorization_hook<T: TryInto<FunctionName>>(
-        mut self,
-        address: ComponentAddress,
-        auth_callback: T,
-    ) -> Self {
-        self.authorize_hook = Some(AuthHook::new(
-            address,
-            auth_callback
-                .try_into()
-                .unwrap_or_else(|_| panic!("{}", ERR_AUTH_HOOK_FN_NAME_LEN)),
-        ));
         self
     }
 

--- a/crates/template_lib/src/resource/builder/non_fungible.rs
+++ b/crates/template_lib/src/resource/builder/non_fungible.rs
@@ -216,7 +216,21 @@ impl NonFungibleResourceBuilder {
     ///     .with_authorization_hook(*alloc.address(), "my_hook")
     ///     .build();
     /// ```
-    /// Sets up who can replace or remove the resource's authorization hook after creation.
+    pub fn with_authorization_hook<T: TryInto<FunctionName>>(
+        mut self,
+        address: ComponentAddress,
+        auth_callback: T,
+    ) -> Self {
+        self.authorize_hook = Some(AuthHook::new(
+            address,
+            auth_callback
+                .try_into()
+                .unwrap_or_else(|_| panic!("{}", ERR_AUTH_HOOK_FN_NAME_LEN)),
+        ));
+        self
+    }
+
+    /// Sets up who can install, replace or remove the resource's authorization hook after creation.
     ///
     /// A hook is [`LOCKED`](tari_template_lib_types::access_rules::LOCKED) by default: it binds for the life of
     /// the resource, and a hook that panics or denies unconditionally leaves every vault of the resource
@@ -234,20 +248,6 @@ impl NonFungibleResourceBuilder {
     /// ```
     pub fn with_authorization_hook_updater<U: Into<UpdateRule>>(mut self, updater: U) -> Self {
         self.access_rules = self.access_rules.set_auth_hook_updater(updater);
-        self
-    }
-
-    pub fn with_authorization_hook<T: TryInto<FunctionName>>(
-        mut self,
-        address: ComponentAddress,
-        auth_callback: T,
-    ) -> Self {
-        self.authorize_hook = Some(AuthHook::new(
-            address,
-            auth_callback
-                .try_into()
-                .unwrap_or_else(|_| panic!("{}", ERR_AUTH_HOOK_FN_NAME_LEN)),
-        ));
         self
     }
 

--- a/crates/template_lib/src/resource/builder/non_fungible.rs
+++ b/crates/template_lib/src/resource/builder/non_fungible.rs
@@ -216,6 +216,27 @@ impl NonFungibleResourceBuilder {
     ///     .with_authorization_hook(*alloc.address(), "my_hook")
     ///     .build();
     /// ```
+    /// Sets up who can replace or remove the resource's authorization hook after creation.
+    ///
+    /// A hook is [`LOCKED`](tari_template_lib_types::access_rules::LOCKED) by default: it binds for the life of
+    /// the resource, and a hook that panics or denies unconditionally leaves every vault of the resource
+    /// unspendable. Setting an updater buys the ability to repair or retire the hook, at the cost of letting
+    /// whoever satisfies the updater change the rules that existing holders are relying on.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use tari_template_lib::{caller_context::CallerContext, prelude::{OWNER, ResourceBuilder}};
+    /// ResourceBuilder::non_fungible()
+    ///     .with_authorization_hook(CallerContext::current_component_address(), "my_hook")
+    ///     .with_authorization_hook_updater(OWNER)
+    ///     .build();
+    /// ```
+    pub fn with_authorization_hook_updater<U: Into<UpdateRule>>(mut self, updater: U) -> Self {
+        self.access_rules = self.access_rules.set_auth_hook_updater(updater);
+        self
+    }
+
     pub fn with_authorization_hook<T: TryInto<FunctionName>>(
         mut self,
         address: ComponentAddress,

--- a/crates/template_lib/src/resource/builder/stealth.rs
+++ b/crates/template_lib/src/resource/builder/stealth.rs
@@ -240,6 +240,27 @@ impl StealthResourceBuilder {
     ///     .with_authorization_hook(*alloc.address(), "my_hook")
     ///     .build();
     /// ```
+    /// Sets up who can replace or remove the resource's authorization hook after creation.
+    ///
+    /// A hook is [`LOCKED`](tari_template_lib_types::access_rules::LOCKED) by default: it binds for the life of
+    /// the resource, and a hook that panics or denies unconditionally leaves every vault of the resource
+    /// unspendable. Setting an updater buys the ability to repair or retire the hook, at the cost of letting
+    /// whoever satisfies the updater change the rules that existing holders are relying on.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use tari_template_lib::{caller_context::CallerContext, prelude::{OWNER, ResourceBuilder}};
+    /// ResourceBuilder::stealth()
+    ///     .with_authorization_hook(CallerContext::current_component_address(), "my_hook")
+    ///     .with_authorization_hook_updater(OWNER)
+    ///     .build();
+    /// ```
+    pub fn with_authorization_hook_updater<U: Into<UpdateRule>>(mut self, updater: U) -> Self {
+        self.access_rules = self.access_rules.set_auth_hook_updater(updater);
+        self
+    }
+
     pub fn with_authorization_hook<T: TryInto<FunctionName>>(
         mut self,
         address: ComponentAddress,

--- a/crates/template_lib/src/resource/builder/stealth.rs
+++ b/crates/template_lib/src/resource/builder/stealth.rs
@@ -240,7 +240,21 @@ impl StealthResourceBuilder {
     ///     .with_authorization_hook(*alloc.address(), "my_hook")
     ///     .build();
     /// ```
-    /// Sets up who can replace or remove the resource's authorization hook after creation.
+    pub fn with_authorization_hook<T: TryInto<FunctionName>>(
+        mut self,
+        address: ComponentAddress,
+        auth_callback: T,
+    ) -> Self {
+        self.authorize_hook = Some(AuthHook::new(
+            address,
+            auth_callback
+                .try_into()
+                .unwrap_or_else(|_| panic!("{}", ERR_AUTH_HOOK_FN_NAME_LEN)),
+        ));
+        self
+    }
+
+    /// Sets up who can install, replace or remove the resource's authorization hook after creation.
     ///
     /// A hook is [`LOCKED`](tari_template_lib_types::access_rules::LOCKED) by default: it binds for the life of
     /// the resource, and a hook that panics or denies unconditionally leaves every vault of the resource
@@ -258,20 +272,6 @@ impl StealthResourceBuilder {
     /// ```
     pub fn with_authorization_hook_updater<U: Into<UpdateRule>>(mut self, updater: U) -> Self {
         self.access_rules = self.access_rules.set_auth_hook_updater(updater);
-        self
-    }
-
-    pub fn with_authorization_hook<T: TryInto<FunctionName>>(
-        mut self,
-        address: ComponentAddress,
-        auth_callback: T,
-    ) -> Self {
-        self.authorize_hook = Some(AuthHook::new(
-            address,
-            auth_callback
-                .try_into()
-                .unwrap_or_else(|_| panic!("{}", ERR_AUTH_HOOK_FN_NAME_LEN)),
-        ));
         self
     }
 

--- a/crates/template_lib/src/resource/manager.rs
+++ b/crates/template_lib/src/resource/manager.rs
@@ -959,7 +959,9 @@ impl ResourceManager {
         resp.decode().expect("[update_access_rule] Failed")
     }
 
-    /// Replaces the resource's authorization hook, or removes it when `auth_hook` is `None`.
+    /// Replaces the resource's authorization hook, or removes it when `auth_hook` is `None`. A resource that
+    /// has no hook gains one, so a holder cannot rely on a resource staying hook-free once the updater permits
+    /// a change.
     ///
     /// Authorization is gated by the resource's
     /// [`auth_hook_updater`](tari_template_lib_types::access_rules::ResourceAccessRules::auth_hook_updater),

--- a/crates/template_lib/src/resource/manager.rs
+++ b/crates/template_lib/src/resource/manager.rs
@@ -81,6 +81,7 @@ use crate::{
         SetFreezeStealthUtxosArg,
         StealthTransferResourceArg,
         UpdateAccessRuleArg,
+        UpdateAuthHookArg,
         VaultFreezeFlags,
     },
     models::{Bucket, BucketId, NonFungible, ResourceAddressAllocation},
@@ -956,6 +957,43 @@ impl ResourceManager {
         });
 
         resp.decode().expect("[update_access_rule] Failed")
+    }
+
+    /// Replaces the resource's authorization hook, or removes it when `auth_hook` is `None`.
+    ///
+    /// Authorization is gated by the resource's
+    /// [`auth_hook_updater`](tari_template_lib_types::access_rules::ResourceAccessRules::auth_hook_updater),
+    /// which is [`UpdateRule::Locked`](tari_template_lib_types::access_rules::UpdateRule::Locked) unless the
+    /// resource was created with
+    /// [`set_auth_hook_updater`](tari_template_lib_types::access_rules::ResourceAccessRules::set_auth_hook_updater).
+    ///
+    /// The hook being replaced is not consulted, so a hook that denies or panics can still be repaired or
+    /// retired. A new hook must satisfy the same signature checks as one supplied at resource creation, and
+    /// its component must already exist.
+    ///
+    /// # Panics
+    ///
+    /// - The caller does not satisfy the resource's `auth_hook_updater`.
+    /// - `auth_hook` names a component or method that does not exist, or a method whose signature is not that of an
+    ///   authorization hook.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use tari_template_lib::prelude::AuthHook;
+    /// // Repair a broken hook by pointing the resource at a new component.
+    /// resource_manager.set_auth_hook(Some(AuthHook::new(new_component, "authorize".try_into().unwrap())));
+    /// // Retire the hook entirely.
+    /// resource_manager.set_auth_hook(None);
+    /// ```
+    pub fn set_auth_hook(&self, auth_hook: Option<AuthHook>) {
+        let resp: InvokeResult = call_engine(EngineOp::ResourceInvoke, &ResourceInvokeArg {
+            resource_ref: self.resource_address.into(),
+            action: ResourceAction::UpdateAuthHook,
+            args: invoke_args![UpdateAuthHookArg { auth_hook }],
+        });
+
+        resp.decode().expect("[set_auth_hook] Failed")
     }
 
     /// Replaces the resource's metadata map.

--- a/crates/template_lib_types/src/access_rules.rs
+++ b/crates/template_lib_types/src/access_rules.rs
@@ -483,13 +483,14 @@ pub struct ResourceAccessRules {
     update_metadata: AccessRule,
     #[n(15)]
     metadata_updater: UpdateRule,
-    /// Who may replace or remove the resource's [`AuthHook`](crate::AuthHook). The hook itself is not an
-    /// [`AccessRule`], so this updater stands alone rather than pairing with one.
+    /// Who may install, replace or remove the resource's [`AuthHook`](crate::AuthHook). The hook itself is not
+    /// an [`AccessRule`], so this updater stands alone rather than pairing with one.
     ///
     /// A hook runs on nearly every resource action, so one that panics or denies unconditionally takes the
     /// resource offline and strands the balances in its vaults. `Locked` — the default — keeps a hook binding
     /// for the life of the resource; anything else lets the hook be repaired or retired, at the cost of letting
-    /// whoever satisfies the updater change the rules that existing holders are relying on.
+    /// whoever satisfies the updater change the rules that existing holders are relying on — up to and
+    /// including giving a hook-free resource a hook.
     #[n(16)]
     #[cbor(default)]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -625,10 +626,16 @@ impl ResourceAccessRules {
         self
     }
 
-    /// Sets up who can replace or remove the resource's authorization hook. Locked by default, which makes a
-    /// hook binding for the life of the resource.
+    /// Sets up who can install, replace or remove the resource's authorization hook. Locked by default, which
+    /// makes a hook binding for the life of the resource.
     pub fn set_auth_hook_updater<U: Into<UpdateRule>>(mut self, updater: U) -> Self {
-        self.auth_hook_updater = updater.into();
+        let updater = updater.into();
+        // A `caller_component`/`direct_caller_template` requirement always evaluates to false on a resource, so
+        // an updater carrying one is indistinguishable from `Locked` — the bricking this updater exists to avoid.
+        if let UpdateRule::AccessRule(rule) = &updater {
+            Self::assert_no_caller_requirement(rule);
+        }
+        self.auth_hook_updater = updater;
         self
     }
 
@@ -684,6 +691,7 @@ impl ResourceAccessRules {
     /// Writes the rules as a protocol version 0 substate hash preimage: every field but `auth_hook_updater`,
     /// which version 0 resources do not carry.
     #[cfg(feature = "borsh")]
+    #[doc(hidden)]
     pub fn borsh_serialize_v0<W: borsh::io::Write>(&self, writer: &mut W) -> borsh::io::Result<()> {
         // Destructured so that a field added to the struct fails to compile here rather than being silently
         // dropped from the version 0 preimage.
@@ -1105,6 +1113,27 @@ mod tests {
         ));
         assert!(rule.contains_caller_component_or_template());
         assert!(!rule.contains_scoped_to_component_or_template());
+    }
+
+    #[test]
+    fn auth_hook_updater_defaults_to_locked() {
+        assert!(matches!(
+            ResourceAccessRules::new().auth_hook_updater(),
+            UpdateRule::Locked
+        ));
+        assert!(matches!(
+            ResourceAccessRules::deny_all().auth_hook_updater(),
+            UpdateRule::Locked
+        ));
+    }
+
+    /// Such an updater always evaluates to false on a resource, so it would be `Locked` wearing a disguise:
+    /// the hook could never be repaired, which is the failure this updater exists to prevent.
+    #[test]
+    #[should_panic(expected = "always evaluate to false on resource rules")]
+    fn auth_hook_updater_rejects_a_caller_requirement() {
+        let address = ComponentAddress::new(ObjectKey::default());
+        ResourceAccessRules::new().set_auth_hook_updater(rule!(caller_component(address)));
     }
 
     #[test]

--- a/crates/template_lib_types/src/access_rules.rs
+++ b/crates/template_lib_types/src/access_rules.rs
@@ -422,12 +422,13 @@ impl ResourceAuthAction {
     }
 }
 
-#[derive(Debug, Clone, Encode, Decode, CborLen)]
+#[derive(Debug, Clone, Default, Encode, Decode, CborLen)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub enum UpdateRule {
     #[n(0)]
+    #[default]
     Locked,
     #[n(1)]
     Owner,
@@ -482,6 +483,17 @@ pub struct ResourceAccessRules {
     update_metadata: AccessRule,
     #[n(15)]
     metadata_updater: UpdateRule,
+    /// Who may replace or remove the resource's [`AuthHook`](crate::AuthHook). The hook itself is not an
+    /// [`AccessRule`], so this updater stands alone rather than pairing with one.
+    ///
+    /// A hook runs on nearly every resource action, so one that panics or denies unconditionally takes the
+    /// resource offline and strands the balances in its vaults. `Locked` — the default — keeps a hook binding
+    /// for the life of the resource; anything else lets the hook be repaired or retired, at the cost of letting
+    /// whoever satisfies the updater change the rules that existing holders are relying on.
+    #[n(16)]
+    #[cbor(default)]
+    #[cfg_attr(feature = "serde", serde(default))]
+    auth_hook_updater: UpdateRule,
 }
 
 impl ResourceAccessRules {
@@ -520,6 +532,7 @@ impl ResourceAccessRules {
             deposit_updater: UpdateRule::Locked,
             update_nft_data: AccessRule::AllowAll,
             nft_data_updater: UpdateRule::Owner,
+            auth_hook_updater: UpdateRule::Locked,
         }
     }
 
@@ -542,6 +555,7 @@ impl ResourceAccessRules {
             freeze_updater: UpdateRule::Locked,
             update_metadata: AccessRule::DenyAll,
             metadata_updater: UpdateRule::Locked,
+            auth_hook_updater: UpdateRule::Locked,
         }
     }
 
@@ -611,6 +625,18 @@ impl ResourceAccessRules {
         self
     }
 
+    /// Sets up who can replace or remove the resource's authorization hook. Locked by default, which makes a
+    /// hook binding for the life of the resource.
+    pub fn set_auth_hook_updater<U: Into<UpdateRule>>(mut self, updater: U) -> Self {
+        self.auth_hook_updater = updater.into();
+        self
+    }
+
+    /// Returns the updater rule that governs who may replace or remove the resource's authorization hook.
+    pub fn auth_hook_updater(&self) -> &UpdateRule {
+        &self.auth_hook_updater
+    }
+
     /// Returns a reference to the access rule for the specified action
     pub fn get_access_rule(&self, action: &ResourceAuthAction) -> &AccessRule {
         match action {
@@ -653,6 +679,50 @@ impl ResourceAccessRules {
             ResourceAuthAction::UpdateMetadata => self.update_metadata = rule,
             ResourceAuthAction::Freeze => self.freeze = rule,
         }
+    }
+
+    /// Writes the rules as a protocol version 0 substate hash preimage: every field but `auth_hook_updater`,
+    /// which version 0 resources do not carry.
+    #[cfg(feature = "borsh")]
+    pub fn borsh_serialize_v0<W: borsh::io::Write>(&self, writer: &mut W) -> borsh::io::Result<()> {
+        // Destructured so that a field added to the struct fails to compile here rather than being silently
+        // dropped from the version 0 preimage.
+        let Self {
+            mint,
+            mint_updater,
+            burn,
+            burn_updater,
+            recall,
+            recall_updater,
+            withdraw,
+            withdraw_updater,
+            deposit,
+            deposit_updater,
+            update_nft_data,
+            nft_data_updater,
+            freeze,
+            freeze_updater,
+            update_metadata,
+            metadata_updater,
+            auth_hook_updater: _,
+        } = self;
+
+        borsh::BorshSerialize::serialize(mint, writer)?;
+        borsh::BorshSerialize::serialize(mint_updater, writer)?;
+        borsh::BorshSerialize::serialize(burn, writer)?;
+        borsh::BorshSerialize::serialize(burn_updater, writer)?;
+        borsh::BorshSerialize::serialize(recall, writer)?;
+        borsh::BorshSerialize::serialize(recall_updater, writer)?;
+        borsh::BorshSerialize::serialize(withdraw, writer)?;
+        borsh::BorshSerialize::serialize(withdraw_updater, writer)?;
+        borsh::BorshSerialize::serialize(deposit, writer)?;
+        borsh::BorshSerialize::serialize(deposit_updater, writer)?;
+        borsh::BorshSerialize::serialize(update_nft_data, writer)?;
+        borsh::BorshSerialize::serialize(nft_data_updater, writer)?;
+        borsh::BorshSerialize::serialize(freeze, writer)?;
+        borsh::BorshSerialize::serialize(freeze_updater, writer)?;
+        borsh::BorshSerialize::serialize(update_metadata, writer)?;
+        borsh::BorshSerialize::serialize(metadata_updater, writer)
     }
 }
 

--- a/docs/developer-docs/src/content/docs/guides/authorization-and-access.mdx
+++ b/docs/developer-docs/src/content/docs/guides/authorization-and-access.mdx
@@ -10,6 +10,7 @@ In this guide, you will:
 - Understand the importance of authorization and access control in smart contract security.
 - Learn how to define and apply access rules for components and their methods.
 - Discover how to set permissions for resources, including minting, burning, and metadata access.
+- Delegate a resource's authorization to a component hook, and keep the ability to repair or retire it.
 - Explore identity management and the different types of callers in the Tari Ootle environment.
 - Follow best practices for securing templates and managing digital assets.
 
@@ -161,6 +162,9 @@ Each `ResourceBuilder` exposes one method per action. All accept `(rule, updater
 - `.update_metadata(rule, updater)` — who can change the metadata (the token symbol always stays immutable).
 - `.update_non_fungible_data(rule, updater)` — who can change the mutable data on individual NFTs (non-fungible only).
 
+A resource can also delegate its decisions to a component method rather than a static rule — see
+[Authorization hooks](#authorization-hooks).
+
 ##### UpdateRule
 
 `UpdateRule` controls who can later change an access rule, and has three variants:
@@ -199,6 +203,7 @@ Calling `ResourceAccessRules::new()` (the default) yields safe baseline rules:
 - `mint`, `burn`, `recall`, `freeze`, `update_metadata`: `DenyAll`, updater `Locked`.
 - `withdraw`, `deposit`: `AllowAll`, updater `Locked`.
 - `update_non_fungible_data`: `AllowAll`, updater `Owner`.
+- The auth hook updater: `Locked` (see [Authorization hooks](#authorization-hooks)).
 
 Locked-by-default means a resource issued with `ResourceAccessRules::new()` and no overrides can never have its
 `recall`, `mint`, etc. silently re-enabled later. To leave room for future tightening or relaxation, pass `OWNER`
@@ -218,6 +223,54 @@ The action is one of `ResourceAuthAction::{Mint, Burn, Recall, Withdraw, Deposit
 If the field's updater is `Locked`, this call fails even for the owner. If the updater is `Owner`, only the resource
 owner can succeed. If the updater is `AccessRule(rule)`, only a caller satisfying `rule` can succeed — the owner
 has **no implicit override**.
+
+##### Authorization hooks
+
+An access rule is a static predicate. When a decision needs to look at live state — a blocklist, a per-holder cap, a
+paused flag — a resource can instead delegate to a **hook**: a method on a component that the engine calls on every
+mint, burn, recall, withdraw, deposit, freeze, metadata update and NFT data update. The hook takes the action and an
+`AuthHookCaller`, returns nothing, and **denies by panicking**.
+
+```rust
+let alloc = CallerContext::allocate_component_address(None);
+let tokens = ResourceBuilder::public_fungible()
+    .with_authorization_hook(alloc.get_address(), "authorize")
+    // Without this, the hook binds for the life of the resource.
+    .with_authorization_hook_updater(OWNER)
+    .initial_supply(1_000_000u64);
+```
+
+The hook must be a non-mutable method returning `()` and taking `(&self, ResourceAuthAction, AuthHookCaller)`; the
+engine rejects the resource at creation otherwise. It is skipped when the acting component *is* the hook's own
+component, and when the hook's component does not exist yet — which is what lets a template allocate the address,
+build the resource, and create the component afterwards.
+
+Because the hook runs on nearly every action, a hook that panics, denies unconditionally, or fails to decode its
+arguments takes the whole resource offline: no transfers, no burns, no metadata changes, and every balance in its
+vaults becomes unspendable. `.with_authorization_hook_updater(...)` is what buys the ability to recover:
+
+```rust
+// Retire a broken hook entirely...
+ResourceManager::get(my_resource).set_auth_hook(None);
+// ...or point the resource at a repaired one.
+ResourceManager::get(my_resource)
+    .set_auth_hook(Some(AuthHook::new(fixed_component, "authorize".try_into().unwrap())));
+```
+
+The updater is `Locked` by default, so a hook stays permanently binding unless the issuer opts out — which is the
+same trust promise `LOCKED` makes for the access rules, and for the same reason: a holder who reads the substate can
+see that the hook governing their tokens can never change. Opting out has a real cost, so make it deliberately:
+
+- Whoever satisfies the updater can retire a hook that holders were relying on, and can give a **hook-free** resource
+  a hook. A resource inspected today as unhooked is not guaranteed to stay that way.
+- The outgoing hook is **not** consulted when it is replaced. That is what makes a denying hook recoverable, and it
+  means the hook cannot defend itself.
+- A replacement is validated exactly like one supplied at creation, so a mistyped method name fails the transaction
+  rather than bricking the resource.
+
+`caller_component(...)` / `direct_caller_template(...)` are rejected in the updater's access rule: they always
+evaluate to false on a resource, so such an updater would be `Locked` wearing a disguise — the hook could never be
+repaired.
 
 ### Identity Management
 
@@ -239,5 +292,7 @@ execution scope, while `caller_component(...)` / `direct_caller_template(...)` r
 - **Principle of Least Privilege:** Grant only the necessary permissions. Avoid `AllowAll` unless it's genuinely intended for public methods.
 - **Clear Ownership:** Define and manage component/resource ownership clearly.
 - **Test Thoroughly:** Always write comprehensive tests to ensure your access rules behave as expected.
+- **Budget for a Broken Hook:** An auth hook runs on nearly every resource action, so a bug in it strands every
+  balance of that resource. Set an updater unless the hook's permanence is itself the guarantee you are selling.
 
 By effectively utilizing access rules, you can ensure the security and integrity of your Tari Ootle Templates and the assets they manage.


### PR DESCRIPTION
## Description

A resource's authorization hook was fixed at creation: no setter on `Resource`, no `ResourceAction` to change it. The hook runs on nearly every resource action, so a hook that panics, denies unconditionally, or fails to decode its arguments takes the whole resource offline — no transfers, no burns, no metadata changes — and the balances in its vaults become unspendable. Recovery meant migrating the hook component to a new template, which needs an owner rule that permits migration; a resource whose hook component was created with `OwnerRule::None`, or which points at a component the author does not control, had no recovery at all.

Every other authorization field on a resource is already mutable under a per-field `UpdateRule`. This wires the hook into the same pattern.

- `ResourceAccessRules` gains `auth_hook_updater: UpdateRule`, alongside the eight updaters that already exist, with `set_auth_hook_updater` following the existing builder shape.
- `ResourceAction::UpdateAuthHook` + `ResourceManager::set_auth_hook(Option<AuthHook>)` set or clear the hook, gated by that updater. `None` removes the hook entirely.
- The four `ResourceBuilder` variants get `.with_authorization_hook_updater(rule)`.
- The default is `UpdateRule::Locked` — stricter than deny-all, since not even the owner can change it. Today's immutability is preserved for every existing resource, and an author who wants a permanently binding hook still gets one by default.

Two deliberate calls:

- **The hook being replaced is not invoked.** A hook that denies or panics is the failure this action exists to repair, so asking it to approve its own removal would defeat the point. This matches `UpdateAccessRule`, which does not invoke the hook either.
- **A replacement hook is validated exactly like one supplied at creation** — same `check_resource_auth_hook` signature checks. Its `argument` field is now parameterised so a rejection names `UpdateAuthHookArg` rather than `CreateResourceArg` on this path.

## Protocol version

`ResourceAccessRules` is part of the resource substate, so a new field changes the resource's borsh hash preimage. This is bundled into **protocol version 1**, which is unlaunched everywhere:

`ResourceHashMessage` is split into `ResourceHashMessageV0`/`V1` the way `TransactionReceiptHashMessage` already is. V0 writes the access rules without `auth_hook_updater` (`ResourceAccessRules::borsh_serialize_v0`, destructured so a future field fails to compile rather than being silently dropped), V1 writes the whole struct. `SubstateValueHashMessage` takes a second type parameter for the resource; the variant tags are unchanged under both versions.

`version_0_reproduces_the_pre_auth_hook_updater_hash` pins a hash captured from `hash_substate` at 4da937665, so esmeralda's committed resources still re-derive their state roots. Every other network launches at V1, so no activation needs coordinating.

CBOR/serde decode of existing resources is covered by `#[cbor(default)]` / `#[serde(default)]` on the new field, which resolves to `UpdateRule::Locked`.

## Does this break existing templates?

No. `ResourceAccessRules`'s fields are private and it is only constructed through `new()` / `deny_all()` / the builder methods, so the new field is source-compatible. `ResourceAction` gains a variant at the end. Nothing in the workspace matched `ResourceAction` exhaustively outside the engine.

`scripts/crate_versioning.py impact tari_template_lib_types --breaking` reports no bumps outstanding — every affected crate is already on an unreleased breaking version.

## Motivation and Context

Closes #2514. The failure mode is unrecoverable locked funds and the fix is a schema change, so it wants deciding before mainnet.

## How Has This Been Tested?

`cargo test -p tari_engine --test access_rules` — 32 pass, including five new ones:

- `auth_hook_is_locked_by_default` — the update is denied on a resource built the old way.
- `a_denying_auth_hook_can_be_removed_by_the_owner` — a hook that panics blocks a deposit; after `set_auth_hook(None)` the same transfer succeeds.
- `a_denying_auth_hook_can_be_replaced_by_the_owner` — swapping in a permitting hook unblocks the resource.
- `a_replacement_auth_hook_must_have_a_hook_signature` — all six invalid-hook shapes are rejected on the update path.
- `badge_holder_can_update_an_auth_hook_gated_on_their_badge` — `UpdateRule::AccessRule`: the owner is denied, the badge holder succeeds.

`cargo test -p tari_engine_types` — 88 pass, including the pinned V0 resource hash, `version_0_does_not_cover_auth_hook_updater`, `version_1_covers_auth_hook_updater`, and the existing pinned V0/V1 receipt hashes.

`cargo lints clippy --all-targets` — clean.

## What process can a PR reviewer use to test or verify this change?

Check that `ResourceAccessRules::borsh_serialize_v0` writes exactly the pre-change field order, then confirm `version_0_reproduces_the_pre_auth_hook_updater_hash` still passes — a transcription slip there changes esmeralda's committed resource hashes.

The other judgement call worth a second opinion: `UpdateAuthHook` deliberately skips the outgoing hook. That is what makes a broken hook recoverable, but it does mean whoever satisfies `auth_hook_updater` can retire a hook that holders were relying on. `Locked` by default is what keeps that opt-in.

<!-- Base branch: development -->
