### PR TITLE
feat(engine)!: derive caller identity from virtual badges

### DIFF
--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -82,6 +82,7 @@ use tari_ootle_transaction_validation::{
     BasicValidations,
     BlobReferenceValidator,
     EpochRangeValidator,
+    InputSubstateValidator,
     PublishTemplateLimitValidator,
     SignatureLimitValidator,
     StealthTransactionLimitsValidator,
@@ -563,6 +564,14 @@ pub fn create_node_transaction_validator<TProvider: TemplateProvider>(
         .and_then(TemplateExistsValidator::new(template_manager))
 }
 
+/// Builds the validations applied when a transaction is admitted to this node's mempool: the node-local chain
+/// plus the two epoch-window rules and the ingress-only input check.
+///
+/// [`InputSubstateValidator`] is deliberately here rather than in [`create_node_transaction_validator`], which
+/// also backs `TariBlockTransactionValidator`. A rejection rule in block validation is a consensus rule: an
+/// upgraded validator would refuse a block that a non-upgraded one accepts. Refusing at ingress costs the
+/// sender and nothing else, and a transaction that slips past an un-upgraded node's mempool still aborts at
+/// input resolution as it does today.
 pub fn create_mempool_transaction_validator<TProvider: TemplateProvider>(
     network: Network,
     template_manager: TProvider,
@@ -571,7 +580,8 @@ pub fn create_mempool_transaction_validator<TProvider: TemplateProvider>(
     WithContext::<Epoch, Transaction, TransactionValidationError>::new()
         .map_context(
             |_| (),
-            create_node_transaction_validator(network, template_manager, constants),
+            create_node_transaction_validator(network, template_manager, constants)
+                .and_then(InputSubstateValidator::new()),
         )
         .and_then(EpochRangeValidator::new())
         .and_then(TransactionValidityWindowValidator::new(

--- a/crates/engine/src/runtime/auth.rs
+++ b/crates/engine/src/runtime/auth.rs
@@ -6,7 +6,7 @@ use std::fmt::Display;
 use indexmap::IndexSet;
 use tari_template_lib::{
     models::ProofId,
-    types::{NonFungibleAddress, ResourceAddress},
+    types::{ComponentAddress, NonFungibleAddress, ResourceAddress, TemplateAddress},
 };
 
 #[derive(Debug, Clone, Default)]
@@ -20,6 +20,13 @@ pub struct AuthorizationScope {
     /// the transaction signer public key
     virtual_proofs: IndexSet<NonFungibleAddress>,
 
+    /// System-issued badges naming the frame's immediate caller: the caller's component (when it has one) and its
+    /// template. Held per frame rather than in the transaction-wide `virtual_proofs` so that a callee only ever sees
+    /// the frame directly below it — the badges are re-derived at every push and never merged into a parent or child
+    /// scope. There is no path from a badge to a [`ProofId`], so a callee cannot forward the identity it was called
+    /// with.
+    caller_badges: IndexSet<NonFungibleAddress>,
+
     /// Resource-based proofs
     proofs: IndexSet<ProofId>,
 }
@@ -28,6 +35,7 @@ impl AuthorizationScope {
     pub fn new(virtual_proofs: IndexSet<NonFungibleAddress>) -> Self {
         Self {
             virtual_proofs,
+            caller_badges: IndexSet::new(),
             proofs: IndexSet::new(),
         }
     }
@@ -35,22 +43,33 @@ impl AuthorizationScope {
     pub fn empty() -> Self {
         Self {
             virtual_proofs: IndexSet::new(),
+            caller_badges: IndexSet::new(),
             proofs: IndexSet::new(),
         }
     }
 
-    pub fn virtual_proofs(&self) -> &IndexSet<NonFungibleAddress> {
-        &self.virtual_proofs
+    /// Stamps the identity of the frame that is pushing the frame this scope belongs to. The component badge is
+    /// omitted for a static function frame, which has no component identity.
+    pub(super) fn set_caller(&mut self, component: Option<ComponentAddress>, template: TemplateAddress) {
+        self.caller_badges.clear();
+        if let Some(component) = component {
+            self.caller_badges
+                .insert(NonFungibleAddress::caller_component_badge(component));
+        }
+        self.caller_badges
+            .insert(NonFungibleAddress::direct_caller_template_badge(template));
+    }
+
+    fn badges(&self) -> impl Iterator<Item = &NonFungibleAddress> {
+        self.virtual_proofs.iter().chain(&self.caller_badges)
     }
 
     pub fn contains_badge(&self, nf_address: &NonFungibleAddress) -> bool {
-        self.virtual_proofs.contains(nf_address)
+        self.virtual_proofs.contains(nf_address) || self.caller_badges.contains(nf_address)
     }
 
     pub fn contains_badge_of_resource(&self, resource_address: &ResourceAddress) -> bool {
-        self.virtual_proofs
-            .iter()
-            .any(|badge| badge.resource_address() == resource_address)
+        self.badges().any(|badge| badge.resource_address() == resource_address)
     }
 
     pub fn proofs(&self) -> &IndexSet<ProofId> {
@@ -77,8 +96,8 @@ impl AuthorizationScope {
 impl Display for AuthorizationScope {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "Virtual: [")?;
-        for proof in &self.virtual_proofs {
-            write!(f, "{}", proof)?;
+        for badge in self.badges() {
+            write!(f, "{}", badge)?;
         }
         write!(f, "], Proofs: [")?;
         for proof in &self.proofs {

--- a/crates/engine/src/runtime/error.rs
+++ b/crates/engine/src/runtime/error.rs
@@ -214,6 +214,16 @@ pub enum RuntimeError {
     WriteInReadOnlyContext,
     #[error("Host operation '{operation}' is forbidden inside a read-only (spend-script) context")]
     ForbiddenInReadOnlyContext { operation: &'static str },
+    #[error("Write to {id} attempted in a resource auth hook, which may only modify its own component state")]
+    WriteOutsideOwnComponent { id: SubstateId },
+    #[error("Host operation '{operation}' is forbidden inside a resource auth hook")]
+    ForbiddenInAuthHookContext { operation: &'static str },
+    #[error("Recall on resource {resource_address} targeted vault {vault_id}, which holds resource {vault_resource}")]
+    RecallResourceMismatch {
+        vault_id: VaultId,
+        resource_address: ResourceAddress,
+        vault_resource: ResourceAddress,
+    },
     #[error("Spend script rejected the spend: {details}")]
     SpendScriptRejected { details: Box<RuntimeError> },
     #[error("Spend condition not met: {details}")]

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -1573,7 +1573,7 @@ where
                     // to be unforgeable.
                     if resource_address.is_system_reserved() {
                         return Err(RuntimeError::InvalidArgument {
-                            argument: "address_allocation",
+                            argument: "resource_address",
                             reason: format!("Resource address {resource_address} is reserved by the system"),
                         });
                     }

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -1387,7 +1387,7 @@ where
                     let component = state.get_component(&component_lock)?;
                     state
                         .authorization()
-                        .require_component_ownership(ComponentAction::SetAccessRules, component.as_ownership())?;
+                        .require_ownership(ComponentAction::SetAccessRules, component.as_ownership())?;
 
                     state.modify_component_with(&component_lock, |component| {
                         if access_rules == *component.access_rules() {
@@ -1567,6 +1567,16 @@ where
                         },
                         None => state_mut.id_provider()?.new_resource_address()?,
                     };
+
+                    // The system's resource addresses must stay under the system's control: the genesis resources
+                    // are created once, and the two caller-badge resources must stay empty for the engine's badges
+                    // to be unforgeable.
+                    if resource_address.is_system_reserved() {
+                        return Err(RuntimeError::InvalidArgument {
+                            argument: "address_allocation",
+                            reason: format!("Resource address {resource_address} is reserved by the system"),
+                        });
+                    }
 
                     let mut payload = Metadata::from_iter([("resource_type", resource.resource_type().to_string())]);
                     if let Some(symbol) = resource.metadata().get(TOKEN_SYMBOL) {
@@ -1855,14 +1865,6 @@ where
                         })?;
                 let UpdateAccessRuleArg { action, new_rule } = args.assert_one_arg()?;
 
-                if new_rule.contains_caller_component_or_template() {
-                    return Err(RuntimeError::InvalidArgument {
-                        argument: "new_rule",
-                        reason: "caller_component/direct_caller_template cannot be used on a resource access rule"
-                            .to_string(),
-                    });
-                }
-
                 let resource_lock = self.tracker.write_with(|state_mut| {
                     let resource_lock = state_mut.write_lock_substate(SubstateId::Resource(resource_address))?;
 
@@ -1871,9 +1873,7 @@ where
 
                     let authorized = match updater {
                         UpdateRule::Locked => false,
-                        UpdateRule::Owner => state_mut
-                            .authorization()
-                            .check_ownership_in_current_frame(resource.as_ownership())?,
+                        UpdateRule::Owner => state_mut.authorization().check_ownership(resource.as_ownership())?,
                         UpdateRule::AccessRule(rule) => state_mut.authorization().check_access_rule(rule)?,
                     };
 
@@ -1918,9 +1918,7 @@ where
 
                     let authorized = match updater {
                         UpdateRule::Locked => false,
-                        UpdateRule::Owner => state_mut
-                            .authorization()
-                            .check_ownership_in_current_frame(resource.as_ownership())?,
+                        UpdateRule::Owner => state_mut.authorization().check_ownership(resource.as_ownership())?,
                         UpdateRule::AccessRule(rule) => state_mut.authorization().check_access_rule(rule)?,
                     };
 
@@ -3817,7 +3815,7 @@ where
             let component = state.get_component(locked)?;
             state
                 .authorization()
-                .require_component_ownership(action, component.as_ownership())
+                .require_ownership(action, component.as_ownership())
         })
     }
 

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -170,7 +170,7 @@ use crate::{
         error::{ArgumentValidationError, LimitError},
         locking::{LockError, LockedSubstate},
         pay_fee::PayFee,
-        scope::PushCallFrame,
+        scope::{FrameWriteMode, PushCallFrame},
         tracker::{ComputeAllowance, FinalizedState, StateTracker},
     },
     state_store::StateReader,
@@ -197,9 +197,10 @@ pub struct RuntimeInterfaceImpl<TStore, TTemplateProvider> {
     /// set immediately before invoking the predicate and cleared immediately after, so `spend_context_invoke` (which
     /// re-enters this same interface through the runtime pointer) can serve the `SpendContext` accessors.
     spend_exec_context: Option<SpendScriptExecution>,
-    /// One-shot flag: when set, the next pushed call frame is restricted to a read-only, non-cross-template sandbox
-    /// (used for the spend-script predicate frame). Consumed by `push_call_frame`.
-    restricted_frame_pending: bool,
+    /// One-shot: when set, the next pushed call frame is restricted to this write mode and denied cross-template
+    /// calls. Used for the spend-script predicate frame (`ReadOnly`) and the resource auth hook frame
+    /// (`OwnComponent`). Consumed by `push_call_frame`.
+    restricted_frame_pending: Option<FrameWriteMode>,
 }
 
 impl<TStore: StateReader + Clone + 'static, TTemplateProvider: TemplateProvider<Template = LoadedTemplate>>
@@ -224,7 +225,7 @@ impl<TStore: StateReader + Clone + 'static, TTemplateProvider: TemplateProvider<
             blobs,
             runtime_pointer: None,
             spend_exec_context: None,
-            restricted_frame_pending: false,
+            restricted_frame_pending: None,
         };
         runtime.invoke_modules_on_initialize()?;
         Ok(runtime)
@@ -238,40 +239,51 @@ impl<TStore: StateReader + Clone + 'static, TTemplateProvider: TemplateProvider<
     }
 
     fn invoke_modules_on_runtime_call(&mut self, function: &'static str) -> Result<(), RuntimeError> {
-        // Core read-only sandbox enforcement runs first and unconditionally. It deliberately does NOT live in a
+        // Core sandbox enforcement runs first and unconditionally. It deliberately does NOT live in a
         // RuntimeModule: modules are optional, observer-style functionality (fees, call tracking), so making a
         // security invariant depend on one would mean dropping that module silently re-opens the sandbox. This is the
         // single per-host-op entry point, so enforcing here covers every op that routes through it regardless of
         // which modules are registered.
-        self.enforce_read_only_restrictions(function)?;
+        self.enforce_frame_restrictions(function)?;
         for module in self.modules.iter() {
             module.on_runtime_call(&mut self.tracker, function)?;
         }
         Ok(())
     }
 
-    /// Layer (b) of the spend-script sandbox: deny the effectful or non-deterministic host ops that are NOT mediated by
-    /// the write-lock chokepoint (layer (a) in `WorkingState::write_lock_substate` / `new_substate`, which neutralises
-    /// every state write). Together they make a spend-script predicate provably side-effect-free and deterministic.
+    /// Layer (b) of the frame sandbox: deny the effectful or non-deterministic host ops that are NOT mediated by the
+    /// write-lock chokepoint (layer (a) in `WorkingState::write_lock_substate` / `new_substate`, which neutralises
+    /// every state write). Together they make a spend-script predicate provably side-effect-free and deterministic,
+    /// and confine a resource auth hook to its own component state.
     ///
-    /// The list contains only WASM host ops (each backed by an `EngineOp`), because a read-only frame only exists while
-    /// a predicate's WASM is executing — instruction-level operations such as `pay_fee` and `publish_template` have no
-    /// `EngineOp`, run only at the top level, and so can never execute in a read-only context. `call_invoke` is also
-    /// blocked at the frame level (`allow_cross_template_calls == false`) and listed here for defence in depth.
-    fn enforce_read_only_restrictions(&self, function: &'static str) -> Result<(), RuntimeError> {
+    /// Events are permitted in both modes: an event is an output of execution that no later code can observe, and it
+    /// is discarded with the transaction if the frame fails, so it is neither a side effect on state nor a source of
+    /// non-determinism.
+    ///
+    /// The lists contain only WASM host ops (each backed by an `EngineOp`), because a restricted frame only exists
+    /// while template WASM is executing — instruction-level operations such as `pay_fee` and `publish_template` have
+    /// no `EngineOp`, run only at the top level, and so can never execute in a restricted context. `call_invoke` is
+    /// also blocked at the frame level (`allow_cross_template_calls == false`) and listed here for defence in depth.
+    fn enforce_frame_restrictions(&self, function: &'static str) -> Result<(), RuntimeError> {
         const FORBIDDEN_IN_READ_ONLY: &[&str] = &[
             "call_invoke",
             "generate_random_invoke",
             "generate_uuid",
-            "emit_event",
             "proof_invoke",
             "bucket_invoke",
         ];
+        const FORBIDDEN_IN_OWN_COMPONENT: &[&str] = &["call_invoke", "proof_invoke", "bucket_invoke"];
 
-        if self.tracker.is_in_read_only_context() && FORBIDDEN_IN_READ_ONLY.contains(&function) {
-            return Err(RuntimeError::ForbiddenInReadOnlyContext { operation: function });
+        match self.tracker.current_frame_write_mode() {
+            FrameWriteMode::Full => Ok(()),
+            FrameWriteMode::OwnComponent if FORBIDDEN_IN_OWN_COMPONENT.contains(&function) => {
+                Err(RuntimeError::ForbiddenInAuthHookContext { operation: function })
+            },
+            FrameWriteMode::ReadOnly if FORBIDDEN_IN_READ_ONLY.contains(&function) => {
+                Err(RuntimeError::ForbiddenInReadOnlyContext { operation: function })
+            },
+            FrameWriteMode::OwnComponent | FrameWriteMode::ReadOnly => Ok(()),
         }
-        Ok(())
     }
 
     fn invoke_modules_on_before_finalize(&mut self) -> Result<(), RuntimeError> {
@@ -441,19 +453,23 @@ impl<TStore: StateReader + Clone + 'static, TTemplateProvider: TemplateProvider<
             Ok::<_, RuntimeError>(was_in_scope)
         })?;
 
-        // The signature of a call back is (action: ResourceAuthAction, auth_caller: AuthHookCaller)
-        let ret = self
-            .invoke_component_method(auth_hook.component_address, &auth_hook.method, invoke_args![
-                action,
-                auth_caller
-            ])
-            .map_err(|e| match e {
-                RuntimeError::CrossTemplateCallMethodError { details, .. } => RuntimeError::AccessDeniedAuthHook {
-                    action_ident: action.into(),
-                    details: details.to_string(),
-                },
-                _ => e,
-            })?;
+        // The signature of a call back is (action: ResourceAuthAction, auth_caller: AuthHookCaller).
+        // The hook frame carries the acting component's caller badges, and the acting component never chose the hook
+        // code, so the frame is confined to its own component state: it cannot use those badges to act on any vault
+        // or resource, nor call out to a frame that could.
+        self.restricted_frame_pending = Some(FrameWriteMode::OwnComponent);
+        let ret = self.invoke_component_method(auth_hook.component_address, &auth_hook.method, invoke_args![
+            action,
+            auth_caller
+        ]);
+        self.restricted_frame_pending = None;
+        let ret = ret.map_err(|e| match e {
+            RuntimeError::CrossTemplateCallMethodError { details, .. } => RuntimeError::AccessDeniedAuthHook {
+                action_ident: action.into(),
+                details: details.to_string(),
+            },
+            _ => e,
+        })?;
         // Enforce that the return type is actually empty. We cannot rely on InstructionResult::return_type field
         // because that comes from the template definition which is defined by the template author and may not reflect
         // actual behaviour. `is_unit` accepts either `Value::Null` (ciborium/serde encoding of `()`) or
@@ -588,12 +604,6 @@ impl<TStore: StateReader + Clone + 'static, TTemplateProvider: TemplateProvider<
                 reason: format!("Authorize hook '{}' not found", hook),
             })?;
 
-        if func.is_mut {
-            return Err(RuntimeError::InvalidArgument {
-                argument,
-                reason: format!("Authorize hook '{}' cannot be mutable", hook),
-            });
-        }
         if !matches!(func.output, Type::Unit) {
             return Err(RuntimeError::InvalidArgument {
                 argument,
@@ -1063,10 +1073,10 @@ impl<TStore: StateReader + Clone + 'static, TTemplateProvider: TemplateProvider<
         // Make the introspection context reachable for the duration of the call (re-entered via the runtime pointer),
         // and restrict the predicate's frame to a read-only, non-cross-template sandbox.
         self.spend_exec_context = Some(exec);
-        self.restricted_frame_pending = true;
+        self.restricted_frame_pending = Some(FrameWriteMode::ReadOnly);
         let result = self.invoke_template_function(&tf.template, &tf.function, args);
         self.spend_exec_context = None;
-        self.restricted_frame_pending = false;
+        self.restricted_frame_pending = None;
 
         result
             .map(|_| ())
@@ -1740,6 +1750,17 @@ where
 
                 self.tracker.write_with(|state_mut| {
                     let vault_lock = state_mut.write_lock_substate(arg.vault_id.into())?;
+
+                    // The recall rule that authorized this action belongs to `resource_address`, so it may only
+                    // reach vaults holding that resource.
+                    let vault_resource = *state_mut.get_vault(&vault_lock)?.resource_address();
+                    if vault_resource != resource_address {
+                        return Err(RuntimeError::RecallResourceMismatch {
+                            vault_id: arg.vault_id,
+                            resource_address,
+                            vault_resource,
+                        });
+                    }
 
                     let resource = state_mut.recall_resource_from_vault(&vault_lock, &arg.resource)?;
 
@@ -3852,12 +3873,11 @@ where
 
     fn push_call_frame(&mut self, frame: PushCallFrame) -> Result<(), RuntimeError> {
         self.tracker.push_call_frame(frame)?;
-        // A spend-script predicate is invoked via the generic `call_function` path, so we restrict the frame it just
-        // pushed here rather than threading a flag through that path. The predicate's WASM only runs after this
-        // returns, so the read-only/no-cross-template restriction is in place before any host op can be issued.
-        if self.restricted_frame_pending {
-            self.restricted_frame_pending = false;
-            self.tracker.write_with(|state| state.make_current_frame_read_only())?;
+        // Spend-script predicates and auth hooks are invoked via the generic `call_function` / `call_method` paths,
+        // so we restrict the frame they just pushed here rather than threading a flag through those paths. The WASM
+        // only runs after this returns, so the restriction is in place before any host op can be issued.
+        if let Some(mode) = self.restricted_frame_pending.take() {
+            self.tracker.write_with(|state| state.restrict_current_frame(mode))?;
         }
         Ok(())
     }

--- a/crates/engine/src/runtime/scope.rs
+++ b/crates/engine/src/runtime/scope.rs
@@ -307,6 +307,22 @@ impl Display for CallScope {
     }
 }
 
+/// How much of the ledger a call frame may mutate. Ordered from least to most restrictive so that a child frame
+/// can never be less restricted than its parent (`FrameWriteMode::max`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum FrameWriteMode {
+    /// Any substate the frame can lock may be written.
+    Full,
+    /// Only the component the frame is executing on, through the lock taken at push. Every other write funnelling
+    /// through `WorkingState::write_lock_substate` / `new_substate` is rejected, so the frame cannot touch a vault,
+    /// resource or any other component. Resource auth hooks run in this mode: the acting component did not choose
+    /// the hook code, so the hook must not be able to act on the acting component's behalf beyond its own state.
+    OwnComponent,
+    /// No state mutation at all. Spend-script predicate frames run in this mode so they are provably
+    /// side-effect-free.
+    ReadOnly,
+}
+
 #[derive(Debug, Clone)]
 pub struct CallFrame {
     scope: CallScope,
@@ -315,10 +331,7 @@ pub struct CallFrame {
     entity_id: EntityId,
     allow_cross_template_calls: bool,
     allow_migration_calls: bool,
-    /// When set, every state mutation funnelling through `WorkingState::write_lock_substate` /
-    /// `new_substate` is rejected with `RuntimeError::WriteInReadOnlyContext`. Set for spend-script
-    /// predicate frames so they are provably side-effect-free.
-    read_only: bool,
+    write_mode: FrameWriteMode,
 }
 
 impl CallFrame {
@@ -330,7 +343,7 @@ impl CallFrame {
             entity_id,
             allow_cross_template_calls: true,
             allow_migration_calls: false,
-            read_only: false,
+            write_mode: FrameWriteMode::Full,
         }
     }
 
@@ -347,7 +360,7 @@ impl CallFrame {
             entity_id,
             allow_cross_template_calls: true,
             allow_migration_calls: false,
-            read_only: false,
+            write_mode: FrameWriteMode::Full,
         }
     }
 
@@ -364,7 +377,7 @@ impl CallFrame {
             entity_id,
             allow_cross_template_calls: false,
             allow_migration_calls: true,
-            read_only: false,
+            write_mode: FrameWriteMode::Full,
         }
     }
 
@@ -404,17 +417,26 @@ impl CallFrame {
         self.allow_migration_calls
     }
 
-    pub fn is_read_only(&self) -> bool {
-        self.read_only
+    pub fn write_mode(&self) -> FrameWriteMode {
+        self.write_mode
     }
 
-    /// Restricts this frame to a read-only, non-cross-template sandbox, as used for spend-script
-    /// predicate evaluation. The two restrictions are load-bearing in tandem: read-only blocks every
-    /// state write at the lock layer, while disabling cross-template calls prevents the predicate
-    /// from re-entering other templates.
-    pub fn restrict_to_read_only(&mut self) {
-        self.read_only = true;
+    /// Restricts this frame to `mode` (never loosening an existing restriction) and disables cross-template
+    /// calls. The two restrictions are load-bearing in tandem: the write mode blocks state writes at the lock
+    /// layer, while disabling cross-template calls prevents the frame from re-entering other templates, which
+    /// would otherwise run with the identity of this frame as their caller.
+    pub fn restrict(&mut self, mode: FrameWriteMode) {
+        self.write_mode = self.write_mode.max(mode);
         self.allow_cross_template_calls = false;
+    }
+
+    /// A frame is never less restricted than the frame that pushed it: a sandboxed frame must not be able to
+    /// escape its sandbox by calling into a frame that would then write on its behalf.
+    pub fn inherit_restrictions(&mut self, parent: &CallFrame) {
+        self.write_mode = self.write_mode.max(parent.write_mode);
+        if !parent.allow_cross_template_calls {
+            self.allow_cross_template_calls = false;
+        }
     }
 }
 

--- a/crates/engine/src/runtime/scope.rs
+++ b/crates/engine/src/runtime/scope.rs
@@ -219,7 +219,7 @@ impl CallScope {
     pub fn include_owned_in_scope(&mut self, values: &IndexedWellKnownTypes) {
         for addr in values.referenced_substates() {
             // These are never able to bring these into scope
-            if addr.is_public_key_identity() || addr.is_transaction_receipt() || addr.is_template() {
+            if addr.is_virtual() || addr.is_transaction_receipt() || addr.is_template() {
                 continue;
             }
             self.add_substate_to_owned(addr);
@@ -229,7 +229,7 @@ impl CallScope {
     pub fn include_refs_in_scope(&mut self, values: &IndexedWellKnownTypes) {
         for addr in values.referenced_substates() {
             // Never able to bring these into scope
-            if addr.is_public_key_identity() || addr.is_vault() || addr.is_read_only() {
+            if addr.is_virtual() || addr.is_vault() || addr.is_read_only() {
                 continue;
             }
             self.add_substate_to_referenced(addr);

--- a/crates/engine/src/runtime/tracker.rs
+++ b/crates/engine/src/runtime/tracker.rs
@@ -55,7 +55,7 @@ use crate::{
         RuntimeError,
         error::ArgumentValidationError,
         locking::LockedSubstate,
-        scope::{CallScope, PushCallFrame},
+        scope::{CallScope, FrameWriteMode, PushCallFrame},
         working_state::{ChargeableState, WorkingState},
         workspace::Workspace,
     },
@@ -614,13 +614,13 @@ impl<TStore: StateReader> StateTracker<TStore> {
         self.read_with(|state| state.fee_state().is_dry_run())
     }
 
-    /// Whether the current call frame is a read-only spend-script sandbox. Used by the engine's core read-only
-    /// enforcement to deny the few effectful host ops that bypass the lock layer.
-    pub fn is_in_read_only_context(&self) -> bool {
+    /// The write mode of the current call frame. Used by the engine's core sandbox enforcement to deny the few
+    /// effectful host ops that bypass the lock layer.
+    pub fn current_frame_write_mode(&self) -> FrameWriteMode {
         self.working_state
             .as_ref()
-            .map(|state| state.is_read_only_context())
-            .unwrap_or(false)
+            .map(|state| state.current_frame_write_mode())
+            .unwrap_or(FrameWriteMode::Full)
     }
 
     pub(super) fn read_with<R, F: FnOnce(&WorkingState<TStore>) -> R>(&self, f: F) -> R {

--- a/crates/engine/src/runtime/tracker_auth.rs
+++ b/crates/engine/src/runtime/tracker_auth.rs
@@ -16,24 +16,9 @@ use tari_template_lib::types::{
 };
 
 use crate::{
-    runtime::{
-        ActionIdent,
-        AuthorizationScope,
-        RuntimeError,
-        working_state::{MethodCaller, WorkingState},
-    },
+    runtime::{ActionIdent, AuthorizationScope, RuntimeError, working_state::WorkingState},
     state_store::StateReader,
 };
-
-/// The identity an access rule is evaluated against.
-#[derive(Clone, Copy)]
-enum RuleContext {
-    /// Resource, ownership and covenant checks: the current (top) frame is the actor.
-    CurrentFrame,
-    /// Component method checks: the actor is the frame immediately below the callee. `None` when the
-    /// method is invoked directly by a top-level transaction instruction (the signer is the caller).
-    Caller(Option<MethodCaller>),
-}
 
 pub struct Authorization<'a, TStore> {
     state: &'a WorkingState<TStore>,
@@ -56,10 +41,7 @@ impl<'a, TStore: StateReader> Authorization<'a, TStore> {
         let component = self.state.get_component(locked)?;
         let scope = self.state.current_call_scope()?.auth_scope();
 
-        // The callee frame is already on top of the stack here, so both the ownership check and the
-        // method access rule must be evaluated against the caller (the frame below the callee).
-        let context = RuleContext::Caller(self.state.method_caller());
-        if check_ownership(self.state, scope, component.as_ownership(), context)? {
+        if check_ownership(self.state, scope, component.as_ownership())? {
             // Owner can call any component method
             return Ok(());
         }
@@ -74,7 +56,7 @@ impl<'a, TStore: StateReader> Authorization<'a, TStore> {
                 })?;
 
         let access_rule = component.access_rules().get_method_access_rule(method);
-        if !check_access_rule(self.state, scope, access_rule, context)? {
+        if !check_access_rule(self.state, scope, access_rule)? {
             return Err(RuntimeError::AccessDenied {
                 action_ident: ActionIdent::ComponentCallMethod {
                     component_address,
@@ -95,13 +77,13 @@ impl<'a, TStore: StateReader> Authorization<'a, TStore> {
 
         // Check ownership.
         // A resource is only recallable by explicit access rules
-        if !action.is_recall() && check_ownership(self.state, scope, resource_ownership, RuleContext::CurrentFrame)? {
+        if !action.is_recall() && check_ownership(self.state, scope, resource_ownership)? {
             // Owner can invoke any resource method
             return Ok(());
         }
 
         let rule = resource_access_rules.get_access_rule(&action);
-        if !check_access_rule(self.state, scope, rule, RuleContext::CurrentFrame)? {
+        if !check_access_rule(self.state, scope, rule)? {
             return Err(RuntimeError::AccessDenied {
                 action_ident: action.into(),
             });
@@ -112,45 +94,24 @@ impl<'a, TStore: StateReader> Authorization<'a, TStore> {
 
     pub fn check_access_rule(&self, rule: &AccessRule) -> Result<bool, RuntimeError> {
         let scope = self.state.current_call_scope()?.auth_scope();
-        check_access_rule(self.state, scope, rule, RuleContext::CurrentFrame)
+        check_access_rule(self.state, scope, rule)
     }
 
-    /// Returns `true` if the current frame satisfies the ownership rule of a non-component substate
-    /// (resource, fee pool). The current frame is the actor for these substates.
-    pub fn check_ownership_in_current_frame(&self, ownership: Ownership<'_>) -> Result<bool, RuntimeError> {
+    /// Returns `true` if the current frame satisfies `ownership`. Every authorization check is evaluated against the
+    /// current frame's scope: a component's own frame is already on top of the stack when its ownership rule is
+    /// checked, and that scope carries its caller's identity as virtual badges.
+    pub fn check_ownership(&self, ownership: Ownership<'_>) -> Result<bool, RuntimeError> {
         let scope = self.state.current_call_scope()?.auth_scope();
-        check_ownership(self.state, scope, ownership, RuleContext::CurrentFrame)
+        check_ownership(self.state, scope, ownership)
     }
 
-    /// Requires that the current frame satisfies the ownership rule of a non-component substate
-    /// (resource, fee pool). Component ownership must use
-    /// [`require_component_ownership`](Self::require_component_ownership).
-    pub fn require_ownership_in_current_frame<A: Into<ActionIdent>>(
+    /// Requires that the current frame satisfies `ownership`.
+    pub fn require_ownership<A: Into<ActionIdent>>(
         &self,
         action: A,
         ownership: Ownership<'_>,
     ) -> Result<(), RuntimeError> {
-        if !self.check_ownership_in_current_frame(ownership)? {
-            return Err(RuntimeError::AccessDeniedOwnerRequired { action: action.into() });
-        }
-        Ok(())
-    }
-
-    /// Requires that the caller of the current component satisfies the component's ownership rule. A component
-    /// ownership rule is always evaluated against the caller (the frame below the current one), because every
-    /// component action runs with the component's own frame already on top of the stack.
-    pub fn require_component_ownership<A: Into<ActionIdent>>(
-        &self,
-        action: A,
-        ownership: Ownership<'_>,
-    ) -> Result<(), RuntimeError> {
-        let context = RuleContext::Caller(self.state.method_caller());
-        if !check_ownership(
-            self.state,
-            self.state.current_call_scope()?.auth_scope(),
-            ownership,
-            context,
-        )? {
+        if !self.check_ownership(ownership)? {
             return Err(RuntimeError::AccessDeniedOwnerRequired { action: action.into() });
         }
         Ok(())
@@ -161,11 +122,10 @@ fn check_ownership<TStore: StateReader>(
     state: &WorkingState<TStore>,
     scope: &AuthorizationScope,
     ownership: Ownership<'_>,
-    context: RuleContext,
 ) -> Result<bool, RuntimeError> {
     match ownership.owner_rule.as_ref() {
         SubstateOwnerRule::None => Ok(false),
-        SubstateOwnerRule::ByAccessRule(rule) => check_access_rule(state, scope, rule, context),
+        SubstateOwnerRule::ByAccessRule(rule) => check_access_rule(state, scope, rule),
         SubstateOwnerRule::ByPublicKey(key) => {
             let owner_proof = NonFungibleAddress::from_public_key(*key);
             Ok(scope.contains_badge(&owner_proof))
@@ -177,12 +137,11 @@ fn check_access_rule<TStore: StateReader>(
     state: &WorkingState<TStore>,
     scope: &AuthorizationScope,
     rule: &AccessRule,
-    context: RuleContext,
 ) -> Result<bool, RuntimeError> {
     match rule {
         AccessRule::AllowAll => Ok(true),
         AccessRule::DenyAll => Ok(false),
-        AccessRule::Restricted(rule) => check_restricted_access_rule(state, scope, rule, context),
+        AccessRule::Restricted(rule) => check_restricted_access_rule(state, scope, rule),
     }
 }
 
@@ -190,13 +149,12 @@ fn check_restricted_access_rule<TStore: StateReader>(
     state: &WorkingState<TStore>,
     scope: &AuthorizationScope,
     rule: &RestrictedAccessRule,
-    context: RuleContext,
 ) -> Result<bool, RuntimeError> {
     match rule {
-        RestrictedAccessRule::Require(rule) => check_require_rule(state, scope, rule, context),
+        RestrictedAccessRule::Require(rule) => check_require_rule(state, scope, rule),
         RestrictedAccessRule::AnyOf(rules) => {
             for rule in rules {
-                if check_restricted_access_rule(state, scope, rule, context)? {
+                if check_restricted_access_rule(state, scope, rule)? {
                     return Ok(true);
                 }
             }
@@ -208,7 +166,7 @@ fn check_restricted_access_rule<TStore: StateReader>(
                 return Ok(false);
             }
             for rule in rules {
-                if !check_restricted_access_rule(state, scope, rule, context)? {
+                if !check_restricted_access_rule(state, scope, rule)? {
                     return Ok(false);
                 }
             }
@@ -221,13 +179,12 @@ fn check_require_rule<TStore: StateReader>(
     state: &WorkingState<TStore>,
     scope: &AuthorizationScope,
     rule: &RequireRule,
-    context: RuleContext,
 ) -> Result<bool, RuntimeError> {
     match rule {
-        RequireRule::Require(requirement) => check_requirement(state, scope, requirement, context),
+        RequireRule::Require(requirement) => check_requirement(state, scope, requirement),
         RequireRule::AnyOf(requirements) => {
             for requirement in requirements {
-                if check_requirement(state, scope, requirement, context)? {
+                if check_requirement(state, scope, requirement)? {
                     return Ok(true);
                 }
             }
@@ -240,7 +197,7 @@ fn check_require_rule<TStore: StateReader>(
                 return Ok(false);
             }
             for requirement in requirements {
-                if !check_requirement(state, scope, requirement, context)? {
+                if !check_requirement(state, scope, requirement)? {
                     return Ok(false);
                 }
             }
@@ -254,7 +211,7 @@ fn check_require_rule<TStore: StateReader>(
             }
             let mut satisfied = 0u16;
             for requirement in requirements {
-                if check_requirement(state, scope, requirement, context)? {
+                if check_requirement(state, scope, requirement)? {
                     satisfied += 1;
                     if satisfied == *n {
                         return Ok(true);
@@ -271,7 +228,6 @@ fn check_requirement<TStore: StateReader>(
     state: &WorkingState<TStore>,
     scope: &AuthorizationScope,
     requirement: &RuleRequirement,
-    context: RuleContext,
 ) -> Result<bool, RuntimeError> {
     match requirement {
         RuleRequirement::Resource(resx) => {
@@ -313,15 +269,13 @@ fn check_requirement<TStore: StateReader>(
             let current = state.current_template()?;
             Ok(current == address)
         },
-        // `CallerComponent` / `DirectCallerTemplate` mean "the caller is this component/template": they are only
-        // meaningful on method checks, and a top-level signer has no component/template identity to match.
-        RuleRequirement::CallerComponent(address) => match context {
-            RuleContext::Caller(Some(caller)) => Ok(caller.component == Some(*address)),
-            RuleContext::Caller(None) | RuleContext::CurrentFrame => Ok(false),
+        // Sugar for the caller badges the engine stamps into a frame's scope at push. Both badge resources are
+        // empty by invariant, so the scope's badges are the only thing that can satisfy these.
+        RuleRequirement::CallerComponent(address) => {
+            Ok(scope.contains_badge(&NonFungibleAddress::caller_component_badge(*address)))
         },
-        RuleRequirement::DirectCallerTemplate(address) => match context {
-            RuleContext::Caller(Some(caller)) => Ok(caller.template == *address),
-            RuleContext::Caller(None) | RuleContext::CurrentFrame => Ok(false),
+        RuleRequirement::DirectCallerTemplate(address) => {
+            Ok(scope.contains_badge(&NonFungibleAddress::direct_caller_template_badge(*address)))
         },
     }
 }

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -174,15 +174,6 @@ pub(super) struct WorkingState<TStore> {
     confidential_totals: ConfidentialTransactionTotals,
 }
 
-/// The caller identity of a component method access check: the component and/or template that was
-/// current immediately before the callee's frame was pushed. `None` when the method is invoked
-/// directly from a top-level transaction instruction (no caller frame).
-#[derive(Clone, Copy, Debug)]
-pub(super) struct MethodCaller {
-    pub component: Option<ComponentAddress>,
-    pub template: TemplateAddress,
-}
-
 impl<TStore: StateReader> WorkingState<TStore> {
     pub fn new(
         state_store: TStore,
@@ -1274,7 +1265,7 @@ impl<TStore: StateReader> WorkingState<TStore> {
                 })?;
 
             self.authorization()
-                .require_ownership_in_current_frame(NativeAction::WithdrawValidatorFunds, fee_pool.as_ownership())?;
+                .require_ownership(NativeAction::WithdrawValidatorFunds, fee_pool.as_ownership())?;
         }
 
         let pool_mut = self
@@ -1501,22 +1492,6 @@ impl<TStore: StateReader> WorkingState<TStore> {
             .and_then(|lock| lock.substate_id().as_component_address()))
     }
 
-    /// Returns the caller of the current component method, i.e. the component/template that was
-    /// current immediately before the callee's frame was pushed. `None` when the method is invoked
-    /// directly from a top-level transaction instruction (no caller frame).
-    pub fn method_caller(&self) -> Option<MethodCaller> {
-        if self.call_frames.len() < 2 {
-            return None;
-        }
-        let caller = &self.call_frames[self.call_frames.len() - 2];
-        let component = caller
-            .scope()
-            .get_current_component_lock()
-            .and_then(|lock| lock.substate_id().as_component_address());
-        let template = *caller.current_template();
-        Some(MethodCaller { component, template })
-    }
-
     pub fn get_auth_caller(&self, resource_lock: &LockedSubstate) -> Result<AuthHookCaller, RuntimeError> {
         let resource_address =
             resource_lock
@@ -1546,12 +1521,26 @@ impl<TStore: StateReader> WorkingState<TStore> {
         let current = self.current_call_scope()?;
         new_frame.scope_mut().update_from_parent(current);
 
-        if self.call_frame_depth() == 0 {
+        match self.call_frames.last() {
             // If this is the first call frame, then we use the base auth scope (virtual proofs are carried from the
-            // base to the first call scope)
-            new_frame
-                .scope_mut()
-                .set_auth_scope(self.initial_call_scope.auth_scope().clone());
+            // base to the first call scope). A top-level instruction has no caller frame, so there is no caller
+            // identity to stamp: the signer is the caller.
+            None => {
+                new_frame
+                    .scope_mut()
+                    .set_auth_scope(self.initial_call_scope.auth_scope().clone());
+            },
+            // Otherwise stamp the pushing frame's identity into the callee's scope as virtual badges. This is the
+            // callee's only view of who called it, and it is not inherited: the frame the callee pushes in turn gets
+            // the callee's identity, not this one.
+            Some(caller) => {
+                let component = caller
+                    .scope()
+                    .get_current_component_lock()
+                    .and_then(|lock| lock.substate_id().as_component_address());
+                let template = *caller.current_template();
+                new_frame.scope_mut().auth_scope_mut().set_caller(component, template);
+            },
         }
 
         self.call_frames.push(new_frame);

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -78,7 +78,7 @@ use crate::{
         address_allocation::AllocatedAddress,
         fee_state::FeeState,
         locking::LockedSubstate,
-        scope::{CallFrame, CallScope},
+        scope::{CallFrame, CallScope, FrameWriteMode},
         state_store::WorkingStateStore,
         tracker_auth::Authorization,
         validation::{
@@ -251,10 +251,8 @@ impl<TStore: StateReader> WorkingState<TStore> {
         address: K,
         value: V,
     ) -> Result<(), RuntimeError> {
-        if self.is_read_only_context() {
-            return Err(RuntimeError::WriteInReadOnlyContext);
-        }
         let address = address.into();
+        self.check_write_allowed(&address)?;
         let value = value.into();
         self.enforce_substate_size_limit(&value)?;
         self.current_call_scope_mut()?.add_substate_to_scope(address.clone())?;
@@ -272,10 +270,19 @@ impl<TStore: StateReader> WorkingState<TStore> {
     }
 
     pub fn write_lock_substate(&mut self, addr: SubstateId) -> Result<LockedSubstate, RuntimeError> {
-        if self.is_read_only_context() {
-            return Err(RuntimeError::WriteInReadOnlyContext);
-        }
+        self.check_write_allowed(&addr)?;
         self.lock_substate(addr, LockFlag::Write)
+    }
+
+    /// The single chokepoint for the frame write mode. In `OwnComponent` mode the only permitted write is to the
+    /// component locked at frame push, and that goes through the existing lock rather than a new one, so every
+    /// request for a new write lock or a new substate is refused.
+    fn check_write_allowed(&self, addr: &SubstateId) -> Result<(), RuntimeError> {
+        match self.current_frame_write_mode() {
+            FrameWriteMode::Full => Ok(()),
+            FrameWriteMode::OwnComponent => Err(RuntimeError::WriteOutsideOwnComponent { id: addr.clone() }),
+            FrameWriteMode::ReadOnly => Err(RuntimeError::WriteInReadOnlyContext),
+        }
     }
 
     pub fn unlock_substate(&mut self, lock: LockedSubstate) -> Result<(), RuntimeError> {
@@ -1428,19 +1435,22 @@ impl<TStore: StateReader> WorkingState<TStore> {
         self.call_frames.last().ok_or(RuntimeError::NoActiveCallFrame)
     }
 
-    /// Whether the current call frame is a read-only sandbox (a spend-script predicate frame). When
-    /// true, `write_lock_substate` and `new_substate` reject with `RuntimeError::WriteInReadOnlyContext`.
-    pub fn is_read_only_context(&self) -> bool {
-        self.call_frames.last().map(|f| f.is_read_only()).unwrap_or(false)
+    /// The write mode of the current call frame. Outside any frame (top-level instruction processing) writes
+    /// are unrestricted.
+    pub fn current_frame_write_mode(&self) -> FrameWriteMode {
+        self.call_frames
+            .last()
+            .map(|f| f.write_mode())
+            .unwrap_or(FrameWriteMode::Full)
     }
 
-    /// Marks the current (most recently pushed) call frame as a read-only spend-script sandbox. Must be
-    /// called immediately after the predicate frame is pushed and before the predicate executes.
-    pub fn make_current_frame_read_only(&mut self) -> Result<(), RuntimeError> {
+    /// Restricts the current (most recently pushed) call frame to `mode` and disables its cross-template calls.
+    /// Must be called immediately after the frame is pushed and before its code executes.
+    pub fn restrict_current_frame(&mut self, mode: FrameWriteMode) -> Result<(), RuntimeError> {
         self.call_frames
             .last_mut()
             .ok_or(RuntimeError::NoActiveCallFrame)?
-            .restrict_to_read_only();
+            .restrict(mode);
         Ok(())
     }
 
@@ -1540,6 +1550,7 @@ impl<TStore: StateReader> WorkingState<TStore> {
                     .and_then(|lock| lock.substate_id().as_component_address());
                 let template = *caller.current_template();
                 new_frame.scope_mut().auth_scope_mut().set_caller(component, template);
+                new_frame.inherit_restrictions(caller);
             },
         }
 

--- a/crates/engine/tests/access_rules.rs
+++ b/crates/engine/tests/access_rules.rs
@@ -1662,8 +1662,10 @@ mod resource_access_rules {
         );
     }
 
+    /// A caller requirement is an ordinary badge requirement, so a resource rule may be updated to one: the
+    /// resource's minter becomes "whoever is executing on behalf of this component".
     #[test]
-    fn update_access_rule_rejects_caller_requirement() {
+    fn update_access_rule_accepts_caller_requirement() {
         let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/access_rules"]);
 
         let (owner_proof, _, owner_key) = test.create_owner_proof();
@@ -1686,10 +1688,7 @@ mod resource_access_rules {
             .decode::<ComponentAddress>()
             .unwrap();
 
-        // `update_access_rule` goes through the engine path (not the WASM builder), so it must reject a
-        // caller requirement with a recoverable `InvalidArgument` error rather than asserting/aborting the
-        // node the way a `panic!` in a WASM builder would be unreachable here.
-        let reason = test.execute_expect_failure(
+        test.execute_expect_success(
             Transaction::builder_localnet(Epoch(1))
                 .call_method(component_address, "update_tokens_access_rule", args![
                     ResourceAuthAction::Mint,
@@ -1698,11 +1697,6 @@ mod resource_access_rules {
                 .build_and_seal(&owner_key),
             vec![owner_proof],
         );
-
-        assert_reject_reason(reason, RuntimeError::InvalidArgument {
-            argument: "new_rule",
-            reason: "caller_component/direct_caller_template cannot be used on a resource access rule".to_string(),
-        });
     }
 
     #[test]

--- a/crates/engine/tests/access_rules.rs
+++ b/crates/engine/tests/access_rules.rs
@@ -2,7 +2,7 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 use std::collections::{BTreeMap, HashMap};
 
-use tari_engine::runtime::{ActionIdent, LockError, RuntimeError};
+use tari_engine::runtime::{ActionIdent, RuntimeError};
 use tari_ootle_transaction::{Epoch, Transaction, args};
 use tari_template_lib::{
     args::ComponentAction,
@@ -1225,12 +1225,81 @@ mod resource_access_rules {
             vec![user_proof.clone()],
         );
 
-        assert_reject_reason(
-            result,
-            RuntimeError::LockError(LockError::MultipleWriteLockRequested {
-                address: user_account.into(),
-            }),
+        assert_reject_reason(result, RuntimeError::ForbiddenInAuthHookContext {
+            operation: "call_invoke",
+        });
+    }
+
+    #[test]
+    fn it_allows_hook_to_update_its_own_state() {
+        let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/access_rules"]);
+
+        let (_owner_account, owner_proof, owner_key) = test.create_empty_account();
+        let (user_account, user_proof, user_key) = test.create_empty_account();
+
+        let access_rules_template = test.get_template_address("AccessRulesTest");
+
+        let result = test.execute_expect_success(
+            Transaction::builder_localnet(Epoch(1))
+                .call_function(access_rules_template, "with_auth_hook", args![
+                    true,
+                    "counting_auth_hook"
+                ])
+                .build_and_seal(&owner_key),
+            vec![owner_proof.clone()],
         );
+
+        let component_address = result.finalize.execution_results[0]
+            .decode::<ComponentAddress>()
+            .unwrap();
+
+        let result = test.execute_expect_success(
+            Transaction::builder_localnet(Epoch(1))
+                .call_method(component_address, "take_tokens", args![10])
+                .put_last_instruction_output_on_workspace("tokens")
+                .call_method(user_account, "deposit", args![Workspace("tokens")])
+                .call_method(component_address, "get_value", args![])
+                .build_and_seal(&user_key),
+            vec![user_proof.clone()],
+        );
+
+        let value = result.finalize.execution_results[3].decode::<u32>().unwrap();
+        assert_eq!(value, 1, "the hook fired once for the deposit");
+    }
+
+    #[test]
+    fn it_disallows_hook_that_writes_outside_its_own_component() {
+        let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/access_rules"]);
+
+        let (_owner_account, owner_proof, owner_key) = test.create_empty_account();
+        let (user_account, user_proof, user_key) = test.create_empty_account();
+
+        let access_rules_template = test.get_template_address("AccessRulesTest");
+
+        let result = test.execute_expect_success(
+            Transaction::builder_localnet(Epoch(1))
+                .call_function(access_rules_template, "with_auth_hook", args![
+                    true,
+                    "hook_creates_vault"
+                ])
+                .build_and_seal(&owner_key),
+            vec![owner_proof.clone()],
+        );
+
+        let component_address = result.finalize.execution_results[0]
+            .decode::<ComponentAddress>()
+            .unwrap();
+
+        let result = test.execute_expect_failure(
+            Transaction::builder_localnet(Epoch(1))
+                .call_method(component_address, "take_tokens", args![10])
+                .put_last_instruction_output_on_workspace("tokens")
+                .call_method(user_account, "deposit", args![Workspace("tokens")])
+                .build_and_seal(&user_key),
+            vec![user_proof.clone()],
+        );
+
+        assert_reject_reason(result, "attempted in a resource auth hook");
     }
 
     #[test]
@@ -1279,11 +1348,14 @@ mod resource_access_rules {
             vec![user_proof.clone()],
         );
 
-        // Check that the access hook fails (it does not have permission to call set in the state component)
-        // even though the transaction signer has ownership of the object and the previous call to set works.
-        assert_reject_reason(result, RuntimeError::AccessDeniedAuthHook {
+        // Check that the access hook fails: a hook frame may not call out to any other component, even though the
+        // transaction signer has ownership of the object and the previous call to set works.
+        assert_reject_reason(&result, RuntimeError::AccessDeniedAuthHook {
             action_ident: ResourceAuthAction::Deposit.into(),
             details: String::new(),
+        });
+        assert_reject_reason(&result, RuntimeError::ForbiddenInAuthHookContext {
+            operation: "call_invoke",
         });
     }
 
@@ -1294,7 +1366,6 @@ mod resource_access_rules {
         let access_rules_template = test.get_template_address("AccessRulesTest");
 
         [
-            "invalid_auth_hook1",
             "invalid_auth_hook2",
             "invalid_auth_hook3",
             "invalid_auth_hook4",
@@ -1472,7 +1543,6 @@ mod resource_access_rules {
             .unwrap();
 
         for hook in [
-            "invalid_auth_hook1",
             "invalid_auth_hook2",
             "invalid_auth_hook3",
             "invalid_auth_hook4",

--- a/crates/engine/tests/caller_badge.rs
+++ b/crates/engine/tests/caller_badge.rs
@@ -6,8 +6,12 @@
 //! checkable wherever any other badge is (so a *resource* rule can gate on the caller), and it names only the
 //! immediate caller (so it cannot be forwarded down a call chain).
 
+use tari_engine::runtime::RuntimeError;
+use tari_engine_types::substate::SubstateId;
 use tari_ootle_transaction::args;
 use tari_template_lib::types::{
+    ComponentAddress,
+    ResourceAddress,
     access_rules::ResourceAuthAction,
     constants::{CALLER_COMPONENT_RESOURCE_ADDRESS, DIRECT_CALLER_TEMPLATE_RESOURCE_ADDRESS},
 };
@@ -161,6 +165,46 @@ fn resource_withdraw_rule_denies_a_caller_from_another_template() {
         vec![test.owner_proof()],
     );
     assert_access_denied_for_action(reason, ResourceAuthAction::Withdraw);
+}
+
+/// A resource auth hook runs with the acting component's caller badges in scope, and the acting component never
+/// chose the hook code: anyone can bind a hook to a token and deposit that token into any account. The hook frame is
+/// therefore confined to its own component state, so those badges cannot be spent on a resource gated on the
+/// depositor.
+#[test]
+fn auth_hook_cannot_spend_the_depositors_caller_badge() {
+    let mut test = TemplateTest::new(CRATE_PATH, [
+        "tests/templates/caller_badge_resource",
+        "tests/templates/caller_badge_hook",
+    ]);
+    let holder_template = test.get_template_address("GatedResource");
+    let attacker_template = test.get_template_address("HookAttacker");
+    let (victim, _, _) = test.create_empty_account();
+
+    let result = test.execute_expect_success(
+        test.transaction()
+            .call_function(holder_template, "new_mint_gated", args![victim])
+            .put_last_instruction_output_on_workspace("holder")
+            .call_method("holder", "resource_address", args![])
+            .put_last_instruction_output_on_workspace("gated")
+            .call_function(attacker_template, "new", args![Workspace("gated")])
+            .build_and_seal(test.secret_key()),
+        vec![test.owner_proof()],
+    );
+    let gated: ResourceAddress = result.finalize.execution_results[2].decode().unwrap();
+    let attacker: ComponentAddress = result.finalize.execution_results[4].decode().unwrap();
+
+    let reason = test.execute_expect_failure(
+        test.transaction()
+            .call_method(attacker, "take_junk", args![])
+            .put_last_instruction_output_on_workspace("junk")
+            .call_method(victim, "deposit", args![Workspace("junk")])
+            .build_and_seal(test.secret_key()),
+        vec![test.owner_proof()],
+    );
+    assert_reject_reason(&reason, RuntimeError::WriteOutsideOwnComponent {
+        id: SubstateId::Resource(gated),
+    });
 }
 
 /// A caller badge is issued into an authorization scope and is not backed by a resource, so there is no path

--- a/crates/engine/tests/caller_badge.rs
+++ b/crates/engine/tests/caller_badge.rs
@@ -1,0 +1,140 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! Caller identity is a virtual badge stamped into a frame's authorization scope at push, not a predicate
+//! evaluated once at method entry. These tests cover the two properties that follow from that: the badge is
+//! checkable wherever any other badge is (so a *resource* rule can gate on the caller), and it names only the
+//! immediate caller (so it cannot be forwarded down a call chain).
+
+use tari_ootle_transaction::args;
+use tari_template_lib::types::{ComponentAddress, ObjectKey, access_rules::ResourceAuthAction};
+use tari_template_test_tooling::{TemplateTest, support::assert_error::assert_access_denied_for_action};
+
+const CRATE_PATH: &str = env!("CARGO_MANIFEST_DIR");
+
+const TEMPLATES: [&str; 2] = [
+    "tests/templates/caller_component_caller",
+    "tests/templates/caller_badge_resource",
+];
+
+/// `withdrawable(rule!(caller_component(a)))` puts the gate on the resource: a holder whose own methods are
+/// `allow_all` may still only move the tokens while it is executing on behalf of `a`.
+#[test]
+fn resource_withdraw_rule_allows_the_gated_caller() {
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATES);
+    let caller_template = test.get_template_address("Caller");
+    let holder_template = test.get_template_address("GatedResource");
+
+    test.execute_expect_success(
+        test.transaction()
+            .call_function(caller_template, "new", args![])
+            .put_last_instruction_output_on_workspace("gate")
+            .call_function(holder_template, "new", args![Workspace("gate")])
+            .put_last_instruction_output_on_workspace("holder")
+            .call_method("gate", "withdraw_from", args![Workspace("holder")])
+            .build_and_seal(test.secret_key()),
+        vec![test.owner_proof()],
+    );
+}
+
+/// A top-level `CallMethod` carries no caller badge, so the holder's own `allow_all` method is reached but
+/// the withdraw inside it is denied by the resource rule.
+#[test]
+fn resource_withdraw_rule_denies_a_top_level_signer() {
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATES);
+    let caller_template = test.get_template_address("Caller");
+    let holder_template = test.get_template_address("GatedResource");
+
+    test.execute_expect_success(
+        test.transaction()
+            .call_function(caller_template, "new", args![])
+            .put_last_instruction_output_on_workspace("gate")
+            .call_function(holder_template, "new", args![Workspace("gate")])
+            .build_and_seal(test.secret_key()),
+        vec![test.owner_proof()],
+    );
+    let holder = test
+        .read_only_state_store()
+        .get_first_component_of(holder_template)
+        .unwrap()
+        .unwrap();
+
+    let reason = test.execute_expect_failure(
+        test.transaction()
+            .call_method(holder, "withdraw_once", args![])
+            .build_and_seal(test.secret_key()),
+        vec![test.owner_proof()],
+    );
+    assert_access_denied_for_action(reason, ResourceAuthAction::Withdraw);
+}
+
+/// A component that is not the gated one is denied, even though it can call the holder's method.
+#[test]
+fn resource_withdraw_rule_denies_an_unrelated_component() {
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATES);
+    let caller_template = test.get_template_address("Caller");
+    let holder_template = test.get_template_address("GatedResource");
+
+    let reason = test.execute_expect_failure(
+        test.transaction()
+            .call_function(caller_template, "new", args![])
+            .put_last_instruction_output_on_workspace("gate")
+            .call_function(caller_template, "new", args![])
+            .put_last_instruction_output_on_workspace("intruder")
+            .call_function(holder_template, "new", args![Workspace("gate")])
+            .put_last_instruction_output_on_workspace("holder")
+            .call_method("intruder", "withdraw_from", args![Workspace("holder")])
+            .build_and_seal(test.secret_key()),
+        vec![test.owner_proof()],
+    );
+    assert_access_denied_for_action(reason, ResourceAuthAction::Withdraw);
+}
+
+/// The badge is re-derived at every frame push and never inherited: with `gate -> forwarder -> holder`, the
+/// holder's frame carries the forwarder's badge, not the gate's. Without this, any static function or method
+/// the gated component transitively reaches would act as a proxy for it.
+#[test]
+fn caller_badge_is_not_inherited_through_an_intermediate_frame() {
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATES);
+    let caller_template = test.get_template_address("Caller");
+    let holder_template = test.get_template_address("GatedResource");
+
+    let reason = test.execute_expect_failure(
+        test.transaction()
+            .call_function(caller_template, "new", args![])
+            .put_last_instruction_output_on_workspace("gate")
+            .call_function(caller_template, "new", args![])
+            .put_last_instruction_output_on_workspace("forwarder")
+            .call_function(holder_template, "new", args![Workspace("gate")])
+            .put_last_instruction_output_on_workspace("holder")
+            .call_method("gate", "withdraw_via", args![
+                Workspace("forwarder"),
+                Workspace("holder")
+            ])
+            .build_and_seal(test.secret_key()),
+        vec![test.owner_proof()],
+    );
+    assert_access_denied_for_action(reason, ResourceAuthAction::Withdraw);
+}
+
+/// A caller badge is issued into an authorization scope and is not backed by a resource, so there is no path
+/// from a badge to a `Proof` that a callee could capture and forward. Both badge resource addresses must stay
+/// empty for that to hold.
+#[test]
+fn caller_badge_resources_hold_no_tokens() {
+    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/caller_badge_mint_attempt"]);
+    let template = test.get_template_address("BadgeMintAttempt");
+    let component = ComponentAddress::new(ObjectKey::default());
+
+    for (function, arg) in [
+        ("mint_caller_component_badge", args![component]),
+        ("mint_direct_caller_template_badge", args![template]),
+    ] {
+        test.execute_expect_failure(
+            test.transaction()
+                .call_function(template, function, arg)
+                .build_and_seal(test.secret_key()),
+            vec![test.owner_proof()],
+        );
+    }
+}

--- a/crates/engine/tests/caller_badge.rs
+++ b/crates/engine/tests/caller_badge.rs
@@ -7,8 +7,14 @@
 //! immediate caller (so it cannot be forwarded down a call chain).
 
 use tari_ootle_transaction::args;
-use tari_template_lib::types::{ComponentAddress, ObjectKey, access_rules::ResourceAuthAction};
-use tari_template_test_tooling::{TemplateTest, support::assert_error::assert_access_denied_for_action};
+use tari_template_lib::types::{
+    access_rules::ResourceAuthAction,
+    constants::{CALLER_COMPONENT_RESOURCE_ADDRESS, DIRECT_CALLER_TEMPLATE_RESOURCE_ADDRESS},
+};
+use tari_template_test_tooling::{
+    TemplateTest,
+    support::assert_error::{assert_access_denied_for_action, assert_reject_reason},
+};
 
 const CRATE_PATH: &str = env!("CARGO_MANIFEST_DIR");
 
@@ -117,24 +123,67 @@ fn caller_badge_is_not_inherited_through_an_intermediate_frame() {
     assert_access_denied_for_action(reason, ResourceAuthAction::Withdraw);
 }
 
+/// A static function frame has no component identity, so the template badge is the only one stamped. A
+/// `CallFunction` of the gated template must therefore satisfy `direct_caller_template` on a resource rule.
+#[test]
+fn resource_withdraw_rule_allows_a_static_function_of_the_gated_template() {
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATES);
+    let caller_template = test.get_template_address("Caller");
+    let holder_template = test.get_template_address("GatedResource");
+
+    test.execute_expect_success(
+        test.transaction()
+            .call_function(holder_template, "new_template_gated", args![caller_template])
+            .put_last_instruction_output_on_workspace("holder")
+            .call_function(caller_template, "withdraw_from_static", args![Workspace("holder")])
+            .build_and_seal(test.secret_key()),
+        vec![test.owner_proof()],
+    );
+}
+
+/// The template badge names the immediate caller's template, so a caller from any other template is denied
+/// even though its own frame is a perfectly ordinary component frame.
+#[test]
+fn resource_withdraw_rule_denies_a_caller_from_another_template() {
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATES);
+    let caller_template = test.get_template_address("Caller");
+    let holder_template = test.get_template_address("GatedResource");
+
+    // Gated on the holder's own template, which the `Caller` component is not.
+    let reason = test.execute_expect_failure(
+        test.transaction()
+            .call_function(caller_template, "new", args![])
+            .put_last_instruction_output_on_workspace("caller")
+            .call_function(holder_template, "new_template_gated", args![holder_template])
+            .put_last_instruction_output_on_workspace("holder")
+            .call_method("caller", "withdraw_from", args![Workspace("holder")])
+            .build_and_seal(test.secret_key()),
+        vec![test.owner_proof()],
+    );
+    assert_access_denied_for_action(reason, ResourceAuthAction::Withdraw);
+}
+
 /// A caller badge is issued into an authorization scope and is not backed by a resource, so there is no path
 /// from a badge to a `Proof` that a callee could capture and forward. Both badge resource addresses must stay
-/// empty for that to hold.
+/// empty for that to hold: a mint must fail because there is nothing at the address, not for any other reason.
 #[test]
 fn caller_badge_resources_hold_no_tokens() {
     let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/caller_badge_mint_attempt"]);
     let template = test.get_template_address("BadgeMintAttempt");
-    let component = ComponentAddress::new(ObjectKey::default());
 
-    for (function, arg) in [
-        ("mint_caller_component_badge", args![component]),
-        ("mint_direct_caller_template_badge", args![template]),
+    for (function, resource) in [
+        ("mint_caller_component_badge", CALLER_COMPONENT_RESOURCE_ADDRESS),
+        (
+            "mint_direct_caller_template_badge",
+            DIRECT_CALLER_TEMPLATE_RESOURCE_ADDRESS,
+        ),
     ] {
-        test.execute_expect_failure(
+        let reason = test.execute_expect_failure(
             test.transaction()
-                .call_function(template, function, arg)
+                .call_function(template, function, args![])
                 .build_and_seal(test.secret_key()),
             vec![test.owner_proof()],
         );
+        assert_reject_reason(reason, format!("{resource} not found"));
     }
 }

--- a/crates/engine/tests/recall.rs
+++ b/crates/engine/tests/recall.rs
@@ -4,11 +4,13 @@
 use std::collections::BTreeMap;
 
 use ootle_byte_type::ToByteType;
+use tari_engine::runtime::RuntimeError;
 use tari_ootle_transaction::{Epoch, Transaction, args};
 use tari_template_lib::types::{Amount, ComponentAddress, NonFungibleId, ResourceAddress, VaultId};
 use tari_template_test_tooling::{
     TemplateTest,
     support::{
+        assert_error::assert_reject_reason,
         confidential::{generate_confidential_output_statement, generate_withdraw_proof},
         value_proof::value_proofs_for_commitment,
     },
@@ -97,4 +99,72 @@ fn it_recalls_all_resource_types() {
     let vault = test.read_only_state_store().get_vault(&stealth_vault).unwrap();
     let stealth_balance = vault.balance();
     assert_eq!(stealth_balance, Amount::from(2u64));
+}
+
+/// The recall rule that authorizes the action belongs to the named resource, so it must not reach a vault holding
+/// some other resource, whatever that resource's own recall rule says. An attacker who could recall under their own
+/// permissive rule would pull the victim's tokens into a bucket and deposit them into their own account.
+#[test]
+fn it_rejects_recall_from_a_vault_of_another_resource() {
+    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/recall"]);
+    let recall_template = test.get_template_address("Recall");
+    let (account, _, _) = test.create_empty_account();
+    let (thief_account, _, _) = test.create_empty_account();
+
+    let mut components = Vec::new();
+    for _ in 0..2 {
+        let (mut initial_supply, mask, _) = generate_confidential_output_statement(1000, None);
+        initial_supply.output_revealed_amount = Amount::from(1000u64);
+        let value_proofs = value_proofs_for_commitment(1000u64, &mask);
+
+        let result = test.execute_expect_success(
+            Transaction::builder_localnet(Epoch(1))
+                .call_function(recall_template, "new", args![initial_supply, value_proofs])
+                .build_and_seal(test.secret_key()),
+            vec![],
+        );
+        let component: ComponentAddress = result.finalize.execution_results[0].get_value("$.0").unwrap().unwrap();
+        let fungible: ResourceAddress = result.finalize.execution_results[0].get_value("$.1").unwrap().unwrap();
+
+        let withdraw = generate_withdraw_proof(&mask, 10, Some(980), 10u64);
+        test.execute_expect_success(
+            Transaction::builder_localnet(Epoch(1))
+                .call_method(component, "withdraw_some", args![withdraw.proof])
+                .put_last_instruction_output_on_workspace("buckets")
+                .call_method(account, "deposit", args![Workspace("buckets.0")])
+                .call_method(account, "deposit", args![Workspace("buckets.1")])
+                .call_method(account, "deposit", args![Workspace("buckets.2")])
+                .call_method(account, "deposit", args![Workspace("buckets.3")])
+                .build_and_seal(test.secret_key()),
+            vec![],
+        );
+        components.push((component, fungible));
+    }
+    let (attacker, attacker_resource) = components[0];
+    let (_, victim_resource) = components[1];
+
+    let vaults: BTreeMap<ResourceAddress, VaultId> = test.extract_component_value(account, "$.0");
+    let victim_vault = vaults[&victim_resource];
+
+    let reason = test.execute_expect_failure(
+        Transaction::builder_localnet(Epoch(1))
+            .call_method(attacker, "recall_fungible_to_bucket", args![victim_vault, 6])
+            .put_last_instruction_output_on_workspace("stolen")
+            .call_method(thief_account, "deposit", args![Workspace("stolen")])
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+    assert_reject_reason(&reason, RuntimeError::RecallResourceMismatch {
+        vault_id: victim_vault,
+        resource_address: attacker_resource,
+        vault_resource: victim_resource,
+    });
+
+    let vault = test.read_only_state_store().get_vault(&victim_vault).unwrap();
+    assert_eq!(vault.balance(), Amount::from(10u64), "the victim keeps every token");
+    let thief_vaults: BTreeMap<ResourceAddress, VaultId> = test.extract_component_value(thief_account, "$.0");
+    assert!(
+        !thief_vaults.contains_key(&victim_resource),
+        "the thief never received the victim's resource"
+    );
 }

--- a/crates/engine/tests/spend_script.rs
+++ b/crates/engine/tests/spend_script.rs
@@ -711,22 +711,30 @@ fn read_only_sandbox_blocks_state_mutation() {
     assert_reject_reason(&reason, "read-only execution context");
 }
 
+/// An event is an output of execution that no later code can observe, so a predicate may emit one without
+/// compromising the sandbox.
 #[test]
-fn sandbox_denies_emit_event() {
+fn sandbox_allows_emit_event() {
     let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
     let script_template = test.get_template_address(SCRIPT_TEMPLATE);
-    let (resx, mint) = mint_utxo(&mut test, script_condition(script_template, "try_emit_event", vec![]));
+    let (resx, mint) = mint_utxo(&mut test, script_condition(script_template, "emit_event", vec![]));
 
     let transfer = spend_into(&mint, key_path(test.to_public_key_bytes()));
-    let reason = test.execute_expect_failure(
+    let result = test.execute_expect_success(
         Transaction::builder_localnet(Epoch(1))
             .stealth_transfer(resx, transfer.statement)
             .finish()
             .seal(test.secret_key()),
         vec![],
     );
-    assert_reject_reason(&reason, "Spend script rejected the spend");
-    assert_reject_reason(&reason, "forbidden inside a read-only");
+    assert!(
+        result
+            .finalize
+            .events
+            .iter()
+            .any(|event| event.topic().ends_with(".spend_script_test")),
+        "the predicate's event is in the transaction's events"
+    );
 }
 
 #[test]

--- a/crates/engine/tests/templates/access_rules/src/lib.rs
+++ b/crates/engine/tests/templates/access_rules/src/lib.rs
@@ -331,7 +331,16 @@ mod access_rules_template {
             ResourceManager::get(self.tokens.resource_address()).set_auth_hook(hook);
         }
 
-        pub fn invalid_auth_hook1(&mut self, _action: ResourceAuthAction, _caller: AuthHookCaller) {}
+        /// A mutable hook records each invocation in its own state, the one write a hook frame may make.
+        pub fn counting_auth_hook(&mut self, _action: ResourceAuthAction, _caller: AuthHookCaller) {
+            self.value += 1;
+        }
+
+        /// Attempts a state write outside the hook's own component. The hook frame is confined to its own
+        /// component state, so the engine refuses the vault creation.
+        pub fn hook_creates_vault(&self, _action: ResourceAuthAction, _caller: AuthHookCaller) {
+            let _vault = Vault::new_empty(self.tokens.resource_address());
+        }
 
         pub fn invalid_auth_hook2(&self, _action: String, _caller: AuthHookCaller) {}
 

--- a/crates/engine/tests/templates/caller_badge_hook/Cargo.toml
+++ b/crates/engine/tests/templates/caller_badge_hook/Cargo.toml
@@ -1,0 +1,11 @@
+[workspace]
+[package]
+name = "caller_badge_hook"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+tari_template_lib = { path = "../../../../template_lib" }
+
+[lib]
+crate-type = ["cdylib"]

--- a/crates/engine/tests/templates/caller_badge_hook/src/lib.rs
+++ b/crates/engine/tests/templates/caller_badge_hook/src/lib.rs
@@ -1,0 +1,44 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use tari_template_lib::prelude::*;
+
+/// A resource whose auth hook runs inside whichever component acts on the resource, and so with that
+/// component's caller badges in scope. The hook tries to spend those badges on a resource gated on the
+/// acting component.
+#[template]
+mod hook_attacker {
+    use super::*;
+
+    pub struct HookAttacker {
+        junk: Vault,
+        target: ResourceAddress,
+    }
+
+    impl HookAttacker {
+        pub fn new(target: ResourceAddress) -> Component<Self> {
+            let alloc = CallerContext::allocate_component_address(None);
+            let junk = ResourceBuilder::public_fungible()
+                .with_authorization_hook(alloc.get_address(), "hook")
+                .initial_supply(1000u32);
+
+            Component::new(Self {
+                junk: Vault::from_bucket(junk),
+                target,
+            })
+            .with_address_allocation(alloc)
+            .with_owner_rule(OwnerRule::None)
+            .with_access_rules(ComponentAccessRules::allow_all())
+            .create()
+        }
+
+        pub fn take_junk(&mut self) -> Bucket {
+            self.junk.withdraw(Amount::new(1))
+        }
+
+        pub fn hook(&self, _action: ResourceAuthAction, _caller: AuthHookCaller) {
+            let minted = ResourceManager::get(self.target).mint_fungible(Amount::new(1));
+            minted.burn();
+        }
+    }
+}

--- a/crates/engine/tests/templates/caller_badge_mint_attempt/Cargo.toml
+++ b/crates/engine/tests/templates/caller_badge_mint_attempt/Cargo.toml
@@ -1,0 +1,11 @@
+[workspace]
+[package]
+name = "caller_badge_mint_attempt"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+tari_template_lib = { path = "../../../../template_lib" }
+
+[lib]
+crate-type = ["cdylib"]

--- a/crates/engine/tests/templates/caller_badge_mint_attempt/src/lib.rs
+++ b/crates/engine/tests/templates/caller_badge_mint_attempt/src/lib.rs
@@ -1,0 +1,31 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use tari_template_lib::prelude::*;
+
+/// Attempts to obtain a real token of a caller-badge resource. Nothing exists at either badge resource
+/// address, so there is no resource to mint from and therefore no path from a caller badge to a `Proof`.
+#[template]
+mod mint_attempt {
+    use super::*;
+
+    pub struct BadgeMintAttempt;
+
+    impl BadgeMintAttempt {
+        pub fn mint_caller_component_badge(gate: ComponentAddress) -> Bucket {
+            ResourceManager::get(CALLER_COMPONENT_RESOURCE_ADDRESS).mint_non_fungible(
+                NonFungibleId::from_u256((*gate.as_object_key()).into_array()),
+                &(),
+                &(),
+            )
+        }
+
+        pub fn mint_direct_caller_template_badge(gate: TemplateAddress) -> Bucket {
+            ResourceManager::get(DIRECT_CALLER_TEMPLATE_RESOURCE_ADDRESS).mint_non_fungible(
+                NonFungibleId::from_u256(gate.into_array()),
+                &(),
+                &(),
+            )
+        }
+    }
+}

--- a/crates/engine/tests/templates/caller_badge_mint_attempt/src/lib.rs
+++ b/crates/engine/tests/templates/caller_badge_mint_attempt/src/lib.rs
@@ -12,17 +12,17 @@ mod mint_attempt {
     pub struct BadgeMintAttempt;
 
     impl BadgeMintAttempt {
-        pub fn mint_caller_component_badge(gate: ComponentAddress) -> Bucket {
+        pub fn mint_caller_component_badge() -> Bucket {
             ResourceManager::get(CALLER_COMPONENT_RESOURCE_ADDRESS).mint_non_fungible(
-                NonFungibleId::from_u256((*gate.as_object_key()).into_array()),
+                NonFungibleId::from_u256([0u8; 32]),
                 &(),
                 &(),
             )
         }
 
-        pub fn mint_direct_caller_template_badge(gate: TemplateAddress) -> Bucket {
+        pub fn mint_direct_caller_template_badge() -> Bucket {
             ResourceManager::get(DIRECT_CALLER_TEMPLATE_RESOURCE_ADDRESS).mint_non_fungible(
-                NonFungibleId::from_u256(gate.into_array()),
+                NonFungibleId::from_u256([0u8; 32]),
                 &(),
                 &(),
             )

--- a/crates/engine/tests/templates/caller_badge_resource/Cargo.toml
+++ b/crates/engine/tests/templates/caller_badge_resource/Cargo.toml
@@ -1,0 +1,11 @@
+[workspace]
+[package]
+name = "caller_badge_resource"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+tari_template_lib = { path = "../../../../template_lib" }
+
+[lib]
+crate-type = ["cdylib"]

--- a/crates/engine/tests/templates/caller_badge_resource/src/lib.rs
+++ b/crates/engine/tests/templates/caller_badge_resource/src/lib.rs
@@ -29,15 +29,27 @@ mod gated_resource {
             .create()
         }
 
+        /// As [`Self::new`], but gated on the caller's *template* so that a static function of `gate`
+        /// satisfies the rule as well as a component instance of it.
+        pub fn new_template_gated(gate: TemplateAddress) -> Component<Self> {
+            let tokens = ResourceBuilder::public_fungible()
+                .with_owner_rule(OwnerRule::None)
+                .withdrawable(rule!(direct_caller_template(gate)), LOCKED)
+                .initial_supply(1000u32);
+
+            Component::new(GatedResource {
+                vault: Vault::from_bucket(tokens),
+            })
+            .with_owner_rule(OwnerRule::None)
+            .with_access_rules(ComponentAccessRules::allow_all())
+            .create()
+        }
+
         /// Withdraws and immediately returns the tokens, so the call succeeds or fails purely on the
         /// resource's withdraw rule.
         pub fn withdraw_once(&mut self) {
             let bucket = self.vault.withdraw(Amount::new(1));
             self.vault.deposit(bucket);
-        }
-
-        pub fn balance(&self) -> Amount {
-            self.vault.balance()
         }
     }
 }

--- a/crates/engine/tests/templates/caller_badge_resource/src/lib.rs
+++ b/crates/engine/tests/templates/caller_badge_resource/src/lib.rs
@@ -1,0 +1,43 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use tari_template_lib::prelude::*;
+
+/// A resource whose withdraw rule is gated on the caller of whichever component holds it, held in a
+/// vault by a component whose methods are open to everyone. Only the resource rule decides who may move
+/// the tokens, so the gate applies to every holder rather than to one hand-written method gate.
+#[template]
+mod gated_resource {
+    use super::*;
+
+    pub struct GatedResource {
+        vault: Vault,
+    }
+
+    impl GatedResource {
+        pub fn new(gate: ComponentAddress) -> Component<Self> {
+            let tokens = ResourceBuilder::public_fungible()
+                .with_owner_rule(OwnerRule::None)
+                .withdrawable(rule!(caller_component(gate)), LOCKED)
+                .initial_supply(1000u32);
+
+            Component::new(GatedResource {
+                vault: Vault::from_bucket(tokens),
+            })
+            .with_owner_rule(OwnerRule::None)
+            .with_access_rules(ComponentAccessRules::allow_all())
+            .create()
+        }
+
+        /// Withdraws and immediately returns the tokens, so the call succeeds or fails purely on the
+        /// resource's withdraw rule.
+        pub fn withdraw_once(&mut self) {
+            let bucket = self.vault.withdraw(Amount::new(1));
+            self.vault.deposit(bucket);
+        }
+
+        pub fn balance(&self) -> Amount {
+            self.vault.balance()
+        }
+    }
+}

--- a/crates/engine/tests/templates/caller_badge_resource/src/lib.rs
+++ b/crates/engine/tests/templates/caller_badge_resource/src/lib.rs
@@ -45,6 +45,25 @@ mod gated_resource {
             .create()
         }
 
+        /// A resource whose mint rule is gated on the caller of whichever component mints it.
+        pub fn new_mint_gated(gate: ComponentAddress) -> Component<Self> {
+            let tokens = ResourceBuilder::public_fungible()
+                .with_owner_rule(OwnerRule::None)
+                .mintable(rule!(caller_component(gate)), LOCKED)
+                .initial_supply(1000u32);
+
+            Component::new(GatedResource {
+                vault: Vault::from_bucket(tokens),
+            })
+            .with_owner_rule(OwnerRule::None)
+            .with_access_rules(ComponentAccessRules::allow_all())
+            .create()
+        }
+
+        pub fn resource_address(&self) -> ResourceAddress {
+            self.vault.resource_address()
+        }
+
         /// Withdraws and immediately returns the tokens, so the call succeeds or fails purely on the
         /// resource's withdraw rule.
         pub fn withdraw_once(&mut self) {

--- a/crates/engine/tests/templates/caller_component_caller/src/lib.rs
+++ b/crates/engine/tests/templates/caller_component_caller/src/lib.rs
@@ -47,5 +47,10 @@ mod caller {
         pub fn withdraw_via(&self, next: ComponentAddress, holder: ComponentAddress) {
             ComponentManager::get(next).invoke("withdraw_from", args![holder]);
         }
+
+        // A static (template-function) caller has no component instance, only a template identity.
+        pub fn withdraw_from_static(holder: ComponentAddress) {
+            ComponentManager::get(holder).invoke("withdraw_once", args![]);
+        }
     }
 }

--- a/crates/engine/tests/templates/caller_component_caller/src/lib.rs
+++ b/crates/engine/tests/templates/caller_component_caller/src/lib.rs
@@ -16,6 +16,8 @@ mod caller {
                 .method("call_bar", rule!(allow_all))
                 .method("call_ping", rule!(allow_all))
                 .method("call_open_bar", rule!(allow_all))
+                .method("withdraw_from", rule!(allow_all))
+                .method("withdraw_via", rule!(allow_all))
                 .default(rule!(deny_all));
 
             Component::new(Caller)
@@ -34,6 +36,16 @@ mod caller {
 
         pub fn call_ping(&self, callee: ComponentAddress) -> u64 {
             ComponentManager::get(callee).call("ping", args![])
+        }
+
+        pub fn withdraw_from(&self, holder: ComponentAddress) {
+            ComponentManager::get(holder).invoke("withdraw_once", args![]);
+        }
+
+        /// Forwards through `next`, so the holder's frame is entered by `next` rather than by this
+        /// component.
+        pub fn withdraw_via(&self, next: ComponentAddress, holder: ComponentAddress) {
+            ComponentManager::get(next).invoke("withdraw_from", args![holder]);
         }
     }
 }

--- a/crates/engine/tests/templates/recall/src/lib.rs
+++ b/crates/engine/tests/templates/recall/src/lib.rs
@@ -94,6 +94,12 @@ mod template {
             }
         }
 
+        /// Recalls under this component's fungible resource rule and hands the bucket back to the caller, who
+        /// decides where it goes.
+        pub fn recall_fungible_to_bucket(&mut self, vault_id: VaultId, amount: Amount) -> Bucket {
+            ResourceManager::get(self.fungible.resource_address()).recall_fungible_amount(vault_id, amount)
+        }
+
         pub fn recall_fungible(&mut self, vault_id: VaultId, amount: Amount) {
             // NOTE: this call will only succeed if the resource is contained in the vault
             let bucket =

--- a/crates/engine/tests/templates/spend_script/src/lib.rs
+++ b/crates/engine/tests/templates/spend_script/src/lib.rs
@@ -78,8 +78,8 @@ mod spend_scripts {
             engine().create_component(0u32, OwnerRule::default(), AccessRules::allow_all(), None);
         }
 
-        /// Attempts to emit an event, which is on the spend-script deny-list.
-        pub fn try_emit_event(_ctx: SpendContext) {
+        /// Emits an event, which the sandbox permits.
+        pub fn emit_event(_ctx: SpendContext) {
             emit_event("spend_script_test", Metadata::new());
         }
 

--- a/crates/engine_types/src/substate.rs
+++ b/crates/engine_types/src/substate.rs
@@ -316,12 +316,19 @@ impl SubstateId {
         matches!(self, Self::NonFungible(addr) if *addr.resource_address() == PUBLIC_IDENTITY_RESOURCE_ADDRESS)
     }
 
-    /// Returns `true` for non-fungibles that the engine issues rather than stores: public-key identities and the
-    /// caller badges stamped into an authorization scope at frame push. They have no substate, so they are never
-    /// resolved as a transaction input nor brought into a call scope.
+    /// Returns `true` for substate ids the engine reserves and never stores: public-key identities, the caller
+    /// badges stamped into an authorization scope at frame push, and the two resources those badges are namespaced
+    /// by. Nothing can ever be resolved or locked at one of these, so they are neither derived as transaction
+    /// inputs nor brought into a call scope, and a transaction naming one as an input is rejected at validation.
     pub fn is_virtual(&self) -> bool {
-        matches!(self, Self::NonFungible(addr) if addr.resource_address().is_caller_badge()) ||
-            self.is_public_key_identity()
+        match self {
+            Self::NonFungible(addr) => {
+                let resource = addr.resource_address();
+                resource.is_caller_badge() || *resource == PUBLIC_IDENTITY_RESOURCE_ADDRESS
+            },
+            Self::Resource(addr) => addr.is_caller_badge(),
+            _ => false,
+        }
     }
 
     pub const fn is_vault(&self) -> bool {

--- a/crates/engine_types/src/substate.rs
+++ b/crates/engine_types/src/substate.rs
@@ -316,8 +316,12 @@ impl SubstateId {
         matches!(self, Self::NonFungible(addr) if *addr.resource_address() == PUBLIC_IDENTITY_RESOURCE_ADDRESS)
     }
 
+    /// Returns `true` for non-fungibles that the engine issues rather than stores: public-key identities and the
+    /// caller badges stamped into an authorization scope at frame push. They have no substate, so they are never
+    /// resolved as a transaction input nor brought into a call scope.
     pub fn is_virtual(&self) -> bool {
-        self.is_public_key_identity()
+        matches!(self, Self::NonFungible(addr) if addr.resource_address().is_caller_badge()) ||
+            self.is_public_key_identity()
     }
 
     pub const fn is_vault(&self) -> bool {

--- a/crates/template_lib/src/prelude.rs
+++ b/crates/template_lib/src/prelude.rs
@@ -58,7 +58,13 @@ pub use tari_template_lib_types::{
     },
     bytes::Bytes,
     confidential::{ConfidentialOutputStatement, ConfidentialWithdrawProof},
-    constants::{PUBLIC_IDENTITY_RESOURCE_ADDRESS, STEALTH_TARI_RESOURCE_ADDRESS, TARI_TOKEN},
+    constants::{
+        CALLER_COMPONENT_RESOURCE_ADDRESS,
+        DIRECT_CALLER_TEMPLATE_RESOURCE_ADDRESS,
+        PUBLIC_IDENTITY_RESOURCE_ADDRESS,
+        STEALTH_TARI_RESOURCE_ADDRESS,
+        TARI_TOKEN,
+    },
     crypto::{
         BalanceProofSignature,
         PedersenCommitmentBytes,

--- a/crates/template_lib/src/resource/builder/confidential.rs
+++ b/crates/template_lib/src/resource/builder/confidential.rs
@@ -232,6 +232,11 @@ impl ConfidentialResourceBuilder {
     /// The resource will fail to build if the component's template does not have a method with the correct signature.
     /// Hooks are only run when the resource is acted on by an external component.
     ///
+    /// The hook runs in a sandboxed frame: it may read, emit events and (when declared `&mut self`) update its own
+    /// component state, but it cannot write any other substate, act on any vault or resource, or call another
+    /// component. The acting component's caller badges are in scope for the hook's own method rule, and the sandbox
+    /// is what stops the hook spending them on the acting component's behalf.
+    ///
     /// ## Examples
     ///
     /// Building a resource with a hook from within a component

--- a/crates/template_lib/src/resource/builder/fungible.rs
+++ b/crates/template_lib/src/resource/builder/fungible.rs
@@ -429,6 +429,11 @@ impl FungibleResourceBuilder {
     /// The resource will fail to build if the component's template does not have a method with the specified signature.
     /// Hooks are only run when the resource is acted on by an external component.
     ///
+    /// The hook runs in a sandboxed frame: it may read, emit events and (when declared `&mut self`) update its own
+    /// component state, but it cannot write any other substate, act on any vault or resource, or call another
+    /// component. The acting component's caller badges are in scope for the hook's own method rule, and the sandbox
+    /// is what stops the hook spending them on the acting component's behalf.
+    ///
     /// ## Examples
     ///
     /// Building a resource with a hook from within a component

--- a/crates/template_lib/src/resource/builder/non_fungible.rs
+++ b/crates/template_lib/src/resource/builder/non_fungible.rs
@@ -197,6 +197,11 @@ impl NonFungibleResourceBuilder {
     /// The resource will fail to build if the component's template does not have a method with the specified signature.
     /// Hooks are only run when the resource is acted on by an external component.
     ///
+    /// The hook runs in a sandboxed frame: it may read, emit events and (when declared `&mut self`) update its own
+    /// component state, but it cannot write any other substate, act on any vault or resource, or call another
+    /// component. The acting component's caller badges are in scope for the hook's own method rule, and the sandbox
+    /// is what stops the hook spending them on the acting component's behalf.
+    ///
     /// ## Examples
     ///
     /// Building a resource with a hook from within a component

--- a/crates/template_lib/src/resource/builder/stealth.rs
+++ b/crates/template_lib/src/resource/builder/stealth.rs
@@ -221,6 +221,11 @@ impl StealthResourceBuilder {
     /// The resource will fail to build if the component's template does not have a method with the correct signature.
     /// Hooks are only run when the resource is acted on by an external component.
     ///
+    /// The hook runs in a sandboxed frame: it may read, emit events and (when declared `&mut self`) update its own
+    /// component state, but it cannot write any other substate, act on any vault or resource, or call another
+    /// component. The acting component's caller badges are in scope for the hook's own method rule, and the sandbox
+    /// is what stops the hook spending them on the acting component's behalf.
+    ///
     /// ## Examples
     ///
     /// Building a resource with a hook from within a component

--- a/crates/template_lib_types/src/access_rules.rs
+++ b/crates/template_lib_types/src/access_rules.rs
@@ -64,17 +64,6 @@ impl AccessRule {
             )
         })
     }
-
-    /// Returns `true` if the rule contains `CallerComponent` or `DirectCallerTemplate`, which always evaluate
-    /// to `false` in a current-frame context (resource rules and covenants).
-    pub fn contains_caller_component_or_template(&self) -> bool {
-        self.contains_requirement(&|r| {
-            matches!(
-                r,
-                RuleRequirement::CallerComponent(_) | RuleRequirement::DirectCallerTemplate(_)
-            )
-        })
-    }
 }
 
 /// An enum that represents the possible ways to restrict access to components or resources
@@ -231,11 +220,13 @@ pub enum RuleRequirement {
     /// Requires execution within a specific template (the current frame is that template)
     #[n(3)]
     ScopedToTemplate(#[n(0)] TemplateAddress),
-    /// Requires a call from a specific component: the caller of a component method is that component
+    /// Requires the badge naming a specific component as the caller. Shorthand for
+    /// `NonFungibleAddress(NonFungibleAddress::caller_component_badge(address))`.
     #[n(4)]
     CallerComponent(#[n(0)] ComponentAddress),
-    /// Requires that the immediate caller of a component method is code from a specific template: any component
-    /// instance of it, or any static function of it
+    /// Requires the badge naming a specific template as the immediate caller's: any component instance of it, or any
+    /// static function of it. Shorthand for
+    /// `NonFungibleAddress(NonFungibleAddress::direct_caller_template_badge(address))`.
     #[n(5)]
     DirectCallerTemplate(#[n(0)] TemplateAddress),
 }
@@ -498,15 +489,6 @@ pub struct ResourceAccessRules {
 }
 
 impl ResourceAccessRules {
-    /// Rejects rules that are meaningless in a resource (current-frame) context.
-    fn assert_no_caller_requirement(rule: &AccessRule) {
-        assert!(
-            !rule.contains_caller_component_or_template(),
-            "`caller_component(..)`/`direct_caller_template(..)` always evaluate to false on resource rules; use \
-             `component(..)`/`template(..)` or a proof requirement instead"
-        );
-    }
-
     /// Builds a new set of access rules for a resource.
     ///
     /// By default:
@@ -562,7 +544,6 @@ impl ResourceAccessRules {
 
     /// Sets up who can mint new tokens of the resource
     pub fn mintable<U: Into<UpdateRule>>(mut self, rule: AccessRule, updater: U) -> Self {
-        Self::assert_no_caller_requirement(&rule);
         self.mint = rule;
         self.mint_updater = updater.into();
         self
@@ -570,7 +551,6 @@ impl ResourceAccessRules {
 
     /// Sets up who can burn (destroy) tokens of the resource
     pub fn burnable<U: Into<UpdateRule>>(mut self, rule: AccessRule, updater: U) -> Self {
-        Self::assert_no_caller_requirement(&rule);
         self.burn = rule;
         self.burn_updater = updater.into();
         self
@@ -579,7 +559,6 @@ impl ResourceAccessRules {
     /// Sets up who can recall tokens of the resource.
     /// A recall is the forceful withdrawal of tokens from any external vault
     pub fn recallable<U: Into<UpdateRule>>(mut self, rule: AccessRule, updater: U) -> Self {
-        Self::assert_no_caller_requirement(&rule);
         self.recall = rule;
         self.recall_updater = updater.into();
         self
@@ -588,7 +567,6 @@ impl ResourceAccessRules {
     /// Sets up who can freeze a vault (or UTXO in the case of stealth) containing this resource, preventing
     /// withdrawals.
     pub fn freezable<U: Into<UpdateRule>>(mut self, rule: AccessRule, updater: U) -> Self {
-        Self::assert_no_caller_requirement(&rule);
         self.freeze = rule;
         self.freeze_updater = updater.into();
         self
@@ -596,7 +574,6 @@ impl ResourceAccessRules {
 
     /// Sets up who can withdraw tokens of the resource from any vault
     pub fn withdrawable<U: Into<UpdateRule>>(mut self, rule: AccessRule, updater: U) -> Self {
-        Self::assert_no_caller_requirement(&rule);
         self.withdraw = rule;
         self.withdraw_updater = updater.into();
         self
@@ -604,7 +581,6 @@ impl ResourceAccessRules {
 
     /// Sets up who can deposit tokens of the resource into any vault
     pub fn depositable<U: Into<UpdateRule>>(mut self, rule: AccessRule, updater: U) -> Self {
-        Self::assert_no_caller_requirement(&rule);
         self.deposit = rule;
         self.deposit_updater = updater.into();
         self
@@ -612,7 +588,6 @@ impl ResourceAccessRules {
 
     /// Sets up who can update the mutable data of the tokens in the resource
     pub fn update_non_fungible_data<U: Into<UpdateRule>>(mut self, rule: AccessRule, updater: U) -> Self {
-        Self::assert_no_caller_requirement(&rule);
         self.update_nft_data = rule;
         self.nft_data_updater = updater.into();
         self
@@ -620,7 +595,6 @@ impl ResourceAccessRules {
 
     /// Sets up who can update the resource's metadata. The token symbol remains immutable once set.
     pub fn update_metadata<U: Into<UpdateRule>>(mut self, rule: AccessRule, updater: U) -> Self {
-        Self::assert_no_caller_requirement(&rule);
         self.update_metadata = rule;
         self.metadata_updater = updater.into();
         self
@@ -629,13 +603,7 @@ impl ResourceAccessRules {
     /// Sets up who can install, replace or remove the resource's authorization hook. Locked by default, which
     /// makes a hook binding for the life of the resource.
     pub fn set_auth_hook_updater<U: Into<UpdateRule>>(mut self, updater: U) -> Self {
-        let updater = updater.into();
-        // A `caller_component`/`direct_caller_template` requirement always evaluates to false on a resource, so
-        // an updater carrying one is indistinguishable from `Locked` — the bricking this updater exists to avoid.
-        if let UpdateRule::AccessRule(rule) = &updater {
-            Self::assert_no_caller_requirement(rule);
-        }
-        self.auth_hook_updater = updater;
+        self.auth_hook_updater = updater.into();
         self
     }
 
@@ -746,9 +714,12 @@ impl Default for ResourceAccessRules {
 /// `n_of` constructs.
 ///
 /// `component(addr)` / `template(addr)` require execution within a component/template, while
-/// `caller_component(addr)` / `direct_caller_template(addr)` require a call from that component/template and are
-/// intended for component method access rules. "Direct" means the immediate caller only: if A calls B and B calls C,
-/// C's rule sees B.
+/// `caller_component(addr)` / `direct_caller_template(addr)` require the badge of that component/template, which the
+/// engine stamps into a frame's authorization scope naming its immediate caller. "Direct" means the immediate caller
+/// only: if A calls B and B calls C, C's frame carries B's badge, not A's. Because they are badges they hold for the
+/// lifetime of the frame and are checkable wherever a proof requirement is — component method rules, owner rules,
+/// resource rules and spend conditions alike. They are re-derived at every frame push and are not capturable as a
+/// `Proof`, so a callee cannot forward the identity it was called with.
 ///
 /// **Caution:** `caller_component` / `direct_caller_template` match the immediate caller's identity, which is only as
 /// trustworthy as the code that makes the call. A method that forwards a caller-supplied component and method (a
@@ -758,10 +729,8 @@ impl Default for ResourceAccessRules {
 /// call anywhere in that template.
 ///
 /// `component(addr)` / `template(addr)` are constant on component **method** rules and owner rules (they always
-/// describe the current frame, i.e. the component itself), and `caller_component(addr)` /
-/// `direct_caller_template(addr)` always evaluate to `false` on **resource** rules. The builder methods reject both at
-/// construction, and the engine rejects them on component creation, `ComponentAction::SetAccessRules` and
-/// `ResourceAction::UpdateAccessRule`.
+/// describe the current frame, i.e. the component itself). The builder methods reject them at construction, and the
+/// engine rejects them on component creation and `ComponentAction::SetAccessRules`.
 ///
 /// # Examples:
 ///
@@ -784,9 +753,9 @@ impl Default for ResourceAccessRules {
 /// // Restricted access to a template
 /// let template_address = tari_template_lib_types::TemplateAddress::default();
 /// let template_rule = rule!(template(template_address));
-/// // Restricted access to calls from a specific component (component method rules)
+/// // Restricted access to calls from a specific component
 /// let caller_component_rule = rule!(caller_component(component_address));
-/// // Restricted access to calls from a specific template (component method rules)
+/// // Restricted access to calls from a specific template
 /// let caller_template_rule = rule!(direct_caller_template(template_address));
 /// // Restricted access to a non-fungible token
 /// let non_fungible_address = tari_template_lib_types::NonFungibleAddress::from_public_key(
@@ -1079,17 +1048,12 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "always evaluate to false on resource rules")]
-    fn resource_rule_rejects_caller_component() {
-        let address = ComponentAddress::new(ObjectKey::default());
-        ResourceAccessRules::new().mintable(rule!(caller_component(address)), LOCKED);
-    }
-
-    #[test]
-    #[should_panic(expected = "always evaluate to false on resource rules")]
-    fn resource_rule_rejects_direct_caller_template() {
-        let address = TemplateAddress::default();
-        ResourceAccessRules::new().withdrawable(rule!(direct_caller_template(address)), LOCKED);
+    fn resource_rule_allows_caller_requirements() {
+        let component = ComponentAddress::new(ObjectKey::default());
+        let template = TemplateAddress::default();
+        ResourceAccessRules::new()
+            .mintable(rule!(caller_component(component)), LOCKED)
+            .withdrawable(rule!(direct_caller_template(template)), LOCKED);
     }
 
     #[test]
@@ -1111,8 +1075,38 @@ mod tests {
             resource(ResourceAddress::new(ObjectKey::default())),
             caller_component(component)
         ));
-        assert!(rule.contains_caller_component_or_template());
         assert!(!rule.contains_scoped_to_component_or_template());
+        assert!(
+            rule!(any_of(
+                resource(ResourceAddress::new(ObjectKey::default())),
+                component(component)
+            ))
+            .contains_scoped_to_component_or_template()
+        );
+    }
+
+    #[test]
+    fn caller_badges_are_namespaced_by_their_own_resource() {
+        let component = ComponentAddress::new(ObjectKey::default());
+        let template = TemplateAddress::default();
+
+        let component_badge = NonFungibleAddress::caller_component_badge(component);
+        let template_badge = NonFungibleAddress::direct_caller_template_badge(template);
+
+        assert_eq!(
+            *component_badge.resource_address(),
+            crate::constants::CALLER_COMPONENT_RESOURCE_ADDRESS
+        );
+        assert_eq!(
+            *template_badge.resource_address(),
+            crate::constants::DIRECT_CALLER_TEMPLATE_RESOURCE_ADDRESS
+        );
+        // A component address and a template address are both 32 bytes, so the two badge resources must
+        // keep them apart: an all-zero component must never match an all-zero template.
+        assert_ne!(component_badge, template_badge);
+        assert!(component_badge.resource_address().is_caller_badge());
+        assert!(template_badge.resource_address().is_caller_badge());
+        assert!(component_badge.resource_address().is_system_reserved());
     }
 
     #[test]
@@ -1127,13 +1121,14 @@ mod tests {
         ));
     }
 
-    /// Such an updater always evaluates to false on a resource, so it would be `Locked` wearing a disguise:
-    /// the hook could never be repaired, which is the failure this updater exists to prevent.
+    /// A caller requirement is a badge on a resource rule, so an updater carrying one is satisfiable rather than
+    /// `Locked` wearing a disguise: the component it names can repair the hook, which is what this updater exists
+    /// to guarantee.
     #[test]
-    #[should_panic(expected = "always evaluate to false on resource rules")]
-    fn auth_hook_updater_rejects_a_caller_requirement() {
+    fn auth_hook_updater_accepts_a_caller_requirement() {
         let address = ComponentAddress::new(ObjectKey::default());
-        ResourceAccessRules::new().set_auth_hook_updater(rule!(caller_component(address)));
+        let rules = ResourceAccessRules::new().set_auth_hook_updater(rule!(caller_component(address)));
+        assert!(matches!(rules.auth_hook_updater(), UpdateRule::AccessRule(_)));
     }
 
     #[test]

--- a/crates/template_lib_types/src/access_rules.rs
+++ b/crates/template_lib_types/src/access_rules.rs
@@ -731,7 +731,10 @@ impl Default for ResourceAccessRules {
 /// **Caution, the other way round:** calling out hands the callee your identity as a live badge for the whole of its
 /// frame, usable at every auth point it reaches — a resource rule, an ownership rule, a spend condition — not only at
 /// the method it entered through. Weigh that before calling into code you do not control, and gate the rules that
-/// matter on a proof the callee cannot obtain rather than on the caller badge alone.
+/// matter on a proof the callee cannot obtain rather than on the caller badge alone. A resource auth hook is the one
+/// call-out you do not choose (any resource may bind one, and anyone may deposit that resource into an account), so
+/// the engine confines a hook frame to its own component state: the badge satisfies the hook's method rule but
+/// cannot be spent on any vault or resource from inside the hook.
 ///
 /// `component(addr)` / `template(addr)` are constant on component **method** rules and owner rules (they always
 /// describe the current frame, i.e. the component itself). The builder methods reject them at construction, and the

--- a/crates/template_lib_types/src/access_rules.rs
+++ b/crates/template_lib_types/src/access_rules.rs
@@ -721,6 +721,11 @@ impl Default for ResourceAccessRules {
 /// resource rules and spend conditions alike. They are re-derived at every frame push and are not capturable as a
 /// `Proof`, so a callee cannot forward the identity it was called with.
 ///
+/// `any_caller_component` and `any_caller_template` take no address: they ask only whether there was a caller of that
+/// kind. `any_caller_component` is satisfied by any component caller and by no top-level instruction;
+/// `any_caller_template` by any frame below the top level, i.e. by code reached from a template rather than directly
+/// from a transaction instruction.
+///
 /// **Caution:** `caller_component` / `direct_caller_template` match the immediate caller's identity, which is only as
 /// trustworthy as the code that makes the call. A method that forwards a caller-supplied component and method (a
 /// "proxy" method) delegates that identity, so anyone who can call the proxy can act as the proxied component/template.
@@ -765,6 +770,9 @@ impl Default for ResourceAccessRules {
 /// let caller_component_rule = rule!(caller_component(component_address));
 /// // Restricted access to calls from a specific template
 /// let caller_template_rule = rule!(direct_caller_template(template_address));
+/// // Restricted to any component caller at all, and to any caller at all
+/// let any_component_caller_rule = rule!(any_caller_component);
+/// let any_caller_rule = rule!(any_caller_template);
 /// // Restricted access to a non-fungible token
 /// let non_fungible_address = tari_template_lib_types::NonFungibleAddress::from_public_key(
 ///     tari_template_lib_types::crypto::RistrettoPublicKeyBytes::default(),
@@ -803,6 +811,10 @@ macro_rules! __restricted_access_rule {
     ($a:ident($($tail:tt)*)) => {
         $crate::access_rules::RestrictedAccessRule::Require($crate::__require_rule!($a($($tail)*)))
     };
+    // Requirements that name no address, e.g. `any_caller_component`.
+    ($a:ident) => {
+        $crate::access_rules::RestrictedAccessRule::Require($crate::__require_rule!($a))
+    };
 }
 
 #[macro_export]
@@ -818,6 +830,10 @@ macro_rules! __require_rule {
     };
     ($a:ident($b:expr)) => {
         $crate::access_rules::RequireRule::Require($crate::__rule_requirement!($a($b)))
+    };
+    // Requirements that name no address, e.g. `any_caller_component`.
+    ($a:ident) => {
+        $crate::access_rules::RequireRule::Require($crate::__rule_requirement!($a))
     };
 }
 
@@ -844,6 +860,12 @@ macro_rules! __rule_requirement {
     (direct_caller_template($x: expr)) => {
         $crate::access_rules::RuleRequirement::DirectCallerTemplate($x)
     };
+    (any_caller_component) => {
+        $crate::access_rules::RuleRequirement::Resource($crate::constants::CALLER_COMPONENT_RESOURCE_ADDRESS)
+    };
+    (any_caller_template) => {
+        $crate::access_rules::RuleRequirement::Resource($crate::constants::DIRECT_CALLER_TEMPLATE_RESOURCE_ADDRESS)
+    };
 }
 
 #[macro_export]
@@ -861,16 +883,37 @@ macro_rules! __build_vec {
         $crate::__build_vec_inner!(@ { items, $item_fn } $a($b),);
         items
     }};
+
+    (@ {$item_fn:ident} $a:ident, $($tail:tt)*) => {{
+        let mut items = Vec::with_capacity(1 + $crate::__expr_counter!($($tail)*));
+        $crate::__build_vec_inner!(@ { items, $item_fn } $a, $($tail)*);
+        items
+    }};
+
+    (@ {$item_fn:ident} $a:ident $(,)?) => {{
+        let mut items = Vec::new();
+        $crate::__build_vec_inner!(@ { items, $item_fn } $a,);
+        items
+    }};
 }
 
 #[macro_export]
 macro_rules! __build_vec_inner {
+    // Terminator: a no-address item recurses with an empty tail once it is the last in the list.
+    (@ { $this:ident, $item_fn:ident }) => {};
     (@ { $this:ident, $item_fn:ident } $a:ident($e:expr), $($tail:tt)*) => {
         $crate::access_rules::__push(&mut $this, $crate::$item_fn!($a($e)));
         $crate::__build_vec_inner!(@ {$this, $item_fn } $($tail)*);
     };
     (@ { $this:ident, $item_fn:ident } $a:ident($e:expr) $(,)*) => {
         $crate::access_rules::__push(&mut $this, $crate::$item_fn!($a($e)));
+    };
+    (@ { $this:ident, $item_fn:ident } $a:ident, $($tail:tt)*) => {
+        $crate::access_rules::__push(&mut $this, $crate::$item_fn!($a));
+        $crate::__build_vec_inner!(@ {$this, $item_fn } $($tail)*);
+    };
+    (@ { $this:ident, $item_fn:ident } $a:ident $(,)*) => {
+        $crate::access_rules::__push(&mut $this, $crate::$item_fn!($a));
     };
 }
 
@@ -1090,6 +1133,43 @@ mod tests {
                 component(component)
             ))
             .contains_scoped_to_component_or_template()
+        );
+    }
+
+    #[test]
+    fn any_caller_sugar_needs_no_constant() {
+        assert_eq!(
+            rule!(any_caller_component),
+            AccessRule::Restricted(RestrictedAccessRule::Require(RequireRule::Require(
+                RuleRequirement::Resource(crate::constants::CALLER_COMPONENT_RESOURCE_ADDRESS)
+            )))
+        );
+        assert_eq!(
+            rule!(any_caller_template),
+            AccessRule::Restricted(RestrictedAccessRule::Require(RequireRule::Require(
+                RuleRequirement::Resource(crate::constants::DIRECT_CALLER_TEMPLATE_RESOURCE_ADDRESS)
+            )))
+        );
+    }
+
+    /// The no-address forms have to compose like every other requirement, in any position of a combinator.
+    #[test]
+    fn any_caller_sugar_composes() {
+        let pk = RistrettoPublicKeyBytes::default();
+        let component = ComponentAddress::new(ObjectKey::default());
+
+        let leading = rule!(any_of(any_caller_component, public_key(pk)));
+        let trailing = rule!(any_of(public_key(pk), any_caller_component));
+        assert_ne!(leading, trailing); // ordering is preserved, so these are distinct rules
+        assert!(leading.contains_requirement(&|r| matches!(r, RuleRequirement::Resource(_))));
+        assert!(trailing.contains_requirement(&|r| matches!(r, RuleRequirement::Resource(_))));
+
+        let middle = rule!(all_of(caller_component(component), any_caller_template, public_key(pk)));
+        assert!(middle.contains_requirement(&|r| matches!(r, RuleRequirement::Resource(_))));
+
+        // A bare requirement on its own inside a combinator.
+        assert!(
+            rule!(any_of(any_caller_component)).contains_requirement(&|r| matches!(r, RuleRequirement::Resource(_)))
         );
     }
 

--- a/crates/template_lib_types/src/access_rules.rs
+++ b/crates/template_lib_types/src/access_rules.rs
@@ -728,6 +728,11 @@ impl Default for ResourceAccessRules {
 /// create) and any static function of it (which anyone can call), so it is only as strong as the least careful outgoing
 /// call anywhere in that template.
 ///
+/// **Caution, the other way round:** calling out hands the callee your identity as a live badge for the whole of its
+/// frame, usable at every auth point it reaches — a resource rule, an ownership rule, a spend condition — not only at
+/// the method it entered through. Weigh that before calling into code you do not control, and gate the rules that
+/// matter on a proof the callee cannot obtain rather than on the caller badge alone.
+///
 /// `component(addr)` / `template(addr)` are constant on component **method** rules and owner rules (they always
 /// describe the current frame, i.e. the component itself). The builder methods reject them at construction, and the
 /// engine rejects them on component creation and `ComponentAction::SetAccessRules`.

--- a/crates/template_lib_types/src/constants.rs
+++ b/crates/template_lib_types/src/constants.rs
@@ -16,6 +16,29 @@ pub const PUBLIC_IDENTITY_RESOURCE_ADDRESS: ResourceAddress = ResourceAddress::n
     1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 ]));
 
+/// Resource address of the virtual badge that names the component a frame is executing on behalf of.
+/// A frame pushed by a component method call carries the badge
+/// `nft_<CALLER_COMPONENT_RESOURCE_ADDRESS>_uuid_<caller component address>` in its authorization scope, so
+/// `rule!(caller_component(addr))` — and equivalently `require(NonFungibleAddress)` of that badge — is
+/// re-checkable at every auth point for the lifetime of the frame.
+///
+/// No resource exists at this address and none may be created: the badge is issued by the engine at frame push
+/// and cannot be minted, held in a vault, or captured as a `Proof`.
+/// resource_0100000000000000000000000000000000000000000000000000000000000001
+pub const CALLER_COMPONENT_RESOURCE_ADDRESS: ResourceAddress = ResourceAddress::new(ObjectKey::from_array([
+    1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+]));
+
+/// Resource address of the virtual badge that names the template of a frame's immediate caller. Stamped
+/// alongside [`CALLER_COMPONENT_RESOURCE_ADDRESS`] at every frame push, and the only caller badge a static
+/// function call yields (a function frame has no component identity).
+///
+/// Subject to the same restrictions as [`CALLER_COMPONENT_RESOURCE_ADDRESS`].
+/// resource_0100000000000000000000000000000000000000000000000000000000000002
+pub const DIRECT_CALLER_TEMPLATE_RESOURCE_ADDRESS: ResourceAddress = ResourceAddress::new(ObjectKey::from_array([
+    1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2,
+]));
+
 /// The Tari network native resource address. This token is used for paying network fees, among other things. It is a
 /// fungible resource with a divisibility of 6, meaning that the smallest unit is 0.000001 TARI.
 /// resource_0101010101010101010101010101010101010101010101010101010101010101

--- a/crates/template_lib_types/src/constants.rs
+++ b/crates/template_lib_types/src/constants.rs
@@ -22,8 +22,9 @@ pub const PUBLIC_IDENTITY_RESOURCE_ADDRESS: ResourceAddress = ResourceAddress::n
 /// `rule!(caller_component(addr))` — and equivalently `require(NonFungibleAddress)` of that badge — is
 /// re-checkable at every auth point for the lifetime of the frame.
 ///
-/// Requiring the resource rather than a specific badge — `rule!(resource(CALLER_COMPONENT_RESOURCE_ADDRESS))` —
-/// reads as "called by some component", satisfied by any component caller and by no top-level instruction.
+/// `rule!(any_caller_component)` requires this resource rather than a specific badge, and so reads as "called by
+/// some component": satisfied by any component caller and by no top-level instruction. Template code should use
+/// that spelling rather than naming this address.
 ///
 /// No resource exists at this address and none may be created: the badge is issued by the engine at frame push
 /// and cannot be minted, held in a vault, or captured as a `Proof`.
@@ -35,8 +36,8 @@ pub const CALLER_COMPONENT_RESOURCE_ADDRESS: ResourceAddress = ResourceAddress::
 /// Resource address of the virtual badge that names the template of a frame's immediate caller. Stamped
 /// alongside [`CALLER_COMPONENT_RESOURCE_ADDRESS`] at every frame push, and the only caller badge a static
 /// function call yields (a function frame has no component identity). Since every frame below the top level
-/// carries one, `rule!(resource(DIRECT_CALLER_TEMPLATE_RESOURCE_ADDRESS))` reads as "reached from template code
-/// rather than directly from a transaction instruction".
+/// carries one, `rule!(any_caller_template)` reads as "reached from template code rather than directly from a
+/// transaction instruction".
 ///
 /// Subject to the same restrictions as [`CALLER_COMPONENT_RESOURCE_ADDRESS`].
 /// resource_0100000000000000000000000000000000000000000000000000000000000002

--- a/crates/template_lib_types/src/constants.rs
+++ b/crates/template_lib_types/src/constants.rs
@@ -22,6 +22,9 @@ pub const PUBLIC_IDENTITY_RESOURCE_ADDRESS: ResourceAddress = ResourceAddress::n
 /// `rule!(caller_component(addr))` — and equivalently `require(NonFungibleAddress)` of that badge — is
 /// re-checkable at every auth point for the lifetime of the frame.
 ///
+/// Requiring the resource rather than a specific badge — `rule!(resource(CALLER_COMPONENT_RESOURCE_ADDRESS))` —
+/// reads as "called by some component", satisfied by any component caller and by no top-level instruction.
+///
 /// No resource exists at this address and none may be created: the badge is issued by the engine at frame push
 /// and cannot be minted, held in a vault, or captured as a `Proof`.
 /// resource_0100000000000000000000000000000000000000000000000000000000000001
@@ -31,7 +34,9 @@ pub const CALLER_COMPONENT_RESOURCE_ADDRESS: ResourceAddress = ResourceAddress::
 
 /// Resource address of the virtual badge that names the template of a frame's immediate caller. Stamped
 /// alongside [`CALLER_COMPONENT_RESOURCE_ADDRESS`] at every frame push, and the only caller badge a static
-/// function call yields (a function frame has no component identity).
+/// function call yields (a function frame has no component identity). Since every frame below the top level
+/// carries one, `rule!(resource(DIRECT_CALLER_TEMPLATE_RESOURCE_ADDRESS))` reads as "reached from template code
+/// rather than directly from a transaction instruction".
 ///
 /// Subject to the same restrictions as [`CALLER_COMPONENT_RESOURCE_ADDRESS`].
 /// resource_0100000000000000000000000000000000000000000000000000000000000002

--- a/crates/template_lib_types/src/substates/non_fungible.rs
+++ b/crates/template_lib_types/src/substates/non_fungible.rs
@@ -9,11 +9,15 @@ use tari_template_abi::{
     rust::{fmt, fmt::Display, prelude::*, str::FromStr, write},
 };
 
-use super::{BinaryTag, ResourceAddress};
+use super::{BinaryTag, ComponentAddress, ResourceAddress, TemplateAddress};
 use crate::{
     MaxString,
     address_prefixes,
-    constants::PUBLIC_IDENTITY_RESOURCE_ADDRESS,
+    constants::{
+        CALLER_COMPONENT_RESOURCE_ADDRESS,
+        DIRECT_CALLER_TEMPLATE_RESOURCE_ADDRESS,
+        PUBLIC_IDENTITY_RESOURCE_ADDRESS,
+    },
     crypto::RistrettoPublicKeyBytes,
     hex::{fixed_bytes_from_hex, write_hex_fmt},
 };
@@ -272,6 +276,24 @@ impl NonFungibleAddress {
         Self::new(
             PUBLIC_IDENTITY_RESOURCE_ADDRESS,
             NonFungibleId::from_public_key(public_key),
+        )
+    }
+
+    /// The virtual badge naming `address` as the component a frame is executing on behalf of. Stamped into a
+    /// callee's authorization scope by the engine; see [`CALLER_COMPONENT_RESOURCE_ADDRESS`].
+    pub fn caller_component_badge(address: ComponentAddress) -> Self {
+        Self::new(
+            CALLER_COMPONENT_RESOURCE_ADDRESS,
+            NonFungibleId::U256(address.as_object_key().into_array()),
+        )
+    }
+
+    /// The virtual badge naming `address` as the template of a frame's immediate caller. See
+    /// [`DIRECT_CALLER_TEMPLATE_RESOURCE_ADDRESS`].
+    pub fn direct_caller_template_badge(address: TemplateAddress) -> Self {
+        Self::new(
+            DIRECT_CALLER_TEMPLATE_RESOURCE_ADDRESS,
+            NonFungibleId::U256(address.into_array()),
         )
     }
 

--- a/crates/template_lib_types/src/substates/resource.rs
+++ b/crates/template_lib_types/src/substates/resource.rs
@@ -35,7 +35,12 @@ use crate::{
     KeyParseError,
     ObjectKey,
     address_prefixes,
-    constants::{PUBLIC_IDENTITY_RESOURCE_ADDRESS, STEALTH_TARI_RESOURCE_ADDRESS},
+    constants::{
+        CALLER_COMPONENT_RESOURCE_ADDRESS,
+        DIRECT_CALLER_TEMPLATE_RESOURCE_ADDRESS,
+        PUBLIC_IDENTITY_RESOURCE_ADDRESS,
+        STEALTH_TARI_RESOURCE_ADDRESS,
+    },
 };
 
 const TAG: u64 = BinaryTag::ResourceAddress.as_u64();
@@ -75,6 +80,19 @@ impl ResourceAddress {
 
     pub fn is_public_key_resource(&self) -> bool {
         *self == PUBLIC_IDENTITY_RESOURCE_ADDRESS
+    }
+
+    /// Returns `true` for the resource addresses the system reserves. No template may create a resource at one of
+    /// these: the identity and TARI resources are created in the genesis state, and the two caller-badge resources
+    /// are virtual — nothing may exist at them for the engine's badges to be unforgeable.
+    pub fn is_system_reserved(&self) -> bool {
+        *self == PUBLIC_IDENTITY_RESOURCE_ADDRESS || *self == STEALTH_TARI_RESOURCE_ADDRESS || self.is_caller_badge()
+    }
+
+    /// Returns `true` if this is one of the two virtual caller-badge resources: badges of it are issued by the
+    /// engine at frame push and exist only inside an authorization scope.
+    pub fn is_caller_badge(&self) -> bool {
+        *self == CALLER_COMPONENT_RESOURCE_ADDRESS || *self == DIRECT_CALLER_TEMPLATE_RESOURCE_ADDRESS
     }
 }
 

--- a/crates/transaction_validation/src/builder.rs
+++ b/crates/transaction_validation/src/builder.rs
@@ -8,6 +8,7 @@ use crate::{
     BasicValidations,
     BlobReferenceValidator,
     EpochRangeValidator,
+    InputSubstateValidator,
     PublishTemplateLimitValidator,
     SignatureLimitValidator,
     StealthTransactionLimitsValidator,
@@ -23,7 +24,7 @@ use crate::{
 
 /// Builds the structural (context-free) mempool validations suitable for any transaction entry
 /// point: network match, basic well-formedness, the per-transaction byte and weight caps, blob references,
-/// and signature verification.
+/// input addressability, and signature verification.
 ///
 /// These never depend on lagging runtime state (epoch, template existence), so they cannot
 /// false-reject and are safe to run at the indexer before forwarding to validator committees. The
@@ -40,6 +41,7 @@ pub fn create_structural_transaction_validator(
         // transaction failing it could not have been relayed regardless of what it weighs.
         .and_then(TransactionSizeValidator::new(max_transaction_size_bytes))
         .and_then(BlobReferenceValidator::new())
+        .and_then(InputSubstateValidator::new())
         .and_then(TransactionWeightValidator::new(max_transaction_weight))
         .and_then(StealthTransactionLimitsValidator::new())
         .and_then(PublishTemplateLimitValidator::new())

--- a/crates/transaction_validation/src/builder.rs
+++ b/crates/transaction_validation/src/builder.rs
@@ -27,9 +27,12 @@ use crate::{
 /// input addressability, and signature verification.
 ///
 /// These never depend on lagging runtime state (epoch, template existence), so they cannot
-/// false-reject and are safe to run at the indexer before forwarding to validator committees. The
-/// validator node composes the same validators plus the context-dependent ones (dry-run rejection,
-/// template existence, epoch range).
+/// false-reject and are safe to run at the indexer before forwarding to validator committees.
+///
+/// The validator node does not compose this chain. It assembles an equivalent one in
+/// `create_node_transaction_validator` so that it can split the checks that back block validation from the
+/// ingress-only ones — a rejection rule in block validation is a consensus rule. The two must be kept in step
+/// by hand.
 pub fn create_structural_transaction_validator(
     network: Network,
     max_transaction_weight: u64,

--- a/crates/transaction_validation/src/error.rs
+++ b/crates/transaction_validation/src/error.rs
@@ -1,6 +1,7 @@
 //    Copyright 2024 The Tari Project
 //    SPDX-License-Identifier: BSD-3-Clause
 
+use tari_engine_types::substate::SubstateId;
 use tari_networking::NetworkingError;
 use tari_ootle_common_types::Epoch;
 use tari_ootle_storage::{StorageError, consensus_models::TransactionPoolError};
@@ -55,6 +56,15 @@ pub enum TransactionValidationError {
     NetworkMismatch { actual: Network, expected: Network },
     #[error("Transaction {transaction_id} contains a pay fee instruction, which is not allowed")]
     ContainsPayFeeInstruction { transaction_id: TransactionId },
+    #[error(
+        "Transaction {transaction_id} declares reserved substate {substate_id} as an input. Public-key identities, \
+         caller badges and the resources those badges belong to are issued or reserved by the engine and never \
+         stored, so no version of one can be locked."
+    )]
+    ReservedSubstateInput {
+        transaction_id: TransactionId,
+        substate_id: SubstateId,
+    },
     #[error("Dry run transactions are not allowed")]
     DryRunNotAllowed,
     #[error("Transaction {transaction_id} weight {weight} exceeds the maximum allowed weight {max_weight}")]
@@ -155,6 +165,7 @@ impl TransactionValidationError {
             Self::UnknownNetwork { .. } |
             Self::NetworkMismatch { .. } |
             Self::ContainsPayFeeInstruction { .. } |
+            Self::ReservedSubstateInput { .. } |
             Self::DryRunNotAllowed |
             Self::TransactionExceedsMaxWeight { .. } |
             Self::TransactionExceedsMaxSize { .. } |

--- a/crates/transaction_validation/src/input_substates.rs
+++ b/crates/transaction_validation/src/input_substates.rs
@@ -1,0 +1,128 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use log::*;
+use tari_ootle_transaction::Transaction;
+
+use crate::{TransactionValidationError, Validator};
+
+const LOG_TARGET: &str = "tari::ootle::mempool::validators::input_substates";
+
+/// Rejects a transaction that declares a substate the engine reserves and never stores — a public-key identity, a
+/// caller badge, or one of the two resources those badges are namespaced by — as an input.
+///
+/// Such an input can never resolve: consensus would abort the transaction at input resolution having already
+/// sequenced it. The address alone decides this, with no reference to any node's view of state, so refusing it at
+/// ingress cannot false-reject and the cost falls on the sender rather than on a committee.
+///
+/// Authority over the badges themselves does not rest here — an input reaches `CallScope`, never the
+/// `AuthorizationScope` that badges are checked against, and both badge resources are empty by invariant. This
+/// rejects the request as nonsense, earlier and with a reason that names the mistake.
+#[derive(Debug, Clone, Default)]
+pub struct InputSubstateValidator;
+
+impl InputSubstateValidator {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Validator<Transaction> for InputSubstateValidator {
+    type Context = ();
+    type Error = TransactionValidationError;
+
+    fn validate(&self, _context: &(), transaction: &Transaction) -> Result<(), Self::Error> {
+        if let Some(input) = transaction
+            .all_inputs_iter()
+            .find(|input| input.substate_id().is_virtual())
+        {
+            let substate_id = input.substate_id().clone();
+            warn!(target: LOG_TARGET, "InputSubstateValidator - FAIL: reserved substate {substate_id} declared as an input");
+            return Err(TransactionValidationError::ReservedSubstateInput {
+                transaction_id: transaction.calculate_id(),
+                substate_id,
+            });
+        }
+
+        debug!(target: LOG_TARGET, "InputSubstateValidator - OK");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tari_common_types::types::PrivateKey;
+    use tari_engine_types::substate::SubstateId;
+    use tari_ootle_common_types::Epoch;
+    use tari_template_lib::types::{
+        Amount,
+        ComponentAddress,
+        NonFungibleAddress,
+        ObjectKey,
+        constants::{CALLER_COMPONENT_RESOURCE_ADDRESS, DIRECT_CALLER_TEMPLATE_RESOURCE_ADDRESS, TARI_TOKEN},
+        crypto::RistrettoPublicKeyBytes,
+    };
+
+    use super::*;
+
+    fn transaction_with_input(input: SubstateId) -> Transaction {
+        Transaction::builder_localnet(Epoch(1))
+            .pay_fee_from_component(ComponentAddress::from_array([1u8; 32]), Amount::new(1000))
+            .add_input(input)
+            .build_and_seal(&PrivateKey::from(1u64))
+    }
+
+    fn validate(input: SubstateId) -> Result<(), TransactionValidationError> {
+        InputSubstateValidator::new().validate(&(), &transaction_with_input(input))
+    }
+
+    #[test]
+    fn it_refuses_a_caller_component_badge() {
+        let badge = NonFungibleAddress::caller_component_badge(ComponentAddress::new(ObjectKey::default()));
+        assert!(matches!(
+            validate(badge.into()),
+            Err(TransactionValidationError::ReservedSubstateInput { .. })
+        ));
+    }
+
+    #[test]
+    fn it_refuses_a_direct_caller_template_badge() {
+        let badge = NonFungibleAddress::direct_caller_template_badge(Default::default());
+        assert!(matches!(
+            validate(badge.into()),
+            Err(TransactionValidationError::ReservedSubstateInput { .. })
+        ));
+    }
+
+    /// The badge resources hold nothing and have no substate of their own, so naming the resource is as
+    /// unresolvable as naming a badge.
+    #[test]
+    fn it_refuses_a_badge_resource() {
+        assert!(matches!(
+            validate(CALLER_COMPONENT_RESOURCE_ADDRESS.into()),
+            Err(TransactionValidationError::ReservedSubstateInput { .. })
+        ));
+        assert!(matches!(
+            validate(DIRECT_CALLER_TEMPLATE_RESOURCE_ADDRESS.into()),
+            Err(TransactionValidationError::ReservedSubstateInput { .. })
+        ));
+    }
+
+    /// A signer badge is issued from the transaction's signatures, not resolved from state, so naming one as an
+    /// input is the same mistake.
+    #[test]
+    fn it_refuses_a_public_key_identity() {
+        let identity = NonFungibleAddress::from_public_key(RistrettoPublicKeyBytes::default());
+        assert!(matches!(
+            validate(identity.into()),
+            Err(TransactionValidationError::ReservedSubstateInput { .. })
+        ));
+    }
+
+    /// The genesis resources are ordinary stored substates and must stay nameable.
+    #[test]
+    fn it_accepts_a_real_substate() {
+        validate(TARI_TOKEN.into()).unwrap();
+        validate(ComponentAddress::from_array([2u8; 32]).into()).unwrap();
+    }
+}

--- a/crates/transaction_validation/src/input_substates.rs
+++ b/crates/transaction_validation/src/input_substates.rs
@@ -59,7 +59,11 @@ mod tests {
         ComponentAddress,
         NonFungibleAddress,
         ObjectKey,
-        constants::{CALLER_COMPONENT_RESOURCE_ADDRESS, DIRECT_CALLER_TEMPLATE_RESOURCE_ADDRESS, TARI_TOKEN},
+        constants::{
+            CALLER_COMPONENT_RESOURCE_ADDRESS,
+            DIRECT_CALLER_TEMPLATE_RESOURCE_ADDRESS,
+            PUBLIC_IDENTITY_RESOURCE_ADDRESS,
+        },
         crypto::RistrettoPublicKeyBytes,
     };
 
@@ -119,10 +123,16 @@ mod tests {
         ));
     }
 
-    /// The genesis resources are ordinary stored substates and must stay nameable.
+    /// The identity *resource* is stored in the genesis state even though its non-fungibles are issued from
+    /// signatures, so it must stay nameable — every account transaction reaches it through
+    /// `get_dependent_substates`, which adds the resource of any non-fungible child.
+    #[test]
+    fn it_accepts_the_identity_resource() {
+        validate(PUBLIC_IDENTITY_RESOURCE_ADDRESS.into()).unwrap();
+    }
+
     #[test]
     fn it_accepts_a_real_substate() {
-        validate(TARI_TOKEN.into()).unwrap();
         validate(ComponentAddress::from_array([2u8; 32]).into()).unwrap();
     }
 }

--- a/crates/transaction_validation/src/lib.rs
+++ b/crates/transaction_validation/src/lib.rs
@@ -21,6 +21,8 @@ mod dry_run;
 pub use dry_run::*;
 mod epoch_range;
 pub use epoch_range::*;
+mod input_substates;
+pub use input_substates::*;
 mod network;
 pub use network::*;
 mod publish_template_limits;

--- a/crates/wallet/sdk/src/apis/substate.rs
+++ b/crates/wallet/sdk/src/apis/substate.rs
@@ -254,6 +254,11 @@ where
         substate_ids: &mut HashSet<SubstateRequirement>,
     ) -> Result<(), SubstateApiError> {
         for addr in value.referenced_substates() {
+            // Component state legitimately holds engine-issued addresses — an `Account` approval is keyed on a
+            // spender badge, which is commonly a public-key identity — and those have no substate to fetch or lock.
+            if addr.is_virtual() {
+                continue;
+            }
             self.insert_substate_if_absent(&addr, unversioned, substate_ids).await?;
         }
 

--- a/docs/developer-docs/src/content/docs/guides/authorization-and-access.mdx
+++ b/docs/developer-docs/src/content/docs/guides/authorization-and-access.mdx
@@ -74,6 +74,7 @@ restricted rule wraps one or more **requirements**:
 - `rule!(caller_component(address))` — the immediate caller is the given component.
 - `rule!(direct_caller_template(address))` — the immediate caller is code from the given template: any component
   instance of it, or any static function of it.
+- `rule!(any_caller_component)` / `rule!(any_caller_template)` — there was a caller of that kind, whoever it was.
 - `rule!(any_of(...))`, `rule!(all_of(...))`, `rule!(m_of_n(n, ...))` — combine requirements.
 
 #### Caller vs. current component
@@ -109,19 +110,23 @@ A method or function invoked directly by a top-level transaction instruction has
 is a signer — so `caller_component` / `direct_caller_template` rules **deny** it. Use a badge, public key, or
 other proof requirement to allow signer-driven calls.
 
-Requiring the badge **resource** rather than a specific badge asks the weaker question "was there a caller at
-all?":
+Two further forms ask the weaker question "was there a caller at all?", and take no address:
 
 ```rust
 // Satisfied by any component caller, and by no top-level instruction.
-rule!(resource(CALLER_COMPONENT_RESOURCE_ADDRESS))
+rule!(any_caller_component)
 // Satisfied by any frame below the top level, i.e. reached from template code
 // rather than directly from a transaction instruction.
-rule!(resource(DIRECT_CALLER_TEMPLATE_RESOURCE_ADDRESS))
+rule!(any_caller_template)
 ```
 
-No resource exists at either address and none can be created, so these badges cannot be minted, held in a
-vault, or forged by a template.
+You never need to name a badge or a reserved address to write a caller rule. If you do need the badge itself
+— to combine it with other requirements by hand — `NonFungibleAddress::caller_component_badge(addr)` and
+`::direct_caller_template_badge(addr)` build it, the same way `NonFungibleAddress::from_public_key(pk)` does
+for a signer.
+
+No resource exists at either badge address and none can be created, so these badges cannot be minted, held in
+a vault, or forged by a template.
 
 **Caution:** `caller_component` / `direct_caller_template` match the immediate caller's identity, which is only as
 trustworthy as the code that makes the call. A method that forwards a caller-supplied component/template and

--- a/docs/developer-docs/src/content/docs/guides/authorization-and-access.mdx
+++ b/docs/developer-docs/src/content/docs/guides/authorization-and-access.mdx
@@ -71,9 +71,9 @@ restricted rule wraps one or more **requirements**:
 - `rule!(non_fungible(address))` / `rule!(public_key(pk))` — the caller presents proof of an NFT, or a signature by the given public key.
 - `rule!(component(address))` — execution is within the given component (the current frame is that component).
 - `rule!(template(address))` — execution is within the given template (the current frame is that template).
-- `rule!(caller_component(address))` — the caller of a component method is the given component.
-- `rule!(direct_caller_template(address))` — the immediate caller of a component method is code from the given
-  template: any component instance of it, or any static function of it.
+- `rule!(caller_component(address))` — the immediate caller is the given component.
+- `rule!(direct_caller_template(address))` — the immediate caller is code from the given template: any component
+  instance of it, or any static function of it.
 - `rule!(any_of(...))`, `rule!(all_of(...))`, `rule!(m_of_n(n, ...))` — combine requirements.
 
 #### Caller vs. current component
@@ -85,10 +85,9 @@ There are two related but distinct ways a rule can reference a component or temp
   the caller. Use them when a method should only run while that component/template is executing, or when
   the same rule is evaluated for resource/ownership checks where the current frame is the actor.
 
-- `caller_component(address)` / `direct_caller_template(address)` ask _"who called this method?"_. These are
-  meaningful on **component method** access rules. The caller is always the **direct** caller: the frame
-  that was current immediately before the callee's frame was pushed. If A calls B and B calls C, C's rule
-  sees B, never A.
+- `caller_component(address)` / `direct_caller_template(address)` ask _"who called into here?"_. The caller is
+  always the **direct** caller: the frame that was current immediately before this frame was pushed. If A
+  calls B and B calls C, C's frame sees B, never A.
 
   `direct_caller_template(address)` is a **package** identity, not an instance identity. It matches any
   component instance of that template, including instances anyone may create through a public
@@ -96,9 +95,33 @@ There are two related but distinct ways a rule can reference a component or temp
   therefore only as strong as the least careful outgoing call anywhere in that template: a method or
   static function that forwards a caller-chosen component and method lets anyone act as the template.
 
-A method invoked directly by a top-level transaction instruction has no caller component/template frame —
-the caller is a signer — so `caller_component` / `direct_caller_template` rules **deny** it. Use a badge, public
-key, or other proof requirement to allow signer-driven calls.
+Caller identity is issued as a **virtual badge**, not evaluated once at the door. When the engine pushes a
+frame it stamps two badges into that frame's authorization scope — one naming the caller's component (when the
+caller has one) and one naming the caller's template. Two things follow:
+
+- The badges are checkable **wherever any other badge is**, and for the **whole lifetime of the frame**: a
+  component method rule, an owner rule, a **resource** rule, or a stealth spend condition. A helper called
+  deeper inside the same frame can still re-assert "we are acting for A".
+- They are **re-derived at every call and never inherited**. A frame cannot pass on the identity it was called
+  with, and there is no way to capture a caller badge as a `Proof` and hand it onward.
+
+A method or function invoked directly by a top-level transaction instruction has no caller frame — the caller
+is a signer — so `caller_component` / `direct_caller_template` rules **deny** it. Use a badge, public key, or
+other proof requirement to allow signer-driven calls.
+
+Requiring the badge **resource** rather than a specific badge asks the weaker question "was there a caller at
+all?":
+
+```rust
+// Satisfied by any component caller, and by no top-level instruction.
+rule!(resource(CALLER_COMPONENT_RESOURCE_ADDRESS))
+// Satisfied by any frame below the top level, i.e. reached from template code
+// rather than directly from a transaction instruction.
+rule!(resource(DIRECT_CALLER_TEMPLATE_RESOURCE_ADDRESS))
+```
+
+No resource exists at either address and none can be created, so these badges cannot be minted, held in a
+vault, or forged by a template.
 
 **Caution:** `caller_component` / `direct_caller_template` match the immediate caller's identity, which is only as
 trustworthy as the code that makes the call. A method that forwards a caller-supplied component/template and
@@ -109,6 +132,11 @@ owner can migrate the component to any template unless it was created with `Owne
 The same applies to resource auth hooks: the engine invokes the hook with the acting component as the
 caller, and any resource may bind any hook-shaped method. A caller gate on a hook method is therefore never
 sufficient on its own; the hook must check `AuthHookCaller::resource()` against the resources it manages.
+
+**Caution, the other way round:** calling out hands the callee your identity as a live badge for the whole of
+its frame, usable at every auth point it reaches — a resource rule, an ownership rule, a spend condition — not
+only the method it entered through. Weigh that before calling into code you do not control, and gate anything
+that must not be reachable that way on a proof the callee cannot obtain rather than on the caller badge alone.
 
 #### Resource Access Rules
 
@@ -164,6 +192,27 @@ Each `ResourceBuilder` exposes one method per action. All accept `(rule, updater
 
 A resource can also delegate its decisions to a component method rather than a static rule — see
 [Authorization hooks](#authorization-hooks).
+
+##### Gating a resource on the caller
+
+Because caller identity is a badge, `caller_component` / `direct_caller_template` work on resource rules too.
+That lets the gate live on the **resource** rather than on each component that holds it:
+
+```rust
+// These tokens may only be withdrawn — from any vault, in any component —
+// while the acting component is executing on behalf of `treasury`.
+let tokens = ResourceBuilder::public_fungible()
+    .withdrawable(rule!(caller_component(treasury)), LOCKED)
+    .initial_supply(1_000_000u64);
+```
+
+Compare that with putting `rule!(caller_component(treasury))` on a `payout` method of the one component that
+holds the vault. The method gate covers only that holder: any other component holding a vault of the same
+resource withdraws with no check, and the gate cannot be retrofitted onto holders you do not control. The
+resource rule is evaluated on every withdrawal, whichever component performs it.
+
+The rule is checked against the frame that **acts on the resource**, so it reads as "the component touching
+these tokens was called by `treasury`", not "the transaction was signed by `treasury`".
 
 ##### UpdateRule
 
@@ -284,8 +333,8 @@ Callers are identified by various types, depending on the context:
 The `auth` module in `tari_template_lib` provides utilities for working with identities and proofs within your templates.
 
 These identities appear in `rule!` requirements: `component(...)` / `template(...)` refer to the current
-execution scope, while `caller_component(...)` / `direct_caller_template(...)` refer to the method's caller (see
-[Caller vs. current component](#caller-vs-current-component)).
+execution scope, while `caller_component(...)` / `direct_caller_template(...)` refer to the frame's immediate
+caller, carried as a virtual badge (see [Caller vs. current component](#caller-vs-current-component)).
 
 ### Best Practices
 

--- a/docs/developer-docs/src/content/docs/guides/authorization-and-access.mdx
+++ b/docs/developer-docs/src/content/docs/guides/authorization-and-access.mdx
@@ -138,6 +138,12 @@ its frame, usable at every auth point it reaches — a resource rule, an ownersh
 only the method it entered through. Weigh that before calling into code you do not control, and gate anything
 that must not be reachable that way on a proof the callee cannot obtain rather than on the caller badge alone.
 
+A resource auth hook is the one call-out you do not choose: any resource may bind a hook, and anyone may deposit
+that resource into an account. The engine therefore runs a hook in a sandboxed frame that may read, emit events
+and update its own component state (when declared `&mut self`), but cannot write any other substate, act on any
+vault or resource, or call another component. The acting component's badge satisfies the hook's own method
+rule, and the sandbox is what stops the hook spending it on the acting component's behalf.
+
 #### Resource Access Rules
 
 Resources can also have access rules, typically governing who can mint, burn, recall, freeze, or update metadata.
@@ -289,10 +295,16 @@ let tokens = ResourceBuilder::public_fungible()
     .initial_supply(1_000_000u64);
 ```
 
-The hook must be a non-mutable method returning `()` and taking `(&self, ResourceAuthAction, AuthHookCaller)`; the
-engine rejects the resource at creation otherwise. It is skipped when the acting component *is* the hook's own
-component, and when the hook's component does not exist yet — which is what lets a template allocate the address,
-build the resource, and create the component afterwards.
+The hook returns `()` and takes `(ResourceAuthAction, AuthHookCaller)`; the engine rejects the resource at creation
+otherwise. It is skipped when the acting component *is* the hook's own component, and when the hook's component does
+not exist yet — which is what lets a template allocate the address, build the resource, and create the component
+afterwards.
+
+A hook frame is confined to its own component: it may take `&mut self` and update that component's state, and the
+engine refuses every other write, new substate, cross-template call, bucket and proof from inside it. That
+confinement is what makes a hook safe to run with the acting component's caller badges. The engine invokes the hook
+on the acting component's behalf without that component choosing to call it, so the badge satisfies the hook's own
+method rule but cannot be spent on any vault or resource from inside the hook.
 
 Because the hook runs on nearly every action, a hook that panics, denies unconditionally, or fails to decode its
 arguments takes the whole resource offline: no transfers, no burns, no metadata changes, and every balance in its

--- a/docs/developer-docs/src/content/docs/guides/stealth-resources.mdx
+++ b/docs/developer-docs/src/content/docs/guides/stealth-resources.mdx
@@ -309,7 +309,7 @@ leaf has no recursion to bound.
 
 | Atom | Gates the spend on |
 |---|---|
-| `AccessRule(rule)` | A native access rule evaluated against the transaction's auth scope (signer badges, resource proofs, component scope, `m_of_n`, …) |
+| `AccessRule(rule)` | A native access rule evaluated against the spending frame's auth scope (signer badges, resource proofs, component scope, caller badges, `m_of_n`, …) |
 | `Builtin(predicate)` | A native, consensus-fixed **local** predicate: a timelock or a hashlock |
 | `Covenant(covenant)` | A native, consensus-fixed constraint on the *spending transfer's* outputs and value flow |
 | `TemplateFunction(tf)` | A stateless WASM predicate &mdash; a **spend script** &mdash; committed as `{template, function, args}` |


### PR DESCRIPTION
Closes #2549.

## What changed

Caller identity was a **predicate evaluated once, at method entry**: `RuleContext::Caller` reached the
component-method check alone, and `CallerComponent` / `DirectCallerTemplate` returned `false` everywhere else
(and were rejected at construction on resource rules). So "resource R may only be withdrawn while executing on
behalf of A" was inexpressible — the gate had to be replicated on every holder of R, and was consumed at the
door.

Caller identity is now a **badge**, as in Radix. Two virtual resources are reserved:

| constant | badge id | Radix equivalent |
| --- | --- | --- |
| `CALLER_COMPONENT_RESOURCE_ADDRESS` (`resource_0100…0001`) | `U256(component address)` | `GLOBAL_CALLER_VIRTUAL_BADGE` |
| `DIRECT_CALLER_TEMPLATE_RESOURCE_ADDRESS` (`resource_0100…0002`) | `U256(template address)` | `PACKAGE_OF_DIRECT_CALLER_VIRTUAL_BADGE` |

`push_frame` stamps the pushing frame's component (when it has one) and its template into the callee's
`AuthorizationScope`, so the identity holds for the frame's lifetime and is checkable at every auth point —
method rules, owner rules, **resource rules**, spend conditions.

No template needs a reserved constant: `rule!(caller_component(a))` / `rule!(direct_caller_template(t))` gate
on a specific caller, `rule!(any_caller_component)` / `rule!(any_caller_template)` ask only whether there was
a caller of that kind, and `NonFungibleAddress::caller_component_badge(a)` builds the badge itself, mirroring
`from_public_key`.

Three load-bearing constraints:

1. **Never inherited.** A new per-frame `caller_badges` field, not the transaction-wide `Arc<IndexSet<..>>`,
   merged into neither parent nor child. B's frame carries A's badge; C's carries B's.
2. **Not capturable as a `Proof`.** Proofs originate only from vaults and buckets, and both badge resources
   are empty by invariant.
3. **Unforgeable address.** `is_system_reserved()` covers both badge resources plus the two genesis ones, and
   `ResourceAction::Create` rejects them.

Because caller identity is an ordinary badge, `RuleContext`, `MethodCaller`,
`contains_caller_component_or_template`, the construction-time rejections, and the
`check_ownership_in_current_frame` / `require_component_ownership` split all go away. `n(4)` / `n(5)` survive
as sugar for the badge check, keeping the CBOR indices stable.

## Three vulnerabilities fixed (`5edb7a814`)

- **Auth hook escalation — introduced by this PR.** A hook frame is pushed by the acting component, so it
  carried that component's caller badges with full write access. Any resource may bind a hook and anyone may
  deposit it into an account, so a hook could spend `caller_component(V)` against a third party's resource
  rules. Hook frames now run in `FrameWriteMode::OwnComponent`: no write locks, new substates, cross-template
  calls, buckets or proofs — only the component locked at push stays writable.
- **Sandbox escape (pre-existing).** A pushed frame now inherits its parent's write mode, so a spend-script
  frame can no longer reach a writable one through a hook.
- **Recall unbound from its resource (pre-existing).** `Recall` authorised against `resource_ref`'s rule but
  recalled from any vault, so `recallable(allow_all)` could drain a vault of any other resource. The vault's
  resource must now match.

## Input validation

Nothing in the validator chain looked at declared inputs, so naming a reserved substate was admitted,
gossiped and sequenced, only to abort at input resolution. `InputSubstateValidator` rejects it at ingress
(sender-fault: the address alone decides it).

Wired into the indexer's structural chain and the VN's `create_mempool_transaction_validator` — deliberately
**not** `create_node_transaction_validator`, which also backs `TariBlockTransactionValidator`. A rejection
rule in block validation is a consensus rule, for no gain: such a transaction already aborts
deterministically.

`SubstateId::is_virtual()` grows to cover the two badge resources; all three existing callers want the wider
set.

**A separate wallet bug rides along.** A template may store an engine-issued address in component state — an
`Account` approval keyed on a public-key identity. `add_component_dependencies` walked those into the
declared input set, and `insert_substate_if_absent` inserts with no network fetch on the `unversioned` path,
which every real call site takes. The wallet reported no error and the transaction aborted on chain. That is
a live break today, independent of this PR; it now applies the same `is_virtual()` filter
`to_referenced_substates` already does. (Code path verified; no affected live account demonstrated.)

## Compatibility

**No existing template breaks** — method and owner rules behave as before; the change is additive where
caller rules previously evaluated `false` or were rejected at construction.

**No `ProtocolVersion` gate.** `n(4)` / `n(5)` came from #2503, which landed after `v0.40.0` and is in no tag
(`git tag --contains bea8abb0b` is empty), so no committed substate can carry one.

**Validators must upgrade together**, as with any access-rule evaluation change. `crate_versioning.py impact
tari_template_lib_types --breaking` reports no bumps needed. Bindings unchanged: `RuleRequirement` gains no
variant, and the reserved addresses have no TS counterpart.

## Tests & docs

`crates/engine/tests/caller_badge.rs` — the motivating resource-gated-on-caller scenario (allowed via the
gate; denied for a top-level signer, an unrelated component, and through an intermediate frame),
`direct_caller_template` via a static function (the `component: None` path), neither badge resource yielding
a token, and the hook-escalation cases. Plus `recall.rs`, `spend_script.rs` and `access_rules.rs` coverage for
the three fixes.

`guides/authorization-and-access.mdx` moves from the predicate model to the badge model, adds a **Gating a
resource on the caller** section, and warns that calling out hands the callee a live badge for its whole
frame.

## Out of scope

`direct_caller_template(T)` still matches both a static function of `T` and a method on any instance of it,
where Radix's `PackageBlueprint` arm fires only for functions. Independent change, as the issue says.
