### PR TITLE
fix(common_types)!: enforce shard bounds for fee pool addresses and shard groups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12005,6 +12005,7 @@ dependencies = [
  "prost-types 0.14.3",
  "rand 0.10.1",
  "serde",
+ "serde_json",
  "tari_bor",
  "tari_crypto",
  "tari_engine_types",

--- a/applications/tari_walletd/src/handlers/validator.rs
+++ b/applications/tari_walletd/src/handlers/validator.rs
@@ -68,9 +68,12 @@ pub async fn handle_get_validator_fees(
 
     let ids = shards
         .into_iter()
-        .map(|shard| derive_fee_pool_address(&claim_public_key, NUM_PRESHARDS, shard))
-        .map(SubstateId::from)
-        .collect::<Vec<_>>();
+        .map(|shard| {
+            derive_fee_pool_address(&claim_public_key, NUM_PRESHARDS, shard)
+                .map(SubstateId::from)
+                .map_err(|err| invalid_params("shard_group", Some(err)))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
 
     let mut fees = HashMap::with_capacity(ids.len());
     const CHUNK_SIZE: usize = 20;
@@ -137,8 +140,11 @@ pub async fn handle_claim_validator_fees(
     let fee_pool_addresses = req
         .shards
         .iter()
-        .map(|shard| derive_fee_pool_address(&claim_public_key, NUM_PRESHARDS, *shard))
-        .collect::<Vec<_>>();
+        .map(|shard| {
+            derive_fee_pool_address(&claim_public_key, NUM_PRESHARDS, *shard)
+                .map_err(|err| invalid_params("shards", Some(err)))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
 
     // build the transaction
     let max_fee = req.max_fee.max(1);

--- a/crates/common_types/Cargo.toml
+++ b/crates/common_types/Cargo.toml
@@ -33,6 +33,9 @@ serde = { workspace = true, default-features = true }
 ts-rs = { workspace = true, optional = true }
 thiserror = { workspace = true }
 
+[dev-dependencies]
+serde_json = { workspace = true }
+
 [package.metadata.cargo-machete]
 ignored = ["prost", "prost-types"] # false positive, used in OUT_DIR structs
 

--- a/crates/common_types/src/fee_pool.rs
+++ b/crates/common_types/src/fee_pool.rs
@@ -12,8 +12,8 @@ use crate::{NumPreshards, shard::Shard};
 /// grown — every existing pool then migrates to the lower-numbered child shard rather than fanning out by pk bits.
 /// Reserving two bytes lets `NumPreshards` grow to at most `2^16` without changing the layout.
 ///
-/// `shard` must be in `1..=num_preshards`: shard 0 is the global shard and has no index, and an index that does not
-/// fit in `shard_bits` would wrap into another shard's prefix, silently yielding an address in the wrong shard.
+/// `shard` must be in `1..=num_preshards`: shard 0 is the global shard and has no index, and an index outside that
+/// range does not fit in `shard_bits` and aliases another shard's prefix.
 pub fn derive_fee_pool_address(
     public_key_bytes: &RistrettoPublicKeyBytes,
     num_preshards: NumPreshards,
@@ -37,7 +37,7 @@ pub fn derive_fee_pool_address(
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-#[error("Shard {shard} cannot hold a validator fee pool: expected a shard in 1..={}", .num_preshards.as_u32())]
+#[error("Shard {} cannot hold a validator fee pool: expected a shard in 1..={}", .shard.as_u32(), .num_preshards.as_u32())]
 pub struct InvalidFeePoolShard {
     pub shard: Shard,
     pub num_preshards: NumPreshards,

--- a/crates/common_types/src/fee_pool.rs
+++ b/crates/common_types/src/fee_pool.rs
@@ -11,26 +11,36 @@ use crate::{NumPreshards, shard::Shard};
 /// prefix encode `shard - 1`; the remaining prefix bits are zero so they are stable if `NumPreshards` is later
 /// grown — every existing pool then migrates to the lower-numbered child shard rather than fanning out by pk bits.
 /// Reserving two bytes lets `NumPreshards` grow to at most `2^16` without changing the layout.
+///
+/// `shard` must be in `1..=num_preshards`: shard 0 is the global shard and has no index, and an index that does not
+/// fit in `shard_bits` would wrap into another shard's prefix, silently yielding an address in the wrong shard.
 pub fn derive_fee_pool_address(
     public_key_bytes: &RistrettoPublicKeyBytes,
     num_preshards: NumPreshards,
     shard: Shard,
-) -> ValidatorFeePoolAddress {
+) -> Result<ValidatorFeePoolAddress, InvalidFeePoolShard> {
+    if shard.is_global() || shard.as_u32() > num_preshards.as_u32() {
+        return Err(InvalidFeePoolShard { shard, num_preshards });
+    }
     // For num_preshards = 256, log2(256) = 8
     let shard_bits = num_preshards.as_u32().trailing_zeros();
     // shift required to place the shard index in the top `shard_bits` of the 2-byte prefix
     let shift = u16::BITS - shard_bits;
     // shard 0 is global, so shard is count-based; convert to an index
-    let shard_index = shard
-        .as_u32()
-        .checked_sub(1)
-        .expect("derive_fee_pool_address: shard 0 is reserved for global");
+    let shard_index = shard.as_u32() - 1;
     let prefix = (shard_index << shift) as u16;
 
     let mut address = [0u8; 32];
     address[..2].copy_from_slice(&prefix.to_be_bytes());
     address[2..].copy_from_slice(&public_key_bytes[2..]);
-    ValidatorFeePoolAddress::from_array(address)
+    Ok(ValidatorFeePoolAddress::from_array(address))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("Shard {shard} cannot hold a validator fee pool: expected a shard in 1..={}", .num_preshards.as_u32())]
+pub struct InvalidFeePoolShard {
+    pub shard: Shard,
+    pub num_preshards: NumPreshards,
 }
 
 #[cfg(test)]
@@ -42,7 +52,7 @@ mod tests {
     use crate::SubstateAddress;
 
     fn assert_pool_lands_in_shard(pk: &RistrettoPublicKeyBytes, num_preshards: NumPreshards, shard: Shard) {
-        let fee_pool_address = derive_fee_pool_address(pk, num_preshards, shard);
+        let fee_pool_address = derive_fee_pool_address(pk, num_preshards, shard).unwrap();
         let addr = SubstateAddress::from_substate_id(&fee_pool_address.into(), 0);
         assert_eq!(addr.to_shard(num_preshards), shard);
     }
@@ -75,11 +85,25 @@ mod tests {
         let pk_a = RistrettoPublicKeyBytes::from(pk_a);
         let pk_b = RistrettoPublicKeyBytes::from(pk_b);
 
-        let addr_a = derive_fee_pool_address(&pk_a, NumPreshards::P256, Shard::from(42));
-        let addr_b = derive_fee_pool_address(&pk_b, NumPreshards::P256, Shard::from(42));
+        let addr_a = derive_fee_pool_address(&pk_a, NumPreshards::P256, Shard::from(42)).unwrap();
+        let addr_b = derive_fee_pool_address(&pk_b, NumPreshards::P256, Shard::from(42)).unwrap();
         assert_ne!(addr_a, addr_b);
         assert_pool_lands_in_shard(&pk_a, NumPreshards::P256, Shard::from(42));
         assert_pool_lands_in_shard(&pk_b, NumPreshards::P256, Shard::from(42));
+    }
+
+    #[test]
+    fn it_rejects_shards_outside_the_preshard_range() {
+        let pk = RistrettoPublicKeyBytes::from([0xff; 32]);
+        for (num_preshards, shard) in [
+            (NumPreshards::P256, Shard::global()),
+            (NumPreshards::P256, Shard::from(257)),
+            (NumPreshards::P2, Shard::from(3)),
+            (NumPreshards::P64, Shard::from(u32::MAX)),
+        ] {
+            let err = derive_fee_pool_address(&pk, num_preshards, shard).unwrap_err();
+            assert_eq!(err, InvalidFeePoolShard { shard, num_preshards });
+        }
     }
 
     #[test]
@@ -88,7 +112,7 @@ mod tests {
         // regardless of pk. This relies on the prefix bits below the current shard-bits being zero.
         let pk = RistrettoPublicKeyBytes::from([0xff; 32]);
         for shard in [1u32, 17, 64, 128, 256] {
-            let addr = derive_fee_pool_address(&pk, NumPreshards::P256, Shard::from(shard));
+            let addr = derive_fee_pool_address(&pk, NumPreshards::P256, Shard::from(shard)).unwrap();
             // P256 has no finer NumPreshards variant yet, so simulate the split by reading top 9 bits manually:
             // under a hypothetical P512, the shard index would be (byte0 << 1) | (byte1 >> 7).
             let bytes = SubstateAddress::from_substate_id(&addr.into(), 0).into_array();

--- a/crates/common_types/src/shard_group.rs
+++ b/crates/common_types/src/shard_group.rs
@@ -10,33 +10,64 @@ use std::{
 };
 
 use borsh::BorshSerialize;
-use minicbor::{CborLen, Decode, Encode};
-use serde::{Deserialize, Serialize};
+use minicbor::{CborLen, Decode, Decoder, Encode, decode};
+use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::{NumPreshards, SubstateAddress, shard::Shard, uint::U256};
 
-#[derive(
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    Serialize,
-    Deserialize,
-    BorshSerialize,
-    Encode,
-    Decode,
-    CborLen,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, BorshSerialize, Encode, CborLen)]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub struct ShardGroup {
     #[n(0)]
     start: Shard,
     #[n(1)]
     end_inclusive: Shard,
+}
+
+/// The wire shape of a [`ShardGroup`], read before `start <= end_inclusive` is checked.
+///
+/// `ShardGroup` promises that ordering to every consumer — `len`, `is_empty`, `shard_iter` and
+/// `to_substate_address_range` all take it as given — so deserialization upholds it exactly as the
+/// constructors do, and a value that violates it is a decode error rather than a `ShardGroup` the
+/// rest of the API cannot describe. `Encode` and `CborLen` stay derived on `ShardGroup`, so this
+/// mirror must keep the same field indices and types; the round-trip tests enforce that.
+#[derive(Deserialize, Decode)]
+struct UncheckedShardGroup {
+    #[n(0)]
+    start: Shard,
+    #[n(1)]
+    end_inclusive: Shard,
+}
+
+impl UncheckedShardGroup {
+    fn check(self) -> Option<ShardGroup> {
+        ShardGroup::new_checked(self.start, self.end_inclusive)
+    }
+
+    fn invalid_bounds_message(&self) -> String {
+        format!(
+            "invalid ShardGroup: start ({}) is greater than end_inclusive ({})",
+            self.start.as_u32(),
+            self.end_inclusive.as_u32()
+        )
+    }
+}
+
+impl<'de> Deserialize<'de> for ShardGroup {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let unchecked = UncheckedShardGroup::deserialize(deserializer)?;
+        let message = unchecked.invalid_bounds_message();
+        unchecked.check().ok_or_else(|| serde::de::Error::custom(message))
+    }
+}
+
+impl<'b, C> Decode<'b, C> for ShardGroup {
+    fn decode(d: &mut Decoder<'b>, ctx: &mut C) -> Result<Self, decode::Error> {
+        let pos = d.position();
+        let unchecked = UncheckedShardGroup::decode(d, ctx)?;
+        let message = unchecked.invalid_bounds_message();
+        unchecked.check().ok_or_else(|| decode::Error::message(message).at(pos))
+    }
 }
 
 impl ShardGroup {
@@ -113,14 +144,10 @@ impl ShardGroup {
         Self::new_checked(start, end)
     }
 
+    /// Iterates over every shard in the group. Yields nothing when the bounds are inverted, which
+    /// only a [`Self::new_unchecked`] value can be.
     pub fn shard_iter(self) -> impl Iterator<Item = Shard> + 'static {
-        iter::successors(Some(self.start), move |&shard| {
-            if shard == self.end_inclusive {
-                None
-            } else {
-                Some(Shard::from(shard.as_u32() + 1))
-            }
-        })
+        (self.start.as_u32()..=self.end_inclusive.as_u32()).map(Shard::from)
     }
 
     pub fn shard_iter_with_global(self) -> impl Iterator<Item = Shard> + 'static {
@@ -234,6 +261,36 @@ mod tests {
         );
         assert_eq!(ShardGroup::decode_from_u32(ShardGroup::MAX_ENCODED_VALUE + 1), None);
         assert_eq!(ShardGroup::decode_from_u32(u32::MAX), None);
+    }
+
+    #[test]
+    fn it_round_trips_a_valid_group() {
+        let sg = ShardGroup::new(10, 20);
+        let bytes = tari_bor::encode(&sg).unwrap();
+        assert_eq!(tari_bor::decode::<ShardGroup>(&bytes).unwrap(), sg);
+
+        let json = serde_json::to_string(&sg).unwrap();
+        assert_eq!(serde_json::from_str::<ShardGroup>(&json).unwrap(), sg);
+    }
+
+    #[test]
+    fn it_rejects_inverted_bounds_when_deserializing() {
+        let inverted = ShardGroup::new_unchecked(5, 2);
+
+        let bytes = tari_bor::encode(&inverted).unwrap();
+        tari_bor::decode::<ShardGroup>(&bytes).unwrap_err();
+
+        serde_json::from_str::<ShardGroup>(r#"{"start":5,"end_inclusive":2}"#).unwrap_err();
+    }
+
+    #[test]
+    fn shard_iter_terminates_on_inverted_bounds() {
+        assert_eq!(ShardGroup::new_unchecked(5, 2).shard_iter().count(), 0);
+        assert_eq!(ShardGroup::new(5, 7).shard_iter().collect::<Vec<_>>(), vec![
+            Shard::from(5),
+            Shard::from(6),
+            Shard::from(7)
+        ]);
     }
 
     #[test]

--- a/crates/common_types/src/shard_group.rs
+++ b/crates/common_types/src/shard_group.rs
@@ -39,34 +39,28 @@ struct UncheckedShardGroup {
     end_inclusive: Shard,
 }
 
-impl UncheckedShardGroup {
-    fn check(self) -> Option<ShardGroup> {
-        ShardGroup::new_checked(self.start, self.end_inclusive)
-    }
-
-    fn invalid_bounds_message(&self) -> String {
-        format!(
-            "invalid ShardGroup: start ({}) is greater than end_inclusive ({})",
-            self.start.as_u32(),
-            self.end_inclusive.as_u32()
-        )
-    }
+fn invalid_bounds_message(start: Shard, end_inclusive: Shard) -> String {
+    format!(
+        "invalid ShardGroup: start ({}) is greater than end_inclusive ({})",
+        start.as_u32(),
+        end_inclusive.as_u32()
+    )
 }
 
 impl<'de> Deserialize<'de> for ShardGroup {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let unchecked = UncheckedShardGroup::deserialize(deserializer)?;
-        let message = unchecked.invalid_bounds_message();
-        unchecked.check().ok_or_else(|| serde::de::Error::custom(message))
+        let UncheckedShardGroup { start, end_inclusive } = UncheckedShardGroup::deserialize(deserializer)?;
+        Self::new_checked(start, end_inclusive)
+            .ok_or_else(|| serde::de::Error::custom(invalid_bounds_message(start, end_inclusive)))
     }
 }
 
 impl<'b, C> Decode<'b, C> for ShardGroup {
     fn decode(d: &mut Decoder<'b>, ctx: &mut C) -> Result<Self, decode::Error> {
         let pos = d.position();
-        let unchecked = UncheckedShardGroup::decode(d, ctx)?;
-        let message = unchecked.invalid_bounds_message();
-        unchecked.check().ok_or_else(|| decode::Error::message(message).at(pos))
+        let UncheckedShardGroup { start, end_inclusive } = UncheckedShardGroup::decode(d, ctx)?;
+        Self::new_checked(start, end_inclusive)
+            .ok_or_else(|| decode::Error::message(invalid_bounds_message(start, end_inclusive)).at(pos))
     }
 }
 

--- a/crates/common_types/src/shard_group.rs
+++ b/crates/common_types/src/shard_group.rs
@@ -41,9 +41,10 @@ struct UncheckedShardGroup {
 
 fn invalid_bounds_message(start: Shard, end_inclusive: Shard) -> String {
     format!(
-        "invalid ShardGroup: start ({}) is greater than end_inclusive ({})",
+        "invalid ShardGroup ({}-{}): expected start <= end_inclusive <= {}",
         start.as_u32(),
-        end_inclusive.as_u32()
+        end_inclusive.as_u32(),
+        Shard::max().as_u32()
     )
 }
 
@@ -69,16 +70,21 @@ impl ShardGroup {
 
     /// Creates a new ShardGroup with the given start and end inclusive shards.
     /// ## Panics
-    /// Panics if the start shard is greater than the end shard.
+    /// Panics if the start shard is greater than the end shard, or the end shard is beyond
+    /// [`Shard::max`].
     pub fn new<T: Into<Shard> + Copy>(start: T, end_inclusive: T) -> Self {
         Self::new_checked(start, end_inclusive)
-            .expect("INVARIANT: start shard must be less than or equal to end_inclusive")
+            .expect("INVARIANT: start shard must be less than or equal to end_inclusive and at most Shard::max()")
     }
 
+    /// Creates a new ShardGroup, returning None unless `start <= end_inclusive <= Shard::max()`.
+    ///
+    /// The upper bound is what keeps `len` and `encode_as_u32` total: a group ending at
+    /// `u32::MAX` satisfies the ordering yet overflows `end_inclusive + 1`.
     pub fn new_checked<T: Into<Shard> + Copy>(start: T, end_inclusive: T) -> Option<Self> {
         let start = start.into();
         let end_inclusive = end_inclusive.into();
-        if start > end_inclusive {
+        if start > end_inclusive || end_inclusive > Shard::max() {
             return None;
         }
         Some(Self { start, end_inclusive })
@@ -275,6 +281,18 @@ mod tests {
         tari_bor::decode::<ShardGroup>(&bytes).unwrap_err();
 
         serde_json::from_str::<ShardGroup>(r#"{"start":5,"end_inclusive":2}"#).unwrap_err();
+    }
+
+    #[test]
+    fn it_rejects_an_end_beyond_the_maximum_shard() {
+        assert_eq!(ShardGroup::new_checked(1, Shard::max().as_u32() + 1), None);
+        assert_eq!(ShardGroup::new_checked(0, u32::MAX), None);
+        assert!(ShardGroup::new_checked(1, Shard::max().as_u32()).is_some());
+
+        // `len` is only total because the end is bounded: `u32::MAX + 1` would overflow.
+        let bytes = tari_bor::encode(&ShardGroup::new_unchecked(0, u32::MAX)).unwrap();
+        tari_bor::decode::<ShardGroup>(&bytes).unwrap_err();
+        serde_json::from_str::<ShardGroup>(r#"{"start":0,"end_inclusive":4294967295}"#).unwrap_err();
     }
 
     #[test]

--- a/crates/consensus/src/hotstuff/common.rs
+++ b/crates/consensus/src/hotstuff/common.rs
@@ -400,7 +400,8 @@ pub fn apply_leader_fee_to_substate_store<TTx: StateStoreReadTransaction>(
         return Ok(());
     }
 
-    let fee_substate_id = derive_fee_pool_address(claim_public_key_bytes, num_preshards, shard);
+    let fee_substate_id = derive_fee_pool_address(claim_public_key_bytes, num_preshards, shard)
+        .map_err(|err| HotStuffError::InvariantError(err.to_string()))?;
     store.update_in_place(
         &fee_substate_id.into(),
         |value_mut| {

--- a/crates/consensus_tests/src/consensus.rs
+++ b/crates/consensus_tests/src/consensus.rs
@@ -1619,7 +1619,7 @@ async fn multishard_validator_fee_claim() {
         .start()
         .await;
     // Create and send publish template transaction
-    let address = derive_fee_pool_address(&claim_bytes, test.num_preshards(), Shard::first());
+    let address = derive_fee_pool_address(&claim_bytes, test.num_preshards(), Shard::first()).unwrap();
     let claim_tx = Transaction::builder_localnet(Epoch(1))
         .claim_validator_fees(address)
         .add_input(address)

--- a/crates/state_store_rocksdb/src/codecs/shard_group.rs
+++ b/crates/state_store_rocksdb/src/codecs/shard_group.rs
@@ -39,6 +39,14 @@ impl DbDecoder<ShardGroup> for ShardGroupCodec {
     fn decode(&self, bytes: &[u8]) -> Result<(ShardGroup, usize), RocksDbStorageError> {
         let (start, n_start) = self.inner.decode(bytes)?;
         let (end, n_end) = self.inner.decode(&bytes[n_start..])?;
-        Ok((ShardGroup::new(start, end), n_start + n_end))
+        let shard_group = ShardGroup::new_checked(start, end).ok_or_else(|| RocksDbStorageError::MalformedData {
+            operation: "ShardGroupCodec::decode",
+            details: format!(
+                "start ({}) is greater than end_inclusive ({})",
+                start.as_u32(),
+                end.as_u32()
+            ),
+        })?;
+        Ok((shard_group, n_start + n_end))
     }
 }


### PR DESCRIPTION
Closes #2469

## Description

Two shard-bound invariants that untrusted input could break.

### 1. `derive_fee_pool_address` panicked on the global shard

It panicked on `shard == 0` (`checked_sub(1).expect(...)`) and, for a shard above `num_preshards`, silently wrapped the shard index into another shard's prefix — returning a valid-looking address in the wrong shard.

Both are reachable from wallet daemon JSON-RPC input, not just from internal misuse:

- `validators.claim_fees` maps the caller's `shards: Vec<Shard>` straight into it (only emptiness is checked), so `shards: [0]` panics the handler. The release profile sets `panic = 'abort'`, so that takes down the daemon process.
- `validators.get_fees` iterates a caller-supplied `shard_group`, which reached the same panic.

The function now returns `Result<ValidatorFeePoolAddress, InvalidFeePoolShard>`, checking `1..=num_preshards` where the address is derived instead of leaving the invariant to every caller:

- wallet daemon: maps the error to an invalid-params JSON-RPC response.
- consensus (`apply_leader_fee_to_substate_store`): its shard always comes from the local committee's shard group, so the error maps to `HotStuffError::InvariantError`.

### 2. `ShardGroup` did not uphold `start <= end_inclusive` when deserialized

`ShardGroup` documents that ordering and its API takes it as given — `is_empty` is a const `false`, `len` underflows without it, and `shard_iter` was `iter::successors` walking until it *reached* `end_inclusive`. `new`, `new_checked`, `decode_from_u32` and `FromStr` all enforce it, but the derived `Deserialize`/`Decode` did not, so an inverted group like `{"start": 5, "end_inclusive": 2}` deserialized fine. Iterating one never terminated: it grew until the `shard + 1` counter overflowed (release builds have `overflow-checks = true`), after allocating ~4 billion shards. `validators.get_fees` did exactly that with a caller-supplied group.

`Deserialize` and `Decode` now go through `new_checked`, so an inverted group is a deserialization error rather than a value no accessor can describe, and `shard_iter` walks an inclusive range, which terminates for any bounds — a `new_unchecked` value (foreign proposals build one from unvalidated peer data before validation rejects it) now yields nothing instead of looping.

`new_checked` also bounds the end at `Shard::max()`. `len` adds one to `end_inclusive` before subtracting `start`, so a group ending at `u32::MAX` passes the ordering check and still overflows; `NumPreshards` tops out at 256, which `encode_as_u32`/`decode_from_u32` already assume, so requiring `end_inclusive <= Shard::max()` makes `len` total for every group the constructors can produce.

`state_store_rocksdb`'s `ShardGroupCodec` decodes the two shards separately and rebuilt the group with the panicking constructor, bypassing `Decode` entirely; it now returns `MalformedData`. Two remaining sites read a node's own SQLite columns the same way (`storage_sqlite/src/global/models/committee.rs:39`, `backend_adapter.rs:804`) — plumbing an error through those row mappings is left for a follow-up.

Reported by AFAP in #2469 (suggestion 2); the `ShardGroup` half came out of reviewing the first fix. Suggestions 1 and 3 in that issue do not hold — diffs do routinely carry fee-pool Up/Down changes, so the assertion suggested there would reject ordinary claim transactions, and no `circuit_layout.rs` exists in this repo. Both are answered on the issue, so merging this closes it.

No crate version bumps: `scripts/crate_versioning.py impact tari_ootle_common_types --breaking` reports every affected crate is already on an unreleased bump.

## Motivation and Context

An authenticated wallet daemon RPC call could crash the daemon (shard 0) or hang it while allocating billions of shard ids (inverted shard group), and an out-of-range shard could silently produce a fee pool address that does not live in the requested shard.

## How Has This Been Tested?

- New unit tests: `it_rejects_shards_outside_the_preshard_range` (shard 0, `num_preshards + 1` at two widths, `u32::MAX`), `it_rejects_inverted_bounds_when_deserializing` and `it_rejects_an_end_beyond_the_maximum_shard` (both JSON and CBOR), `it_round_trips_a_valid_group` (the hand-written `Decode` must match the still-derived `Encode`/`CborLen` framing) and `shard_iter_terminates_on_inverted_bounds`.
- Existing `tari_ootle_common_types` tests pass.
- `cargo lints clippy --all-targets` on `tari_ootle_common_types`, `tari_consensus`, `tari_ootle_walletd`, `consensus_tests`; `cargo check --all-targets` additionally on `tari_validator_node`, `tari_indexer`, `tari_ootle_p2p`, `tari_ootle_storage`.

## What process can a PR reviewer use to test or verify this change?

Against a wallet daemon: `validators.claim_fees` with `shards: [0]` aborted the daemon before this change and now returns an invalid-params error; `validators.get_fees` with `shard_group: {"start": 5, "end_inclusive": 2}` hung allocating before, and is now rejected at deserialization.

## Breaking Changes

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

`derive_fee_pool_address` changes signature (public API of `tari_ootle_common_types`). No consensus or state changes: derived addresses for valid shards are unchanged, and `ShardGroup`'s encoding is untouched — only decoding of groups that were already outside the type's stated invariant now fails.
