### PR TITLE
fix(transaction_generator): count skipped entries against the file's transaction budget

### DIFF
--- a/utilities/transaction_generator/src/transaction_reader.rs
+++ b/utilities/transaction_generator/src/transaction_reader.rs
@@ -22,6 +22,7 @@ pub fn read_transactions<R: Read + Seek + Send + 'static>(
             let mut len_bytes = [0u8; 2];
             reader.read_exact(&mut len_bytes).unwrap();
             let len = usize::from(u16::from_le_bytes(len_bytes));
+            remaining -= 1;
 
             if skip_remaining > 0 {
                 skip_remaining -= 1;
@@ -36,7 +37,6 @@ pub fn read_transactions<R: Read + Seek + Send + 'static>(
                 // Receiver has closed the channel, so we're done
                 break;
             }
-            remaining -= 1;
         }
     });
     Ok(receiver)

--- a/utilities/transaction_generator/tests/read_skip.rs
+++ b/utilities/transaction_generator/tests/read_skip.rs
@@ -1,0 +1,56 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! `read_transactions` yields the file's entries from `skip` onwards, in file order.
+
+use std::io::{Cursor, Seek, SeekFrom};
+
+use tari_ootle_transaction::{Epoch, Network, Transaction, TransactionId};
+use transaction_generator::{read_transactions, transaction_builders::free_coins, write_transactions};
+
+const NUM_TRANSACTIONS: u64 = 8;
+
+/// A transaction file holding [`NUM_TRANSACTIONS`] entries, positioned at its start.
+fn write_file() -> Cursor<Vec<u8>> {
+    let mut buf = Cursor::new(Vec::new());
+    write_transactions(
+        NUM_TRANSACTIONS,
+        Box::new(free_coins::builder(Network::LocalNet, Epoch(1))),
+        &|_| {},
+        &mut buf,
+    )
+    .unwrap();
+    buf.seek(SeekFrom::Start(0)).unwrap();
+    buf
+}
+
+fn read_ids(file: Cursor<Vec<u8>>, skip: u64) -> Vec<TransactionId> {
+    read_transactions(file, skip)
+        .unwrap()
+        .into_iter()
+        .map(|t: Transaction| t.calculate_id())
+        .collect()
+}
+
+#[test]
+fn reads_every_transaction_when_nothing_is_skipped() {
+    let ids = read_ids(write_file(), 0);
+    assert_eq!(ids.len(), NUM_TRANSACTIONS as usize);
+}
+
+#[test]
+fn reads_the_tail_of_the_file_after_a_skip() {
+    const SKIP: u64 = 5;
+    // The same bytes read twice: each transaction is sealed with a fresh random key, so a second
+    // call to `write_file` would produce a different set to compare against.
+    let file = write_file();
+    let all = read_ids(file.clone(), 0);
+    let tail = read_ids(file, SKIP);
+
+    assert_eq!(tail, all[SKIP as usize..]);
+}
+
+#[test]
+fn skipping_every_transaction_yields_nothing() {
+    assert!(read_ids(write_file(), NUM_TRANSACTIONS).is_empty());
+}

--- a/utilities/transaction_generator/tests/read_skip_stops_at_eof.rs
+++ b/utilities/transaction_generator/tests/read_skip_stops_at_eof.rs
@@ -1,0 +1,56 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! The reader stops at the file's last entry when `skip` is non-zero.
+//!
+//! An over-read fails inside the reader's own thread, after it has sent every transaction the
+//! caller is owed, so the received count is the same either way and only the panic tells them
+//! apart — hence the panic hook. Hooks are process-wide, so this test has a binary to itself.
+
+use std::{
+    io::{Cursor, Seek, SeekFrom},
+    panic,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+};
+
+use tari_ootle_transaction::{Epoch, Network};
+use transaction_generator::{read_transactions, transaction_builders::free_coins, write_transactions};
+
+const NUM_TRANSACTIONS: u64 = 8;
+const SKIP: u64 = 5;
+
+#[test]
+fn reading_a_skipped_file_to_its_end_does_not_over_read() {
+    let mut file = Cursor::new(Vec::new());
+    write_transactions(
+        NUM_TRANSACTIONS,
+        Box::new(free_coins::builder(Network::LocalNet, Epoch(1))),
+        &|_| {},
+        &mut file,
+    )
+    .unwrap();
+    file.seek(SeekFrom::Start(0)).unwrap();
+
+    let panicked = Arc::new(AtomicBool::new(false));
+    let previous = panic::take_hook();
+    panic::set_hook({
+        let panicked = Arc::clone(&panicked);
+        Box::new(move |info| {
+            panicked.store(true, Ordering::SeqCst);
+            eprintln!("reader panicked: {info}");
+        })
+    });
+
+    let transactions: Vec<_> = read_transactions(file, SKIP).unwrap().into_iter().collect();
+
+    panic::set_hook(previous);
+
+    assert_eq!(transactions.len(), (NUM_TRANSACTIONS - SKIP) as usize);
+    assert!(
+        !panicked.load(Ordering::SeqCst),
+        "the reader read past the end of the file"
+    );
+}


### PR DESCRIPTION
## Problem

`read_transactions` decremented its budget only for transactions it *sent*, not for entries it skipped. With a non-zero `skip` the loop therefore walked `skip` entries past the end of the file and died on the read.

The failure is quiet in the worst way: the reader thread panics only *after* it has sent every transaction the caller is owed. So `transaction_submitter --skip 5000 -n 15000` against a 20,000-transaction file yields the correct 15,000 transactions, then panics with

```
thread '<unnamed>' panicked at utilities/transaction_generator/src/transaction_reader.rs:23:47:
called `Result::unwrap()` on an `Err` value: Error { kind: UnexpectedEof, ... }
```

abandoning the remainder of the run. Hit while flooding a local swarm to measure throughput — the run lost ~1,000 of 15,000 submissions before anyone noticed.

## Fix

Decrement `remaining` once per entry walked rather than once per transaction sent, so a skipped entry draws on the same budget.

## Tests

`tests/read_skip.rs` covers the reader's contract: a full read, the tail after a skip (compared by transaction id against the same bytes read twice, since each transaction is sealed with a fresh random key), and skipping the whole file.

`tests/read_skip_stops_at_eof.rs` is the regression test. The over-read is invisible in the received count — it's identical with and without the bug — so the test watches for the panic through a `panic` hook. Hooks are process-wide, so it takes a test binary to itself. Verified to fail without the fix:

```
test reading_a_skipped_file_to_its_end_does_not_over_read ... FAILED
the reader read past the end of the file
```

`cargo lints clippy -p transaction_generator --all-targets` clean and `cargo +nightly-2025-12-05 fmt --all` applied before the rebase onto `development`; CI covers the rebased tree.