### PR TITLE
chore(consensus)!: lower mainnet base_layer_confirmations to 780

### DIFF
--- a/applications/tari_walletd/src/services/auto_claim_burn_service.rs
+++ b/applications/tari_walletd/src/services/auto_claim_burn_service.rs
@@ -67,7 +67,7 @@ fn claim_after_epoch(mined_in_epoch: Option<u64>) -> Epoch {
 ///
 /// ## Epoch-safety
 /// A claim is only valid once L2 validators have synced the L1 block containing the burn into a
-/// committed epoch. That sync lags the L1 tip by `base_layer_confirmations` (e.g. 1000 blocks on
+/// committed epoch. That sync lags the L1 tip by `base_layer_confirmations` (e.g. 780 blocks on
 /// mainnet), so submitting too early is rejected. Each proof file records the L1 epoch the burn was
 /// mined in (`mined_in_epoch`); this service reads it and only submits once the network reports a
 /// strictly later epoch. Proofs without that field (older L1 wallets) are attempted eagerly and

--- a/crates/consensus/src/consensus_constants.rs
+++ b/crates/consensus/src/consensus_constants.rs
@@ -194,7 +194,14 @@ impl ConsensusConstants {
         epoch_end_spread_blocks: 5,
     };
     pub const MAINNET: Self = Self {
-        base_layer_confirmations: 1000,
+        // Minotari's own `coinbase_min_maturity` (720) plus one epoch of margin — 13 whole L1 epochs
+        // (`vn_epoch_length` is 60 on mainnet), so the lag lands on an epoch boundary and the only
+        // rounding a claimant sees is the wallet's "strictly past the mined-in epoch" gate. The depth
+        // is deliberately generous because the bound is one-way: a burn claim proved against a header
+        // that a deeper reorg later orphans has already credited L2 state that consensus cannot roll
+        // back, whereas an over-deep lag only costs the claimant time. At mainnet's 2 minute block time
+        // a burn becomes claimable ~26 hours after it is mined.
+        base_layer_confirmations: 780,
         committee_size_per_shard_group: 40,
         num_preshards: NumPreshards::current(),
         pacemaker_block_time: Duration::from_secs(10),


### PR DESCRIPTION
## Motivation

The mainnet epoch oracle lags the L1 tip by `base_layer_confirmations` before it stores block headers, and a burn claim can only be proved against a stored header. At 1000 blocks and mainnet's 2 minute block time, that made a burn claimable ~33 hours after it was mined.

1000 also does not divide into the 60-block L1 epoch, so the wallet's `current_epoch > mined_in_epoch` gate (`auto_claim_burn_service.rs`) added an arbitrary 0-59 block remainder on top of it.

## Change

`base_layer_confirmations` on mainnet: `1000` → `780`.

780 is Minotari's own `coinbase_min_maturity` (720) plus one epoch of margin, and is 13 whole L1 epochs. The lag therefore lands on an epoch boundary, and the auto-claim gate is the only rounding a claimant sees.

| | blocks | @ 2 min target | @ 1.89 min (current chain) |
|---|---|---|---|
| before | 1000 | ~33.3 h | ~31.5 h |
| after | 780 | ~26.0 h | ~24.6 h |

The depth stays deliberately generous because the bound is one-way: a claim proved against a header that a deeper reorg later orphans has already credited L2 state that consensus cannot roll back (the oracle does not even attempt surgical recovery for reorgs deeper than `height_lag`), whereas an over-deep lag only costs the claimant time.

Marked `!` since consensus constants must be uniform network-wide.

## Test plan

- [ ] CI
