### PR TITLE
docs(consensus): state the claim burn lag in blocks, not epochs

### DIFF
--- a/crates/consensus/src/consensus_constants.rs
+++ b/crates/consensus/src/consensus_constants.rs
@@ -194,13 +194,14 @@ impl ConsensusConstants {
         epoch_end_spread_blocks: 5,
     };
     pub const MAINNET: Self = Self {
-        // Minotari's own `coinbase_min_maturity` (720) plus one epoch of margin — 13 whole L1 epochs
-        // (`vn_epoch_length` is 60 on mainnet), so the lag lands on an epoch boundary and the only
-        // rounding a claimant sees is the wallet's "strictly past the mined-in epoch" gate. The depth
-        // is deliberately generous because the bound is one-way: a burn claim proved against a header
-        // that a deeper reorg later orphans has already credited L2 state that consensus cannot roll
-        // back, whereas an over-deep lag only costs the claimant time. At mainnet's 2 minute block time
-        // a burn becomes claimable ~26 hours after it is mined.
+        // Minotari's `coinbase_min_maturity` (720) plus 60 blocks (~2 hours) of margin. Must stay a
+        // multiple of the L1 `vn_epoch_length` — 60 today, 10 once the shorter-epoch fork lands — so
+        // the lag ends on an epoch boundary, leaving the wallet's "strictly past the mined-in epoch"
+        // gate as the only rounding a claimant sees. The depth is deliberately generous because the
+        // bound is one-way: a burn claim proved against a header that a deeper reorg later orphans has
+        // already credited L2 state that consensus cannot roll back, whereas an over-deep lag only
+        // costs the claimant time. At mainnet's 2 minute block time a burn becomes claimable
+        // ~26 hours after it is mined.
         base_layer_confirmations: 780,
         committee_size_per_shard_group: 40,
         num_preshards: NumPreshards::current(),

--- a/docs/developer-docs/src/content/docs/guides/claim-burn.mdx
+++ b/docs/developer-docs/src/content/docs/guides/claim-burn.mdx
@@ -106,8 +106,9 @@ deleted and the affected range is rescanned, so the store converges on the canon
 
 <Aside type="caution" title="Claims are delayed by the confirmation depth">
   A burn is not claimable until the validators have scanned its block, and validators deliberately scan behind the
-  tip so that only reorg-safe headers are stored. The lag is the network's `base_layer_confirmations` constant:
-  on the order of a day on mainnet and a few hours on testnets. The claim must also be submitted in an epoch after
+  tip so that only reorg-safe headers are stored. The lag is the network's `base_layer_confirmations` constant,
+  counted in L1 blocks: 780 blocks on mainnet is around a day at the 2 minute block time, while 100 blocks on
+  Esmeralda is well under an hour at its 15 second blocks. The claim must also be submitted in an epoch after
   the one the burn was mined in. The wallet daemon's auto-claim service waits this out for you.
 </Aside>
 


### PR DESCRIPTION
Follow-up to #2565.

The rationale comment on mainnet `base_layer_confirmations` justified 780 as "13 whole L1 epochs (`vn_epoch_length` is 60 on mainnet)". That framing expires when the L1 shortens `vn_epoch_length` to 10. The property the constant actually needs is that it is a multiple of the epoch length so the lag ends on a boundary — 780 satisfies that under both 60 and 10 — so the comment now states the margin in blocks (720 + 60) and names both epoch lengths.

Also corrects the claim burn guide: it put the testnet wait at "a few hours", but Esmeralda's 100 blocks is ~25 minutes at its 15 second block time. Both networks now carry their block count so the wait can be recomputed from the block time.

No value changes.

## Test plan

- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
