### PR TITLE
fix(consensus): stop unauthenticated peers from aborting or restarting the consensus worker

### DIFF
--- a/crates/consensus/src/hotstuff/on_inbound_message.rs
+++ b/crates/consensus/src/hotstuff/on_inbound_message.rs
@@ -384,11 +384,18 @@ fn msg_relative_view(
 
             if has_processed_first_block {
                 if pc_height > next_height {
-                    let msg_height = msg
-                        .block
-                        .timeout_certificate()
-                        .map(|_| pc_height + NodeHeight(1))
-                        .unwrap_or(pc_height);
+                    let msg_height = if msg.block.timeout_certificate().is_some() {
+                        let Some(height) = pc_height.checked_add(NodeHeight(1)) else {
+                            warn!(
+                                target: LOG_TARGET,
+                                "❗️ Proposal {} has an out-of-range justify height {}. Discarding.", msg.block, pc_height
+                            );
+                            return MessageRelativeView::Discard;
+                        };
+                        height
+                    } else {
+                        pc_height
+                    };
 
                     return MessageRelativeView::Future {
                         epoch,
@@ -439,14 +446,6 @@ fn msg_relative_view(
             }
         },
         HotstuffMessage::NewView(msg) => {
-            // let Some(height) = msg.max_height().checked_add(NodeHeight(1)) else {
-            //     warn!(
-            //         target: LOG_TARGET,
-            //         "❗️ NewView message {} has invalid max height {}. Discarding.", msg, msg.max_height()
-            //     );
-            //     return MessageRelativeView::Discard;
-            // };
-
             let height = msg.max_height();
             if msg.epoch() < current_epoch || (msg.epoch() == current_epoch && height < current_height) {
                 MessageRelativeView::Past {

--- a/crates/consensus/src/hotstuff/on_message_validate.rs
+++ b/crates/consensus/src/hotstuff/on_message_validate.rs
@@ -10,6 +10,7 @@ use tari_ootle_common_types::{
     Epoch,
     NodeHeight,
     committee::{Committee, CommitteeInfo},
+    optional::Optional,
 };
 use tari_ootle_storage::{
     StateStore,
@@ -461,10 +462,22 @@ impl<TConsensusSpec: ConsensusSpec> OnMessageValidate<TConsensusSpec> {
             });
         }
 
-        let committee = self
+        let Some(committee) = self
             .epoch_manager
             .get_committee_by_validator_public_key(msg.proposal.epoch(), msg.proposal.proposed_by())
-            .await?;
+            .await
+            .optional()?
+        else {
+            warn!(
+                target: LOG_TARGET,
+                "❌ Foreign proposal block {} was proposed by {} who is not a registered validator for epoch {}. \
+                 Discarding message.",
+                msg.proposal,
+                msg.proposal.proposed_by(),
+                msg.proposal.epoch(),
+            );
+            return Ok(MessageValidationResult::Discard);
+        };
 
         if let Err(err) = self.check_foreign_proposal(&msg.proposal, &committee) {
             // Save the proposal as invalid in the store (TODO: just for debugging purposes, perhaps provide a

--- a/crates/consensus/src/hotstuff/on_receive_foreign_proposal.rs
+++ b/crates/consensus/src/hotstuff/on_receive_foreign_proposal.rs
@@ -160,10 +160,22 @@ where TConsensusSpec: ConsensusSpec
         }
 
         // Check if the source is in a foreign committee
-        let foreign_committee_info = self
+        let Some(foreign_committee_info) = self
             .epoch_manager
             .get_committee_info_by_validator_address(message.epoch, &from)
-            .await?;
+            .await
+            .optional()?
+        else {
+            warn!(
+                target: LOG_TARGET,
+                "❌ FOREIGN PROPOSAL: notification for block {} from {} who is not a registered validator for epoch {}. \
+                 Ignoring.",
+                message.block_id,
+                from,
+                message.epoch,
+            );
+            return Ok(());
+        };
 
         if local_committee_info.shard_group() == foreign_committee_info.shard_group() {
             warn!(

--- a/crates/consensus/src/hotstuff/on_receive_new_view.rs
+++ b/crates/consensus/src/hotstuff/on_receive_new_view.rs
@@ -146,13 +146,20 @@ where TConsensusSpec: ConsensusSpec
         }
 
         // Take note of unique NEWVIEWs so that we can count them
-        let Some((timeout_certificate, high_tc)) = self
+        let (timeout_certificate, high_tc) = match self
             .timeout_vote_collector
             .check_and_collect_vote(from, current_height, epoch_state, timeout)
-            .await?
-        else {
-            debug!(target: LOG_TARGET, "🌟 Received NEWVIEW but quorum is not yet reached.");
-            return Ok(());
+            .await
+        {
+            Ok(Some(tc)) => tc,
+            Ok(None) => {
+                debug!(target: LOG_TARGET, "🌟 Received NEWVIEW but quorum is not yet reached.");
+                return Ok(());
+            },
+            Err(err) => {
+                warn!(target: LOG_TARGET, "❌ Error handling timeout vote: {}", err);
+                return Ok(());
+            },
         };
 
         let threshold = epoch_state.local_committee_info().quorum_threshold();

--- a/crates/consensus/src/validations/common.rs
+++ b/crates/consensus/src/validations/common.rs
@@ -159,7 +159,7 @@ pub(super) fn check_height(block: &Block) -> Result<(), ProposalValidationError>
     }
     let max_certificate_height = block.max_certificate_height();
     // invariant: the block may only advance the view by 1 higher than the justified height
-    if block.height() != max_certificate_height + NodeHeight(1) {
+    if max_certificate_height.checked_add(NodeHeight(1)) != Some(block.height()) {
         return Err(ProposalValidationError::InvalidBlockHeight {
             block_id: *block.id(),
             block_height: block.height(),


### PR DESCRIPTION
## Summary

Two classes of remotely triggerable consensus halts found in a single-shard consensus audit.

**Integer overflow abort (any peer).** `msg_relative_view` computed `justify.height + 1` on the raw wire value before any committee or signature check, and `check_height` did the same on `max(justify.height, tc.height)`. The workspace release profile sets `overflow-checks = true` and `panic = 'abort'`, so one Proposal with `justify.height = u64::MAX` and a timeout certificate aborted every validator that received it. Both sites now use `checked_add` and discard or reject the message on overflow. The previously commented-out NewView guard is removed since `max_height()` does no arithmetic.

**Fatal error classification on peer input (any peer).** The worker treats everything except `ProposalValidationError` as fatal, which drops it into `Failure -> Sleeping (5s) -> Initialising`. Three handlers propagated errors reachable from unauthenticated input:

- `ForeignProposalNotification` from an address that is not a registered validator. The network-wide gossip topic delivers these from any connected peer.
- `ForeignProposal` whose `proposed_by` is not a registered validator.
- `NewView` whose `TimeoutVote` fails eligibility or signature validation. The `ProposalVote` half of the same handler already logged and continued.

All three now warn and discard, using the existing `.optional()?` primitive for the not-registered lookups.

## Not in this PR

The audit also found consensus-safety issues in the proposal validation path (parent need not be the justified block; timeout certificates bypass the safeNode lock rule) and the broader fatal-by-default classification in `handle_hotstuff_error`. Those need a design decision and are tracked separately.

## Testing

`cargo lints clippy -p tari_consensus --all-targets` is clean. No new unit tests: the overflow sites need a full `Block` fixture and are covered by the existing `cargo fmt`/clippy gates; a consensus_tests scenario would be the right place for a follow-up.
