### PR TITLE
fix(consensus): ratify an EndEpoch hash from an observed boundary, not an activated epoch

### DIFF
--- a/applications/tari_indexer/src/bootstrap.rs
+++ b/applications/tari_indexer/src/bootstrap.rs
@@ -544,7 +544,7 @@ async fn create_epoch_oracle<TStore: EpochOracleStore + BaseLayerBlockHeaderStor
     }
 }
 
-async fn create_base_layer_epoch_oracle<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + 'static>(
+async fn create_base_layer_epoch_oracle<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + Clone + 'static>(
     config: &ApplicationConfig,
     store: TStore,
     consensus_constants: &ConsensusConstants,

--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -640,7 +640,7 @@ async fn create_epoch_oracle<TStore: EpochOracleStore + BaseLayerBlockHeaderStor
     }
 }
 
-async fn create_base_layer_epoch_oracle<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + 'static>(
+async fn create_base_layer_epoch_oracle<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + Clone + 'static>(
     config: &ApplicationConfig,
     store: TStore,
     consensus_constants: &ConsensusConstants,

--- a/applications/tari_validator_node/src/epoch_metrics.rs
+++ b/applications/tari_validator_node/src/epoch_metrics.rs
@@ -156,7 +156,7 @@ impl<O: EpochEventOracle + Send> EpochEventOracle for MeteredEpochOracle<O> {
         self.inner.is_within_epoch_end_spread(current_epoch)
     }
 
-    fn observed_epoch_boundary_hash(&self, epoch: Epoch) -> Option<FixedHash> {
+    fn observed_epoch_boundary_hash(&self, epoch: Epoch) -> anyhow::Result<Option<FixedHash>> {
         self.inner.observed_epoch_boundary_hash(epoch)
     }
 }

--- a/applications/tari_validator_node/src/epoch_metrics.rs
+++ b/applications/tari_validator_node/src/epoch_metrics.rs
@@ -23,6 +23,7 @@ use prometheus_client::{
     },
     registry::Registry,
 };
+use tari_common_types::types::FixedHash;
 use tari_epoch_manager::{
     epoch_event_oracle::{EpochEvent, EpochEventOracle},
     service::EpochManagerHandle,
@@ -153,6 +154,10 @@ impl<O: EpochEventOracle + Send> EpochEventOracle for MeteredEpochOracle<O> {
 
     fn is_within_epoch_end_spread(&self, current_epoch: Epoch) -> bool {
         self.inner.is_within_epoch_end_spread(current_epoch)
+    }
+
+    fn observed_epoch_boundary_hash(&self, epoch: Epoch) -> Option<FixedHash> {
+        self.inner.observed_epoch_boundary_hash(epoch)
     }
 }
 

--- a/crates/consensus/src/hotstuff/on_receive_local_proposal.rs
+++ b/crates/consensus/src/hotstuff/on_receive_local_proposal.rs
@@ -320,26 +320,30 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveLocalProposalHandler<TConsensusSpec
         debug!(target: LOG_TARGET, "process_block: [{}] processing block: {}", current_epoch, valid_block);
 
         let em_epoch = self.epoch_manager.current_epoch().await?;
-        // Accept an EndEpoch proposal when our oracle has advanced past `current_epoch`, OR when
-        // the oracle believes we are close enough to the epoch boundary to vote speculatively.
-        // The speculative branch rescues the case where a short base-layer reorg near the lag
-        // horizon leaves our scanner a handful of blocks behind the leader's — without this,
-        // such splits can wedge consensus because every node requires the strict inequality.
-        let can_propose_epoch_end =
-            em_epoch > current_epoch || self.epoch_manager.is_within_epoch_end_spread(current_epoch).await?;
         let is_epoch_end = valid_block.block().is_epoch_end();
 
-        // Our own oracle's view of the next epoch's boundary hash, used by the voter to ratify the hash
-        // carried in an EndEpoch command. `None` if our oracle has not yet observed the next epoch — in
-        // which case the voter abstains rather than lending quorum to an unratified hash.
+        // Our own view of the next epoch's boundary hash, used by the voter to ratify the hash carried
+        // in an EndEpoch command. `None` if we have not observed that boundary — in which case the
+        // voter abstains rather than lending quorum to an unratified hash. Having observed the boundary
+        // is what qualifies a node to ratify, not having activated the epoch: the scanner stores headers
+        // before the resulting `EpochChanged` event is applied, and during a catch-up that event can sit
+        // behind several epoch activations.
         let expected_next_epoch_hash = if is_epoch_end {
             self.epoch_manager
-                .get_epoch_hash(current_epoch + Epoch(1))
-                .await
-                .optional()?
+                .get_observed_epoch_hash(current_epoch + Epoch(1))
+                .await?
         } else {
             None
         };
+
+        // Accept an EndEpoch proposal when our oracle has advanced past `current_epoch`, when we have
+        // scanned the boundary block that ends it, OR when the oracle believes we are close enough to
+        // the boundary to vote speculatively. The latter branches rescue the case where a short
+        // base-layer reorg near the lag horizon leaves our scanner behind the leader's — without them,
+        // such splits can wedge consensus because every node requires the strict inequality.
+        let can_propose_epoch_end = em_epoch > current_epoch ||
+            expected_next_epoch_hash.is_some() ||
+            self.epoch_manager.is_within_epoch_end_spread(current_epoch).await?;
 
         let mut on_ready_to_vote_on_local_block = self.on_ready_to_vote_on_local_block.clone();
 

--- a/crates/consensus_tests/src/epoch_change.rs
+++ b/crates/consensus_tests/src/epoch_change.rs
@@ -220,6 +220,63 @@ async fn epoch_change_unobserved_next_hash_is_not_voted() {
     test.assert_clean_shutdown().await;
 }
 
+/// A validator whose oracle has scanned the next epoch's boundary block, but has not yet applied the
+/// `EpochChanged` event that activates it, votes for the `EndEpoch`.
+///
+/// This is the counterpart to `epoch_change_unobserved_next_hash_is_not_voted`: there the validator
+/// cannot see the boundary and must abstain; here it can, and abstaining would be a self-inflicted
+/// stall. The two gates are deliberately different questions — "has the epoch ended?" and "can I
+/// verify the hash this block proposes?" — and the boundary block answers both.
+///
+/// The window is real on a lagging node: the scanner writes headers as it crosses them, while the
+/// `EpochChanged` those scans produce queue behind epoch activations that each reassign committees.
+///
+/// The test caps only `current_epoch()` for validator "1", leaving `get_epoch_hash(Epoch(2))`
+/// answering, and asserts every validator — including the capped one — reaches `Epoch(2)`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn epoch_change_observed_boundary_is_voted_before_activation() {
+    setup_logger();
+    let mut test = Test::builder()
+        .modify_config(|cfg| {
+            cfg.epoch_end_grace_period = Duration::from_millis(10);
+        })
+        .modify_consensus_constants(|c| {
+            c.pacemaker_block_time = Duration::from_secs(2);
+        })
+        .with_test_timeout(Duration::from_secs(60))
+        .add_committee(0, vec!["1", "2", "3", "4"])
+        .start()
+        .await;
+
+    let unactivated_addr = TestAddress::new("1");
+
+    test.start_epoch(Epoch(1)).await;
+
+    for _ in 0..3 {
+        test.send_transaction_to_all(Decision::Commit, 1, 1, 1).await;
+    }
+
+    // Cap only `current_epoch()`. Validator "1"'s oracle still answers `get_epoch_hash(Epoch(2))` —
+    // it has the boundary block — but `em_epoch > current_epoch` is false, so its vote can only come
+    // from that observation.
+    test.get_validator(&unactivated_addr)
+        .epoch_manager
+        .set_oracle_current_epoch_cap(Epoch(1));
+
+    test.start_epoch(Epoch(2)).await;
+
+    for _ in 0..3 {
+        test.send_transaction_to_all(Decision::Commit, 1, 1, 1).await;
+    }
+
+    wait_for_all_validators_at_epoch(&mut test, Epoch(2), Duration::from_secs(30)).await;
+
+    log::info!("✅ validator with an observed but unactivated boundary voted the EOE and advanced with the committee");
+
+    test.stop();
+    test.assert_clean_shutdown().await;
+}
+
 /// Walks the chain from the leaf of `epoch` looking for a committed `EndEpoch` block.
 fn chain_has_committed_epoch_end<TTx: StateStoreReadTransaction>(
     tx: &TTx,
@@ -330,12 +387,16 @@ async fn epoch_change_no_vote_wedge_escalates_on_future_qc() {
         test.send_transaction_to_all(Decision::Commit, 1, 1, 1).await;
     }
 
-    // Cap validator "1"'s view of `current_epoch()`. Unlike `set_oracle_visible_epoch` (which
-    // only caps `get_epoch_hash`), this makes the vote-time check
-    // `em_epoch > current_epoch` fail for this validator — reproducing the no-vote path.
+    // Wedge validator "1" at the vote-time gates: the `current_epoch()` cap fails
+    // `em_epoch > current_epoch`, and the oracle cap leaves it without a next-epoch hash to ratify
+    // against. Both are needed — a validator that can still see the Epoch(2) boundary votes for the
+    // EndEpoch on the strength of that observation alone.
     test.get_validator(&lagging_addr)
         .epoch_manager
         .set_oracle_current_epoch_cap(Epoch(1));
+    test.get_validator(&lagging_addr)
+        .epoch_manager
+        .set_oracle_visible_epoch(Epoch(1));
 
     // Take validator "1" offline so the network delivers no messages to/from it. This stops
     // its (now-wedged) view from blocking leader rotation on the honest committee — peers
@@ -382,6 +443,7 @@ async fn epoch_change_no_vote_wedge_escalates_on_future_qc() {
     // Epoch(2) proposals reach validator "1" — each carries an authenticated 2f+1 QC over
     // Epoch(2). The first one trips the probe in `MessageBuffer::next`.
     lagged.epoch_manager.clear_oracle_current_epoch_cap();
+    lagged.epoch_manager.clear_oracle_visible_epoch();
     test.network().go_online(&lagging_addr).await;
 
     // Honest validators keep producing proposals in Epoch(2); send more transactions to
@@ -453,10 +515,15 @@ async fn epoch_change_multi_epoch_lag_escalates_on_future_qc() {
         test.send_transaction_to_all(Decision::Commit, 1, 1, 1).await;
     }
 
-    // Lag and remove validator "1" before peers cross any epoch boundaries.
+    // Lag and remove validator "1" before peers cross any epoch boundaries. Capping the oracle too
+    // keeps it from ratifying an EndEpoch off an observed boundary, which would let it follow the
+    // epoch change it is supposed to lag behind.
     test.get_validator(&lagging_addr)
         .epoch_manager
         .set_oracle_current_epoch_cap(Epoch(1));
+    test.get_validator(&lagging_addr)
+        .epoch_manager
+        .set_oracle_visible_epoch(Epoch(1));
     test.network().go_offline(lagging_addr.clone()).await;
 
     // First boundary: Epoch(1) → Epoch(2). The honest three commit and roll over.
@@ -489,6 +556,7 @@ async fn epoch_change_multi_epoch_lag_escalates_on_future_qc() {
     // messages reach validator "1". Each carries a 2f+1 QC over Epoch(3) — which would
     // have been discarded outright before the gate was lifted (3 > 1 + 1).
     lagged.epoch_manager.clear_oracle_current_epoch_cap();
+    lagged.epoch_manager.clear_oracle_visible_epoch();
     test.network().go_online(&lagging_addr).await;
 
     for _ in 0..3 {

--- a/crates/consensus_tests/src/support/epoch_manager.rs
+++ b/crates/consensus_tests/src/support/epoch_manager.rs
@@ -84,6 +84,11 @@ impl TestEpochManager {
         *self.oracle_visible_epoch.lock().unwrap() = Some(epoch);
     }
 
+    /// Remove the oracle view cap for this validator, standing in for its scanner catching up.
+    pub fn clear_oracle_visible_epoch(&self) {
+        *self.oracle_visible_epoch.lock().unwrap() = None;
+    }
+
     fn oracle_visible_epoch(&self) -> Option<Epoch> {
         *self.oracle_visible_epoch.lock().unwrap()
     }

--- a/crates/consensus_tests/src/support/epoch_manager.rs
+++ b/crates/consensus_tests/src/support/epoch_manager.rs
@@ -20,6 +20,7 @@ use tari_ootle_common_types::{
     VersionedSubstateId,
     VotePower,
     committee::{Committee, CommitteeInfo},
+    optional::Optional,
 };
 use tari_ootle_storage::{StorageError, global::models::ValidatorNode};
 use tari_template_lib_types::crypto::RistrettoPublicKeyBytes;
@@ -519,6 +520,10 @@ impl EpochManagerReader for TestEpochManager {
 
     async fn is_within_epoch_end_spread(&self, _current_epoch: Epoch) -> Result<bool, EpochManagerError> {
         Ok(false)
+    }
+
+    async fn get_observed_epoch_hash(&self, epoch: Epoch) -> Result<Option<FixedHash>, EpochManagerError> {
+        self.get_epoch_hash(epoch).await.optional()
     }
 
     async fn get_birthday_epoch(&self) -> Result<Option<Epoch>, EpochManagerError> {

--- a/crates/epoch_manager/src/epoch_event_oracle/traits.rs
+++ b/crates/epoch_manager/src/epoch_event_oracle/traits.rs
@@ -3,6 +3,7 @@
 
 use std::future::Future;
 
+use tari_common_types::types::FixedHash;
 use tari_ootle_common_types::Epoch;
 
 use crate::epoch_event_oracle::EpochEvent;
@@ -23,5 +24,16 @@ pub trait EpochEventOracle {
     /// only accepting `EndEpoch` once the epoch has actually changed locally.
     fn is_within_epoch_end_spread(&self, _current_epoch: Epoch) -> bool {
         false
+    }
+
+    /// Returns the boundary hash the oracle has observed for `epoch`, if it has observed one.
+    ///
+    /// This answers "have I seen this epoch's boundary?" independently of whether the corresponding
+    /// `EpochChanged` event has been applied, which lets the voter ratify an `EndEpoch` hash it has
+    /// genuinely scanned while the event is still queued behind an epoch activation. The default
+    /// implementation returns `None`, so an oracle that cannot observe boundaries ahead of its own
+    /// events is unaffected.
+    fn observed_epoch_boundary_hash(&self, _epoch: Epoch) -> Option<FixedHash> {
+        None
     }
 }

--- a/crates/epoch_manager/src/epoch_event_oracle/traits.rs
+++ b/crates/epoch_manager/src/epoch_event_oracle/traits.rs
@@ -26,14 +26,17 @@ pub trait EpochEventOracle {
         false
     }
 
-    /// Returns the boundary hash the oracle has observed for `epoch`, if it has observed one.
+    /// Returns the boundary hash the oracle has observed for `epoch`, or `None` if it has observed
+    /// none. An error means the oracle could not determine either way and must be distinguished from
+    /// `None`: a caller that treats a failed lookup as "not observed" turns a broken store into a
+    /// silent abstention.
     ///
     /// This answers "have I seen this epoch's boundary?" independently of whether the corresponding
     /// `EpochChanged` event has been applied, which lets the voter ratify an `EndEpoch` hash it has
     /// genuinely scanned while the event is still queued behind an epoch activation. The default
     /// implementation returns `None`, so an oracle that cannot observe boundaries ahead of its own
     /// events is unaffected.
-    fn observed_epoch_boundary_hash(&self, _epoch: Epoch) -> Option<FixedHash> {
-        None
+    fn observed_epoch_boundary_hash(&self, _epoch: Epoch) -> anyhow::Result<Option<FixedHash>> {
+        Ok(None)
     }
 }

--- a/crates/epoch_manager/src/error.rs
+++ b/crates/epoch_manager/src/error.rs
@@ -43,6 +43,8 @@ pub enum EpochManagerError {
     },
     #[error("Failed to submit layer one transaction: {details}")]
     FailedToSubmitLayerOneTransaction { details: String },
+    #[error("Epoch event oracle error: {details}")]
+    EpochEventOracleError { details: String },
 }
 
 impl EpochManagerError {

--- a/crates/epoch_manager/src/service/epoch_manager_service.rs
+++ b/crates/epoch_manager/src/service/epoch_manager_service.rs
@@ -540,8 +540,10 @@ impl<TSpec: EpochManagerSpec> EpochManagerService<TSpec> {
                 let result = match self.inner.get_epoch_hash(epoch).optional() {
                     Ok(Some(activated)) => Ok(Some(activated)),
                     Ok(None) => self.epoch_events.observed_epoch_boundary_hash(epoch).map_err(|err| {
+                        // `{:#}` keeps anyhow's source chain: the diesel error underneath is the part
+                        // that says why the store was unreadable.
                         EpochManagerError::EpochEventOracleError {
-                            details: err.to_string(),
+                            details: format!("{err:#}"),
                         }
                     }),
                     Err(err) => Err(err),

--- a/crates/epoch_manager/src/service/epoch_manager_service.rs
+++ b/crates/epoch_manager/src/service/epoch_manager_service.rs
@@ -537,11 +537,15 @@ impl<TSpec: EpochManagerSpec> EpochManagerService<TSpec> {
             EpochManagerRequest::GetObservedEpochHash { epoch, reply } => {
                 // An activated epoch's stored hash wins: it is the one the self-healing correction
                 // maintains and that `lock_epoch` freezes once consensus has committed against it.
-                let result = self
-                    .inner
-                    .get_epoch_hash(epoch)
-                    .optional()
-                    .map(|activated| activated.or_else(|| self.epoch_events.observed_epoch_boundary_hash(epoch)));
+                let result = match self.inner.get_epoch_hash(epoch).optional() {
+                    Ok(Some(activated)) => Ok(Some(activated)),
+                    Ok(None) => self.epoch_events.observed_epoch_boundary_hash(epoch).map_err(|err| {
+                        EpochManagerError::EpochEventOracleError {
+                            details: err.to_string(),
+                        }
+                    }),
+                    Err(err) => Err(err),
+                };
                 handle(reply, result, context);
             },
             EpochManagerRequest::GetBirthdayEpoch { reply } => {

--- a/crates/epoch_manager/src/service/epoch_manager_service.rs
+++ b/crates/epoch_manager/src/service/epoch_manager_service.rs
@@ -534,6 +534,16 @@ impl<TSpec: EpochManagerSpec> EpochManagerService<TSpec> {
                     context,
                 );
             },
+            EpochManagerRequest::GetObservedEpochHash { epoch, reply } => {
+                // An activated epoch's stored hash wins: it is the one the self-healing correction
+                // maintains and that `lock_epoch` freezes once consensus has committed against it.
+                let result = self
+                    .inner
+                    .get_epoch_hash(epoch)
+                    .optional()
+                    .map(|activated| activated.or_else(|| self.epoch_events.observed_epoch_boundary_hash(epoch)));
+                handle(reply, result, context);
+            },
             EpochManagerRequest::GetBirthdayEpoch { reply } => {
                 handle(reply, Ok(self.inner.birthday_epoch()), context);
             },

--- a/crates/epoch_manager/src/service/handle.rs
+++ b/crates/epoch_manager/src/service/handle.rs
@@ -404,6 +404,15 @@ impl<TAddr: NodeAddressable> EpochManagerReader for EpochManagerHandle<TAddr> {
         rx.await.map_err(|_| EpochManagerError::ReceiveError)?
     }
 
+    async fn get_observed_epoch_hash(&self, epoch: Epoch) -> Result<Option<FixedHash>, EpochManagerError> {
+        let (tx, rx) = oneshot::channel();
+        self.tx_request
+            .send(EpochManagerRequest::GetObservedEpochHash { epoch, reply: tx })
+            .await
+            .map_err(|_| EpochManagerError::SendError)?;
+        rx.await.map_err(|_| EpochManagerError::ReceiveError)?
+    }
+
     async fn get_birthday_epoch(&self) -> Result<Option<Epoch>, EpochManagerError> {
         let (tx, rx) = oneshot::channel();
         self.tx_request

--- a/crates/epoch_manager/src/service/types.rs
+++ b/crates/epoch_manager/src/service/types.rs
@@ -130,6 +130,10 @@ pub enum EpochManagerRequest<TAddr> {
         current_epoch: Epoch,
         reply: Reply<bool>,
     },
+    GetObservedEpochHash {
+        epoch: Epoch,
+        reply: Reply<Option<FixedHash>>,
+    },
     GetBirthdayEpoch {
         reply: Reply<Option<Epoch>>,
     },

--- a/crates/epoch_manager/src/traits.rs
+++ b/crates/epoch_manager/src/traits.rs
@@ -238,6 +238,15 @@ pub trait EpochManagerReader: Send + Sync {
         current_epoch: Epoch,
     ) -> impl Future<Output = Result<bool, EpochManagerError>> + Send;
 
+    /// This node's own view of `epoch`'s boundary hash: the hash stored when the epoch was activated
+    /// if it has been, otherwise a boundary the epoch event oracle has observed but not yet activated.
+    /// `None` when this node has seen neither, in which case it has nothing of its own to ratify an
+    /// `EndEpoch` proposal against.
+    fn get_observed_epoch_hash(
+        &self,
+        epoch: Epoch,
+    ) -> impl Future<Output = Result<Option<FixedHash>, EpochManagerError>> + Send;
+
     /// The first epoch for which the network has validators.
     fn get_birthday_epoch(&self) -> impl Future<Output = Result<Option<Epoch>, EpochManagerError>> + Send;
 }

--- a/crates/epoch_oracles/src/base_layer/oracle.rs
+++ b/crates/epoch_oracles/src/base_layer/oracle.rs
@@ -898,10 +898,6 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore, TClient: BaseNodeClie
         }
     }
 
-    /// Returns the boundary block hash we have stored for `epoch`, or `None` if we have not scanned
-    /// it. The stored header only counts as the boundary when its height is exactly the epoch's first
-    /// height: a scan range that starts mid-epoch stores a first header that is not the boundary, and
-    /// ratifying against that would compare the wrong hash.
     /// Returns true when our lagged scanner position is within `epoch_end_spread_blocks` of the
     /// next epoch boundary. Used by consensus to accept `EndEpoch` proposals speculatively when
     /// peers' oracles have already crossed and ours is almost there.

--- a/crates/epoch_oracles/src/base_layer/oracle.rs
+++ b/crates/epoch_oracles/src/base_layer/oracle.rs
@@ -889,7 +889,7 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore, TClient: BaseNodeClie
     /// it. The stored header only counts as the boundary when its height is exactly the epoch's first
     /// height: a scan range that starts mid-epoch stores a first header that is not the boundary, and
     /// ratifying against that would compare the wrong hash.
-    fn observed_epoch_boundary_hash(&self, epoch: Epoch) -> anyhow::Result<Option<FixedHash>> {
+    fn observed_epoch_boundary_hash(&self, epoch: Epoch) -> Result<Option<FixedHash>, BaseLayerOracleError> {
         // The epoch length is only known once a scan has obtained the L1 constants; until then we
         // cannot say which height opens the epoch.
         let Some(epoch_length) = self.cached_epoch_length else {
@@ -898,7 +898,11 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore, TClient: BaseNodeClie
         let Some(boundary_height) = epoch.as_u64().checked_mul(epoch_length) else {
             return Ok(None);
         };
-        let Some(boundary) = self.store.get_first_block_header_in_epoch(epoch)? else {
+        let Some(boundary) = self
+            .store
+            .get_first_block_header_in_epoch(epoch)
+            .map_err(BaseLayerOracleError::StoreError)?
+        else {
             return Ok(None);
         };
         Ok((boundary.height == boundary_height).then_some(boundary.block_hash))
@@ -1043,7 +1047,7 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + Send + 'static, TCli
         // `inner` is briefly None while a scan task is in flight; the voter then falls back to the
         // activated epoch hash alone.
         match self.inner.as_deref() {
-            Some(inner) => inner.observed_epoch_boundary_hash(epoch),
+            Some(inner) => Ok(inner.observed_epoch_boundary_hash(epoch)?),
             None => Ok(None),
         }
     }

--- a/crates/epoch_oracles/src/base_layer/oracle.rs
+++ b/crates/epoch_oracles/src/base_layer/oracle.rs
@@ -889,11 +889,19 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore, TClient: BaseNodeClie
     /// it. The stored header only counts as the boundary when its height is exactly the epoch's first
     /// height: a scan range that starts mid-epoch stores a first header that is not the boundary, and
     /// ratifying against that would compare the wrong hash.
-    fn observed_epoch_boundary_hash(&self, epoch: Epoch) -> Option<FixedHash> {
-        let epoch_length = self.cached_epoch_length?;
-        let boundary_height = epoch.as_u64().checked_mul(epoch_length)?;
-        let boundary = self.store.get_first_block_header_in_epoch(epoch).ok()??;
-        (boundary.height == boundary_height).then_some(boundary.block_hash)
+    fn observed_epoch_boundary_hash(&self, epoch: Epoch) -> anyhow::Result<Option<FixedHash>> {
+        // The epoch length is only known once a scan has obtained the L1 constants; until then we
+        // cannot say which height opens the epoch.
+        let Some(epoch_length) = self.cached_epoch_length else {
+            return Ok(None);
+        };
+        let Some(boundary_height) = epoch.as_u64().checked_mul(epoch_length) else {
+            return Ok(None);
+        };
+        let Some(boundary) = self.store.get_first_block_header_in_epoch(epoch)? else {
+            return Ok(None);
+        };
+        Ok((boundary.height == boundary_height).then_some(boundary.block_hash))
     }
 
     /// Returns true when our lagged scanner position is within `epoch_end_spread_blocks` of the
@@ -1031,10 +1039,13 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + Send + 'static, TCli
             .unwrap_or(false)
     }
 
-    fn observed_epoch_boundary_hash(&self, epoch: Epoch) -> Option<FixedHash> {
+    fn observed_epoch_boundary_hash(&self, epoch: Epoch) -> anyhow::Result<Option<FixedHash>> {
         // `inner` is briefly None while a scan task is in flight; the voter then falls back to the
         // activated epoch hash alone.
-        self.inner.as_deref()?.observed_epoch_boundary_hash(epoch)
+        match self.inner.as_deref() {
+            Some(inner) => inner.observed_epoch_boundary_hash(epoch),
+            None => Ok(None),
+        }
     }
 }
 
@@ -1405,11 +1416,11 @@ mod tests {
 
         // Epoch 3 opens at height 15, which we have scanned.
         assert_eq!(
-            inner.observed_epoch_boundary_hash(Epoch(3)),
+            inner.observed_epoch_boundary_hash(Epoch(3)).unwrap(),
             Some(hash_header(NETWORK, &chain[15]))
         );
         // Epoch 4 opens at height 20, above our lagged scan position.
-        assert_eq!(inner.observed_epoch_boundary_hash(Epoch(4)), None);
+        assert_eq!(inner.observed_epoch_boundary_hash(Epoch(4)).unwrap(), None);
     }
 
     #[tokio::test]
@@ -1431,7 +1442,7 @@ mod tests {
             }])
             .unwrap();
 
-        assert_eq!(inner.observed_epoch_boundary_hash(Epoch(2)), None);
+        assert_eq!(inner.observed_epoch_boundary_hash(Epoch(2)).unwrap(), None);
     }
 
     #[tokio::test]

--- a/crates/epoch_oracles/src/base_layer/oracle.rs
+++ b/crates/epoch_oracles/src/base_layer/oracle.rs
@@ -5,6 +5,10 @@ use std::{
     collections::{HashMap, VecDeque},
     future::{Future, poll_fn},
     pin::Pin,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
     task::{Context, Poll},
 };
 
@@ -81,6 +85,11 @@ type ScanTask<TStore, TClient> = Pin<Box<dyn Future<Output = TaskOutput<TStore, 
 #[allow(clippy::struct_excessive_bools)]
 pub struct BaseLayerOracle<TStore, TClient = GrpcBaseNodeClient> {
     inner: Option<Box<BaseLayerOracleInner<TStore, TClient>>>,
+    /// Handles for the epoch-boundary lookup, held here rather than in `inner` because `inner` is
+    /// owned by the scan task for the whole of each batch — the boundary must stay readable while a
+    /// catch-up is in flight, which is when a lagging voter needs it.
+    store: TStore,
+    epoch_length: Arc<AtomicU64>,
     is_initialized: bool,
     is_done: bool,
     has_more: bool,
@@ -105,16 +114,20 @@ struct BaseLayerOracleInner<TStore, TClient> {
     // instead of being held for the whole batch.
     header_buf: Vec<BlockHeaderModel>,
     network: Network,
-    /// Epoch length in base-layer blocks, cached from consensus constants on the first scan
-    /// that obtains them. `None` until the first scan completes.
-    cached_epoch_length: Option<u64>,
+    /// Epoch length in base-layer blocks, cached from consensus constants on the first scan that
+    /// obtains them. Shared with the owning `BaseLayerOracle`, which reads it while this inner state
+    /// is away in a scan task. Zero until the first scan completes.
+    epoch_length: Arc<AtomicU64>,
 }
 
-impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + 'static, TClient: BaseNodeClient>
+impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + Clone + 'static, TClient: BaseNodeClient>
     BaseLayerOracle<TStore, TClient>
 {
     pub fn new(store: TStore, base_node_client: TClient, config: BaseLayerEpochOracleConfig, network: Network) -> Self {
+        let epoch_length = Arc::new(AtomicU64::new(0));
         Self {
+            store: store.clone(),
+            epoch_length: epoch_length.clone(),
             inner: Some(Box::new(BaseLayerOracleInner {
                 config,
                 store,
@@ -128,7 +141,7 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + 'static, TClient: Ba
                 pending_events: VecDeque::new(),
                 header_buf: Vec::new(),
                 network,
-                cached_epoch_length: None,
+                epoch_length,
             })),
             is_initialized: false,
             is_done: false,
@@ -221,7 +234,7 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore, TClient: BaseNodeClie
                         .base_node_client
                         .get_consensus_constants(tip.height_of_longest_chain)
                         .await?;
-                    self.cached_epoch_length = Some(constants.epoch_length());
+                    self.epoch_length.store(constants.epoch_length(), Ordering::Relaxed);
                     let lagged_height = tip.height_of_longest_chain.saturating_sub(self.config.height_lag);
                     let epoch = constants.height_to_epoch(lagged_height);
                     // If no progress has been made since restarting, we still need to tell the epoch manager that
@@ -463,7 +476,7 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore, TClient: BaseNodeClie
             .base_node_client
             .get_consensus_constants(tip.height_of_longest_chain)
             .await?;
-        self.cached_epoch_length = Some(constants.epoch_length());
+        self.epoch_length.store(constants.epoch_length(), Ordering::Relaxed);
 
         // Acquire and scan this batch's blocks. The validator node needs every header (e.g. for
         // burn-proof validation), so it streams and stores the full contiguous range. The indexer
@@ -889,25 +902,6 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore, TClient: BaseNodeClie
     /// it. The stored header only counts as the boundary when its height is exactly the epoch's first
     /// height: a scan range that starts mid-epoch stores a first header that is not the boundary, and
     /// ratifying against that would compare the wrong hash.
-    fn observed_epoch_boundary_hash(&self, epoch: Epoch) -> Result<Option<FixedHash>, BaseLayerOracleError> {
-        // The epoch length is only known once a scan has obtained the L1 constants; until then we
-        // cannot say which height opens the epoch.
-        let Some(epoch_length) = self.cached_epoch_length else {
-            return Ok(None);
-        };
-        let Some(boundary_height) = epoch.as_u64().checked_mul(epoch_length) else {
-            return Ok(None);
-        };
-        let Some(boundary) = self
-            .store
-            .get_first_block_header_in_epoch(epoch)
-            .map_err(BaseLayerOracleError::StoreError)?
-        else {
-            return Ok(None);
-        };
-        Ok((boundary.height == boundary_height).then_some(boundary.block_hash))
-    }
-
     /// Returns true when our lagged scanner position is within `epoch_end_spread_blocks` of the
     /// next epoch boundary. Used by consensus to accept `EndEpoch` proposals speculatively when
     /// peers' oracles have already crossed and ours is almost there.
@@ -915,9 +909,7 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore, TClient: BaseNodeClie
         if self.config.epoch_end_spread_blocks == 0 {
             return false;
         }
-        let Some(epoch_length) = self.cached_epoch_length else {
-            return false;
-        };
+        let epoch_length = self.epoch_length.load(Ordering::Relaxed);
         if epoch_length == 0 {
             return false;
         }
@@ -1044,13 +1036,41 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + Send + 'static, TCli
     }
 
     fn observed_epoch_boundary_hash(&self, epoch: Epoch) -> anyhow::Result<Option<FixedHash>> {
-        // `inner` is briefly None while a scan task is in flight; the voter then falls back to the
-        // activated epoch hash alone.
-        match self.inner.as_deref() {
-            Some(inner) => Ok(inner.observed_epoch_boundary_hash(epoch)?),
-            None => Ok(None),
-        }
+        Ok(lookup_epoch_boundary_hash(
+            &self.store,
+            self.epoch_length.load(Ordering::Relaxed),
+            epoch,
+        )?)
     }
+}
+
+/// Returns the boundary block hash stored for `epoch`, or `None` if it has not been scanned.
+///
+/// A stored header only counts as the boundary when its height is exactly the epoch's first height:
+/// a scan range that opens mid-epoch stores a first header that is not the boundary, and ratifying
+/// against that would compare the wrong hash. `epoch_length` is zero until a scan has obtained the
+/// L1 constants, before which the opening height is unknown.
+fn lookup_epoch_boundary_hash<TStore: BaseLayerBlockHeaderStore>(
+    store: &TStore,
+    epoch_length: u64,
+    epoch: Epoch,
+) -> Result<Option<FixedHash>, BaseLayerOracleError> {
+    // Zero is the pre-constants state, which a node whose base layer has not reached `start_height`
+    // stays in through initial sync: it has crossed no boundary either, so nothing is observed.
+    if epoch_length == 0 {
+        return Ok(None);
+    }
+    // Epochs are derived as `height / epoch_length`, so the product cannot leave the base layer's
+    // height space unless the epoch is corrupt.
+    let boundary_height = epoch
+        .as_u64()
+        .checked_mul(epoch_length)
+        .ok_or(BaseLayerOracleError::EpochHeightOverflow { epoch, epoch_length })?;
+    Ok(store
+        .get_first_block_header_in_epoch(epoch)
+        .map_err(BaseLayerOracleError::StoreError)?
+        .filter(|boundary| boundary.height == boundary_height)
+        .map(|boundary| boundary.block_hash))
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -1061,6 +1081,8 @@ pub enum BaseLayerOracleError {
     BaseNodeError(#[from] BaseNodeClientError),
     #[error("Invalid base node response: {0}")]
     InvalidBaseNodeResponse(String),
+    #[error("Epoch {epoch} overflows the base layer height space at epoch length {epoch_length}")]
+    EpochHeightOverflow { epoch: Epoch, epoch_length: u64 },
 }
 
 enum BlockchainProgression {
@@ -1076,7 +1098,7 @@ enum BlockchainProgression {
 mod tests {
     use std::{
         collections::{HashMap, VecDeque},
-        sync::{Arc, Mutex},
+        sync::{Arc, Mutex, atomic::AtomicU64},
         time::Duration,
     };
 
@@ -1090,14 +1112,14 @@ mod tests {
         types::{BaseLayerConsensusConstants, BaseLayerMetadata, BaseLayerValidatorNode, SideChainUtxos},
     };
     use tari_common_types::types::FixedHash;
-    use tari_epoch_manager::epoch_event_oracle::EpochEvent;
+    use tari_epoch_manager::epoch_event_oracle::{EpochEvent, EpochEventOracle};
     use tari_node_components::blocks::BlockHeader;
     use tari_ootle_common_types::Epoch;
     use tari_ootle_storage::global::BlockHeaderModel;
     use tari_template_lib::types::crypto::RistrettoPublicKeyBytes;
     use tari_transaction_components::{tari_amount::MicroMinotari, transaction_components::CodeTemplateRegistration};
 
-    use super::{BaseLayerOracleInner, hash_header};
+    use super::{BaseLayerOracle, BaseLayerOracleInner, hash_header, lookup_epoch_boundary_hash};
     use crate::{
         base_layer::{
             BaseLayerBlockHeaderStore,
@@ -1357,23 +1379,27 @@ mod tests {
         header
     }
 
+    fn make_config(height_lag: u64) -> BaseLayerEpochOracleConfig {
+        BaseLayerEpochOracleConfig {
+            start_height: 0,
+            height_lag,
+            scanning_interval: Duration::from_secs(1),
+            sidechain_id: None,
+            features: BaseLayerEpochOracleFeatures {
+                sync_headers: true,
+                sync_validator_node_changes: false,
+            },
+            epoch_end_spread_blocks: 0,
+        }
+    }
+
     fn make_inner(
         store: InMemoryStore,
         client: MockBaseNode,
         height_lag: u64,
     ) -> BaseLayerOracleInner<InMemoryStore, MockBaseNode> {
         BaseLayerOracleInner {
-            config: BaseLayerEpochOracleConfig {
-                start_height: 0,
-                height_lag,
-                scanning_interval: Duration::from_secs(1),
-                sidechain_id: None,
-                features: BaseLayerEpochOracleFeatures {
-                    sync_headers: true,
-                    sync_validator_node_changes: false,
-                },
-                epoch_end_spread_blocks: 0,
-            },
+            config: make_config(height_lag),
             store,
             last_scanned_height: 0,
             last_scanned_tip: None,
@@ -1385,7 +1411,7 @@ mod tests {
             pending_events: VecDeque::new(),
             header_buf: Vec::new(),
             network: NETWORK,
-            cached_epoch_length: None,
+            epoch_length: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -1411,28 +1437,28 @@ mod tests {
         let store = InMemoryStore::default();
         let chain = linear_chain(0..=20);
         let client = MockBaseNode::new(chain.clone());
-        let mut inner = make_inner(store.clone(), client, 5);
+        let mut oracle = BaseLayerOracle::new(store.clone(), client, make_config(5), NETWORK);
 
-        // sync_to_tip drops the emitted events, standing in for an epoch manager that has scanned the
-        // boundary but not yet applied the resulting EpochChanged.
+        // Taking `inner` stands in for a scan task owning it: the boundary lookup must not depend on
+        // it, and dropping the emitted events stands in for an epoch manager that has not yet applied
+        // the EpochChanged those scans produced.
+        let mut inner = oracle.inner.take().expect("inner is Some before any scan");
         sync_to_tip(&mut inner).await;
         assert_eq!(inner.last_scanned_height, 15);
+        assert!(oracle.inner.is_none());
 
-        // Epoch 3 opens at height 15, which we have scanned.
+        // Epoch 3 opens at height 15, which the scan has crossed.
         assert_eq!(
-            inner.observed_epoch_boundary_hash(Epoch(3)).unwrap(),
+            oracle.observed_epoch_boundary_hash(Epoch(3)).unwrap(),
             Some(hash_header(NETWORK, &chain[15]))
         );
-        // Epoch 4 opens at height 20, above our lagged scan position.
-        assert_eq!(inner.observed_epoch_boundary_hash(Epoch(4)).unwrap(), None);
+        // Epoch 4 opens at height 20, above the lagged scan position.
+        assert_eq!(oracle.observed_epoch_boundary_hash(Epoch(4)).unwrap(), None);
     }
 
     #[tokio::test]
     async fn observed_boundary_hash_rejects_a_first_header_that_is_not_the_boundary() {
         let store = InMemoryStore::default();
-        let client = MockBaseNode::new(linear_chain(0..=20));
-        let mut inner = make_inner(store.clone(), client, 5);
-        inner.cached_epoch_length = Some(EPOCH_LENGTH);
 
         // A scan range opening mid-epoch makes height 12 epoch 2's lowest stored header; the epoch's
         // boundary at height 10 was never scanned, so there is nothing to ratify against.
@@ -1446,7 +1472,12 @@ mod tests {
             }])
             .unwrap();
 
-        assert_eq!(inner.observed_epoch_boundary_hash(Epoch(2)).unwrap(), None);
+        assert_eq!(
+            lookup_epoch_boundary_hash(&store, EPOCH_LENGTH, Epoch(2)).unwrap(),
+            None
+        );
+        // Before the first scan obtains the L1 constants the opening height is unknown.
+        assert_eq!(lookup_epoch_boundary_hash(&store, 0, Epoch(2)).unwrap(), None);
     }
 
     #[tokio::test]

--- a/crates/epoch_oracles/src/base_layer/oracle.rs
+++ b/crates/epoch_oracles/src/base_layer/oracle.rs
@@ -885,6 +885,17 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore, TClient: BaseNodeClie
         }
     }
 
+    /// Returns the boundary block hash we have stored for `epoch`, or `None` if we have not scanned
+    /// it. The stored header only counts as the boundary when its height is exactly the epoch's first
+    /// height: a scan range that starts mid-epoch stores a first header that is not the boundary, and
+    /// ratifying against that would compare the wrong hash.
+    fn observed_epoch_boundary_hash(&self, epoch: Epoch) -> Option<FixedHash> {
+        let epoch_length = self.cached_epoch_length?;
+        let boundary_height = epoch.as_u64().checked_mul(epoch_length)?;
+        let boundary = self.store.get_first_block_header_in_epoch(epoch).ok()??;
+        (boundary.height == boundary_height).then_some(boundary.block_hash)
+    }
+
     /// Returns true when our lagged scanner position is within `epoch_end_spread_blocks` of the
     /// next epoch boundary. Used by consensus to accept `EndEpoch` proposals speculatively when
     /// peers' oracles have already crossed and ours is almost there.
@@ -1018,6 +1029,12 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + Send + 'static, TCli
             .as_deref()
             .map(|inner| inner.is_within_epoch_end_spread(current_epoch))
             .unwrap_or(false)
+    }
+
+    fn observed_epoch_boundary_hash(&self, epoch: Epoch) -> Option<FixedHash> {
+        // `inner` is briefly None while a scan task is in flight; the voter then falls back to the
+        // activated epoch hash alone.
+        self.inner.as_deref()?.observed_epoch_boundary_hash(epoch)
     }
 }
 
@@ -1372,6 +1389,49 @@ mod tests {
 
     fn linear_chain(heights: std::ops::RangeInclusive<u64>) -> Vec<BlockHeader> {
         heights.map(|h| make_header(h, h)).collect()
+    }
+
+    #[tokio::test]
+    async fn observed_boundary_hash_is_readable_before_the_epoch_is_activated() {
+        let store = InMemoryStore::default();
+        let chain = linear_chain(0..=20);
+        let client = MockBaseNode::new(chain.clone());
+        let mut inner = make_inner(store.clone(), client, 5);
+
+        // sync_to_tip drops the emitted events, standing in for an epoch manager that has scanned the
+        // boundary but not yet applied the resulting EpochChanged.
+        sync_to_tip(&mut inner).await;
+        assert_eq!(inner.last_scanned_height, 15);
+
+        // Epoch 3 opens at height 15, which we have scanned.
+        assert_eq!(
+            inner.observed_epoch_boundary_hash(Epoch(3)),
+            Some(hash_header(NETWORK, &chain[15]))
+        );
+        // Epoch 4 opens at height 20, above our lagged scan position.
+        assert_eq!(inner.observed_epoch_boundary_hash(Epoch(4)), None);
+    }
+
+    #[tokio::test]
+    async fn observed_boundary_hash_rejects_a_first_header_that_is_not_the_boundary() {
+        let store = InMemoryStore::default();
+        let client = MockBaseNode::new(linear_chain(0..=20));
+        let mut inner = make_inner(store.clone(), client, 5);
+        inner.cached_epoch_length = Some(EPOCH_LENGTH);
+
+        // A scan range opening mid-epoch makes height 12 epoch 2's lowest stored header; the epoch's
+        // boundary at height 10 was never scanned, so there is nothing to ratify against.
+        store
+            .add_block_headers([BlockHeaderModel {
+                epoch: Epoch(2),
+                height: 12,
+                block_hash: FixedHash::default(),
+                kernel_merkle_root: FixedHash::default(),
+                validator_node_merkle_root: FixedHash::default(),
+            }])
+            .unwrap();
+
+        assert_eq!(inner.observed_epoch_boundary_hash(Epoch(2)), None);
     }
 
     #[tokio::test]

--- a/crates/epoch_oracles/src/hybrid/oracle.rs
+++ b/crates/epoch_oracles/src/hybrid/oracle.rs
@@ -84,7 +84,7 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + Send + 'static> Epoc
         self.base_layer.is_within_epoch_end_spread(current_epoch)
     }
 
-    fn observed_epoch_boundary_hash(&self, epoch: Epoch) -> Option<FixedHash> {
+    fn observed_epoch_boundary_hash(&self, epoch: Epoch) -> anyhow::Result<Option<FixedHash>> {
         // Epoch boundaries in hybrid mode are scanned by the base-layer oracle; defer to it.
         self.base_layer.observed_epoch_boundary_hash(epoch)
     }

--- a/crates/epoch_oracles/src/hybrid/oracle.rs
+++ b/crates/epoch_oracles/src/hybrid/oracle.rs
@@ -2,6 +2,7 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use log::*;
+use tari_common_types::types::FixedHash;
 use tari_epoch_manager::epoch_event_oracle::{EpochEvent, EpochEventOracle};
 use tari_ootle_common_types::Epoch;
 use tokio::sync::mpsc;
@@ -81,5 +82,10 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + Send + 'static> Epoc
     fn is_within_epoch_end_spread(&self, current_epoch: Epoch) -> bool {
         // Epoch timing in hybrid mode is driven by the base-layer scanner; defer to it.
         self.base_layer.is_within_epoch_end_spread(current_epoch)
+    }
+
+    fn observed_epoch_boundary_hash(&self, epoch: Epoch) -> Option<FixedHash> {
+        // Epoch boundaries in hybrid mode are scanned by the base-layer oracle; defer to it.
+        self.base_layer.observed_epoch_boundary_hash(epoch)
     }
 }

--- a/crates/epoch_oracles/src/lib.rs
+++ b/crates/epoch_oracles/src/lib.rs
@@ -1,7 +1,9 @@
 //    Copyright 2025 The Tari Project
 //    SPDX-License-Identifier: BSD-3-Clause
 
+use tari_common_types::types::FixedHash;
 use tari_epoch_manager::epoch_event_oracle::{EpochEvent, EpochEventOracle};
+use tari_ootle_common_types::Epoch;
 
 use crate::{configured::RealTimeEpochTicker, store::EpochOracleStore};
 
@@ -33,6 +35,14 @@ where
             EpochOracle::Hybrid(hybrid) => hybrid.next_epoch_event().await,
         }
     }
+
+    fn observed_epoch_boundary_hash(&self, epoch: Epoch) -> Option<FixedHash> {
+        match self {
+            EpochOracle::BaseLayer(base_layer) => base_layer.observed_epoch_boundary_hash(epoch),
+            EpochOracle::Configured(configured) => configured.observed_epoch_boundary_hash(epoch),
+            EpochOracle::Hybrid(hybrid) => hybrid.observed_epoch_boundary_hash(epoch),
+        }
+    }
 }
 
 #[cfg(not(feature = "base_layer"))]
@@ -42,6 +52,12 @@ where TStore: EpochOracleStore + Send + 'static
     async fn next_epoch_event(&mut self) -> Option<EpochEvent> {
         match self {
             EpochOracle::Configured(configured) => configured.next_epoch_event().await,
+        }
+    }
+
+    fn observed_epoch_boundary_hash(&self, epoch: Epoch) -> Option<FixedHash> {
+        match self {
+            EpochOracle::Configured(configured) => configured.observed_epoch_boundary_hash(epoch),
         }
     }
 }

--- a/crates/epoch_oracles/src/lib.rs
+++ b/crates/epoch_oracles/src/lib.rs
@@ -36,7 +36,7 @@ where
         }
     }
 
-    fn observed_epoch_boundary_hash(&self, epoch: Epoch) -> Option<FixedHash> {
+    fn observed_epoch_boundary_hash(&self, epoch: Epoch) -> anyhow::Result<Option<FixedHash>> {
         match self {
             EpochOracle::BaseLayer(base_layer) => base_layer.observed_epoch_boundary_hash(epoch),
             EpochOracle::Configured(configured) => configured.observed_epoch_boundary_hash(epoch),
@@ -55,7 +55,7 @@ where TStore: EpochOracleStore + Send + 'static
         }
     }
 
-    fn observed_epoch_boundary_hash(&self, epoch: Epoch) -> Option<FixedHash> {
+    fn observed_epoch_boundary_hash(&self, epoch: Epoch) -> anyhow::Result<Option<FixedHash>> {
         match self {
             EpochOracle::Configured(configured) => configured.observed_epoch_boundary_hash(epoch),
         }


### PR DESCRIPTION
## Problem

Voting for an `EndEpoch` block needs the voter's own view of the next epoch's boundary hash (`expected_next_epoch_hash`). It was read with `get_epoch_hash(current_epoch + 1)`, which reads the `epochs` table. That row is written by `EpochManager::insert_current_epoch`, and the same call does `set_current_epoch(epoch)` — so "I know epoch E+1's hash" was exactly "I have activated epoch E+1".

The scanner stores the boundary header before the resulting `EpochChanged` event is applied. During a catch-up that event can sit behind several epoch activations, each running `assign_validators_for_epoch` and busting the committee cache. A node in that window has genuinely scanned the boundary block and can check the proposed hash against it, but no-voted with `NoVoteReason::EndOfEpochHashNotObserved`.

## Change

- `EpochEventOracle::observed_epoch_boundary_hash(epoch)` — new trait method, default `None`. The base layer oracle answers it from the header store it already keeps, via the existing `get_first_block_header_in_epoch`. A stored header only counts as the boundary when its height is exactly `epoch * epoch_length`, so a scan range opening mid-epoch does not ratify against the wrong hash (the same guard `reset_last_epoch_hash_to_boundary` already applies).
- The store handle and the epoch length live on `BaseLayerOracle`, not in `inner`. `poll_next_event` moves `inner` into the scan task for the whole of each batch, so a lookup that went through `inner` would answer `None` for the duration of every gRPC fetch — the exact catch-up window this PR targets. The epoch length is a shared `AtomicU64`; zero is the pre-constants state the old `Option` spelled `None`.
- `EpochManagerReader::get_observed_epoch_hash(epoch)` — the activated hash when the epoch has been activated (it is the one the self-healing correction maintains and `lock_epoch` freezes), otherwise the observed boundary. Precedence lives in the epoch manager, where both sources are, so consensus makes one call.
- `can_propose_epoch_end` accepts the observed boundary too. Without this the fix is inert: a node in the window would clear ratification and then no-vote at `NotEndOfEpoch`.
- A store failure is an error, not `None` — folding it in made an unreadable store look like a node that had not scanned yet, so the epoch stalled with nothing pointing at the store. It surfaces as `EpochManagerError::EpochEventOracleError`, which is how the activated-hash path beside it already behaves. An epoch whose boundary height overflows reports `EpochHeightOverflow` for the same reason: epochs are `height / epoch_length`, so that is a corrupt epoch, not a large chain.

No change to what a node will ratify: it still only votes for a hash it has seen itself, never one taken on the leader's word.

## Scope: this helps the committee, not the lagging node's own recovery

A node that votes from an observed boundary commits the EOE while `get_epoch_hash(next_epoch)` is still `None`, so `process_end_of_epoch` defers rather than stamping the next genesis and calling `lock_epoch`. `try_resume_pending_end_of_epoch` fires from `EpochManagerEvent::EpochChanged`, published by `on_scanning_complete` on `EpochEvent::DoneForNow` — emitted only once the scan reaches the lagged tip. So on a multi-batch catch-up the node votes and commits promptly but does not open the next epoch until the whole catch-up finishes, even though the activation it is waiting for lands moments later in the queue.

That is the intended scope: the committee gets its quorum instead of stalling on a member that could verify the boundary all along. Accelerating the lagging node's own transition is a separate change to the resume trigger.

Deferring `lock_epoch(next_epoch)` to the resume also widens the window in which `activate_epoch`'s self-healing correction could store a hash other than the one the committee committed. It needs a reorg landing between the queued activation and the resume, so I do not think it is reachable, but it is wider than it was.

## Note for #2568

The `EpochOracle` enum dispatcher in `crates/epoch_oracles/src/lib.rs` does not forward `is_within_epoch_end_spread`, so every variant falls through to the default `false`. That is a second, independent reason `epoch_end_spread_blocks` cannot affect a vote today — the knob never reaches the base layer oracle at all. Deliberately not fixed here, since #2568 proposes removing it; the new method is forwarded through the enum.

## Test plan

- [x] `cargo test -p tari_epoch_oracles --lib --features base_layer` — the boundary is readable with `inner` taken away (the scan-in-flight regression), a first-stored-header that is not the boundary height yields `None`, and so does the pre-constants state
- [x] `cargo test -p consensus_tests epoch_change` — 7 passed, including the new `epoch_change_observed_boundary_is_voted_before_activation`, which fails when the `can_propose_epoch_end` term is removed
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHLL5F3fKuzsMcdJdquy6R
