### PR TITLE
fix(consensus): apply foreign proposal updates when proposing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11874,6 +11874,7 @@ dependencies = [
  "tari_state_tree",
  "tari_template_lib_types",
  "thiserror 2.0.18",
+ "time",
  "tokio",
 ]
 

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -30,3 +30,6 @@ log = { workspace = true }
 serde = { workspace = true, default-features = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, default-features = false, features = ["sync", "time", "macros", "rt"] }
+
+[dev-dependencies]
+time = { workspace = true }

--- a/crates/consensus/src/hotstuff/block_change_set.rs
+++ b/crates/consensus/src/hotstuff/block_change_set.rs
@@ -324,13 +324,16 @@ impl ProposedBlockChangeSet {
     /// The rest of each transaction's change — the pending pool update, foreign pledges, evidence — stays in
     /// the change set. Those describe state that later commands in the same block are evaluated against, so
     /// they must outlive the executions that were produced alongside them.
-    pub fn take_transaction_executions(&mut self) -> impl Iterator<Item = (TransactionId, TransactionExecution)> + '_ {
-        self.transaction_changes.iter_mut().filter_map(|(tx_id, change)| {
-            change
-                .execution
-                .take()
-                .map(|execution| (*tx_id, execution.into_transaction_execution()))
-        })
+    pub fn take_transaction_executions(&mut self) -> Vec<(TransactionId, TransactionExecution)> {
+        self.transaction_changes
+            .iter_mut()
+            .filter_map(|(tx_id, change)| {
+                change
+                    .execution
+                    .take()
+                    .map(|execution| (*tx_id, execution.into_transaction_execution()))
+            })
+            .collect()
     }
 
     pub fn add_transaction_execution(
@@ -656,8 +659,9 @@ mod tests {
 
     use tari_consensus_types::Decision;
     use tari_engine_types::commit_result::AbortReason;
-    use tari_ootle_common_types::{Epoch, NumPreshards};
-    use tari_ootle_storage::consensus_models::TransactionPoolStage;
+    use tari_ootle_common_types::{Epoch, NumPreshards, VersionedSubstateId};
+    use tari_ootle_storage::consensus_models::{SubstatePledge, TransactionPoolStage};
+    use tari_template_lib_types::ComponentAddress;
 
     use super::*;
 
@@ -673,15 +677,26 @@ mod tests {
 
         let mut aborted = local_prepared_record();
         aborted.set_local_decision(Decision::Abort(AbortReason::ExecutionFailure));
+        let transaction_id = *aborted.id();
         change_set.set_next_transaction_update(aborted).unwrap();
+        change_set.add_foreign_pledges(&transaction_id, ShardGroup::all_shards(NumPreshards::P256), vec![
+            SubstatePledge::Output {
+                substate_id: VersionedSubstateId::new(SubstateId::Component(ComponentAddress::from_array([1; 32])), 0),
+            },
+        ]);
 
-        assert_eq!(change_set.take_transaction_executions().count(), 0);
+        assert_eq!(change_set.take_transaction_executions().len(), 0);
 
         let mut committing = local_prepared_record();
         change_set.apply_transaction_update(&mut committing);
         assert!(
             committing.current_decision().is_abort(),
             "pending update must survive execution harvesting so later commands in the block see it"
+        );
+        assert_eq!(
+            change_set.get_foreign_pledges(&transaction_id).count(),
+            1,
+            "foreign pledges must survive execution harvesting so the transaction can still be executed"
         );
     }
 

--- a/crates/consensus/src/hotstuff/block_change_set.rs
+++ b/crates/consensus/src/hotstuff/block_change_set.rs
@@ -319,14 +319,17 @@ impl ProposedBlockChangeSet {
             .and_then(|change| change.execution.take())
     }
 
-    pub fn take_all_transaction_executions(
-        &mut self,
-    ) -> impl Iterator<Item = (TransactionId, TransactionExecution)> + '_ {
-        self.transaction_changes.drain(..).filter_map(|(tx_id, mut change)| {
+    /// Removes the execution recorded for each transaction and yields it.
+    ///
+    /// The rest of each transaction's change — the pending pool update, foreign pledges, evidence — stays in
+    /// the change set. Those describe state that later commands in the same block are evaluated against, so
+    /// they must outlive the executions that were produced alongside them.
+    pub fn take_transaction_executions(&mut self) -> impl Iterator<Item = (TransactionId, TransactionExecution)> + '_ {
+        self.transaction_changes.iter_mut().filter_map(|(tx_id, change)| {
             change
                 .execution
                 .take()
-                .map(|execution| (tx_id, execution.into_transaction_execution()))
+                .map(|execution| (*tx_id, execution.into_transaction_execution()))
         })
     }
 
@@ -651,7 +654,58 @@ impl TransactionChangeSet {
 mod tests {
     use std::mem::size_of;
 
+    use tari_consensus_types::Decision;
+    use tari_engine_types::commit_result::AbortReason;
+    use tari_ootle_common_types::{Epoch, NumPreshards};
+    use tari_ootle_storage::consensus_models::TransactionPoolStage;
+
     use super::*;
+
+    #[test]
+    fn taking_executions_keeps_the_pending_transaction_update() {
+        let leaf = LeafBlock {
+            block_id: BlockId::zero(),
+            height: NodeHeight(1),
+            epoch: Epoch(1),
+            shard_group: ShardGroup::all_shards(NumPreshards::P256),
+        };
+        let mut change_set = ProposedBlockChangeSet::new(leaf);
+
+        let mut aborted = local_prepared_record();
+        aborted.set_local_decision(Decision::Abort(AbortReason::ExecutionFailure));
+        change_set.set_next_transaction_update(aborted).unwrap();
+
+        assert_eq!(change_set.take_transaction_executions().count(), 0);
+
+        let mut committing = local_prepared_record();
+        change_set.apply_transaction_update(&mut committing);
+        assert!(
+            committing.current_decision().is_abort(),
+            "pending update must survive execution harvesting so later commands in the block see it"
+        );
+    }
+
+    fn local_prepared_record() -> TransactionPoolRecord {
+        TransactionPoolRecord::load(
+            TransactionId::new([1; 32]),
+            Evidence::default(),
+            false,
+            0,
+            None,
+            TransactionPoolStage::LocalPrepared,
+            None,
+            Decision::Commit,
+            None,
+            None,
+            true,
+            Epoch(1),
+            None,
+            time::OffsetDateTime::now_utc(),
+            None,
+            0,
+            0,
+        )
+    }
 
     #[test]
     fn check_max_mem_usage() {

--- a/crates/consensus/src/hotstuff/on_propose.rs
+++ b/crates/consensus/src/hotstuff/on_propose.rs
@@ -416,9 +416,9 @@ where TConsensusSpec: ConsensusSpec
         // No need to include evidence from justified block if no transactions are included in the next block
         if !batch.transactions.is_empty() {
             // A replica evaluates this block as: the newly justified block, then the commands in block order
-            // (foreign proposals first, see `Command`'s ordering), all against a single change set. The
-            // commands generated below must be derived from that same sequence, or the proposer commits to
-            // an atom no replica can reproduce and the block is unvotable.
+            // (foreign proposals sort before the transaction commands, see `Command`'s ordering), all against
+            // a single change set. The commands generated below must be derived from that same sequence, or
+            // the proposer commits to an atom no replica can reproduce and the block is unvotable.
             // TODO: we dont need to process transactions here that are not in the batch
             process_newly_justified_block(tx, &justify_block, high_qc_id, local_committee_info, &mut change_set)?;
 

--- a/crates/consensus/src/hotstuff/on_propose.rs
+++ b/crates/consensus/src/hotstuff/on_propose.rs
@@ -415,11 +415,13 @@ where TConsensusSpec: ConsensusSpec
 
         // No need to include evidence from justified block if no transactions are included in the next block
         if !batch.transactions.is_empty() {
-            // TODO(protocol-efficiency): We should process any foreign proposals included in this block to include
-            // evidence. And that should determine if they are ready. However this is difficult because we
-            // get the batch from the database which isnt aware of which foreign proposals we're going to
-            // propose. This is why the system currently never proposes foreign proposals affecting a
-            // transaction in the same block for LocalPrepare/LocalAccept.
+            // A replica evaluates this block as: the newly justified block, then the commands in block order
+            // (foreign proposals first, see `Command`'s ordering), all against a single change set. The
+            // commands generated below must be derived from that same sequence, or the proposer commits to
+            // an atom no replica can reproduce and the block is unvotable.
+            // TODO: we dont need to process transactions here that are not in the batch
+            process_newly_justified_block(tx, &justify_block, high_qc_id, local_committee_info, &mut change_set)?;
+
             for fp in &batch.foreign_proposals {
                 if let Err(err) = process_foreign_block(
                     tx,
@@ -440,10 +442,7 @@ where TConsensusSpec: ConsensusSpec
             }
 
             // Add all (ABORT) executions that may have resulted from foreign proposals
-            executed_transactions.extend(change_set.take_all_transaction_executions());
-
-            // TODO: we dont need to process transactions here that are not in the batch
-            process_newly_justified_block(tx, &justify_block, high_qc_id, local_committee_info, &mut change_set)?;
+            executed_transactions.extend(change_set.take_transaction_executions());
         }
 
         let locked_epoch = LockedEpoch::new(
@@ -498,8 +497,10 @@ where TConsensusSpec: ConsensusSpec
                 );
                 break;
             }
-            // Apply the transaction updates (if any) that occurred as a result of the justified block.
-            // This allows us to propose evidence in the next block that relates to transactions in the justified block.
+            // Apply the transaction updates (if any) that the justified block and this block's foreign
+            // proposals produced. This allows us to propose evidence relating to transactions in the
+            // justified block, and to propose a transaction that a foreign proposal in this block has just
+            // moved to ABORT with the decision that move implies.
             change_set.apply_transaction_update(&mut transaction);
             // Capture before the record is moved. The processing work below (incl. execution) is incurred
             // whether or not a command is produced, so accumulate for every processed transaction.


### PR DESCRIPTION
## Problem

CI run [34367513887](https://github.com/tari-project/tari-ootle/actions/runs/34367513887/job/102519956391) timed out in `consensus::foreign_shard_group_decides_to_abort` — not an assertion, a stall. The committee wedged at `high_qc = NodeHeight(6)` and never formed another QC, spinning dummy blocks until nextest's 600s kill (14 GB of log).

Every block from height 7 on drew zero votes:

```
❌ NO VOTE LocalAccept: transaction fee disagreement tx 38608720… in block [NodeHeight(7) …].
   Leader proposed 5, we calculated 0
```

Block 7 carried two commands for the same transaction: `ForeignProposal(…)` (the foreign committee's `LocalAccept(…, Abort)`) and `LocalAccept(tx)`.

## Cause

A replica evaluates a block as: newly justified block, then commands in block order — foreign proposals first, which `Command`'s ordering explicitly arranges ("Foreign proposals should come first in the block so that they are processed before commands") — all against **one** change set.

`on_propose` did the opposite. It processed foreign proposals, then called `take_all_transaction_executions`, whose `drain(..)` emptied the change set and discarded every pending pool update and foreign pledge it had just recorded, and only then processed the justified block. `apply_transaction_update` in the command loop was left with nothing to apply.

So the leader's record still read `Commit`, the `is_abort()` early return in `local_accept_transaction` was skipped, it executed the transaction and committed to `transaction_fee: 5`. Replicas applied the foreign abort and computed `0`. Nobody voted — including the proposer. The next leader rebuilt the identical block from the same still-pending inputs, so the stall is stable, not transient.

The `TODO` asserting "the system currently never proposes foreign proposals affecting a transaction in the same block for LocalPrepare/LocalAccept" was never enforced — `fetch_next_proposal_batch` picks foreign proposals and the transaction batch independently.

## Fix

Make the proposer's sequence match the replica's: process the justified block first, then the foreign proposals, then harvest executions without clearing the rest of each transaction's change. Commands are now derived from the same state the replica will evaluate them against.

This also restores the foreign pledges arriving in the block being built, which `execute_transaction` reads via `change_set.get_foreign_pledges` and the drain was throwing away.

## Compatibility

No format change — no header field, no encoding, no `hash_substate` input moves; not a `ProtocolVersion` matter and needs no activation entry.

The only blocks whose content differs are ones no honest replica votes for, and a block that never gathers a QC is never committed. Every block that can carry a QC is unchanged, so:

- **No reset, no re-sync.** Indexers consume committed blocks and substates; neither changes.
- **Mixed fleet is safe.** The replica evaluation path is untouched and was always the correct one. An old-code replica votes for a new-code leader's proposal; a new-code replica still refuses an old-code leader's stale one. Liveness returns proportionally as leaders upgrade — no coordinated rollout.

A chain currently wedged this way recovers through ordinary leader-failure/TC recovery once an upgraded node takes a turn as leader.

## Testing

- New unit test `taking_executions_keeps_the_pending_transaction_update` — fails on the old `drain(..)`, passes on the fix (verified both ways).
- `cargo test -p consensus_tests` — 67 passed, 0 failed.
- `cargo test -p tari_consensus --lib` — 22 passed, 0 failed.
- `cargo lints clippy -p tari_consensus --all-targets` — clean.

No deterministic reproduction of the original stall is included. Landing the two commands in one block depends on the foreign proposal arriving inside the window where the transaction is already `LocalPrepared`-ready, and `foreign_shard_group_decides_to_abort` only hits it occasionally — it is what caught this, but it is not a reliable guard. The unit test pins the specific invariant that broke instead.

## Note

Unrelated to #2569, which was merely the PR whose CI run surfaced it. That diff is one line in the LocalNet activation schedule; `ProtocolVersion` is not read anywhere on this path, 712 of 713 tests passed on the same shard under it, and the `drain(..)` dates to #1447 (June 2025).
