### PR TITLE
fix(consensus): anchor propose-time foreign proposal processing at the state anchor

### DIFF
--- a/crates/consensus/src/hotstuff/on_propose.rs
+++ b/crates/consensus/src/hotstuff/on_propose.rs
@@ -363,8 +363,9 @@ where TConsensusSpec: ConsensusSpec
         let mut total_leader_fee = 0u64;
         // When filling a timeout gap with a dummy chain, the candidate effectively extends from justify_block (the
         // dummies are empty blocks that carry justify_block's accumulated_data and state forward — see
-        // `calculate_last_dummy_block`). Anchor accumulated_data, the substate store, and the pending state tree
-        // diff lookup at justify_block to match what validators recompute from the reconstructed dummy chain.
+        // `calculate_last_dummy_block`). Anchor accumulated_data, the substate store, the pending state tree
+        // diff lookup and propose-time foreign proposal processing at justify_block to match what validators
+        // recompute from the reconstructed dummy chain.
         // Otherwise speculative state and leader-fee burn that accumulated on a locally-stored fork above the high QC
         // would be incorrectly carried into the new candidate and validators would reject with either an
         // exhaust-burn mismatch or a state Merkle-root mismatch.
@@ -423,9 +424,13 @@ where TConsensusSpec: ConsensusSpec
             process_newly_justified_block(tx, &justify_block, high_qc_id, local_committee_info, &mut change_set)?;
 
             for fp in &batch.foreign_proposals {
+                // Resolves pending transaction pool records along the chain up to this block, so it must be
+                // the anchor the substate store this call also writes to is built on: the justify block
+                // under a dummy chain, the extended leaf otherwise. A replica passes the block it is
+                // evaluating, whose parent chain runs back through any dummies to the justify block.
                 if let Err(err) = process_foreign_block(
                     tx,
-                    &high_qc_certificate.as_leaf_block(),
+                    &state_anchor_leaf,
                     fp,
                     local_committee_info,
                     &mut substate_store,


### PR DESCRIPTION
Raised in review of #2573 as a pre-existing gap of the same class. Independent of that PR — different lines, no conflict, either can land first.

## Problem

`process_foreign_block` uses the `LeafBlock` it is given for exactly one thing: resolving the transaction pool record, via `get_transaction_pool_record` → `transaction_pool_get_for_blocks(to_block_id, …)`, which walks pending updates along the chain *up to that block*. It also mutates the `PendingSubstateStore` it is handed.

The proposer passed it `high_qc_certificate.as_leaf_block()` — the justify block — while everything else in `build_next_block` works at a different point:

| | anchored at |
|---|---|
| substate store (`:383`) | `state_anchor_leaf` |
| `accumulated_data` (`:376`) | justify block / `highest_seen_block` |
| proposal batch (`fetch_next_proposal_batch`) | `start_of_chain_block` |
| change set (`:414`) | `start_of_chain_block` |
| command generation (`:514`) | `start_of_chain_block` |
| **`process_foreign_block` (`:428`)** | **justify block, unconditionally** |

So the records it read and the store it wrote could describe different points in the chain. A replica has no such split: `on_ready_to_vote_on_local_block.rs:1594` passes `local_block.as_leaf()`, the block under evaluation, covering its whole parent chain.

## Fix

Pass `state_anchor_leaf`, which is already the value that expresses this idea — the justify block when a dummy chain carries `justify_block`'s state forward, the extended leaf otherwise — and already anchors `accumulated_data`, the substate store and the pending state tree diff lookup.

## Scope of the behaviour change

Deliberately narrow. `state_anchor_leaf` equals the old argument in both common cases:

- **Steady state** — the leader holds a QC for its own leaf, so justify == leaf. Identical.
- **Dummy chain** (`dummy_block.is_some()`) — `state_anchor_leaf` *is* `justify_block.as_leaf()`. Identical.

The only case that changes is a leader extending an unjustified leaf above the high QC without a dummy chain. There the proposer previously resolved pool records as of the justify block, missing pending updates from the blocks between it and the leaf that the replica will see. Now both read the same point.

## Compatibility

No format change, no `hash_substate` input change, no `ProtocolVersion` involvement. Proposer-side state resolution only; replica evaluation is untouched, so a mixed fleet needs no coordination and nothing about committed history moves.

## Testing

- `cargo test -p consensus_tests` — 67 passed, 0 failed (covers the dummy-chain and leader-failure paths: `dummy_blocks.rs`, `leader_failure.rs`, `stale_qc_carry_forward.rs`).
- `cargo lints clippy -p tari_consensus --all-targets` — clean.

No new test. The divergent case needs a leader whose leaf sits above its high QC with no dummy fill *and* a foreign proposal for a transaction updated in that gap; the harness can build the first half but not reliably the second. The existing dummy-chain coverage pins the case where this must stay a no-op, which is the half that could regress.
