### PR TITLE
fix(engine)!: keep a callee's substates, buckets and proofs out of the caller's scope

### DIFF
--- a/crates/engine/src/runtime/auth.rs
+++ b/crates/engine/src/runtime/auth.rs
@@ -87,10 +87,6 @@ impl AuthorizationScope {
     pub fn contains_proof(&self, proof_id: &ProofId) -> bool {
         self.proofs.contains(proof_id)
     }
-
-    pub(super) fn update_from_child(&mut self, child: AuthorizationScope) {
-        self.proofs.extend(child.proofs);
-    }
 }
 
 impl Display for AuthorizationScope {

--- a/crates/engine/src/runtime/error.rs
+++ b/crates/engine/src/runtime/error.rs
@@ -320,6 +320,10 @@ pub enum RuntimeError {
     LockError(#[from] LockError),
     #[error("{count} substate locks were still active after call")]
     DanglingSubstateLocks { count: usize },
+    #[error("Bucket(s) {} were neither consumed nor returned by the call", .bucket_ids.iter().map(ToString::to_string).collect::<Vec<_>>().join(", "))]
+    UnreturnedBuckets { bucket_ids: Vec<BucketId> },
+    #[error("Proof(s) {} were neither dropped nor returned by the call", .proof_ids.iter().map(ToString::to_string).collect::<Vec<_>>().join(", "))]
+    UnreturnedProofs { proof_ids: Vec<ProofId> },
     #[error("No active call frame")]
     NoActiveCallFrame,
     #[error("Max call depth {max_depth} exceeded")]

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -356,7 +356,12 @@ impl<TStore: StateReader + Clone + 'static, TTemplateProvider: TemplateProvider<
                 let _ignore = state.get_bucket(*bucket_id)?;
             }
 
+            // `get_bucket` scope-checks; `get_proof` does not, so the frame's own scope is checked here to keep a
+            // returned proof to the same rule as a returned bucket.
             for proof_id in value.proof_ids() {
+                if !state.current_call_scope()?.is_proof_in_scope(proof_id) {
+                    return Err(RuntimeError::ProofNotInScope { proof_id: *proof_id });
+                }
                 let _ignore = state.get_proof(*proof_id)?;
             }
 

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -38,7 +38,7 @@ use tari_engine_types::{
     events::Event,
     fees::FeeReceipt,
     hashing::hash_template_code,
-    indexed_value::IndexedValue,
+    indexed_value::{IndexedValue, IndexedWellKnownTypes},
     instruction_result::InstructionResult,
     limits,
     lock::LockFlag,
@@ -3882,8 +3882,8 @@ where
         Ok(())
     }
 
-    fn pop_call_frame(&mut self) -> Result<(), RuntimeError> {
-        self.tracker.pop_call_frame()?;
+    fn pop_call_frame(&mut self, returned: &IndexedWellKnownTypes) -> Result<(), RuntimeError> {
+        self.tracker.pop_call_frame(returned)?;
         Ok(())
     }
 

--- a/crates/engine/src/runtime/mod.rs
+++ b/crates/engine/src/runtime/mod.rs
@@ -61,7 +61,7 @@ use tari_engine_types::{
     component::Component,
     confidential::{ClaimBurnOutputData, MinotariBurnClaimProof},
     fees::FeeReceipt,
-    indexed_value::IndexedValue,
+    indexed_value::{IndexedValue, IndexedWellKnownTypes},
     lock::LockFlag,
     published_template::TemplateBlob,
 };
@@ -219,7 +219,7 @@ pub trait RuntimeInterface {
     fn validate_return_value(&self, value: &IndexedValue) -> Result<(), RuntimeError>;
 
     fn push_call_frame(&mut self, frame: PushCallFrame) -> Result<(), RuntimeError>;
-    fn pop_call_frame(&mut self) -> Result<(), RuntimeError>;
+    fn pop_call_frame(&mut self, returned: &IndexedWellKnownTypes) -> Result<(), RuntimeError>;
     fn publish_template(
         &mut self,
         template: TemplateBlob,

--- a/crates/engine/src/runtime/scope.rs
+++ b/crates/engine/src/runtime/scope.rs
@@ -24,7 +24,20 @@ use crate::runtime::{
 pub struct CallScope {
     orphans: IndexSet<SubstateId>,
     owned: IndexSet<SubstateId>,
+    /// Substates that belong to a component rather than to this frame: seeded at push from the state of the
+    /// component the frame executes on, and extended as orphans are attached to a component's state. They are in
+    /// scope for this frame alone and are dropped when it is popped, so a component's vaults stay reachable only
+    /// from that component.
+    component_owned: IndexSet<SubstateId>,
     referenced: IndexSet<SubstateId>,
+    /// The proofs this frame holds. `auth_scope.proofs()` is the subset that is currently authorizing an action: a
+    /// `ProofAccess` guard leaves that subset when it is dropped while the proof itself is still held, so holding is
+    /// tracked separately from authorizing.
+    proof_scope: IndexSet<ProofId>,
+    /// Buckets and proofs the caller passed in as arguments. They remain the caller's: this frame may leave them
+    /// unconsumed, and the caller keeps them once the frame is popped.
+    inherited_buckets: IndexSet<BucketId>,
+    inherited_proofs: IndexSet<ProofId>,
     component_lock: Option<LockedSubstate>,
     lock_scope: IndexSet<LockId>,
     bucket_scope: IndexSet<BucketId>,
@@ -38,7 +51,11 @@ impl CallScope {
         Self {
             orphans: IndexSet::new(),
             owned: IndexSet::new(),
+            component_owned: IndexSet::new(),
             referenced: IndexSet::new(),
+            proof_scope: IndexSet::new(),
+            inherited_buckets: IndexSet::new(),
+            inherited_proofs: IndexSet::new(),
             component_lock: None,
             lock_scope: IndexSet::new(),
             bucket_scope: IndexSet::new(),
@@ -53,7 +70,11 @@ impl CallScope {
         this
     }
 
+    /// Installs the auth scope this frame starts with. Its proofs came from the frame's caller (the transaction's
+    /// base scope for a top-level instruction), so the caller accounts for them.
     pub(crate) fn set_auth_scope(&mut self, scope: AuthorizationScope) {
+        self.inherited_proofs.extend(scope.proofs().iter().copied());
+        self.proof_scope.extend(scope.proofs().iter().copied());
         self.auth_scope = scope;
     }
 
@@ -66,7 +87,7 @@ impl CallScope {
     }
 
     pub fn is_proof_in_scope(&self, proof_id: &ProofId) -> bool {
-        self.auth_scope.contains_proof(proof_id)
+        self.proof_scope.contains(proof_id)
     }
 
     pub fn is_bucket_in_scope(&self, bucket_id: BucketId) -> bool {
@@ -89,7 +110,10 @@ impl CallScope {
             return true;
         }
 
-        self.owned.contains(address) || self.referenced.contains(address) || self.orphans.contains(address)
+        self.owned.contains(address) ||
+            self.component_owned.contains(address) ||
+            self.referenced.contains(address) ||
+            self.orphans.contains(address)
     }
 
     pub fn add_lock_to_scope(&mut self, lock_id: LockId) {
@@ -116,8 +140,17 @@ impl CallScope {
         self.address_allocation_scope.swap_remove(&id)
     }
 
+    /// Brings a proof into this frame and authorizes it. A proof reaching a frame — created here, passed in as an
+    /// argument, or handed back by a callee — authorizes for the rest of the frame unless the frame drops the
+    /// authorization.
     pub fn add_proof_to_scope(&mut self, proof_id: ProofId) {
+        self.proof_scope.insert(proof_id);
         self.auth_scope_mut().add_proof(proof_id);
+    }
+
+    pub fn remove_proof_from_scope(&mut self, proof_id: &ProofId) {
+        self.proof_scope.swap_remove(proof_id);
+        self.auth_scope.remove_proof(proof_id);
     }
 
     pub fn remove_lock_from_scope(&mut self, lock_id: LockId) -> Result<(), RuntimeError> {
@@ -145,6 +178,17 @@ impl CallScope {
 
     pub fn move_node_to_owned(&mut self, address: &SubstateId) -> Result<(), RuntimeError> {
         if self.orphans.swap_remove(address) && !self.owned.insert(address.clone()) {
+            return Err(RuntimeError::DuplicateSubstate {
+                address: address.clone(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Records that `address` is now reachable from a component's state, so it stops being an orphan of this frame
+    /// and stays with the component when the frame is popped.
+    pub fn attach_node_to_component(&mut self, address: &SubstateId) -> Result<(), RuntimeError> {
+        if self.orphans.swap_remove(address) && !self.component_owned.insert(address.clone()) {
             return Err(RuntimeError::DuplicateSubstate {
                 address: address.clone(),
             });
@@ -206,14 +250,40 @@ impl CallScope {
         // }
     }
 
-    pub fn update_from_child_scope(&mut self, child: CallScope) {
+    /// Merges what a completed child frame hands back into this scope. Only substates the child created and still
+    /// holds loosely, plus the buckets and proofs named in its return value, cross the boundary: everything the child
+    /// could reach through a component's state stays behind with that component.
+    pub fn update_from_child_scope(&mut self, child: CallScope, returned: &IndexedWellKnownTypes) {
         self.owned.extend(child.owned.iter().cloned());
         for owned in &child.owned {
             self.orphans.swap_remove(owned);
         }
-        self.bucket_scope.extend(child.bucket_scope);
+        for bucket_id in returned.bucket_ids() {
+            if child.bucket_scope.contains(bucket_id) {
+                self.bucket_scope.insert(*bucket_id);
+            }
+        }
+        for proof_id in returned.proof_ids() {
+            if child.proof_scope.contains(proof_id) {
+                self.add_proof_to_scope(*proof_id);
+            }
+        }
         self.address_allocation_scope.extend(child.address_allocation_scope);
-        self.auth_scope.update_from_child(child.auth_scope);
+    }
+
+    /// The buckets this frame must account for before it is popped: those it holds that its caller did not lend it.
+    pub fn buckets_owed(&self) -> impl Iterator<Item = &BucketId> {
+        self.bucket_scope
+            .iter()
+            .filter(|id| !self.inherited_buckets.contains(*id))
+    }
+
+    /// The proofs this frame must account for before it is popped: those in its auth scope that its caller did not
+    /// lend it.
+    pub fn proofs_owed(&self) -> impl Iterator<Item = &ProofId> {
+        self.proof_scope
+            .iter()
+            .filter(|id| !self.inherited_proofs.contains(*id))
     }
 
     pub fn include_owned_in_scope(&mut self, values: &IndexedWellKnownTypes) {
@@ -222,7 +292,7 @@ impl CallScope {
             if addr.is_virtual() || addr.is_transaction_receipt() || addr.is_template() {
                 continue;
             }
-            self.add_substate_to_owned(addr);
+            self.component_owned.insert(addr);
         }
     }
 
@@ -237,9 +307,11 @@ impl CallScope {
 
         for bucket_id in values.bucket_ids() {
             self.add_bucket_to_scope(*bucket_id);
+            self.inherited_buckets.insert(*bucket_id);
         }
         for proof_id in values.proof_ids() {
             self.add_proof_to_scope(*proof_id);
+            self.inherited_proofs.insert(*proof_id);
         }
         for allocation in values.component_address_allocations() {
             self.add_address_allocation_to_scope(allocation.id());
@@ -264,6 +336,12 @@ impl Display for CallScope {
                 writeln!(f, "  {}", owned)?;
             }
         }
+        if !self.component_owned.is_empty() {
+            writeln!(f, "Component owned:")?;
+            for owned in &self.component_owned {
+                writeln!(f, "  {}", owned)?;
+            }
+        }
         if !self.referenced.is_empty() {
             writeln!(f, "Referenced:")?;
             for referenced in &self.referenced {
@@ -284,9 +362,9 @@ impl Display for CallScope {
             }
         }
 
-        if !self.auth_scope.proofs().is_empty() {
+        if !self.proof_scope.is_empty() {
             writeln!(f, "Proofs:")?;
-            for proof in self.auth_scope.proofs() {
+            for proof in &self.proof_scope {
                 writeln!(f, "  {}", proof)?;
             }
         }

--- a/crates/engine/src/runtime/scope.rs
+++ b/crates/engine/src/runtime/scope.rs
@@ -185,8 +185,10 @@ impl CallScope {
         Ok(())
     }
 
-    /// Records that `address` is now reachable from a component's state, so it stops being an orphan of this frame
-    /// and stays with the component when the frame is popped.
+    /// Records that an orphan of this frame is now reachable from a component's state, so it stays with the
+    /// component when the frame is popped. An address that is already owned — a root id such as a component or
+    /// resource the frame created — keeps its place in `owned` and still crosses to the caller; those are gated by
+    /// access rules rather than by scope.
     pub fn attach_node_to_component(&mut self, address: &SubstateId) -> Result<(), RuntimeError> {
         if self.orphans.swap_remove(address) && !self.component_owned.insert(address.clone()) {
             return Err(RuntimeError::DuplicateSubstate {
@@ -251,8 +253,12 @@ impl CallScope {
     }
 
     /// Merges what a completed child frame hands back into this scope. Only substates the child created and still
-    /// holds loosely, plus the buckets and proofs named in its return value, cross the boundary: everything the child
-    /// could reach through a component's state stays behind with that component.
+    /// holds loosely, plus the buckets, proofs and address allocations named in its return value, cross the
+    /// boundary: everything the child could reach through a component's state stays behind with that component.
+    ///
+    /// An allocation is as much a capability as a bucket — [`WorkingState::use_allocated_address`] gates on scope
+    /// membership alone, and nothing checks that the template consuming an allocation is the one that made it — so
+    /// it crosses on the same terms.
     pub fn update_from_child_scope(&mut self, child: CallScope, returned: &IndexedWellKnownTypes) {
         self.owned.extend(child.owned.iter().cloned());
         for owned in &child.owned {
@@ -268,7 +274,16 @@ impl CallScope {
                 self.add_proof_to_scope(*proof_id);
             }
         }
-        self.address_allocation_scope.extend(child.address_allocation_scope);
+        for allocation in returned.component_address_allocations() {
+            if child.address_allocation_scope.contains(&allocation.id()) {
+                self.address_allocation_scope.insert(allocation.id());
+            }
+        }
+        for allocation in returned.resource_address_allocations() {
+            if child.address_allocation_scope.contains(&allocation.id()) {
+                self.address_allocation_scope.insert(allocation.id());
+            }
+        }
     }
 
     /// The buckets this frame must account for before it is popped: those it holds that its caller did not lend it.
@@ -278,8 +293,9 @@ impl CallScope {
             .filter(|id| !self.inherited_buckets.contains(*id))
     }
 
-    /// The proofs this frame must account for before it is popped: those in its auth scope that its caller did not
-    /// lend it.
+    /// The proofs this frame must account for before it is popped: those it holds and its caller did not lend it.
+    /// Read from `proof_scope` rather than the auth scope, so a proof whose `ProofAccess` has been dropped is still
+    /// owed.
     pub fn proofs_owed(&self) -> impl Iterator<Item = &ProofId> {
         self.proof_scope
             .iter()

--- a/crates/engine/src/runtime/tracker.rs
+++ b/crates/engine/src/runtime/tracker.rs
@@ -343,8 +343,8 @@ impl<TStore: StateReader> StateTracker<TStore> {
         })
     }
 
-    pub fn pop_call_frame(&mut self) -> Result<(), RuntimeError> {
-        self.write_with(|state| state.pop_frame())
+    pub fn pop_call_frame(&mut self, returned: &IndexedWellKnownTypes) -> Result<(), RuntimeError> {
+        self.write_with(|state| state.pop_frame(returned))
     }
 
     pub fn take_last_instruction_output(&mut self) -> Option<IndexedValue> {

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -830,12 +830,11 @@ impl<TStore: StateReader> WorkingState<TStore> {
     }
 
     pub fn drop_proof(&mut self, proof_id: ProofId) -> Result<(), RuntimeError> {
-        // Remove it from the auth scope if is in scope
         let call_frame_mut = self.current_call_scope_mut()?;
         if !call_frame_mut.is_proof_in_scope(&proof_id) {
             return Err(RuntimeError::ProofNotFound { proof_id });
         }
-        call_frame_mut.auth_scope_mut().remove_proof(&proof_id);
+        call_frame_mut.remove_proof_from_scope(&proof_id);
 
         // Fetch the proof
         let proof = self
@@ -1326,8 +1325,8 @@ impl<TStore: StateReader> WorkingState<TStore> {
 
         let scope_mut = self.current_call_scope_mut()?;
         for address in next_state.referenced_substates() {
-            // Mark any orphaned objects as owned
-            scope_mut.move_node_to_owned(&address)?
+            // Anything the state references now belongs to the component, not to this frame
+            scope_mut.attach_node_to_component(&address)?
         }
 
         Ok(())
@@ -1558,7 +1557,7 @@ impl<TStore: StateReader> WorkingState<TStore> {
         Ok(())
     }
 
-    pub fn pop_frame(&mut self) -> Result<(), RuntimeError> {
+    pub fn pop_frame(&mut self, returned: &IndexedWellKnownTypes) -> Result<(), RuntimeError> {
         let current_frame = self.call_frames.pop().ok_or(RuntimeError::NoActiveCallFrame)?;
 
         let mut scope = current_frame.into_scope();
@@ -1579,9 +1578,35 @@ impl<TStore: StateReader> WorkingState<TStore> {
             });
         }
 
+        // A bucket or proof this frame created is either consumed here or named in the return value. One that is
+        // still live and unreturned has no owner, so it fails the call.
+        let dangling_buckets = scope
+            .buckets_owed()
+            .filter(|id| self.buckets.contains_key(id))
+            .filter(|id| !returned.bucket_ids().contains(id))
+            .copied()
+            .collect::<Vec<_>>();
+        if !dangling_buckets.is_empty() {
+            return Err(RuntimeError::UnreturnedBuckets {
+                bucket_ids: dangling_buckets,
+            });
+        }
+
+        let dangling_proofs = scope
+            .proofs_owed()
+            .filter(|id| self.proofs.contains_key(id))
+            .filter(|id| !returned.proof_ids().contains(id))
+            .copied()
+            .collect::<Vec<_>>();
+        if !dangling_proofs.is_empty() {
+            return Err(RuntimeError::UnreturnedProofs {
+                proof_ids: dangling_proofs,
+            });
+        }
+
         // Update the parent call scope
         debug!(target: LOG_TARGET, "pop_frame:\n{}", scope);
-        self.current_call_scope_mut()?.update_from_child_scope(scope);
+        self.current_call_scope_mut()?.update_from_child_scope(scope, returned);
 
         Ok(())
     }
@@ -2014,8 +2039,9 @@ impl<TStore: StateReader> WorkingState<TStore> {
         address: &SubstateId,
         action: T,
     ) -> Result<(), RuntimeError> {
-        // Since we don't propagate _owned_ substate references up the call stack, if the substate is in scope, then it
-        // was created in this scope and therefore owned.
+        // A substate in scope was either created by this frame or is reachable from the component the frame executes
+        // on. Both are private to this frame: a component's substates are dropped from the scope when the frame is
+        // popped, so they stay reachable only through that component.
         if self.current_call_scope()?.is_substate_in_scope(address) {
             return Ok(());
         }

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -1579,10 +1579,11 @@ impl<TStore: StateReader> WorkingState<TStore> {
         }
 
         // A bucket or proof this frame created is either consumed here or named in the return value. One that is
-        // still live and unreturned has no owner, so it fails the call.
+        // still live and unreturned has no owner, so it fails the call. An emptied bucket carries nothing and is
+        // tolerated, matching `validate_finalized`, so that the transaction has one rule for it rather than two.
         let dangling_buckets = scope
             .buckets_owed()
-            .filter(|id| self.buckets.contains_key(id))
+            .filter(|id| self.buckets.get(id).is_some_and(|bucket| !bucket.is_empty()))
             .filter(|id| !returned.bucket_ids().contains(id))
             .copied()
             .collect::<Vec<_>>();

--- a/crates/engine/src/transaction/processor.rs
+++ b/crates/engine/src/transaction/processor.rs
@@ -569,13 +569,16 @@ where
 
         runtime.interface_mut().update_component_template(new_template)?;
 
-        if let Some(function_def) = migration_function {
+        let returned = if let Some(function_def) = migration_function {
             // Migrate function is defined, so we need to call it
             let result = Self::invoke_template(template, runtime.clone(), &function_def, &final_args)?;
             runtime.interface_mut().validate_return_value(&result.indexed)?;
-        }
+            result.indexed
+        } else {
+            IndexedValue::default()
+        };
 
-        runtime.interface_mut().pop_call_frame()?;
+        runtime.interface_mut().pop_call_frame(returned.well_known_types())?;
 
         Ok(InstructionResult::empty())
     }
@@ -791,7 +794,9 @@ where
                 let result = Self::invoke_template(template, runtime.clone(), &function_def, &resolved_args)?;
 
                 runtime.interface_mut().validate_return_value(&result.indexed)?;
-                runtime.interface_mut().pop_call_frame()?;
+                runtime
+                    .interface_mut()
+                    .pop_call_frame(result.indexed.well_known_types())?;
                 runtime
                     .interface_mut()
                     .set_last_instruction_output(IndexedValue::from_type(&account_address)?)?;
@@ -851,7 +856,9 @@ where
         let result = Self::invoke_template(template, runtime.clone(), &function_def, &resolved_args)?;
 
         runtime.interface_mut().validate_return_value(&result.indexed)?;
-        runtime.interface_mut().pop_call_frame()?;
+        runtime
+            .interface_mut()
+            .pop_call_frame(result.indexed.well_known_types())?;
 
         Ok(result)
     }
@@ -937,7 +944,9 @@ where
         let result = Self::invoke_template(template, runtime.clone(), &function_def, &resolved_args)?;
 
         runtime.interface_mut().validate_return_value(&result.indexed)?;
-        runtime.interface_mut().pop_call_frame()?;
+        runtime
+            .interface_mut()
+            .pop_call_frame(result.indexed.well_known_types())?;
         Ok(result)
     }
 

--- a/crates/engine/tests/shenanigans.rs
+++ b/crates/engine/tests/shenanigans.rs
@@ -548,3 +548,72 @@ fn a_proof_outlives_the_authorization_taken_from_it() {
         vec![],
     );
 }
+
+#[test]
+fn it_does_not_leak_a_callees_vaults_into_a_calling_components_scope() {
+    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/shenanigans"]);
+    let template_addr = test.get_template_address(TEMPLATE_NAME);
+    let (victim, _, _) = test.create_funded_account();
+    let (attacker_account, _, _) = test.create_empty_account();
+
+    let result = test.execute_expect_success(
+        test.transaction()
+            .call_function(template_addr, "with_fungible_vault", args![])
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+    let attacker = result.finalize.execution_results[0]
+        .decode::<ComponentAddress>()
+        .unwrap();
+
+    let vault_id = {
+        let store = test.read_only_state_store();
+        let component = store.get_component(victim).unwrap();
+        let values = IndexedWellKnownTypes::from_value(component.state()).unwrap();
+        values.vault_ids()[0]
+    };
+
+    let reason = test.execute_expect_failure(
+        test.transaction()
+            .call_method(attacker, "call_then_steal_from_vault_as_component", args![
+                victim, vault_id
+            ])
+            .put_last_instruction_output_on_workspace("bucket")
+            .call_method(attacker_account, "deposit", args![Workspace("bucket")])
+            .add_input(vault_id)
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+
+    assert_reject_reason(reason, RuntimeError::SubstateNotOwned {
+        id: vault_id.into(),
+        requested_owner: Box::new(attacker.into()),
+    });
+}
+
+#[test]
+fn it_does_not_leak_a_callees_address_allocation_into_the_callers_scope() {
+    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/shenanigans"]);
+    let template_addr = test.get_template_address(TEMPLATE_NAME);
+
+    let result = test.execute_expect_success(
+        test.transaction()
+            .call_function(template_addr, "with_fungible_vault", args![])
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+    let victim = result.finalize.execution_results[0]
+        .decode::<ComponentAddress>()
+        .unwrap();
+
+    // An allocation is a reservation of an address, and nothing checks that the template consuming one is the
+    // template that made it, so the caller must never be handed one it was not given.
+    let reason = test.execute_expect_failure(
+        test.transaction()
+            .call_function(template_addr, "call_then_use_abandoned_allocation", args![victim, 0u32])
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+
+    assert_reject_reason(reason, RuntimeError::AddressAllocationNotInScope { id: 0 });
+}

--- a/crates/engine/tests/shenanigans.rs
+++ b/crates/engine/tests/shenanigans.rs
@@ -435,3 +435,116 @@ fn it_disallows_withdraws_from_vaults_outside_of_owning_component() {
         requested_owner: Box::new(component.into()),
     });
 }
+
+#[test]
+fn it_does_not_leak_a_callees_vaults_into_the_callers_scope() {
+    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/shenanigans"]);
+    let template_addr = test.get_template_address(TEMPLATE_NAME);
+    let (victim, _, _) = test.create_funded_account();
+    let (attacker, _, _) = test.create_empty_account();
+
+    let vault_id = {
+        let store = test.read_only_state_store();
+        let component = store.get_component(victim).unwrap();
+        let values = IndexedWellKnownTypes::from_value(component.state()).unwrap();
+        values.vault_ids()[0]
+    };
+
+    let reason = test.execute_expect_failure(
+        test.transaction()
+            .call_function(template_addr, "call_then_steal_from_vault", args![victim, vault_id])
+            .put_last_instruction_output_on_workspace("bucket")
+            .call_method(attacker, "deposit", args![Workspace("bucket")])
+            .add_input(vault_id)
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+
+    // Calling the victim leaves the attacker's frame without a component context, so the vault is neither in scope
+    // nor owned by a component the attacker is executing on.
+    assert_reject_reason(reason, RuntimeError::NotInComponentContext {
+        action: VaultAction::Withdraw.into(),
+    });
+}
+
+#[test]
+fn it_rejects_a_bucket_that_is_neither_consumed_nor_returned_by_a_call() {
+    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/shenanigans"]);
+    let template_addr = test.get_template_address(TEMPLATE_NAME);
+
+    let result = test.execute_expect_success(
+        test.transaction()
+            .call_function(template_addr, "with_fungible_vault", args![])
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+    let component = result.finalize.execution_results[0]
+        .decode::<ComponentAddress>()
+        .unwrap();
+
+    let reason = test.execute_expect_failure(
+        test.transaction()
+            .call_method(component, "abandon_bucket", args![])
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+
+    assert_reject_reason(reason, "were neither consumed nor returned by the call");
+}
+
+#[test]
+fn it_rejects_a_proof_that_is_neither_dropped_nor_returned_by_a_call() {
+    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/shenanigans"]);
+    let template_addr = test.get_template_address(TEMPLATE_NAME);
+
+    let result = test.execute_expect_success(
+        test.transaction()
+            .call_function(template_addr, "with_fungible_vault", args![])
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+    let component = result.finalize.execution_results[0]
+        .decode::<ComponentAddress>()
+        .unwrap();
+
+    let reason = test.execute_expect_failure(
+        test.transaction()
+            .call_method(component, "abandon_proof", args![])
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+
+    assert_reject_reason(reason, "were neither dropped nor returned by the call");
+}
+
+#[test]
+fn a_proof_outlives_the_authorization_taken_from_it() {
+    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/shenanigans"]);
+    let template_addr = test.get_template_address(TEMPLATE_NAME);
+
+    let result = test.execute_expect_success(
+        test.transaction()
+            .call_function(template_addr, "with_fungible_vault", args![])
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+    let component = result.finalize.execution_results[0]
+        .decode::<ComponentAddress>()
+        .unwrap();
+
+    test.execute_expect_success(
+        test.transaction()
+            .call_method(component, "authorize_then_drop_proof", args![])
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+
+    test.execute_expect_success(
+        test.transaction()
+            .call_method(component, "authorize_then_return_proof", args![])
+            .put_last_instruction_output_on_workspace("proof")
+            .drop_all_proofs_in_workspace()
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+}

--- a/crates/engine/tests/templates/shenanigans/src/lib.rs
+++ b/crates/engine/tests/templates/shenanigans/src/lib.rs
@@ -178,6 +178,30 @@ mod template {
             stolen.withdraw_all()
         }
 
+        /// The same attack from inside a component frame, where the vault is checked against the component the
+        /// frame executes on rather than against the absence of one.
+        pub fn call_then_steal_from_vault_as_component(&self, victim: ComponentAddress, vault_id: VaultId) -> Bucket {
+            let _balances: Vec<(ResourceAddress, Amount)> =
+                ComponentManager::get(victim).call("get_balances", args![]);
+            let mut stolen = Vault::for_test(vault_id.into());
+            stolen.withdraw_all()
+        }
+
+        /// Allocates an address and hands it to nobody, so the allocation is left in this frame when it returns.
+        pub fn allocate_and_abandon(&self) {
+            let _allocation = CallerContext::allocate_component_address(None);
+        }
+
+        /// Calls a victim whose frame leaves an allocation behind, then names that allocation by id and creates a
+        /// component at the address the victim reserved.
+        pub fn call_then_use_abandoned_allocation(victim: ComponentAddress, allocation_id: u32) -> ComponentAddress {
+            let _: () = ComponentManager::get(victim).call("allocate_and_abandon", args![]);
+            let component = Component::new(Self::default())
+                .with_address_allocation(ComponentAddressAllocation::new(allocation_id))
+                .create();
+            *component.address()
+        }
+
         pub fn with_fungible_vault() -> Component<Self> {
             let tokens = ResourceBuilder::public_fungible().initial_supply(1000u32);
             Component::new(Self {

--- a/crates/engine/tests/templates/shenanigans/src/lib.rs
+++ b/crates/engine/tests/templates/shenanigans/src/lib.rs
@@ -169,6 +169,52 @@ mod template {
             stolen.withdraw_all()
         }
 
+        /// Calls a method the victim permits, then withdraws directly from a vault of the victim's it never
+        /// handed over.
+        pub fn call_then_steal_from_vault(victim: ComponentAddress, vault_id: VaultId) -> Bucket {
+            let _balances: Vec<(ResourceAddress, Amount)> =
+                ComponentManager::get(victim).call("get_balances", args![]);
+            let mut stolen = Vault::for_test(vault_id.into());
+            stolen.withdraw_all()
+        }
+
+        pub fn with_fungible_vault() -> Component<Self> {
+            let tokens = ResourceBuilder::public_fungible().initial_supply(1000u32);
+            Component::new(Self {
+                vault: Some(Vault::from_bucket(tokens)),
+                ..Default::default()
+            })
+            .with_access_rules(AccessRules::allow_all())
+            .with_owner_rule(OwnerRule::ByAccessRule(rule!(allow_all)))
+            .create()
+        }
+
+        pub fn abandon_bucket(&mut self) {
+            let _bucket = self.vault.as_mut().unwrap().withdraw(Amount::from(1u64));
+        }
+
+        /// A `ProofAccess` guard leaves the auth scope when it is dropped; the proof it came from is still held and
+        /// may be dropped or returned afterwards.
+        pub fn authorize_then_drop_proof(&self) {
+            let proof = self.vault.as_ref().unwrap().create_proof();
+            {
+                let _auth = proof.authorize();
+            }
+            proof.drop();
+        }
+
+        pub fn authorize_then_return_proof(&self) -> Proof {
+            let proof = self.vault.as_ref().unwrap().create_proof();
+            {
+                let _auth = proof.authorize();
+            }
+            proof
+        }
+
+        pub fn abandon_proof(&mut self) {
+            let _proof = self.vault.as_ref().unwrap().create_proof();
+        }
+
         pub fn empty_state_on_component(&self, address: ComponentAddress) {
             ComponentManager::get(address).set_state(());
         }


### PR DESCRIPTION
Part of the engine audit wave 1 — the five PRs that close every fund-theft and validator-kill finding. They ship as one coordinated validator + indexer release.

## The bug

`CallScope::include_owned_in_scope` seeded a callee frame's `owned` set with every substate reachable from the component's state — vault ids included — and `update_from_child_scope` then extended the caller's `owned` with the callee's whole set when the frame popped.

So any template could:

1. call a method the victim permits (`Account::get_balances` is `allow_all`),
2. and from that point have the victim's vault in its own scope, so `Vault::for_test(victim_vault).withdraw_all()` passes `check_component_scope`.

TARI's withdraw rule is `AllowAll` (`ResourceAccessRules::new()`), so the withdraw itself is unguarded. The comment above `check_component_scope` claimed owned references are not propagated up the call stack, which was the opposite of what `update_from_child_scope` did. The same propagation also let an attacker component add a victim's vault id to its own state permanently.

The existing `shenanigans.rs` regression tests never call into the victim first, so they passed throughout.

## The fix

Substates reachable through a component's state now live in a separate `component_owned` set. It is in scope for that frame alone and is dropped when the frame is popped; orphans that get attached to component state land there too. Only substates the frame created and still holds loosely cross back to the caller.

Buckets and proofs no longer merge upward either: a frame hands back only those named in its return value, and one it created that is still live and unreturned fails the call with `UnreturnedBuckets` / `UnreturnedProofs`. Buckets and proofs the caller lent as arguments — or that came from the transaction's base auth scope — remain the caller's and are exempt, so `account.deposit(bucket)` and the workspace-proof flow are unaffected.

Which proofs a frame *holds* is now tracked in `CallScope::proof_scope`, separately from the `auth_scope` subset that is currently authorizing an action. The two were one set, which was a live bug of its own: dropping a `ProofAccess` guard also gave up the proof, so `Proof::drop` after `Proof::authorize` failed with `ProofNotFound`, and a proof authorized before being returned never reached the caller.

## Tests

`crates/engine/tests/shenanigans.rs`:

- `it_does_not_leak_a_callees_vaults_into_the_callers_scope` — the attack above. On `development` this transaction **succeeds** and drains the victim's vault into the attacker's account.
- `it_rejects_a_bucket_that_is_neither_consumed_nor_returned_by_a_call`
- `it_rejects_a_proof_that_is_neither_dropped_nor_returned_by_a_call`
- `a_proof_outlives_the_authorization_taken_from_it` — cover for the authorize-then-drop and authorize-then-return patterns the `proof_scope` split fixes.

All 43 `tari_engine` test binaries pass.
