### PR TITLE
fix(engine)!: track spent inputs in WorkingStateStore

### DIFF
--- a/crates/engine/src/runtime/error.rs
+++ b/crates/engine/src/runtime/error.rs
@@ -76,6 +76,8 @@ pub enum RuntimeError {
     WorkspaceError(#[from] WorkspaceError),
     #[error("Substate '{id}' not found or is not a transaction input")]
     SubstateNotFound { id: SubstateId },
+    #[error("Substate '{id}' was already spent earlier in this transaction")]
+    SubstateAlreadySpent { id: SubstateId },
     #[error("Root substate '{id}' not found")]
     RootSubstateNotFound { id: SubstateId },
     #[error("Referenced substate '{id}' not found")]

--- a/crates/engine/src/runtime/state_store.rs
+++ b/crates/engine/src/runtime/state_store.rs
@@ -53,6 +53,9 @@ impl<TStore: StateReader> WorkingStateStore<TStore> {
     }
 
     pub fn try_lock(&mut self, id: SubstateId, lock_flag: LockFlag) -> Result<LockId, RuntimeError> {
+        if self.is_spent(&id) {
+            return Err(RuntimeError::SubstateAlreadySpent { id });
+        }
         if !self.exists(&id)? {
             return Err(RuntimeError::SubstateNotFound { id: id.clone() });
         }
@@ -141,7 +144,22 @@ impl<TStore: StateReader> WorkingStateStore<TStore> {
         })
     }
 
+    /// Whether `id` names a UTXO or confidential output this transaction has already spent. The backing store is
+    /// untouched until the transaction commits, so `downed_utxos` and `downed_confidential_outputs` are the whole
+    /// record of what this transaction has spent; every presence and load path consults them so that a spent output
+    /// reads as gone for the rest of the transaction.
+    fn is_spent(&self, id: &SubstateId) -> bool {
+        match id {
+            SubstateId::Utxo(address) => self.downed_utxos.contains(address),
+            SubstateId::ConfidentialOutput(address) => self.downed_confidential_outputs.contains(address),
+            _ => false,
+        }
+    }
+
     pub fn exists(&self, id: &SubstateId) -> Result<bool, RuntimeError> {
+        if self.is_spent(id) {
+            return Ok(false);
+        }
         let exists = self.new_substates.contains_key(id) ||
             self.loaded_substates.contains_key(id) ||
             self.state_store.exists(id)?;
@@ -149,6 +167,11 @@ impl<TStore: StateReader> WorkingStateStore<TStore> {
     }
 
     pub fn insert(&mut self, id: SubstateId, value: SubstateValue) -> Result<(), RuntimeError> {
+        // A spent address reads as absent to `exists`, so this is the check that keeps the substate diff to one
+        // record per address: a down or an up, never both.
+        if self.is_spent(&id) {
+            return Err(RuntimeError::SubstateAlreadySpent { id });
+        }
         if self.exists(&id)? {
             return Err(RuntimeError::DuplicateSubstate { address: id });
         }
@@ -157,6 +180,9 @@ impl<TStore: StateReader> WorkingStateStore<TStore> {
     }
 
     fn load_and_cache(&mut self, id: SubstateId) -> Result<&SubstateValue, RuntimeError> {
+        if self.is_spent(&id) {
+            return Err(RuntimeError::SubstateAlreadySpent { id });
+        }
         if let Some(s) = self.new_substates.get(&id) {
             return Ok(s);
         }

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -381,6 +381,10 @@ impl<TStore: StateReader> WorkingState<TStore> {
         stmt: &StealthTransferStatement,
         view_key: Option<&RistrettoPublicKey>,
     ) -> Result<ValidatedStealthTransfer, RuntimeError> {
+        // The statement is checked in full before anything is downed, so a statement rejected on its own terms
+        // (duplicate inputs among them) leaves the ledger untouched.
+        let valid_transfer = stealth::validate_transfer(stmt, view_key)?;
+
         for input in &stmt.inputs_statement.inputs {
             let address = UtxoAddress::new(resource_address, input.commitment.into());
             let lock_id = self.store.try_lock(address.clone().into(), LockFlag::Write)?;
@@ -400,7 +404,6 @@ impl<TStore: StateReader> WorkingState<TStore> {
             }
         }
 
-        let valid_transfer = stealth::validate_transfer(stmt, view_key)?;
         Ok(valid_transfer)
     }
 

--- a/crates/engine/tests/stealth.rs
+++ b/crates/engine/tests/stealth.rs
@@ -1076,3 +1076,89 @@ fn transfer_restricted_by_access_rules_component_scope() {
         .collect::<Vec<_>>();
     assert_eq!(utxos.len(), 1);
 }
+
+#[test]
+fn duplicate_inputs_in_one_statement_are_rejected() {
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
+    let mint = stealth::generate_mint_statement(vec![100u64], 0u64, None);
+    let (_faucet, faucet_resx) = setup(&mut test, &mint, None);
+
+    let input = MaskAndValue {
+        mask: mint.output_masks[0].clone(),
+        value: 100,
+    };
+    // The excess folds the inputs positionally, so listing the one 100 UTXO twice balances a statement that pays
+    // out 200.
+    let transfer = stealth::generate_transfer_data([input.clone(), input], 0u64, Some(200), 0);
+
+    let reason = test.execute_expect_failure(
+        test.transaction()
+            .stealth_transfer(faucet_resx, transfer.statement)
+            .finish()
+            .add_signer(&test.to_public_key_bytes(), &mint.output_masks[0])
+            .seal(test.secret_key()),
+        vec![],
+    );
+
+    assert_reject_reason(reason, "Duplicate input commitment");
+}
+
+#[test]
+fn two_statements_may_not_spend_the_same_utxo() {
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
+    let mint = stealth::generate_mint_statement(vec![100u64], 0u64, None);
+    let (_faucet, faucet_resx) = setup(&mut test, &mint, None);
+
+    let input = MaskAndValue {
+        mask: mint.output_masks[0].clone(),
+        value: 100,
+    };
+    let first = stealth::generate_transfer_data([input.clone()], 0u64, Some(100), 0);
+    let second = stealth::generate_transfer_data([input], 0u64, Some(100), 0);
+
+    let reason = test.execute_expect_failure(
+        test.transaction()
+            .stealth_transfer(faucet_resx, first.statement)
+            .stealth_transfer(faucet_resx, second.statement)
+            .finish()
+            .add_signer(&test.to_public_key_bytes(), &mint.output_masks[0])
+            .seal(test.secret_key()),
+        vec![],
+    );
+
+    assert_reject_reason(reason, "was already spent earlier in this transaction");
+}
+
+#[test]
+fn a_utxo_spent_in_this_transaction_cannot_also_be_burnt() {
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
+    let mint = stealth::generate_mint_statement(vec![100u64], 0u64, None);
+    let (faucet, faucet_resx) = setup(&mut test, &mint, None);
+
+    let transfer = stealth::generate_transfer_data(
+        [MaskAndValue {
+            mask: mint.output_masks[0].clone(),
+            value: 100,
+        }],
+        0u64,
+        Some(100),
+        0,
+    );
+
+    let commitment = get_commitment_factory().commit_value(&mint.output_masks[0], 100);
+    let utxo_id = UtxoId::from(commitment.to_byte_type());
+    let value_proof = value_proof::generate_value_proof_mask_knowledge(100u64.into(), &mint.output_masks[0]);
+
+    // The burn targets the UTXO the transfer has just spent, which is a down and an up@v+1 of one address.
+    let reason = test.execute_expect_failure(
+        test.transaction()
+            .stealth_transfer(faucet_resx, transfer.statement)
+            .call_method(faucet, "burn_utxos", args![vec![(utxo_id, value_proof)]])
+            .finish()
+            .add_signer(&test.to_public_key_bytes(), &mint.output_masks[0])
+            .seal(test.secret_key()),
+        vec![],
+    );
+
+    assert_reject_reason(reason, "was already spent earlier in this transaction");
+}

--- a/crates/engine/tests/stealth.rs
+++ b/crates/engine/tests/stealth.rs
@@ -1089,11 +1089,12 @@ fn duplicate_inputs_in_one_statement_are_rejected() {
     };
     // The excess folds the inputs positionally, so listing the one 100 UTXO twice balances a statement that pays
     // out 200.
-    let transfer = stealth::generate_transfer_data([input.clone(), input], 0u64, Some(200), 0);
+    let transfer = stealth::generate_transfer_data([input], 0u64, Some(200), 0);
+    let statement = stealth::spend_first_input_twice(&transfer, &mint.output_masks[0]);
 
     let reason = test.execute_expect_failure(
         test.transaction()
-            .stealth_transfer(faucet_resx, transfer.statement)
+            .stealth_transfer(faucet_resx, statement)
             .finish()
             .add_signer(&test.to_public_key_bytes(), &mint.output_masks[0])
             .seal(test.secret_key()),

--- a/crates/engine_types/src/stealth/transfer.rs
+++ b/crates/engine_types/src/stealth/transfer.rs
@@ -1,6 +1,8 @@
 //    Copyright 2025 The Tari Project
 //    SPDX-License-Identifier: BSD-3-Clause
 
+use std::collections::BTreeSet;
+
 use log::*;
 use ootle_byte_type::ConvertFromByteType;
 use tari_crypto::{
@@ -171,6 +173,17 @@ pub fn validate_transfer(
 }
 
 fn basic_validations(transfer: &StealthTransferStatement) -> Result<(), ResourceError> {
+    // The excess folds the inputs positionally, so a commitment listed n times contributes n times its value to a
+    // balance proof its spender can still construct, while the spend downs the one UTXO once.
+    let mut seen = BTreeSet::new();
+    for input in &transfer.inputs_statement.inputs {
+        if !seen.insert(input.commitment) {
+            return Err(ResourceError::InvalidSpend {
+                details: format!("Duplicate input commitment {} in transfer statement", input.commitment),
+            });
+        }
+    }
+
     if transfer.inputs_statement.revealed_amount.is_negative() {
         return Err(ResourceError::InvalidBalanceProof {
             details: format!(

--- a/crates/template_test_tooling/src/support/stealth.rs
+++ b/crates/template_test_tooling/src/support/stealth.rs
@@ -8,7 +8,14 @@ use tari_crypto::{
     keys::{PublicKey, SecretKey},
     ristretto::{RistrettoPublicKey, RistrettoSecretKey},
 };
-use tari_ootle_wallet_crypto::{MaskAndValue, OutputWitness, StealthInputWitness, StealthOutputWitness, stealth};
+use tari_ootle_wallet_crypto::{
+    MaskAndValue,
+    OutputWitness,
+    StealthInputWitness,
+    StealthOutputWitness,
+    balance_proof::generate_stealth_balance_proof_signature,
+    stealth,
+};
 use tari_template_lib::types::{
     Amount,
     EncryptedData,
@@ -110,6 +117,34 @@ fn generate_stealth_statement_internal(
 
     let stmt = stealth::create_outputs_statement(&output_statements, revealed_output_amount).unwrap();
     (stmt, masks)
+}
+
+/// Rewrites `data` to spend its first input twice, re-signing the balance proof over the doubled input set.
+///
+/// `stealth::create_transfer_statement` refuses to build this, so it is assembled here: the engine has to reject a
+/// double-spent input on its own terms rather than rely on the submitter having used a well-behaved builder. The
+/// spender knows the input mask, so the proof over the doubled set is theirs to construct.
+pub fn spend_first_input_twice(
+    data: &StealthSecretTransferData,
+    input_mask: &RistrettoSecretKey,
+) -> StealthTransferStatement {
+    let mut statement = data.statement.clone();
+    let first = statement.inputs_statement.inputs[0].clone();
+    statement.inputs_statement.inputs.push(first);
+
+    let agg_input_mask = input_mask.clone() + input_mask;
+    let agg_output_mask = data
+        .output_masks
+        .iter()
+        .fold(RistrettoSecretKey::default(), |agg, mask| agg + mask);
+    statement.balance_proof = Some(generate_stealth_balance_proof_signature(
+        &agg_input_mask,
+        &agg_output_mask,
+        &statement.inputs_statement,
+        &statement.outputs_statement,
+    ));
+
+    statement
 }
 
 pub struct StealthSecretTransferData {

--- a/crates/wallet/crypto/src/stealth.rs
+++ b/crates/wallet/crypto/src/stealth.rs
@@ -1,6 +1,8 @@
 //   Copyright 2024 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+use std::collections::HashSet;
+
 use ootle_byte_type::ToByteType;
 use tari_crypto::ristretto::RistrettoSecretKey;
 /// The canonical digest for a
@@ -169,9 +171,21 @@ where
 
     let mut inputs_to_spend = Vec::with_capacity(num_inputs);
     let mut agg_input_mask = RistrettoSecretKey::default();
+    let mut seen = HashSet::with_capacity(num_inputs);
     for input in &inputs {
+        let commitment = input.mask_and_value.to_commitment().to_byte_type();
+        // The excess and the aggregate mask both fold the inputs positionally, so a UTXO listed twice would be
+        // spent twice over. Rejecting it here rather than dropping it keeps the caller's mistake legible: the
+        // balance proof signs the mask difference alone, so a statement whose inputs were silently deduplicated
+        // would fail at the validator as an unbalanced proof.
+        if !seen.insert(commitment) {
+            return Err(WalletCryptoError::InvalidArgument {
+                name: "inputs",
+                details: format!("Input commitment {commitment} appears more than once"),
+            });
+        }
         inputs_to_spend.push(StealthInput {
-            commitment: input.mask_and_value.to_commitment().to_byte_type(),
+            commitment,
             witness: input.witness.clone(),
         });
         agg_input_mask = agg_input_mask + &input.mask_and_value.mask;
@@ -342,7 +356,7 @@ mod tests {
     };
 
     use super::*;
-    use crate::OutputWitness;
+    use crate::{MaskAndValue, OutputWitness};
 
     fn create_valid_proof(amount: u64, minimum_value_promise: u64) -> StealthOutputsStatement {
         let mask = RistrettoSecretKey::random(&mut rand::rng());
@@ -368,6 +382,25 @@ mod tests {
     fn it_is_valid_if_proof_is_valid() {
         let proof = create_valid_proof(100, 0);
         validate_stealth_outputs_statement(&proof, None).unwrap();
+    }
+
+    #[test]
+    fn it_refuses_to_spend_one_input_twice() {
+        let mask = RistrettoSecretKey::random(&mut rand::rng());
+        let input = StealthInputWitness::new(MaskAndValue { mask, value: 100 });
+
+        let err = create_transfer_statement(
+            [input.clone(), input],
+            Amount::zero(),
+            &[] as &[StealthOutputWitness],
+            Amount::from(200u64),
+        )
+        .unwrap_err();
+
+        assert!(
+            matches!(err, WalletCryptoError::InvalidArgument { name: "inputs", .. }),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Part of the engine audit wave 1 (with #2575). They ship as one coordinated validator + indexer release.

## The bug

`WorkingStateStore` kept no record of what the transaction had already spent that its own reads consulted:

- `exists()` answered from the immutable input snapshot, which the backing store leaves untouched until commit, so a downed UTXO still read as present;
- `try_lock` then let it be locked again and `load_and_cache` reloaded it;
- `down_utxo` inserts into an `IndexSet`, so the second down was a no-op.

Three spends followed.

**One UTXO listed n times in a single statement.** `stealth::transfer` folds the inputs positionally into the excess, so a spender — who knows the mask — can build a valid balance proof for n times the UTXO's value. The spend downs the one UTXO once and mints n·v.

**k statements over one UTXO in one transaction.** Up to `max_transfers_per_transaction` (64) in the main intent plus one in the fee intent, each with its own fresh outputs. One down, k output sets. A per-statement dedup alone does not close this.

**Spend then `StealthUtxoBurn`.** The resulting diff carried both a down and an up@v+1 of the same address.

The same shape existed for `down_confidential_output`.

## The fix

`exists`, `try_lock`, `load_and_cache` and `insert` now refuse any id in `downed_utxos` / `downed_confidential_outputs`. Nothing new is persisted and no new substate is introduced — the two sets the transaction already keeps become the spent set that every presence and load path consults.

The checks sit ahead of `down_utxo`, whose collapse-versus-down decision is unchanged: a UTXO mutated earlier in the transaction (unfrozen, say) moves from `loaded_substates` into `new_substates` without becoming new, so it consults the unmodified store to decide, and only a UTXO that did not exist before the transaction may collapse.

Two more, so the rule does not rest on the store alone:

- `stealth::basic_validations` rejects duplicate input commitments outright, which holds for every caller of `validate_transfer`.
- `validate_and_spend_stealth_utxos` validates the statement before downing anything, so a statement rejected on its own terms leaves its inputs unspent.

## Tests

`crates/engine/tests/stealth.rs` — all three of these **succeed** on `development`:

- `duplicate_inputs_in_one_statement_are_rejected`
- `two_statements_may_not_spend_the_same_utxo`
- `a_utxo_spent_in_this_transaction_cannot_also_be_burnt`

All 43 `tari_engine` test binaries plus `tari_engine_types` pass.
