### PR TITLE
fix(engine)!: scope-check proof access; match the resource on vault freeze

### DIFF
--- a/crates/engine/src/runtime/error.rs
+++ b/crates/engine/src/runtime/error.rs
@@ -220,6 +220,12 @@ pub enum RuntimeError {
     WriteOutsideOwnComponent { id: SubstateId },
     #[error("Host operation '{operation}' is forbidden inside a resource auth hook")]
     ForbiddenInAuthHookContext { operation: &'static str },
+    #[error("Freeze on resource {resource_address} targeted vault {vault_id}, which holds resource {vault_resource}")]
+    FreezeResourceMismatch {
+        vault_id: VaultId,
+        resource_address: ResourceAddress,
+        vault_resource: ResourceAddress,
+    },
     #[error("Recall on resource {resource_address} targeted vault {vault_id}, which holds resource {vault_resource}")]
     RecallResourceMismatch {
         vault_id: VaultId,

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -2077,6 +2077,18 @@ where
 
                 self.tracker.write_with(|state_mut| {
                     let vault_lock = state_mut.write_lock_substate(arg.vault_id.into())?;
+
+                    // The freeze rule that authorized this action belongs to `resource_address`, so it may only
+                    // reach vaults holding that resource.
+                    let vault_resource = *state_mut.get_vault(&vault_lock)?.resource_address();
+                    if vault_resource != resource_address {
+                        return Err(RuntimeError::FreezeResourceMismatch {
+                            vault_id: arg.vault_id,
+                            resource_address,
+                            vault_resource,
+                        });
+                    }
+
                     state_mut.set_vault_freeze(&vault_lock, arg.flags)?;
                     let payload =
                         Metadata::from_iter([("vault_id", arg.vault_id.to_string()), ("flags", arg.flags.to_string())]);
@@ -3305,7 +3317,7 @@ where
                 })?;
                 args.assert_no_args("Proof.GetAmount")?;
                 self.tracker.write_with(|state| {
-                    let proof = state.get_proof(proof_id)?;
+                    let proof = state.get_proof_in_scope(proof_id)?;
                     Ok(InvokeResult::encode(&proof.amount())?)
                 })
             },
@@ -3316,7 +3328,7 @@ where
                 })?;
                 args.assert_no_args("Proof.GetResourceAddress")?;
                 self.tracker.write_with(|state| {
-                    let proof = state.get_proof(proof_id)?;
+                    let proof = state.get_proof_in_scope(proof_id)?;
                     Ok(InvokeResult::encode(proof.resource_address())?)
                 })
             },
@@ -3329,7 +3341,7 @@ where
                 args.assert_no_args("Proof.GetResourceType")?;
 
                 self.tracker.write_with(|state| {
-                    let proof = state.get_proof(proof_id)?;
+                    let proof = state.get_proof_in_scope(proof_id)?;
                     Ok(InvokeResult::encode(&proof.resource_type())?)
                 })
             },
@@ -3342,7 +3354,7 @@ where
                 args.assert_no_args("Proof.GetNonFungibles")?;
 
                 self.tracker.write_with(|state| {
-                    let proof = state.get_proof(proof_id)?;
+                    let proof = state.get_proof_in_scope(proof_id)?;
                     let nfts = proof.non_fungible_token_ids();
                     Ok(InvokeResult::encode(&nfts)?)
                 })
@@ -3355,7 +3367,10 @@ where
                 args.assert_no_args("Proof.CreateAccess")?;
 
                 self.tracker.write_with(|state| {
-                    if !state.proof_exists(proof_id) {
+                    // A proof id is a sequential counter shared by the whole transaction, so authority has to come
+                    // from the frame's own scope: a proof it created, was passed as an argument, or a callee handed
+                    // back. Every other live proof in the transaction belongs to someone else.
+                    if !state.proof_exists(proof_id) || !state.current_call_scope()?.is_proof_in_scope(&proof_id) {
                         return Ok(InvokeResult::encode(&Err::<(), _>(NotAuthorized))?);
                     }
                     state.current_call_scope_mut()?.auth_scope_mut().add_proof(proof_id);

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -3385,15 +3385,13 @@ where
                 args.assert_no_args("Proof.DropAuthorize")?;
 
                 self.tracker.write_with(|state| {
-                    // Scope before existence, so an id this frame does not hold answers the same whether or not a
-                    // proof is live at it: the ids are a dense counter, and a frame that could tell the two apart
-                    // could enumerate every proof in the transaction.
-                    if !state.current_call_scope()?.is_proof_in_scope(&proof_id) {
-                        return Err(RuntimeError::ProofNotInScope { proof_id });
-                    }
-                    if !state.proof_exists(proof_id) {
-                        return Err(RuntimeError::ProofNotFound { proof_id });
-                    }
+                    // Giving up an authorization only shrinks this frame's own auth scope, so it succeeds for any
+                    // id: an id the frame never authorized is already in the state being asked for. That makes it
+                    // answerless by construction, which is what keeps it from reporting whether a proof is live at
+                    // an id the frame does not hold — the ids are a dense counter, so an answer would enumerate
+                    // every proof in the transaction. `ProofAccess::drop` is the only route here, and a `Drop` has
+                    // nowhere to report a failure, so a rejection would abort the transaction from a drop point
+                    // the template author never wrote.
                     state.current_call_scope_mut()?.auth_scope_mut().remove_proof(&proof_id);
 
                     Ok(InvokeResult::unit())

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -3385,6 +3385,12 @@ where
                 args.assert_no_args("Proof.DropAuthorize")?;
 
                 self.tracker.write_with(|state| {
+                    // Scope before existence, so an id this frame does not hold answers the same whether or not a
+                    // proof is live at it: the ids are a dense counter, and a frame that could tell the two apart
+                    // could enumerate every proof in the transaction.
+                    if !state.current_call_scope()?.is_proof_in_scope(&proof_id) {
+                        return Err(RuntimeError::ProofNotInScope { proof_id });
+                    }
                     if !state.proof_exists(proof_id) {
                         return Err(RuntimeError::ProofNotFound { proof_id });
                     }

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -844,7 +844,7 @@ impl<TStore: StateReader> WorkingState<TStore> {
     pub fn drop_proof(&mut self, proof_id: ProofId) -> Result<(), RuntimeError> {
         let call_frame_mut = self.current_call_scope_mut()?;
         if !call_frame_mut.is_proof_in_scope(&proof_id) {
-            return Err(RuntimeError::ProofNotFound { proof_id });
+            return Err(RuntimeError::ProofNotInScope { proof_id });
         }
         call_frame_mut.remove_proof_from_scope(&proof_id);
 

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -595,6 +595,15 @@ impl<TStore: StateReader> WorkingState<TStore> {
             .ok_or(RuntimeError::ProofNotFound { proof_id })
     }
 
+    /// Reads a proof the current frame holds. Proof ids come from a counter shared by the whole transaction, so the
+    /// scope check is what keeps one frame from reading the contents of another frame's proof.
+    pub fn get_proof_in_scope(&self, proof_id: ProofId) -> Result<&Proof, RuntimeError> {
+        if !self.current_call_scope()?.is_proof_in_scope(&proof_id) {
+            return Err(RuntimeError::ProofNotInScope { proof_id });
+        }
+        self.get_proof(proof_id)
+    }
+
     pub fn proof_exists(&self, proof_id: ProofId) -> bool {
         self.proofs.contains_key(&proof_id)
     }

--- a/crates/engine/tests/freeze.rs
+++ b/crates/engine/tests/freeze.rs
@@ -4,10 +4,11 @@
 use std::collections::BTreeMap;
 
 use tari_engine::runtime::RuntimeError;
+use tari_engine_types::indexed_value::IndexedWellKnownTypes;
 use tari_ootle_transaction::{Epoch, Transaction, args};
 use tari_template_lib::{
     args::VaultFreezeFlag,
-    types::{ComponentAddress, ResourceAddress, VaultId},
+    types::{ComponentAddress, ResourceAddress, VaultId, constants::TARI_TOKEN},
 };
 use tari_template_test_tooling::{TemplateTest, support::assert_error::assert_reject_reason};
 
@@ -77,4 +78,43 @@ fn it_freezes_vaults_containing_a_freezable_resource() {
             .build_and_seal(test.secret_key()),
         vec![account_proof],
     );
+}
+
+#[test]
+fn it_refuses_to_freeze_a_vault_of_another_resource() {
+    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/freeze"]);
+    let template = test.get_template_address("Freeze");
+    let (account, _, _) = test.create_funded_account();
+
+    let result = test.execute_expect_success(
+        test.transaction()
+            .allocate_component_address("freeze_comp")
+            .call_function(template, "new", args![Workspace("freeze_comp")])
+            .build_and_seal(test.secret_key()),
+        vec![test.owner_proof()],
+    );
+
+    let component: ComponentAddress = result.finalize.execution_results[1].get_value("$.0").unwrap().unwrap();
+    let freeze_resource: ResourceAddress = result.finalize.execution_results[1].get_value("$.1").unwrap().unwrap();
+
+    // The account's only vault holds TARI, not the freezable resource whose Freeze rule authorized the action.
+    let vault_id = {
+        let store = test.read_only_state_store();
+        let component = store.get_component(account).unwrap();
+        let values = IndexedWellKnownTypes::from_value(component.state()).unwrap();
+        values.vault_ids()[0]
+    };
+
+    let reason = test.execute_expect_failure(
+        test.transaction()
+            .call_method(component, "freeze", args![vault_id])
+            .build_and_seal(test.secret_key()),
+        vec![test.owner_proof()],
+    );
+
+    assert_reject_reason(reason, RuntimeError::FreezeResourceMismatch {
+        vault_id,
+        resource_address: freeze_resource,
+        vault_resource: TARI_TOKEN,
+    });
 }

--- a/crates/engine/tests/shenanigans.rs
+++ b/crates/engine/tests/shenanigans.rs
@@ -640,7 +640,11 @@ fn it_refuses_to_authorize_a_proof_the_frame_does_not_hold() {
     // The victim holds a proof across a call into the attacker, which is handed nothing and guesses the id.
     let result = test.execute_expect_success(
         test.transaction()
-            .call_method(victim, "hold_proof_and_call", args![attacker, "try_authorize_proof"])
+            .call_method(victim, "hold_proof_and_call", args![
+                attacker,
+                "try_authorize_proof",
+                0u32
+            ])
             .build_and_seal(test.secret_key()),
         vec![],
     );
@@ -672,10 +676,58 @@ fn it_refuses_to_read_a_proof_the_frame_does_not_hold() {
 
     let reason = test.execute_expect_failure(
         test.transaction()
-            .call_method(victim, "hold_proof_and_call", args![attacker, "read_proof_amount"])
+            .call_method(victim, "hold_proof_and_call", args![
+                attacker,
+                "read_proof_amount",
+                0u32
+            ])
             .build_and_seal(test.secret_key()),
         vec![],
     );
 
     assert_reject_reason(reason, "Encountered unknown or out of scope proof");
+}
+
+/// `DropAuthorize` can only touch the calling frame's own auth scope, so its answer must not tell a frame whether a
+/// proof is live at an id it does not hold — the ids are a dense counter, so that would enumerate the transaction.
+#[test]
+fn it_does_not_reveal_whether_an_out_of_scope_proof_is_live() {
+    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/shenanigans"]);
+    let template_addr = test.get_template_address(TEMPLATE_NAME);
+
+    let result = test.execute_expect_success(
+        test.transaction()
+            .call_function(template_addr, "with_fungible_vault", args![])
+            .call_function(template_addr, "with_fungible_vault", args![])
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+    let victim = result.finalize.execution_results[0]
+        .decode::<ComponentAddress>()
+        .unwrap();
+    let attacker = result.finalize.execution_results[1]
+        .decode::<ComponentAddress>()
+        .unwrap();
+
+    // Id 0 is live and held by the victim; id 7 has no proof at all. Both must draw the same answer.
+    let live = test.execute_expect_failure(
+        test.transaction()
+            .call_method(victim, "hold_proof_and_call", args![
+                attacker,
+                "drop_authorize_proof",
+                0u32
+            ])
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+
+    let absent = test.execute_expect_failure(
+        test.transaction()
+            .call_method(attacker, "drop_authorize_proof", args![7u32])
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+
+    assert_reject_reason(live, RuntimeError::ProofNotInScope { proof_id: 0.into() });
+    assert_reject_reason(absent, RuntimeError::ProofNotInScope { proof_id: 7.into() });
 }

--- a/crates/engine/tests/shenanigans.rs
+++ b/crates/engine/tests/shenanigans.rs
@@ -688,10 +688,11 @@ fn it_refuses_to_read_a_proof_the_frame_does_not_hold() {
     assert_reject_reason(reason, "Encountered unknown or out of scope proof");
 }
 
-/// `DropAuthorize` can only touch the calling frame's own auth scope, so its answer must not tell a frame whether a
-/// proof is live at an id it does not hold — the ids are a dense counter, so that would enumerate the transaction.
+/// Giving up an authorization is confined to the calling frame's own auth scope, so it answers any id: a frame
+/// cannot un-authorize another frame's proof, and cannot learn from the attempt whether a proof is live at an id it
+/// does not hold.
 #[test]
-fn it_does_not_reveal_whether_an_out_of_scope_proof_is_live() {
+fn it_confines_dropping_an_authorization_to_the_calling_frame() {
     let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/shenanigans"]);
     let template_addr = test.get_template_address(TEMPLATE_NAME);
 
@@ -709,8 +710,9 @@ fn it_does_not_reveal_whether_an_out_of_scope_proof_is_live() {
         .decode::<ComponentAddress>()
         .unwrap();
 
-    // Id 0 is live and held by the victim; id 7 has no proof at all. Both must draw the same answer.
-    let live = test.execute_expect_failure(
+    // Id 0 is live and held by the victim. The attacker dropping its authorization touches only the attacker's own
+    // scope, so the victim's own `proof.drop()` after the call still finds it.
+    test.execute_expect_success(
         test.transaction()
             .call_method(victim, "hold_proof_and_call", args![
                 attacker,
@@ -721,13 +723,11 @@ fn it_does_not_reveal_whether_an_out_of_scope_proof_is_live() {
         vec![],
     );
 
-    let absent = test.execute_expect_failure(
+    // An id with no proof at it answers the same, rather than aborting from `ProofAccess::drop`.
+    test.execute_expect_success(
         test.transaction()
             .call_method(attacker, "drop_authorize_proof", args![7u32])
             .build_and_seal(test.secret_key()),
         vec![],
     );
-
-    assert_reject_reason(live, RuntimeError::ProofNotInScope { proof_id: 0.into() });
-    assert_reject_reason(absent, RuntimeError::ProofNotInScope { proof_id: 7.into() });
 }

--- a/crates/engine/tests/shenanigans.rs
+++ b/crates/engine/tests/shenanigans.rs
@@ -617,3 +617,65 @@ fn it_does_not_leak_a_callees_address_allocation_into_the_callers_scope() {
 
     assert_reject_reason(reason, RuntimeError::AddressAllocationNotInScope { id: 0 });
 }
+
+#[test]
+fn it_refuses_to_authorize_a_proof_the_frame_does_not_hold() {
+    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/shenanigans"]);
+    let template_addr = test.get_template_address(TEMPLATE_NAME);
+
+    let result = test.execute_expect_success(
+        test.transaction()
+            .call_function(template_addr, "with_fungible_vault", args![])
+            .call_function(template_addr, "with_fungible_vault", args![])
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+    let victim = result.finalize.execution_results[0]
+        .decode::<ComponentAddress>()
+        .unwrap();
+    let attacker = result.finalize.execution_results[1]
+        .decode::<ComponentAddress>()
+        .unwrap();
+
+    // The victim holds a proof across a call into the attacker, which is handed nothing and guesses the id.
+    let result = test.execute_expect_success(
+        test.transaction()
+            .call_method(victim, "hold_proof_and_call", args![attacker, "try_authorize_proof"])
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+
+    assert_eq!(
+        result.finalize.execution_results[0].decode::<Amount>().unwrap(),
+        Amount::zero()
+    );
+}
+
+#[test]
+fn it_refuses_to_read_a_proof_the_frame_does_not_hold() {
+    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/shenanigans"]);
+    let template_addr = test.get_template_address(TEMPLATE_NAME);
+
+    let result = test.execute_expect_success(
+        test.transaction()
+            .call_function(template_addr, "with_fungible_vault", args![])
+            .call_function(template_addr, "with_fungible_vault", args![])
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+    let victim = result.finalize.execution_results[0]
+        .decode::<ComponentAddress>()
+        .unwrap();
+    let attacker = result.finalize.execution_results[1]
+        .decode::<ComponentAddress>()
+        .unwrap();
+
+    let reason = test.execute_expect_failure(
+        test.transaction()
+            .call_method(victim, "hold_proof_and_call", args![attacker, "read_proof_amount"])
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+
+    assert_reject_reason(reason, "Encountered unknown or out of scope proof");
+}

--- a/crates/engine/tests/shenanigans.rs
+++ b/crates/engine/tests/shenanigans.rs
@@ -688,11 +688,16 @@ fn it_refuses_to_read_a_proof_the_frame_does_not_hold() {
     assert_reject_reason(reason, "Encountered unknown or out of scope proof");
 }
 
-/// Giving up an authorization is confined to the calling frame's own auth scope, so it answers any id: a frame
-/// cannot un-authorize another frame's proof, and cannot learn from the attempt whether a proof is live at an id it
-/// does not hold.
+/// Giving up an authorization answers for any proof id, and leaves the proof with whoever holds it.
+///
+/// The victim gives up its own authorization when the pin's `ProofAccess` temporary drops, so by the time the
+/// attacker runs, proof 0 is in the victim's `proof_scope` and not its `auth_scope`. What this pins is therefore the
+/// holder's `proof_scope` entry surviving the attacker's call, and the call answering at all. The `auth_scope` half
+/// of the isolation is structural — `current_call_scope_mut` is `call_frames.last_mut()`, so a frame has no way to
+/// address another's scope — and observing it would need the victim to hold its guard across the call and then
+/// exercise something gated on the badge, there being no engine query for `auth_scope` membership.
 #[test]
-fn it_confines_dropping_an_authorization_to_the_calling_frame() {
+fn it_answers_a_drop_authorize_for_any_proof_id() {
     let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/shenanigans"]);
     let template_addr = test.get_template_address(TEMPLATE_NAME);
 
@@ -710,8 +715,7 @@ fn it_confines_dropping_an_authorization_to_the_calling_frame() {
         .decode::<ComponentAddress>()
         .unwrap();
 
-    // Id 0 is live and held by the victim. The attacker dropping its authorization touches only the attacker's own
-    // scope, so the victim's own `proof.drop()` after the call still finds it.
+    // Id 0 is live and held by the victim, and the victim's own `proof.drop()` after the call still finds it.
     test.execute_expect_success(
         test.transaction()
             .call_method(victim, "hold_proof_and_call", args![

--- a/crates/engine/tests/templates/shenanigans/src/lib.rs
+++ b/crates/engine/tests/templates/shenanigans/src/lib.rs
@@ -160,10 +160,9 @@ mod template {
             Proof::from_id(proof_id.into()).amount()
         }
 
-        /// `DropAuthorize` on an id this frame does not hold. It can only ever touch this frame's own auth scope, so
-        /// the answer must not reveal whether a proof is live at that id.
+        /// Gives up an authorization for `proof_id`, whatever this frame holds. `ProofAccess::drop` is the only
+        /// route to the action and its field is public, so the guard is built by hand here to name an arbitrary id.
         pub fn drop_authorize_proof(&self, proof_id: u32) -> Amount {
-            // The guard's `Drop` is the only route to `DropAuthorize`, so one is made and dropped here.
             drop(tari_template_lib::models::ProofAccess { id: proof_id.into() });
             Amount::zero()
         }

--- a/crates/engine/tests/templates/shenanigans/src/lib.rs
+++ b/crates/engine/tests/templates/shenanigans/src/lib.rs
@@ -160,6 +160,14 @@ mod template {
             Proof::from_id(proof_id.into()).amount()
         }
 
+        /// `DropAuthorize` on an id this frame does not hold. It can only ever touch this frame's own auth scope, so
+        /// the answer must not reveal whether a proof is live at that id.
+        pub fn drop_authorize_proof(&self, proof_id: u32) -> Amount {
+            // The guard's `Drop` is the only route to `DropAuthorize`, so one is made and dropped here.
+            drop(tari_template_lib::models::ProofAccess { id: proof_id.into() });
+            Amount::zero()
+        }
+
         pub fn take_from_a_vault(&mut self, vault_id: VaultId, amount: Amount) {
             let mut vault = Vault::for_test(vault_id.into());
             let stolen = vault.withdraw(amount);
@@ -232,9 +240,19 @@ mod template {
         }
 
         /// Holds a proof of its own across a call into `other`, which is handed nothing and guesses the id.
-        pub fn hold_proof_and_call(&self, other: ComponentAddress, method: String) -> Amount {
+        ///
+        /// Authorizes `proof_id` from this frame first, where the proof is in scope. An out-of-scope id and an id
+        /// with no proof at it are indistinguishable to `other` by design, so a `proof_id` naming nothing would
+        /// otherwise draw the same answer as the attack being tested. Failing here says so in words no rejection
+        /// from `other` produces.
+        pub fn hold_proof_and_call(&self, other: ComponentAddress, method: String, proof_id: u32) -> Amount {
             let proof = self.vault.as_ref().unwrap().create_proof();
-            let result: Amount = ComponentManager::get(other).call(&method, args![0u32]);
+            assert!(
+                Proof::from_id(proof_id.into()).try_authorize().is_ok(),
+                "proof id {proof_id} is not held by this frame"
+            );
+
+            let result: Amount = ComponentManager::get(other).call(&method, args![proof_id]);
             proof.drop();
             result
         }

--- a/crates/engine/tests/templates/shenanigans/src/lib.rs
+++ b/crates/engine/tests/templates/shenanigans/src/lib.rs
@@ -146,6 +146,20 @@ mod template {
             let _auth = stolen_proof.authorize();
         }
 
+        /// Proof ids are a transaction-wide counter, so a third party can name one it was never handed.
+        /// Takes the id as a plain integer, not a `ProofId`: a `ProofId` argument is how a proof is handed over, so
+        /// this frame is given nothing and guesses instead.
+        pub fn try_authorize_proof(&self, proof_id: u32) -> Amount {
+            match Proof::from_id(proof_id.into()).try_authorize() {
+                Ok(_access) => Amount::from(1u64),
+                Err(_) => Amount::zero(),
+            }
+        }
+
+        pub fn read_proof_amount(&self, proof_id: u32) -> Amount {
+            Proof::from_id(proof_id.into()).amount()
+        }
+
         pub fn take_from_a_vault(&mut self, vault_id: VaultId, amount: Amount) {
             let mut vault = Vault::for_test(vault_id.into());
             let stolen = vault.withdraw(amount);
@@ -211,6 +225,18 @@ mod template {
             .with_access_rules(AccessRules::allow_all())
             .with_owner_rule(OwnerRule::ByAccessRule(rule!(allow_all)))
             .create()
+        }
+
+        pub fn create_vault_proof(&self) -> Proof {
+            self.vault.as_ref().unwrap().create_proof()
+        }
+
+        /// Holds a proof of its own across a call into `other`, which is handed nothing and guesses the id.
+        pub fn hold_proof_and_call(&self, other: ComponentAddress, method: String) -> Amount {
+            let proof = self.vault.as_ref().unwrap().create_proof();
+            let result: Amount = ComponentManager::get(other).call(&method, args![0u32]);
+            proof.drop();
+            result
         }
 
         pub fn abandon_bucket(&mut self) {


### PR DESCRIPTION
Part of the engine audit wave 1 (with #2575 and #2576). They ship as one coordinated validator + indexer release.

> **Stacked on #2575.** This branch carries that commit, because the proof scope check needs the `proof_scope` / `auth_scope` split introduced there. Review the second commit; merge after #2575.

Two unrelated authority checks were missing.

## Proof access was unscoped

`ProofAction::Authorize` asked only whether the proof existed in the transaction-wide `proofs` map, and the read-only getters (`GetAmount`, `GetResourceAddress`, `GetResourceType`, `GetNonFungibles`) asked nothing at all. Proof ids come from a counter shared by the whole transaction, so a component called by a frame that holds a proof could name that proof by id and authorize with it — a badge it was never handed — or read its amount, resource and non-fungible ids.

All five now require the proof to be in the calling frame's scope: created there, passed in as an argument, or handed back by a callee. `Proof::authorize` on an out-of-scope proof returns `NotAuthorized`; the getters return `ProofNotInScope`.

Note on what this deliberately does *not* change: the base auth scope a top-level instruction inherits still carries the transaction's own proofs. That is what `DropAllProofsInWorkspace` exists for — a proof the submitter puts on the workspace authorizes their following instructions, including a call into a third-party component. Removing it breaks the documented workspace-proof flow (three `access_rules` tests are its spec). Placing a proof on the workspace and then calling a stranger stays the submitter's choice to make, in the same way that passing a `Proof` as an argument authorizes the callee.

## `SetVaultFreeze` froze any vault of any resource

`ResourceAction::SetVaultFreeze` authorized `Freeze` against `resource_address` and then write-locked `arg.vault_id` without checking what that vault holds. So anyone could publish a resource with `freezable(rule!(allow_all))` and freeze any vault on the network — including a TARI vault, leaving its owner unable to withdraw or to pay fees. Network-wide, and cheap.

It now requires the vault's resource to match, mirroring `Recall`, and fails with `FreezeResourceMismatch`.

## Tests

- `shenanigans.rs::it_refuses_to_authorize_a_proof_the_frame_does_not_hold` — a victim component holds a proof across a call into an attacker component, which is handed nothing and guesses the id. On `development` the attacker gets the badge.
- `shenanigans.rs::it_refuses_to_read_a_proof_the_frame_does_not_hold`
- `freeze.rs::it_refuses_to_freeze_a_vault_of_another_resource`

All 43 `tari_engine` test binaries pass.
