### PR TITLE
fix(engine)!: gate account ownership on the signer badge

### DIFF
--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -3847,6 +3847,16 @@ where
             .read_with(|state| state.authorization().check_current_component_access_rules(method))
     }
 
+    fn check_signer_badge_in_scope(&self, public_key: RistrettoPublicKeyBytes) -> Result<(), RuntimeError> {
+        self.tracker.read_with(|state| {
+            let badge = NonFungibleAddress::from_public_key(public_key);
+            if !state.base_call_scope().auth_scope().contains_badge(&badge) {
+                return Err(RuntimeError::SignerBadgeNotInScope { public_key });
+            }
+            Ok(())
+        })
+    }
+
     fn check_component_ownership(&self, action: ActionIdent) -> Result<(), RuntimeError> {
         self.tracker.read_with(|state| {
             let locked = state

--- a/crates/engine/src/runtime/mod.rs
+++ b/crates/engine/src/runtime/mod.rs
@@ -106,6 +106,7 @@ use tari_template_lib::{
         NonFungibleAddress,
         TemplateAddress,
         ValidatorFeePoolAddress,
+        crypto::RistrettoPublicKeyBytes,
         engine_args::IntrinsicId,
         stealth::StealthTransferStatement,
     },
@@ -213,6 +214,10 @@ pub trait RuntimeInterface {
     fn check_component_access_rules(&self, method: &str) -> Result<(), RuntimeError>;
     /// Checks whether the current execution context has owner permission of the given component.
     fn check_component_ownership(&self, action: ActionIdent) -> Result<(), RuntimeError>;
+
+    /// Asserts that the signer badge for `public_key` is in the transaction's base auth scope, i.e. that the
+    /// transaction is signed by that key.
+    fn check_signer_badge_in_scope(&self, public_key: RistrettoPublicKeyBytes) -> Result<(), RuntimeError>;
 
     fn update_component_template(&mut self, new_template: TemplateAddress) -> Result<(), RuntimeError>;
 

--- a/crates/engine/src/transaction/error.rs
+++ b/crates/engine/src/transaction/error.rs
@@ -124,6 +124,8 @@ pub enum TransactionErrorKind {
     NotAMigrationFunction { name: String },
     #[error("Migration functions cannot be called directly: {name}")]
     CannotCallMigrationFunctionDirectly { name: String },
+    #[error("The account constructor cannot be called directly. Use the CreateAccount instruction.")]
+    CannotCallAccountConstructor,
     #[error("Invalid CreateAccount operation for component {component_address}: {details}")]
     InvalidCreateAccount {
         component_address: ComponentAddress,

--- a/crates/engine/src/transaction/processor.rs
+++ b/crates/engine/src/transaction/processor.rs
@@ -701,6 +701,13 @@ where
                 address: ACCOUNT_TEMPLATE_ADDRESS,
             })?;
 
+        // The derived address belongs to `public_key_address`, so anything that departs from the rules that key
+        // would get requires that key's signature. Creating the account on the default rules stays permissionless
+        // so that a sender can deposit to an account that does not exist yet.
+        if owner_rule.is_some() || access_rules.is_some() {
+            runtime.interface().check_signer_badge_in_scope(*public_key_address)?;
+        }
+
         let account_address = derive_component_address_from_public_key(&ACCOUNT_TEMPLATE_ADDRESS, public_key_address);
 
         let maybe_existing_account = runtime

--- a/crates/engine/src/transaction/processor.rs
+++ b/crates/engine/src/transaction/processor.rs
@@ -820,6 +820,13 @@ where
         function: &str,
         args: Vec<InstructionArg>,
     ) -> Result<InstructionResult, TransactionErrorKind> {
+        // An account lives at an address derived from its public key, so which rules a component may be created
+        // there under is that key's decision. `CreateAccount` is the sole route to the constructor and is where
+        // that decision is enforced.
+        if *template_address == ACCOUNT_TEMPLATE_ADDRESS && function == ACCOUNT_CONSTRUCTOR_FUNCTION {
+            return Err(TransactionErrorKind::CannotCallAccountConstructor);
+        }
+
         let template = template_provider
             .get_template(template_address)
             .map_err(|e| TransactionErrorKind::FailedToLoadTemplate {

--- a/crates/engine/tests/account.rs
+++ b/crates/engine/tests/account.rs
@@ -6,7 +6,7 @@ use tari_crypto::{keys::PublicKey, ristretto::RistrettoPublicKey};
 use tari_engine::runtime::{ActionIdent, RuntimeError};
 use tari_ootle_transaction::{Epoch, Transaction, args};
 use tari_template_builtin::ACCOUNT_TEMPLATE_ADDRESS;
-use tari_template_lib::types::{Amount, access_rules::ComponentAccessRules, constants::TARI_TOKEN, rule};
+use tari_template_lib::types::{Amount, OwnerRule, access_rules::ComponentAccessRules, constants::TARI_TOKEN, rule};
 use tari_template_test_tooling::{
     TemplateTest,
     support::assert_error::{assert_access_denied_for_action, assert_reject_reason},
@@ -373,4 +373,93 @@ fn put_into_bucket_rejects_resource_mismatch() {
         format!("{reason}").contains("Resource addresses do not match"),
         "expected ResourceAddressMismatch, got: {reason}"
     );
+}
+
+#[test]
+fn custom_ownership_of_another_keys_account_is_refused() {
+    let mut test = TemplateTest::new_builtin_only();
+    let (_payer_proof, _payer_pk, payer_sk) = test.create_owner_proof();
+    let (_victim_proof, victim_pk, _victim_sk) = test.create_owner_proof();
+
+    // The squatter hands itself the owner rule on the address derived from the victim's key.
+    let reason = test.execute_expect_failure(
+        test.transaction()
+            .create_account_custom::<&str>(
+                victim_pk.to_byte_type(),
+                Some(OwnerRule::ByAccessRule(rule!(allow_all))),
+                None,
+                None,
+            )
+            .build_and_seal(&payer_sk),
+        vec![],
+    );
+
+    assert_reject_reason(reason, RuntimeError::SignerBadgeNotInScope {
+        public_key: victim_pk.to_byte_type(),
+    });
+
+    // Custom access rules are gated the same way.
+    let reason = test.execute_expect_failure(
+        test.transaction()
+            .create_account_custom::<&str>(
+                victim_pk.to_byte_type(),
+                None,
+                Some(ComponentAccessRules::new().default(rule!(allow_all))),
+                None,
+            )
+            .build_and_seal(&payer_sk),
+        vec![],
+    );
+
+    assert_reject_reason(reason, RuntimeError::SignerBadgeNotInScope {
+        public_key: victim_pk.to_byte_type(),
+    });
+}
+
+#[test]
+fn custom_ownership_via_the_account_template_is_refused() {
+    let mut test = TemplateTest::new_builtin_only();
+    let (_payer_proof, _payer_pk, payer_sk) = test.create_owner_proof();
+    let (victim_proof, _victim_pk, _victim_sk) = test.create_owner_proof();
+
+    let null: Option<()> = None;
+    let reason = test.execute_expect_failure(
+        test.transaction()
+            .call_function(ACCOUNT_TEMPLATE_ADDRESS, "create", args![
+                victim_proof,
+                Some(OwnerRule::ByAccessRule(rule!(allow_all))),
+                null,
+                null
+            ])
+            .build_and_seal(&payer_sk),
+        vec![],
+    );
+
+    assert_reject_reason(reason, "unknown or out of scope signer badge");
+}
+
+#[test]
+fn an_account_for_another_key_may_still_be_created_on_the_default_rules() {
+    let mut test = TemplateTest::new_builtin_only();
+    let (_payer_proof, _payer_pk, payer_sk) = test.create_owner_proof();
+    let (_victim_proof, victim_pk, _victim_sk) = test.create_owner_proof();
+
+    test.execute_expect_success(
+        test.transaction()
+            .create_account(victim_pk.to_byte_type())
+            .put_last_instruction_output_on_workspace("account")
+            .call_method(xtr_faucet_component(), "take", args![Workspace("account")])
+            .build_and_seal(&payer_sk),
+        vec![],
+    );
+
+    let account = *test
+        .read_only_state_store()
+        .all_accounts()
+        .unwrap()
+        .keys()
+        .next()
+        .unwrap();
+    let vaults = test.read_only_state_store().get_vaults_for_account(account).unwrap();
+    assert_eq!(vaults.get(&TARI_TOKEN).unwrap().balance(), 1_000_000_000u64);
 }

--- a/crates/engine/tests/account.rs
+++ b/crates/engine/tests/account.rs
@@ -87,8 +87,8 @@ fn attempt_to_overwrite_account() {
     let null: Option<()> = None;
     let overwriting_tx = test.execute_expect_failure(
         Transaction::builder_localnet(Epoch(1))
-            // Create component with the same ID
-            // The create account instruction is idempotent, so we'll call the template directly to force an overwrite attempt
+            // `CreateAccount` is idempotent, so a direct call into the template is the only shape an overwrite
+            // attempt can take
             .call_function(
                 ACCOUNT_TEMPLATE_ADDRESS,
                 "create",
@@ -99,10 +99,7 @@ fn attempt_to_overwrite_account() {
         vec![source_account_proof],
     );
 
-    // Check that the previous transaction failed because of an address collision.
-    assert_reject_reason(overwriting_tx, RuntimeError::ComponentAlreadyExists {
-        address: source_account,
-    });
+    assert_reject_reason(overwriting_tx, "The account constructor cannot be called directly");
 
     let store = test.read_only_state_store();
     let account = store.get_account(source_account).unwrap();
@@ -417,7 +414,7 @@ fn custom_ownership_of_another_keys_account_is_refused() {
 }
 
 #[test]
-fn custom_ownership_via_the_account_template_is_refused() {
+fn the_account_constructor_is_not_callable_as_a_function() {
     let mut test = TemplateTest::new_builtin_only();
     let (_payer_proof, _payer_pk, payer_sk) = test.create_owner_proof();
     let (victim_proof, _victim_pk, _victim_sk) = test.create_owner_proof();
@@ -435,7 +432,24 @@ fn custom_ownership_via_the_account_template_is_refused() {
         vec![],
     );
 
-    assert_reject_reason(reason, "unknown or out of scope signer badge");
+    assert_reject_reason(reason, "The account constructor cannot be called directly");
+}
+
+#[test]
+fn the_account_constructor_is_not_reachable_by_a_cross_template_call() {
+    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/shenanigans"]);
+    let template = test.get_template_address("Shenanigans");
+    let (_payer_proof, _payer_pk, payer_sk) = test.create_owner_proof();
+    let (victim_proof, _victim_pk, _victim_sk) = test.create_owner_proof();
+
+    let reason = test.execute_expect_failure(
+        test.transaction()
+            .call_function(template, "create_account_for", args![victim_proof])
+            .build_and_seal(&payer_sk),
+        vec![],
+    );
+
+    assert_reject_reason(reason, "The account constructor cannot be called directly");
 }
 
 #[test]

--- a/crates/engine/tests/templates/shenanigans/src/lib.rs
+++ b/crates/engine/tests/templates/shenanigans/src/lib.rs
@@ -75,6 +75,19 @@ mod template {
             ComponentManager::get(dest_component).call("deposit", args![stolen])
         }
 
+        /// Reaches the account template's constructor through a cross-template call rather than a `CallFunction`
+        /// instruction, claiming the address derived from `victim_badge`'s key under an owner rule of its own.
+        pub fn create_account_for(victim_badge: NonFungibleAddress) -> ComponentAddress {
+            let no_access_rules: Option<AccessRules> = None;
+            let no_bucket: Option<Bucket> = None;
+            TemplateManager::get(BuiltinTemplate::Account.address()).call("create", args![
+                victim_badge,
+                Some(OwnerRule::ByAccessRule(rule!(allow_all))),
+                no_access_rules,
+                no_bucket
+            ])
+        }
+
         pub fn with_vault_copy() -> Self {
             let vault = Vault::new_empty(STEALTH_TARI_RESOURCE_ADDRESS);
             let vault_copy = Vault::for_test(vault.vault_id());

--- a/crates/template_builtin/templates/account/src/lib.rs
+++ b/crates/template_builtin/templates/account/src/lib.rs
@@ -51,6 +51,14 @@ mod account_template {
                 .to_public_key()
                 .unwrap_or_else(|| panic!("public_key_token is not a valid public key: {}", public_key_token));
 
+            // The account's address is derived from `public_key`, so replacing the owner rule or the access rules
+            // that key would otherwise get requires that key's signature on the transaction. Creating an account
+            // for someone else on the default rules stays permissionless, which is what lets a sender deposit to
+            // an account that does not exist yet.
+            if owner_rule.is_some() || access_rules.is_some() {
+                CallerContext::get_signer_proof_for_public_key(public_key).drop();
+            }
+
             // The owner of this account is either provided explicitly or defaults to the provided public key.
             let owner_rule = owner_rule.unwrap_or(OwnerRule::ByPublicKey(public_key));
 

--- a/crates/template_builtin/templates/account/src/lib.rs
+++ b/crates/template_builtin/templates/account/src/lib.rs
@@ -51,14 +51,6 @@ mod account_template {
                 .to_public_key()
                 .unwrap_or_else(|| panic!("public_key_token is not a valid public key: {}", public_key_token));
 
-            // The account's address is derived from `public_key`, so replacing the owner rule or the access rules
-            // that key would otherwise get requires that key's signature on the transaction. Creating an account
-            // for someone else on the default rules stays permissionless, which is what lets a sender deposit to
-            // an account that does not exist yet.
-            if owner_rule.is_some() || access_rules.is_some() {
-                CallerContext::get_signer_proof_for_public_key(public_key).drop();
-            }
-
             // The owner of this account is either provided explicitly or defaults to the provided public key.
             let owner_rule = owner_rule.unwrap_or(OwnerRule::ByPublicKey(public_key));
 


### PR DESCRIPTION
Closes audit finding **C5** (fund theft).

An account's component address is derived from its public key, so which rules a component may be created at that address under is a decision for that key. Two routes answered it in the caller's favour instead.

### The `CreateAccount` instruction

`CreateAccount { public_key, owner_rule, access_rules }` derived the canonical address for any public key and forwarded a caller-supplied `owner_rule`/`access_rules` to the constructor. A squatter could create the victim's account ahead of them, name itself the owner, and collect every subsequent deposit — including the `CreateAccount { victim_pk, bucket }` deposits the victim's own senders make.

The signer badge for `public_key` is now required in the transaction's base auth scope, but only when either rule is supplied. Creating an account for someone else on the default rules stays permissionless, which is what lets a sender deposit to an account that does not exist yet.

### The account template's constructor

`Account::create` was also reachable as a plain function — from a `CallFunction` instruction, and from another template through `TemplateManager::call`, which never touches the instruction. Both land in `TransactionProcessor::call_function`, which now refuses that one function by name (`ACCOUNT_CONSTRUCTOR_FUNCTION`, the same constant `create_account` looks it up with). Any other function added to the account template later stays callable.

That leaves `CreateAccount` as the only way to create an account, and the gate above as the only place the decision is made:

- `create_account` invokes the constructor directly rather than through `call_function`, so the instruction is unaffected.
- The template's methods go through `call_method` and are unaffected.
- Squatting from an attacker's own template is already impossible: `CreateComponentAllocation` derives under `state.current_template()`, so only a frame already executing as the account template can allocate an account address.

### Scope note

A template can no longer create an account on a user's behalf. Given the address derivation, a template doing so *is* the squat; the `CreateAccount` instruction remains available at the transaction level.

### Tests

`crates/engine/tests/account.rs`:

- `custom_ownership_of_another_keys_account_is_refused` — custom owner rule, then custom access rules, over the `CreateAccount` route
- `the_account_constructor_is_not_callable_as_a_function` — the `CallFunction` route
- `the_account_constructor_is_not_reachable_by_a_cross_template_call` — the `TemplateManager::call` route, via a new `Shenanigans::create_account_for`
- `an_account_for_another_key_may_still_be_created_on_the_default_rules` — the permissionless deposit flow still works
- `attempt_to_overwrite_account` — retargeted at the new rejection

Each of the three attack tests was first run against the unfixed code: all three transactions **succeed** and hand the attacker ownership of the victim's account.

Verified with the full `cargo test -p tari_engine` sweep (43 binaries, 0 failures), `cargo test -p tari_template_builtin`, and `cargo lints clippy -p tari_engine --all-targets`.

### Breaking

Rejects transactions that were previously accepted. No template recompile — the builtin account binary is unchanged.
