### PR TITLE
fix(engine)!: remove attacker-reachable panics from execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12021,6 +12021,7 @@ dependencies = [
  "thiserror 2.0.18",
  "wasmer",
  "wasmer-middlewares",
+ "wat",
 ]
 
 [[package]]

--- a/crates/common_types/src/engine_signature.rs
+++ b/crates/common_types/src/engine_signature.rs
@@ -50,10 +50,14 @@ impl RistrettoSchnorrBlake2bVerifier {
 
 impl Verifier for RistrettoSchnorrBlake2bVerifier {
     fn verify(&self, domain: &[u8], message: &[u8], public_key: &PublicKey, signature: &SignaturePayload) -> bool {
-        let sig = signature
-            .ristretto_schnorr_blake2b()
-            .expect("Expected Ristretto Schnorr signature");
-        let ristretto_public_key = public_key.ristretto25519().expect("Expected Ristretto PublicKey");
+        // A caller chooses both the key and the payload, and `PublicKey`/`SignaturePayload` are open enums whose
+        // other variants are valid encodings, so a variant this verifier cannot use is a failed verification.
+        let Some(sig) = signature.ristretto_schnorr_blake2b() else {
+            return false;
+        };
+        let Some(ristretto_public_key) = public_key.ristretto25519() else {
+            return false;
+        };
 
         let Ok(pk) = ristretto_public_key.try_from_byte_type() else {
             return false;

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -69,6 +69,7 @@ criterion = { version = "0.8.1", features = ["html_reports"] }
 minicbor = { workspace = true, default-features = false, features = ["alloc", "derive"] }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
+wat = "1.258"
 
 
 [[bench]]

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -1925,11 +1925,16 @@ impl<TStore: StateReader> WorkingState<TStore> {
         let mut total_fee_overcharge = 0;
         // First collect fees that cannot be refunded (we have to take all fees even if they exceed the required amount)
         for resx in self.fee_state.non_refundable_fee_payments_mut_iter() {
-            // PANIC: this is checked by FeeState
             let paid_amount = resx
                 .unlocked_amount()
                 .to_u64_checked()
-                .expect("invalid fee entry in fee state");
+                .ok_or_else(|| RuntimeError::InvariantError {
+                    function: "finalize_fees_and_refunds",
+                    details: format!(
+                        "Non-refundable fee payment {} does not fit in a u64",
+                        resx.unlocked_amount()
+                    ),
+                })?;
 
             debug!(
                 target: LOG_TARGET,
@@ -1956,11 +1961,16 @@ impl<TStore: StateReader> WorkingState<TStore> {
                     "Collecting {} of refundable fees", resx.unlocked_amount()
                 );
 
-                // PANIC: this is checked by FeeState
-                let paid_amount = resx
-                    .unlocked_amount()
-                    .to_u64_checked()
-                    .expect("invalid fee entry in fee state");
+                let paid_amount =
+                    resx.unlocked_amount()
+                        .to_u64_checked()
+                        .ok_or_else(|| RuntimeError::InvariantError {
+                            function: "finalize_fees_and_refunds",
+                            details: format!(
+                                "Refundable fee payment {} does not fit in a u64",
+                                resx.unlocked_amount()
+                            ),
+                        })?;
 
                 // Withdraw only what is needed
                 let amount_to_withdraw = cmp::min(paid_amount, remaining_fees);
@@ -1981,16 +1991,22 @@ impl<TStore: StateReader> WorkingState<TStore> {
             );
             let vault_mut = substates_to_persist
                 .get_mut(&SubstateId::Vault(*refund_vault))
-                .expect("invariant: vault that made fee payment not in changeset")
-                .as_vault_mut()
-                .expect("invariant: substate substate_id for fee refund is not a vault");
+                .and_then(|substate| substate.as_vault_mut())
+                .ok_or_else(|| RuntimeError::InvariantError {
+                    function: "finalize_fees_and_refunds",
+                    details: format!("Refund target {} is not a vault in the changeset", refund_vault),
+                })?;
             vault_mut.resource_container_mut().deposit(resx.withdraw_all()?)?;
         }
 
-        let total_fees_paid = fee_resource
-            .unlocked_amount()
-            .to_u64_checked()
-            .expect("FeeState guarantees that the total fee payments fit in an u64");
+        let total_fees_paid =
+            fee_resource
+                .unlocked_amount()
+                .to_u64_checked()
+                .ok_or_else(|| RuntimeError::InvariantError {
+                    function: "finalize_fees_and_refunds",
+                    details: format!("Collected fees {} do not fit in a u64", fee_resource.unlocked_amount()),
+                })?;
 
         // The burn is a share of what was collected, overcharge included, and leaders receive the rest.
         let exhaust_burn = exhaust_burn_share(total_fees_paid, self.fee_state.burn_rate());

--- a/crates/engine/src/wasm/environment.rs
+++ b/crates/engine/src/wasm/environment.rs
@@ -219,14 +219,13 @@ impl<T> WasmEnv<T> {
 
         // with_memory_embedded_len expects a pointer to the payload (i.e. after the length prefix), so we need to add
         // the size of the length prefix to the pointer. The global is guest-controlled, so the sum is checked.
-        let offset_ptr =
-            (ptr as u32)
-                .checked_add(WASM_PTR_SIZE as u32)
-                .ok_or(WasmExecutionError::MemoryPointerOutOfRange {
-                    size: 0,
-                    pointer: ptr as u32,
-                    len: WASM_PTR_SIZE as u32,
-                })?;
+        let Some(offset_ptr) = (ptr as u32).checked_add(WASM_PTR_SIZE as u32) else {
+            return Err(WasmExecutionError::MemoryPointerOutOfRange {
+                size: self.get_memory()?.view(store).data_size(),
+                pointer: ptr as u32,
+                len: WASM_PTR_SIZE as u32,
+            });
+        };
         // Load ABI from memory
         // SAFETY: WasmEnv is not used concurrently
         unsafe {

--- a/crates/engine/src/wasm/environment.rs
+++ b/crates/engine/src/wasm/environment.rs
@@ -218,8 +218,15 @@ impl<T> WasmEnv<T> {
             .ok_or(WasmExecutionError::ExportError(ExportError::IncompatibleType))?;
 
         // with_memory_embedded_len expects a pointer to the payload (i.e. after the length prefix), so we need to add
-        // the size of the length prefix to the pointer
-        let offset_ptr = ptr as u32 + WASM_PTR_SIZE as u32;
+        // the size of the length prefix to the pointer. The global is guest-controlled, so the sum is checked.
+        let offset_ptr =
+            (ptr as u32)
+                .checked_add(WASM_PTR_SIZE as u32)
+                .ok_or(WasmExecutionError::MemoryPointerOutOfRange {
+                    size: 0,
+                    pointer: ptr as u32,
+                    len: WASM_PTR_SIZE as u32,
+                })?;
         // Load ABI from memory
         // SAFETY: WasmEnv is not used concurrently
         unsafe {

--- a/crates/engine/tests/account.rs
+++ b/crates/engine/tests/account.rs
@@ -477,3 +477,19 @@ fn an_account_for_another_key_may_still_be_created_on_the_default_rules() {
     let vaults = test.read_only_state_store().get_vaults_for_account(account).unwrap();
     assert_eq!(vaults.get(&TARI_TOKEN).unwrap().balance(), 1_000_000_000u64);
 }
+
+/// A proof over a stealth resource locks and unlocks a stealth container, TARI included.
+#[test]
+fn a_proof_over_a_stealth_resource_can_be_created_and_dropped() {
+    let mut test = TemplateTest::new_builtin_only();
+    let (account, account_proof, account_key) = test.create_funded_account();
+
+    test.execute_expect_success(
+        test.transaction()
+            .call_method(account, "create_proof_for_resource", args![TARI_TOKEN])
+            .put_last_instruction_output_on_workspace("proof")
+            .drop_all_proofs_in_workspace()
+            .build_and_seal(&account_key),
+        vec![account_proof],
+    );
+}

--- a/crates/engine/tests/fungible.rs
+++ b/crates/engine/tests/fungible.rs
@@ -211,6 +211,39 @@ fn minting_past_the_maximum_is_rejected_while_part_of_the_vault_is_locked() {
     assert_reject_reason(reason, "would take the resource balance past the maximum");
 }
 
+/// A confidential vault carries value as commitments and as a revealed balance, and either alone is enough to
+/// take a proof over. `mint_revealed` produces a vault with a revealed balance and no commitments.
+#[test]
+fn a_proof_over_a_confidential_vault_holding_only_revealed_funds() {
+    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/fungible"]);
+    let template = test.get_template_address("Fungible");
+
+    let result = test.execute_expect_success(
+        test.transaction()
+            .call_function(template, "with_supply", args![Amount::from(100u64)])
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+    let component: ComponentAddress = result.finalize.execution_results[0].decode().unwrap();
+
+    let vault = get_confidential_vault(&test, component);
+    assert!(vault.get_confidential_commitments().unwrap().is_empty());
+    let before = vault.balance();
+
+    test.execute_expect_success(
+        test.transaction()
+            .call_method(component, "create_confidential_proof", args![])
+            .put_last_instruction_output_on_workspace("proof")
+            .drop_all_proofs_in_workspace()
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+
+    let vault = get_confidential_vault(&test, component);
+    assert_eq!(vault.balance(), before);
+    assert!(vault.locked_balance().is_zero());
+}
+
 /// Taking a proof over a vault and dropping it again moves its balance between the container's locked and
 /// unlocked fields and leaves the total where it was.
 #[test]

--- a/crates/engine/tests/fungible.rs
+++ b/crates/engine/tests/fungible.rs
@@ -174,3 +174,80 @@ fn minting_past_the_maximum_vault_balance_is_rejected() {
 
     assert_reject_reason(reason, "would take the resource balance past the maximum");
 }
+
+/// A locked balance is still part of the container's balance, so the maximum applies to the two together.
+#[test]
+fn minting_past_the_maximum_is_rejected_while_part_of_the_vault_is_locked() {
+    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/fungible"]);
+    let template = test.get_template_address("Fungible");
+
+    let result = test.execute_expect_success(
+        test.transaction()
+            .call_function(template, "with_supply", args![Amount::from(100u64)])
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+    let component: ComponentAddress = result.finalize.execution_results[0].decode().unwrap();
+
+    // Locking moves 50 out of the unlocked field, so a mint sized to fit there alone still takes the vault's
+    // balance past the maximum once the locked half is counted. The second lock is the operation the bound
+    // protects: it adds the unlocked field onto the locked one.
+    let reason = test.execute_expect_failure(
+        test.transaction()
+            .call_method(component, "create_confidential_proof_by_amount", args![Amount::from(
+                50u64
+            )])
+            .put_last_instruction_output_on_workspace("proof")
+            .call_method(component, "confidential_mint_more", args![
+                ConfidentialOutputStatement::mint_revealed(Amount::MAX - Amount::from(50u64))
+            ])
+            .call_method(component, "create_confidential_proof_by_amount", args![Amount::MAX])
+            .put_last_instruction_output_on_workspace("proof2")
+            .drop_all_proofs_in_workspace()
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+
+    assert_reject_reason(reason, "would take the resource balance past the maximum");
+}
+
+/// Taking a proof over a vault and dropping it again moves its balance between the container's locked and
+/// unlocked fields and leaves the total where it was.
+#[test]
+fn a_proof_over_a_confidential_vault_preserves_the_balance() {
+    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/fungible"]);
+    let template = test.get_template_address("Fungible");
+
+    let result = test.execute_expect_success(
+        test.transaction()
+            .call_function(template, "with_supply", args![Amount::from(100u64)])
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+    let component: ComponentAddress = result.finalize.execution_results[0].decode().unwrap();
+
+    // `lock_all` requires a commitment, so move 60 of the 100 revealed into one, leaving 40 revealed.
+    let to_commitment = generate_withdraw_proof_with_inputs(&[], 60u64, 60, None, 0u64);
+    test.execute_expect_success(
+        test.transaction()
+            .call_method(component, "convert", args![to_commitment.proof])
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+
+    let vault = get_confidential_vault(&test, component);
+    let before = vault.balance() + vault.locked_balance();
+
+    test.execute_expect_success(
+        test.transaction()
+            .call_method(component, "create_confidential_proof", args![])
+            .put_last_instruction_output_on_workspace("proof")
+            .drop_all_proofs_in_workspace()
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+
+    let vault = get_confidential_vault(&test, component);
+    assert_eq!(vault.balance() + vault.locked_balance(), before);
+    assert_eq!(vault.balance(), before);
+}

--- a/crates/engine/tests/fungible.rs
+++ b/crates/engine/tests/fungible.rs
@@ -4,10 +4,13 @@
 use ootle_byte_type::ToByteType;
 use tari_engine_types::{crypto::commit_amount, vault::Vault};
 use tari_ootle_transaction::{Epoch, Transaction, args};
-use tari_template_lib::types::{Amount, ComponentAddress, ResourceType};
+use tari_template_lib::types::{Amount, ComponentAddress, ResourceType, confidential::ConfidentialOutputStatement};
 use tari_template_test_tooling::{
     TemplateTest,
-    support::confidential::{generate_confidential_output_statement, generate_withdraw_proof_with_inputs},
+    support::{
+        assert_error::assert_reject_reason,
+        confidential::{generate_confidential_output_statement, generate_withdraw_proof_with_inputs},
+    },
 };
 
 const CRATE_PATH: &str = env!("CARGO_MANIFEST_DIR");
@@ -144,4 +147,30 @@ fn get_vault_by_resource_type(test: &TemplateTest, component: ComponentAddress, 
             }
         })
         .expect("No vault found for the specified resource type")
+}
+
+/// The confidential resource tracks no supply, so nothing but the vault's own balance bounds a revealed mint.
+#[test]
+fn minting_past_the_maximum_vault_balance_is_rejected() {
+    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/fungible"]);
+    let template = test.get_template_address("Fungible");
+
+    let result = test.execute_expect_success(
+        test.transaction()
+            .call_function(template, "with_supply", args![Amount::MAX])
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+    let component: ComponentAddress = result.finalize.execution_results[0].decode().unwrap();
+
+    let reason = test.execute_expect_failure(
+        test.transaction()
+            .call_method(component, "confidential_mint_more", args![
+                ConfidentialOutputStatement::mint_revealed(1u32)
+            ])
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+
+    assert_reject_reason(reason, "would take the resource balance past the maximum");
 }

--- a/crates/engine/tests/publish_template.rs
+++ b/crates/engine/tests/publish_template.rs
@@ -128,3 +128,30 @@ fn rejects_more_than_one_publish_template() {
 fn generate_random_binary(size_in_bytes: usize) -> Vec<u8> {
     iter::repeat_with(random).take(size_in_bytes).collect()
 }
+
+/// `_ABI_TEMPLATE_DEF` is a guest-controlled global that the loader reads before it validates the instance, and
+/// the pointer arithmetic on it must survive any value the guest puts there.
+#[test]
+fn publish_template_with_an_out_of_range_abi_pointer() {
+    let mut test = TemplateTest::new(CRATE_PATH, &[] as &[&str]);
+    let (account_address, owner_proof, account_key, _) = test.create_funded_account_with_keypair();
+
+    let code = wat::parse_str(
+        r#"
+        (module
+          (memory (export "memory") 1)
+          (global (export "_ABI_TEMPLATE_DEF") i32 (i32.const -1)))
+        "#,
+    )
+    .unwrap();
+
+    let result = test.execute_expect_failure(
+        test.transaction()
+            .pay_fee_from_component(account_address, 200_000u64)
+            .publish_template(code)
+            .build_and_seal(&account_key),
+        vec![owner_proof],
+    );
+
+    assert_reject_reason(result, "Load template error");
+}

--- a/crates/engine/tests/signature.rs
+++ b/crates/engine/tests/signature.rs
@@ -166,3 +166,22 @@ fn check_signature_api() {
         "Expected bad public key to be false"
     );
 }
+
+/// `PublicKey::Zero` is a valid encoding any caller can supply, and this verifier has no Ristretto key to check
+/// against, so verification fails rather than aborting the executor.
+#[test]
+fn check_signature_with_a_zero_public_key() {
+    let (s1, p1) = create_key_pair_from_seed(1);
+    let p1 = PublicKey::from(p1.to_byte_type());
+    let (mut test, _) = setup(vec![p1]);
+    let template_addr = test.get_template_address(TEMPLATE_NAME);
+
+    let result = test.execute_expect_success(
+        test.transaction()
+            .call_function(template_addr, "check_sig", args![PublicKey::Zero, sign_it(&s1)])
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+
+    assert!(!result.finalize.execution_results[0].decode::<bool>().unwrap());
+}

--- a/crates/engine/tests/templates/fungible/src/lib.rs
+++ b/crates/engine/tests/templates/fungible/src/lib.rs
@@ -75,6 +75,18 @@ mod template {
             self.confidential.deposit(bucket);
         }
 
+        pub fn create_confidential_proof_by_amount(&self, amount: Amount) -> Proof {
+            self.confidential.create_proof_by_amount(amount)
+        }
+
+        pub fn create_confidential_proof(&self) -> Proof {
+            self.confidential.create_proof()
+        }
+
+        pub fn confidential_balance(&self) -> Amount {
+            self.confidential.balance()
+        }
+
         pub fn fungible_withdraw(&self, amount: Amount) -> Bucket {
             self.fungible.withdraw(amount)
         }

--- a/crates/engine_types/src/fees.rs
+++ b/crates/engine_types/src/fees.rs
@@ -420,7 +420,10 @@ impl FeeBreakdown {
     pub fn add(&mut self, source: FeeSource, amount: u64) {
         match self.breakdown.entry(source) {
             Entry::Occupied(entry) => {
-                *entry.into_mut() += amount;
+                let total = entry.into_mut();
+                // A breakdown row is a display total, so a charge that would take it past `u64::MAX` pins it there
+                // rather than wrapping. Whether the fee itself is affordable is decided elsewhere.
+                *total = total.saturating_add(amount);
             },
             Entry::Vacant(entry) => {
                 entry.insert(amount);

--- a/crates/engine_types/src/resource_container.rs
+++ b/crates/engine_types/src/resource_container.rs
@@ -275,12 +275,14 @@ impl ResourceContainer {
 
         match (self, other) {
             (
-                Self::Fungible { amount, .. },
+                Self::Fungible {
+                    amount, locked_amount, ..
+                },
                 Self::Fungible {
                     amount: other_amount, ..
                 },
             ) => {
-                *amount = checked_add(*amount, other_amount, "deposit")?;
+                *amount = checked_deposit(*amount, *locked_amount, other_amount)?;
             },
             (
                 Self::NonFungible { token_ids, .. },
@@ -302,6 +304,7 @@ impl ResourceContainer {
                 Self::Confidential {
                     commitments,
                     revealed_amount,
+                    locked_revealed_amount,
                     ..
                 },
                 Self::Confidential {
@@ -317,16 +320,20 @@ impl ResourceContainer {
                         ));
                     }
                 }
-                *revealed_amount = checked_add(*revealed_amount, other_amount, "deposit")?;
+                *revealed_amount = checked_deposit(*revealed_amount, *locked_revealed_amount, other_amount)?;
             },
             (
-                Self::Stealth { revealed_amount, .. },
+                Self::Stealth {
+                    revealed_amount,
+                    locked_amount,
+                    ..
+                },
                 Self::Stealth {
                     revealed_amount: other_amount,
                     ..
                 },
             ) => {
-                *revealed_amount = checked_add(*revealed_amount, other_amount, "deposit")?;
+                *revealed_amount = checked_deposit(*revealed_amount, *locked_amount, other_amount)?;
             },
             (this, other) => {
                 return Err(ResourceError::ResourceTypeMismatch {
@@ -665,7 +672,8 @@ impl ResourceContainer {
                     });
                 }
                 let newly_locked_commitments = mem::take(commitments);
-                let newly_locked_revealed_amount = *revealed_amount;
+                // Sets to zero and returns the amount
+                let newly_locked_revealed_amount = mem::take(revealed_amount);
                 locked_commitments.extend(newly_locked_commitments.iter().copied());
                 *locked_revealed_amount += newly_locked_revealed_amount;
 
@@ -946,6 +954,17 @@ fn checked_add(amount: Amount, other: Amount, operate: &'static str) -> Result<A
     amount
         .checked_add(other)
         .ok_or(ResourceError::BalanceOverflow { operate, amount: other })
+}
+
+/// Returns the new unlocked balance for a deposit of `deposit` into a container holding `unlocked` and `locked`.
+///
+/// A container's balance is the two fields together, so [`Amount::MAX`] bounds their sum rather than either one.
+/// Deposit is the only operation that raises that sum — locking and unlocking move value between the fields and
+/// leave it alone — so bounding it here is what keeps every one of those moves in range.
+fn checked_deposit(unlocked: Amount, locked: Amount, deposit: Amount) -> Result<Amount, ResourceError> {
+    let new_unlocked = checked_add(unlocked, deposit, "deposit")?;
+    checked_add(new_unlocked, locked, "deposit")?;
+    Ok(new_unlocked)
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/engine_types/src/resource_container.rs
+++ b/crates/engine_types/src/resource_container.rs
@@ -666,9 +666,11 @@ impl ResourceContainer {
                 locked_revealed_amount,
                 ..
             } => {
-                if commitments.is_empty() {
+                // A confidential container carries value in two places, so it is empty only when both are.
+                // `mint_revealed` alone produces a vault with a revealed balance and no commitments.
+                if commitments.is_empty() && revealed_amount.is_zero() {
                     return Err(ResourceError::InsufficientBalance {
-                        details: "lock_all: resource container contained no commitments".to_string(),
+                        details: "lock_all: resource container contained no commitments or revealed funds".to_string(),
                     });
                 }
                 let newly_locked_commitments = mem::take(commitments);

--- a/crates/engine_types/src/resource_container.rs
+++ b/crates/engine_types/src/resource_container.rs
@@ -280,7 +280,7 @@ impl ResourceContainer {
                     amount: other_amount, ..
                 },
             ) => {
-                *amount += other_amount;
+                *amount = checked_add(*amount, other_amount, "deposit")?;
             },
             (
                 Self::NonFungible { token_ids, .. },
@@ -317,7 +317,7 @@ impl ResourceContainer {
                         ));
                     }
                 }
-                *revealed_amount += other_amount;
+                *revealed_amount = checked_add(*revealed_amount, other_amount, "deposit")?;
             },
             (
                 Self::Stealth { revealed_amount, .. },
@@ -326,7 +326,7 @@ impl ResourceContainer {
                     ..
                 },
             ) => {
-                *revealed_amount += other_amount;
+                *revealed_amount = checked_add(*revealed_amount, other_amount, "deposit")?;
             },
             (this, other) => {
                 return Err(ResourceError::ResourceTypeMismatch {
@@ -689,7 +689,7 @@ impl ResourceContainer {
                 // Sets to zero and returns the amount
                 let newly_locked_amount = mem::take(revealed_amount);
                 *locked_amount += newly_locked_amount;
-                Ok(Self::public_fungible(resource_address, newly_locked_amount))
+                Ok(Self::stealth(resource_address, newly_locked_amount))
             },
         }
     }
@@ -724,7 +724,7 @@ impl ResourceContainer {
                         ),
                     });
                 }
-                *amount += container.unlocked_amount();
+                *amount = checked_add(*amount, container.unlocked_amount(), "unlock")?;
                 *locked_amount -= container.unlocked_amount();
             },
             Self::NonFungible {
@@ -790,7 +790,7 @@ impl ResourceContainer {
                         ));
                     }
                 }
-                *revealed_amount += container.unlocked_amount();
+                *revealed_amount = checked_add(*revealed_amount, container.unlocked_amount(), "unlock")?;
                 *locked_revealed_amount -= container.unlocked_amount();
             },
             Self::Stealth {
@@ -808,7 +808,7 @@ impl ResourceContainer {
                         ),
                     });
                 }
-                *revealed_amount += container.unlocked_amount();
+                *revealed_amount = checked_add(*revealed_amount, container.unlocked_amount(), "unlock")?;
                 *locked_amount -= container.unlocked_amount();
             },
         }
@@ -940,6 +940,14 @@ impl ResourceContainer {
     }
 }
 
+/// Every balance a container holds is bounded by [`Amount::MAX`]: an addition that would cross it is a rejected
+/// operation, not a wrapped balance.
+fn checked_add(amount: Amount, other: Amount, operate: &'static str) -> Result<Amount, ResourceError> {
+    amount
+        .checked_add(other)
+        .ok_or(ResourceError::BalanceOverflow { operate, amount: other })
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum ResourceError {
     #[error("Attempted to {operate} a {given} resource, but the container resource type is {expected}")]
@@ -955,6 +963,8 @@ pub enum ResourceError {
     },
     #[error("Resource did not contain sufficient balance: {details}")]
     InsufficientBalance { details: String },
+    #[error("{operate} of {amount} would take the resource balance past the maximum")]
+    BalanceOverflow { operate: &'static str, amount: Amount },
     #[error("Invariant error: {0}")]
     InvariantError(String),
     #[error("Operation not allowed: {0}")]


### PR DESCRIPTION
Part of the engine audit wave 1 (with #2575, #2576, #2577 and #2578). They ship as one coordinated validator + indexer release.

The release profile builds with `panic = 'abort'` and `overflow-checks = true`, and nothing on the execution path catches unwinds. Each of the following was a way for a submitter to stop every validator that executed their transaction.

## Validator kills

**`schnorr_verify` on `PublicKey::Zero`.** `RistrettoSchnorrBlake2bVerifier::verify` unwrapped the `PublicKey` and `SignaturePayload` variants with `expect`. `PublicKey::Zero` is a valid CBOR variant and the `#[default]`, reachable from the intrinsic on any caller-supplied key and from any template that verifies one. A variant this verifier cannot use is now a failed verification.

**Guest-controlled pointer arithmetic at publish.** `WasmEnv::load_template_def` computed `ptr as u32 + WASM_PTR_SIZE as u32` on the guest's `_ABI_TEMPLATE_DEF` global, and it runs *before* `validate_instance`. A ~50-byte module declaring that global as `-1` overflowed the `u32`, so a `PublishTemplate` instruction killed every validator that reached `validate_code`. The sum is now checked and yields `MemoryPointerOutOfRange`.

**Resource balance overflow.** `ResourceContainer::deposit` and the re-adds in `unlock` used the raw `Amount` operators, which are a plain `u128` add. A resource with total-supply tracking disabled keeps no running total to catch it, so minting past `Amount::MAX` and depositing overflowed. Both now use a checked add and return `ResourceError::BalanceOverflow`.

**`FeeBreakdown::add`** accumulated a `u64` raw. It saturates rather than wrapping, which is safe because saturation can only pin the total at `u64::MAX` and no `u64` payment can meet that — so an overflowing breakdown rejects the transaction rather than letting a submitter under-pay. The breakdown *is* what affordability is decided against: `FeeState::is_paid_in_full` compares `total_payments()` against `fee_charges.get_total()`.

**A container's whole balance is now bounded, not just its unlocked field.** A container holds its balance in two fields, unlocked and locked, and `Amount::MAX` bounds their sum. Bounding the deposit against the unlocked field alone let the pair exceed it: lock part of a vault, deposit up to `Amount::MAX` into what is left unlocked, and the container holds more than the maximum. The six lock sites then add the unlocked field onto the locked one with a raw `u128` add, which aborts the executor. A confidential resource with total-supply tracking disabled has nothing else in the way, so the mint reaches the container unchallenged. Deposit is the only operation that raises the sum — locking and unlocking move value between the fields — so it is bounded against the pair and every one of those moves is in range.

## Fund inflation, same file

`lock_all`'s `Confidential` arm copied the revealed amount where it moves it, so the amount was added to `locked_revealed_amount` while remaining in `revealed_amount`. `unlock` then returned it a second time, so a proof taken over a confidential vault and dropped again **doubled** the vault's revealed balance — reachable by any template calling `create_proof()` on a confidential vault, in one transaction, with no privileges. The `Fungible` and `Stealth` arms already moved it with `mem::take`.

This one is pre-existing and is not an audit finding; it sits in the function whose `Stealth` arm is fixed above.

**The `expect`s in `finalize_fees_and_refunds`** return `InvariantError`. They are guarded by `FeeState`, but the guard and the unwrap are far apart, and `FeePaymentInMainIntent` is the only thing standing between them.

## Functional break, same file

`ResourceContainer::lock_all`'s `Stealth` arm returned a `public_fungible` container. `unlock` rejects the type mismatch, so **every** proof taken over a stealth vault or bucket — TARI included — aborted the transaction, leaving an undroppable proof behind. `Account::create_proof_for_resource(TARI_TOKEN)` followed by `DropAllProofsInWorkspace` was enough to hit it.

## Tests

Each of these panics or aborts on `development`:

- `signature.rs::check_signature_with_a_zero_public_key`
- `publish_template.rs::publish_template_with_an_out_of_range_abi_pointer` (adds `wat` as a dev-dependency to write the module)
- `fungible.rs::minting_past_the_maximum_vault_balance_is_rejected`
- `account.rs::a_proof_over_a_stealth_resource_can_be_created_and_dropped`
- `fungible.rs::minting_past_the_maximum_is_rejected_while_part_of_the_vault_is_locked`
- `fungible.rs::a_proof_over_a_confidential_vault_preserves_the_balance` (reports `80` where the vault holds `40`)

Each of the last two was also verified against the rest of this branch with only its own fix reverted, so neither passes by way of the other.

All 43 `tari_engine` test binaries plus `tari_engine_types` and `tari_ootle_common_types` pass.

