### PR TITLE
refactor(consensus)!: remove epoch_end_spread_blocks

### DIFF
--- a/applications/tari_indexer/src/bootstrap.rs
+++ b/applications/tari_indexer/src/bootstrap.rs
@@ -563,7 +563,6 @@ async fn create_base_layer_epoch_oracle<TStore: EpochOracleStore + BaseLayerBloc
                 sync_headers: false,
                 sync_validator_node_changes: true,
             },
-            epoch_end_spread_blocks: consensus_constants.epoch_end_spread_blocks,
         },
         config.network,
     ))

--- a/applications/tari_ootle_app_utilities/src/consensus_constants_file.rs
+++ b/applications/tari_ootle_app_utilities/src/consensus_constants_file.rs
@@ -7,13 +7,10 @@ use std::{
     time::Duration,
 };
 
-use log::warn;
 use serde::{Deserialize, Serialize};
 use tari_consensus::consensus_constants::ConsensusConstants;
 use tari_engine_types::fees::{ExhaustBurnRate, MAX_EXHAUST_BURN_RATE_BPS};
 use tari_ootle_transaction::Network;
-
-const LOG_TARGET: &str = "tari::ootle::consensus_constants_file";
 
 /// Overrides for a LocalNet's consensus constants, applied over the network's built-in values.
 ///
@@ -41,10 +38,6 @@ pub struct ConsensusConstantsFile {
     pub max_block_validation_execution_points: Option<u64>,
     pub exhaust_burn_rate_bps: Option<u16>,
     pub max_transaction_validity_epochs: Option<u64>,
-    /// Accepted and ignored, so that an existing constants file that sets it still loads:
-    /// `deny_unknown_fields` would otherwise reject the whole file.
-    #[serde(skip_serializing)]
-    pub epoch_end_spread_blocks: Option<u64>,
 }
 
 impl ConsensusConstantsFile {
@@ -72,13 +65,6 @@ impl ConsensusConstantsFile {
             max_block_validation_execution_points,
             max_transaction_validity_epochs,
         );
-
-        if self.epoch_end_spread_blocks.is_some() {
-            warn!(
-                target: LOG_TARGET,
-                "⚠️ 'epoch_end_spread_blocks' in the consensus constants file is ignored and can be removed."
-            );
-        }
 
         if let Some(secs) = self.pacemaker_block_time_secs {
             constants.pacemaker_block_time = Duration::from_secs(secs);

--- a/applications/tari_ootle_app_utilities/src/consensus_constants_file.rs
+++ b/applications/tari_ootle_app_utilities/src/consensus_constants_file.rs
@@ -12,6 +12,8 @@ use tari_consensus::consensus_constants::ConsensusConstants;
 use tari_engine_types::fees::{ExhaustBurnRate, MAX_EXHAUST_BURN_RATE_BPS};
 use tari_ootle_transaction::Network;
 
+const LOG_TARGET: &str = "tari::ootle::consensus_constants_file";
+
 /// Overrides for a LocalNet's consensus constants, applied over the network's built-in values.
 ///
 /// Consensus constants have to agree across a network, so this is authored once and handed to every
@@ -38,6 +40,11 @@ pub struct ConsensusConstantsFile {
     pub max_block_validation_execution_points: Option<u64>,
     pub exhaust_burn_rate_bps: Option<u16>,
     pub max_transaction_validity_epochs: Option<u64>,
+    /// Accepted and ignored. The leeway this configured could never withhold or grant a vote:
+    /// ratifying an `EndEpoch` independently requires having observed the next epoch's boundary.
+    /// The field is kept because `deny_unknown_fields` would otherwise reject a whole constants
+    /// file that still sets it.
+    #[serde(skip_serializing)]
     pub epoch_end_spread_blocks: Option<u64>,
 }
 
@@ -65,8 +72,14 @@ impl ConsensusConstantsFile {
             max_block_execution_points,
             max_block_validation_execution_points,
             max_transaction_validity_epochs,
-            epoch_end_spread_blocks,
         );
+
+        if self.epoch_end_spread_blocks.is_some() {
+            log::warn!(
+                target: LOG_TARGET,
+                "⚠️ 'epoch_end_spread_blocks' in the consensus constants file is ignored and can be removed."
+            );
+        }
 
         if let Some(secs) = self.pacemaker_block_time_secs {
             constants.pacemaker_block_time = Duration::from_secs(secs);

--- a/applications/tari_ootle_app_utilities/src/consensus_constants_file.rs
+++ b/applications/tari_ootle_app_utilities/src/consensus_constants_file.rs
@@ -7,6 +7,7 @@ use std::{
     time::Duration,
 };
 
+use log::warn;
 use serde::{Deserialize, Serialize};
 use tari_consensus::consensus_constants::ConsensusConstants;
 use tari_engine_types::fees::{ExhaustBurnRate, MAX_EXHAUST_BURN_RATE_BPS};
@@ -40,10 +41,8 @@ pub struct ConsensusConstantsFile {
     pub max_block_validation_execution_points: Option<u64>,
     pub exhaust_burn_rate_bps: Option<u16>,
     pub max_transaction_validity_epochs: Option<u64>,
-    /// Accepted and ignored. The leeway this configured could never withhold or grant a vote:
-    /// ratifying an `EndEpoch` independently requires having observed the next epoch's boundary.
-    /// The field is kept because `deny_unknown_fields` would otherwise reject a whole constants
-    /// file that still sets it.
+    /// Accepted and ignored, so that an existing constants file that sets it still loads:
+    /// `deny_unknown_fields` would otherwise reject the whole file.
     #[serde(skip_serializing)]
     pub epoch_end_spread_blocks: Option<u64>,
 }
@@ -75,7 +74,7 @@ impl ConsensusConstantsFile {
         );
 
         if self.epoch_end_spread_blocks.is_some() {
-            log::warn!(
+            warn!(
                 target: LOG_TARGET,
                 "⚠️ 'epoch_end_spread_blocks' in the consensus constants file is ignored and can be removed."
             );

--- a/applications/tari_swarm_daemon/src/process_manager/instances/manager.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/instances/manager.rs
@@ -43,7 +43,6 @@ const CONSENSUS_CONSTANTS_TEMPLATE: &str = r#"# Consensus constants for this swa
 # missed_proposal_evict_threshold = 10
 # missed_proposal_recovery_threshold = 5
 # max_transaction_validity_epochs = 2160
-# epoch_end_spread_blocks = 1
 "#;
 use crate::{
     config::{InstanceConfig, InstanceType},

--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -658,7 +658,6 @@ async fn create_base_layer_epoch_oracle<TStore: EpochOracleStore + BaseLayerBloc
             scanning_interval: config.epoch_oracle.base_layer.scanning_interval,
             sidechain_id: config.validator_node.sidechain_id.as_ref().map(|p| p.to_byte_type()),
             features,
-            epoch_end_spread_blocks: consensus_constants.epoch_end_spread_blocks,
         },
         config.network,
     ))

--- a/applications/tari_validator_node/src/epoch_metrics.rs
+++ b/applications/tari_validator_node/src/epoch_metrics.rs
@@ -152,10 +152,6 @@ impl<O: EpochEventOracle + Send> EpochEventOracle for MeteredEpochOracle<O> {
         event
     }
 
-    fn is_within_epoch_end_spread(&self, current_epoch: Epoch) -> bool {
-        self.inner.is_within_epoch_end_spread(current_epoch)
-    }
-
     fn observed_epoch_boundary_hash(&self, epoch: Epoch) -> anyhow::Result<Option<FixedHash>> {
         self.inner.observed_epoch_boundary_hash(epoch)
     }

--- a/crates/consensus/src/consensus_constants.rs
+++ b/crates/consensus/src/consensus_constants.rs
@@ -138,12 +138,6 @@ pub struct ConsensusConstants {
     /// consensus sequencing. CONSENSUS RULE: must be uniform network-wide, otherwise nodes
     /// diverge on which transactions may be sequenced.
     pub max_transaction_validity_epochs: u64,
-    /// Number of base-layer blocks of leeway a voter is allowed when accepting `EndEpoch` proposals.
-    /// If the voter's oracle has not yet crossed the next epoch boundary but its lagged scan height
-    /// is within this many blocks of the boundary, the voter accepts `EndEpoch` from peers whose
-    /// oracle has already crossed. Must be uniform network-wide to avoid divergent voting.
-    /// Set to 0 to disable leeway.
-    pub epoch_end_spread_blocks: u64,
 }
 
 impl ConsensusConstants {
@@ -191,7 +185,6 @@ impl ConsensusConstants {
         max_block_validation_execution_points: 7_250_000_000,
         exhaust_burn_rate: ExhaustBurnRate::new(500), // 5%
         max_transaction_validity_epochs: 2160,
-        epoch_end_spread_blocks: 5,
     };
     pub const MAINNET: Self = Self {
         // Minotari's `coinbase_min_maturity` (720) plus 60 blocks (~2 hours) of margin. Must stay a
@@ -240,7 +233,6 @@ impl ConsensusConstants {
         max_block_validation_execution_points: 7_250_000_000,
         exhaust_burn_rate: ExhaustBurnRate::new(500), // 5%
         max_transaction_validity_epochs: 2160,
-        epoch_end_spread_blocks: 10,
     };
     pub const TESTNET: Self = Self {
         base_layer_confirmations: 100,
@@ -281,7 +273,6 @@ impl ConsensusConstants {
         max_block_validation_execution_points: 7_250_000_000,
         exhaust_burn_rate: ExhaustBurnRate::new(500), // 5%
         max_transaction_validity_epochs: 2160,
-        epoch_end_spread_blocks: 5,
     };
 
     pub const fn mainnet() -> Self {
@@ -336,7 +327,6 @@ impl ConsensusConstants {
             max_block_validation_execution_points: 7_250_000_000,
             exhaust_burn_rate: ExhaustBurnRate::new(500), // 5%
             max_transaction_validity_epochs: 2160,
-            epoch_end_spread_blocks: 1,
         }
     }
 

--- a/crates/consensus/src/hotstuff/on_receive_local_proposal.rs
+++ b/crates/consensus/src/hotstuff/on_receive_local_proposal.rs
@@ -336,14 +336,11 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveLocalProposalHandler<TConsensusSpec
             None
         };
 
-        // Accept an EndEpoch proposal when our oracle has advanced past `current_epoch`, when we have
-        // scanned the boundary block that ends it, OR when the oracle believes we are close enough to
-        // the boundary to vote speculatively. The latter branches rescue the case where a short
-        // base-layer reorg near the lag horizon leaves our scanner behind the leader's — without them,
-        // such splits can wedge consensus because every node requires the strict inequality.
-        let can_propose_epoch_end = em_epoch > current_epoch ||
-            expected_next_epoch_hash.is_some() ||
-            self.epoch_manager.is_within_epoch_end_spread(current_epoch).await?;
+        // Accept an EndEpoch proposal when our oracle has advanced past `current_epoch`, or when we
+        // have scanned the boundary block that ends it. The second branch rescues the case where a
+        // short base-layer reorg near the lag horizon leaves our scanner behind the leader's — without
+        // it, such splits can wedge consensus because every node requires the strict inequality.
+        let can_propose_epoch_end = em_epoch > current_epoch || expected_next_epoch_hash.is_some();
 
         let mut on_ready_to_vote_on_local_block = self.on_ready_to_vote_on_local_block.clone();
 

--- a/crates/consensus_tests/src/support/epoch_manager.rs
+++ b/crates/consensus_tests/src/support/epoch_manager.rs
@@ -523,10 +523,6 @@ impl EpochManagerReader for TestEpochManager {
         Ok(())
     }
 
-    async fn is_within_epoch_end_spread(&self, _current_epoch: Epoch) -> Result<bool, EpochManagerError> {
-        Ok(false)
-    }
-
     async fn get_observed_epoch_hash(&self, epoch: Epoch) -> Result<Option<FixedHash>, EpochManagerError> {
         self.get_epoch_hash(epoch).await.optional()
     }

--- a/crates/consensus_tests/src/support/harness.rs
+++ b/crates/consensus_tests/src/support/harness.rs
@@ -705,7 +705,6 @@ impl TestBuilder {
                     max_block_execution_points: 4_500_000_000,
                     max_block_validation_execution_points: 5_000_000_000,
                     exhaust_burn_rate: ExhaustBurnRate::new(500),
-                    epoch_end_spread_blocks: 0,
                 },
                 state_tree_cleanup_interval: Duration::from_secs(1000),
                 epoch_gc_interval: Duration::from_secs(1000),

--- a/crates/epoch_manager/src/epoch_event_oracle/traits.rs
+++ b/crates/epoch_manager/src/epoch_event_oracle/traits.rs
@@ -14,18 +14,6 @@ pub trait EpochEventOracle {
     /// returned.
     fn next_epoch_event(&mut self) -> impl Future<Output = Option<EpochEvent>> + Send;
 
-    /// Returns true when, in the oracle's view, `current_epoch` is close enough to ending that
-    /// consensus should speculatively accept an `EndEpoch` proposal even if the oracle has not
-    /// yet emitted the corresponding `EpochChanged` event.
-    ///
-    /// "Close enough" is deliberately oracle-specific: the base-layer oracle measures proximity
-    /// in base-layer blocks, a wall-clock oracle could measure in seconds, etc. The default
-    /// implementation returns `false` (no leeway), which reduces to the strict behaviour of
-    /// only accepting `EndEpoch` once the epoch has actually changed locally.
-    fn is_within_epoch_end_spread(&self, _current_epoch: Epoch) -> bool {
-        false
-    }
-
     /// Returns the boundary hash the oracle has observed for `epoch`, or `None` if it has observed
     /// none. An error means the oracle could not determine either way and must be distinguished from
     /// `None`: a caller that treats a failed lookup as "not observed" turns a broken store into a

--- a/crates/epoch_manager/src/service/epoch_manager_service.rs
+++ b/crates/epoch_manager/src/service/epoch_manager_service.rs
@@ -527,13 +527,6 @@ impl<TSpec: EpochManagerSpec> EpochManagerService<TSpec> {
             EpochManagerRequest::LockEpoch { epoch, reply } => {
                 handle(reply, self.inner.lock_epoch(epoch), context);
             },
-            EpochManagerRequest::IsWithinEpochEndSpread { current_epoch, reply } => {
-                handle(
-                    reply,
-                    Ok(self.epoch_events.is_within_epoch_end_spread(current_epoch)),
-                    context,
-                );
-            },
             EpochManagerRequest::GetObservedEpochHash { epoch, reply } => {
                 // An activated epoch's stored hash wins: it is the one the self-healing correction
                 // maintains and that `lock_epoch` freezes once consensus has committed against it.

--- a/crates/epoch_manager/src/service/handle.rs
+++ b/crates/epoch_manager/src/service/handle.rs
@@ -392,18 +392,6 @@ impl<TAddr: NodeAddressable> EpochManagerReader for EpochManagerHandle<TAddr> {
         rx.await.map_err(|_| EpochManagerError::ReceiveError)?
     }
 
-    async fn is_within_epoch_end_spread(&self, current_epoch: Epoch) -> Result<bool, EpochManagerError> {
-        let (tx, rx) = oneshot::channel();
-        self.tx_request
-            .send(EpochManagerRequest::IsWithinEpochEndSpread {
-                current_epoch,
-                reply: tx,
-            })
-            .await
-            .map_err(|_| EpochManagerError::SendError)?;
-        rx.await.map_err(|_| EpochManagerError::ReceiveError)?
-    }
-
     async fn get_observed_epoch_hash(&self, epoch: Epoch) -> Result<Option<FixedHash>, EpochManagerError> {
         let (tx, rx) = oneshot::channel();
         self.tx_request

--- a/crates/epoch_manager/src/service/types.rs
+++ b/crates/epoch_manager/src/service/types.rs
@@ -126,10 +126,6 @@ pub enum EpochManagerRequest<TAddr> {
         epoch: Epoch,
         reply: Reply<()>,
     },
-    IsWithinEpochEndSpread {
-        current_epoch: Epoch,
-        reply: Reply<bool>,
-    },
     GetObservedEpochHash {
         epoch: Epoch,
         reply: Reply<Option<FixedHash>>,

--- a/crates/epoch_manager/src/traits.rs
+++ b/crates/epoch_manager/src/traits.rs
@@ -230,14 +230,6 @@ pub trait EpochManagerReader: Send + Sync {
     /// commits, transitioning into `epoch`.
     fn lock_epoch(&self, epoch: Epoch) -> impl Future<Output = Result<(), EpochManagerError>> + Send;
 
-    /// Asks the epoch event oracle whether `current_epoch` is close enough to ending that
-    /// `EndEpoch` proposals should be accepted speculatively, even if this node has not yet
-    /// received its own `EpochChanged` event. The interpretation of "close" is oracle-specific.
-    fn is_within_epoch_end_spread(
-        &self,
-        current_epoch: Epoch,
-    ) -> impl Future<Output = Result<bool, EpochManagerError>> + Send;
-
     /// This node's own view of `epoch`'s boundary hash: the hash stored when the epoch was activated
     /// if it has been, otherwise a boundary the epoch event oracle has observed but not yet activated.
     /// `None` when this node has seen neither, in which case it has nothing of its own to ratify an

--- a/crates/epoch_oracles/src/base_layer/config.rs
+++ b/crates/epoch_oracles/src/base_layer/config.rs
@@ -17,11 +17,6 @@ pub struct BaseLayerEpochOracleConfig {
     pub sidechain_id: Option<RistrettoPublicKeyBytes>,
     /// Features for the base layer epoch oracle.
     pub features: BaseLayerEpochOracleFeatures,
-    /// Number of base-layer blocks of leeway to allow when voting on `EndEpoch` proposals.
-    /// If our scanner has not yet crossed the next epoch boundary, but our scanned (lagged)
-    /// height is within this many blocks of the boundary, we accept EndEpoch proposals from
-    /// peers whose oracle has already crossed. Set to 0 to disable leeway.
-    pub epoch_end_spread_blocks: u64,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/epoch_oracles/src/base_layer/oracle.rs
+++ b/crates/epoch_oracles/src/base_layer/oracle.rs
@@ -897,29 +897,6 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore, TClient: BaseNodeClie
             self.pending_events.shrink_to(TARGET_CAP);
         }
     }
-
-    /// Returns true when our lagged scanner position is within `epoch_end_spread_blocks` of the
-    /// next epoch boundary. Used by consensus to accept `EndEpoch` proposals speculatively when
-    /// peers' oracles have already crossed and ours is almost there.
-    fn is_within_epoch_end_spread(&self, current_epoch: Epoch) -> bool {
-        if self.config.epoch_end_spread_blocks == 0 {
-            return false;
-        }
-        let epoch_length = self.epoch_length.load(Ordering::Relaxed);
-        if epoch_length == 0 {
-            return false;
-        }
-        let Some(next_start) = current_epoch
-            .as_u64()
-            .checked_add(1)
-            .and_then(|e| e.checked_mul(epoch_length))
-        else {
-            return false;
-        };
-        self.last_scanned_height
-            .saturating_add(self.config.epoch_end_spread_blocks) >=
-            next_start
-    }
 }
 
 impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + Send + 'static, TClient: BaseNodeClient + 'static>
@@ -1020,15 +997,6 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + Send + 'static, TCli
     /// This Future is cancel-safe. Returns None if a shutdown is triggered.
     async fn next_epoch_event(&mut self) -> Option<EpochEvent> {
         poll_fn(|cx| self.poll_next_event(cx)).await
-    }
-
-    fn is_within_epoch_end_spread(&self, current_epoch: Epoch) -> bool {
-        // `inner` is briefly None while a scan task is in flight; return false then so voting
-        // falls back to the strict em_epoch > current_epoch check.
-        self.inner
-            .as_deref()
-            .map(|inner| inner.is_within_epoch_end_spread(current_epoch))
-            .unwrap_or(false)
     }
 
     fn observed_epoch_boundary_hash(&self, epoch: Epoch) -> anyhow::Result<Option<FixedHash>> {
@@ -1385,7 +1353,6 @@ mod tests {
                 sync_headers: true,
                 sync_validator_node_changes: false,
             },
-            epoch_end_spread_blocks: 0,
         }
     }
 

--- a/crates/epoch_oracles/src/hybrid/oracle.rs
+++ b/crates/epoch_oracles/src/hybrid/oracle.rs
@@ -79,11 +79,6 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + Send + 'static> Epoc
         }
     }
 
-    fn is_within_epoch_end_spread(&self, current_epoch: Epoch) -> bool {
-        // Epoch timing in hybrid mode is driven by the base-layer scanner; defer to it.
-        self.base_layer.is_within_epoch_end_spread(current_epoch)
-    }
-
     fn observed_epoch_boundary_hash(&self, epoch: Epoch) -> anyhow::Result<Option<FixedHash>> {
         // Epoch boundaries in hybrid mode are scanned by the base-layer oracle; defer to it.
         self.base_layer.observed_epoch_boundary_hash(epoch)


### PR DESCRIPTION
Closes #2568.

## Why it is dead

Voting for an `EndEpoch` block needs two things: `can_propose_epoch_end`, and this node's own view of the next epoch's boundary hash to ratify against. The spread relaxed the first. The second was `get_epoch_hash(current_epoch + 1)`, whose row is written by `EpochManager::insert_current_epoch` — the same call that does `set_current_epoch` — so it asked the same question as `em_epoch > current_epoch` and terminally no-voted with `EndOfEpochHashNotObserved` when it failed. The spread's disjunct could never be the one that mattered.

Leeway voting landed in #2051, hash ratification in #2164, and #2164 subsumed it. On a validator it was doubly dead: the `EpochOracle` enum dispatcher never forwarded `is_within_epoch_end_spread`, so every variant fell through to the default `false` and the configured value never reached the base layer oracle.

Separately, mainnet's `10` becomes exactly one whole epoch once the L1 shortens `vn_epoch_length` to 10, at which point the predicate is unconditionally true — a symptom of the value never having been exercised.

## Why now

#2572 gave `can_propose_epoch_end` a term that does what the spread was reaching for, and that ratification can honour: a node that has scanned the boundary block votes on the strength of that observation, whether or not it has applied the `EpochChanged` that activates the epoch. The leeway is now sized by what the node can actually verify instead of by a block count, so the knob has nothing left to express.

## Change

Removes the constant from all four network profiles and the field from `ConsensusConstants`, the `||` disjunct in `on_receive_local_proposal.rs`, `BaseLayerEpochOracleConfig::epoch_end_spread_blocks`, `EpochEventOracle::is_within_epoch_end_spread` and its base-layer and hybrid implementations, `EpochManagerReader::is_within_epoch_end_spread`, `EpochManagerRequest::IsWithinEpochEndSpread` and its service handler, the `epoch_metrics` pass-through, and the test-harness and bootstrap wiring.

It also comes out of `ConsensusConstantsFile`. That struct is `deny_unknown_fields`, so a devnet constants file that still sets the field now fails to load rather than being accepted and ignored — devnets author this file per network, so a stale one gets edited rather than migrated.

Marked `!` for that and because `ConsensusConstants` is public, though no consensus behaviour changes — the removed branch could not alter a vote.

## Test plan

- [x] `cargo test -p consensus_tests epoch_change` — 7 passed, including both wedge tests and `epoch_change_observed_boundary_is_voted_before_activation`, which is what now covers the case the spread was written for
- [x] `cargo lints clippy --all-targets` across consensus, epoch_manager, epoch_oracles (with `base_layer`), consensus_tests, validator_node, indexer, app_utilities, swarm_daemon
- [x] CI

