### PR TITLE
fix(consensus): resume a deferred end-of-epoch on the periodic tick

### DIFF
--- a/crates/consensus/src/hotstuff/on_receive_local_proposal.rs
+++ b/crates/consensus/src/hotstuff/on_receive_local_proposal.rs
@@ -85,15 +85,6 @@ pub struct OnReceiveLocalProposalHandler<TConsensusSpec: ConsensusSpec> {
     pending_end_of_epoch: Option<PendingEndOfEpoch>,
 }
 
-/// Whether `process_end_of_epoch` was entered from the commit that produced the EOE or from a
-/// retry of a deferral. Only the caller can tell: the retry takes the pending state before
-/// re-entering, so the callee sees an empty slot either way.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum IsRetry {
-    No,
-    Yes,
-}
-
 #[derive(Debug, Clone)]
 struct PendingEndOfEpoch {
     eoe_block: Block,
@@ -500,7 +491,7 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveLocalProposalHandler<TConsensusSpec
             // genesis state.
             let commit_qc = valid_block.justify().clone();
             let next_genesis_state_merkle_root = *valid_block.block().state_merkle_root();
-            self.process_end_of_epoch(eoe_block, commit_qc, next_genesis_state_merkle_root, IsRetry::No)
+            self.process_end_of_epoch(eoe_block, commit_qc, next_genesis_state_merkle_root)
                 .await?;
         }
 
@@ -520,7 +511,6 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveLocalProposalHandler<TConsensusSpec
         eoe_block: Block,
         commit_qc: ProposalCertificate,
         next_genesis_state_merkle_root: FixedHash,
-        is_retry: IsRetry,
     ) -> Result<(), HotStuffError> {
         let _timer = TraceTimer::debug(LOG_TARGET, "process-end-of-epoch");
         let prev_epoch = eoe_block.epoch();
@@ -553,23 +543,12 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveLocalProposalHandler<TConsensusSpec
             .optional()?
             .is_none()
         {
-            // Only the caller knows whether this is the first defer or a retry finding the oracle
-            // still behind — the pending state is taken before the retry re-enters here, so it
-            // cannot be read off `self`. Retries run on a tick for the length of the catch-up, so
-            // only the first defer is news.
-            match is_retry {
-                IsRetry::No => warn!(
-                    target: LOG_TARGET,
-                    "⏳ EOE block {} committed but local oracle has not observed {next_epoch}. \
-                     Deferring next-epoch genesis until oracle catches up.",
-                    eoe_block.id()
-                ),
-                IsRetry::Yes => debug!(
-                    target: LOG_TARGET,
-                    "⏳ EOE block {} still deferred: local oracle has not observed {next_epoch}.",
-                    eoe_block.id()
-                ),
-            }
+            warn!(
+                target: LOG_TARGET,
+                "⏳ EOE block {} committed but local oracle has not observed {next_epoch}. \
+                 Deferring next-epoch genesis until oracle catches up.",
+                eoe_block.id()
+            );
             self.pending_end_of_epoch = Some(PendingEndOfEpoch {
                 eoe_block,
                 commit_qc,
@@ -716,7 +695,6 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveLocalProposalHandler<TConsensusSpec
             pending.eoe_block,
             pending.commit_qc,
             pending.next_genesis_state_merkle_root,
-            IsRetry::Yes,
         )
         .await?;
         Ok(true)

--- a/crates/consensus/src/hotstuff/on_receive_local_proposal.rs
+++ b/crates/consensus/src/hotstuff/on_receive_local_proposal.rs
@@ -534,8 +534,8 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveLocalProposalHandler<TConsensusSpec
 
         // We still need the local oracle to have observed `next_epoch` to assign its committee /
         // validator set. If it has not yet (rare, given the base-layer scan lag keeps the boundary
-        // block buried), defer; `try_resume_pending_end_of_epoch` retries from `on_epoch_manager_event`
-        // or worker startup.
+        // block buried), defer; the worker retries `try_resume_pending_end_of_epoch` on its periodic
+        // tick, on `EpochManagerEvent::EpochChanged` and at startup.
         if self
             .epoch_manager
             .get_epoch_hash(next_epoch)
@@ -677,9 +677,9 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveLocalProposalHandler<TConsensusSpec
         self.pending_end_of_epoch.is_some()
     }
 
-    /// Retry deferred end-of-epoch processing. Called by the worker when the local oracle
-    /// observes the new epoch (via `EpochManagerEvent::EpochChanged`). If the oracle is still
-    /// not ready, `process_end_of_epoch` will re-defer.
+    /// Retry deferred end-of-epoch processing. The worker polls this so that the resume happens
+    /// as soon as the oracle has written the epoch row, without waiting for the base-layer scan
+    /// to finish. If the oracle is still not ready, `process_end_of_epoch` will re-defer.
     pub async fn try_resume_pending_end_of_epoch(&mut self) -> Result<bool, HotStuffError> {
         let Some(pending) = self.pending_end_of_epoch.take() else {
             return Ok(false);

--- a/crates/consensus/src/hotstuff/on_receive_local_proposal.rs
+++ b/crates/consensus/src/hotstuff/on_receive_local_proposal.rs
@@ -85,6 +85,15 @@ pub struct OnReceiveLocalProposalHandler<TConsensusSpec: ConsensusSpec> {
     pending_end_of_epoch: Option<PendingEndOfEpoch>,
 }
 
+/// Whether `process_end_of_epoch` was entered from the commit that produced the EOE or from a
+/// retry of a deferral. Only the caller can tell: the retry takes the pending state before
+/// re-entering, so the callee sees an empty slot either way.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IsRetry {
+    No,
+    Yes,
+}
+
 #[derive(Debug, Clone)]
 struct PendingEndOfEpoch {
     eoe_block: Block,
@@ -491,7 +500,7 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveLocalProposalHandler<TConsensusSpec
             // genesis state.
             let commit_qc = valid_block.justify().clone();
             let next_genesis_state_merkle_root = *valid_block.block().state_merkle_root();
-            self.process_end_of_epoch(eoe_block, commit_qc, next_genesis_state_merkle_root)
+            self.process_end_of_epoch(eoe_block, commit_qc, next_genesis_state_merkle_root, IsRetry::No)
                 .await?;
         }
 
@@ -511,6 +520,7 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveLocalProposalHandler<TConsensusSpec
         eoe_block: Block,
         commit_qc: ProposalCertificate,
         next_genesis_state_merkle_root: FixedHash,
+        is_retry: IsRetry,
     ) -> Result<(), HotStuffError> {
         let _timer = TraceTimer::debug(LOG_TARGET, "process-end-of-epoch");
         let prev_epoch = eoe_block.epoch();
@@ -543,21 +553,22 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveLocalProposalHandler<TConsensusSpec
             .optional()?
             .is_none()
         {
-            // A re-defer means a retry found the oracle still behind, which happens on every tick for
-            // the length of the catch-up. Only the first defer is news; the rest are the same line.
-            if self.pending_end_of_epoch.is_none() {
-                warn!(
+            // Only the caller knows whether this is the first defer or a retry finding the oracle
+            // still behind — the pending state is taken before the retry re-enters here, so it
+            // cannot be read off `self`. Retries run on a tick for the length of the catch-up, so
+            // only the first defer is news.
+            match is_retry {
+                IsRetry::No => warn!(
                     target: LOG_TARGET,
                     "⏳ EOE block {} committed but local oracle has not observed {next_epoch}. \
                      Deferring next-epoch genesis until oracle catches up.",
                     eoe_block.id()
-                );
-            } else {
-                debug!(
+                ),
+                IsRetry::Yes => debug!(
                     target: LOG_TARGET,
                     "⏳ EOE block {} still deferred: local oracle has not observed {next_epoch}.",
                     eoe_block.id()
-                );
+                ),
             }
             self.pending_end_of_epoch = Some(PendingEndOfEpoch {
                 eoe_block,
@@ -705,6 +716,7 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveLocalProposalHandler<TConsensusSpec
             pending.eoe_block,
             pending.commit_qc,
             pending.next_genesis_state_merkle_root,
+            IsRetry::Yes,
         )
         .await?;
         Ok(true)

--- a/crates/consensus/src/hotstuff/on_receive_local_proposal.rs
+++ b/crates/consensus/src/hotstuff/on_receive_local_proposal.rs
@@ -543,12 +543,22 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveLocalProposalHandler<TConsensusSpec
             .optional()?
             .is_none()
         {
-            warn!(
-                target: LOG_TARGET,
-                "⏳ EOE block {} committed but local oracle has not observed {next_epoch}. \
-                 Deferring next-epoch genesis until oracle catches up.",
-                eoe_block.id()
-            );
+            // A re-defer means a retry found the oracle still behind, which happens on every tick for
+            // the length of the catch-up. Only the first defer is news; the rest are the same line.
+            if self.pending_end_of_epoch.is_none() {
+                warn!(
+                    target: LOG_TARGET,
+                    "⏳ EOE block {} committed but local oracle has not observed {next_epoch}. \
+                     Deferring next-epoch genesis until oracle catches up.",
+                    eoe_block.id()
+                );
+            } else {
+                debug!(
+                    target: LOG_TARGET,
+                    "⏳ EOE block {} still deferred: local oracle has not observed {next_epoch}.",
+                    eoe_block.id()
+                );
+            }
             self.pending_end_of_epoch = Some(PendingEndOfEpoch {
                 eoe_block,
                 commit_qc,
@@ -684,9 +694,11 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveLocalProposalHandler<TConsensusSpec
         let Some(pending) = self.pending_end_of_epoch.take() else {
             return Ok(false);
         };
-        info!(
+        // Every attempt logs, and attempts are on a tick, so this stays at debug: a resume that
+        // succeeds announces itself through the genesis it creates.
+        debug!(
             target: LOG_TARGET,
-            "▶️ Resuming deferred end-of-epoch processing for EOE block {}",
+            "▶️ Attempting deferred end-of-epoch processing for EOE block {}",
             pending.eoe_block.id()
         );
         self.process_end_of_epoch(

--- a/crates/consensus/src/hotstuff/worker.rs
+++ b/crates/consensus/src/hotstuff/worker.rs
@@ -355,9 +355,8 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
 
         // Recovery: if the previous run crashed inside `process_end_of_epoch` (e.g. NoEpochFound
         // because the local oracle was lagging), the EOE block is committed on disk but no
-        // checkpoint was written. Detect that here and seed the deferred-EOE state so the next
-        // EpochChanged event (or this startup if the oracle is already current) finishes the
-        // transition.
+        // checkpoint was written. Detect that here and seed the deferred-EOE state so a later
+        // retry (or this startup if the oracle is already current) finishes the transition.
         self.recover_pending_end_of_epoch(current_epoch).await?;
 
         // Catch up on any epoch change the oracle observed before this worker subscribed to epoch events.
@@ -515,6 +514,12 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
                 },
 
                 _ = periodic_tasks.tick() => {
+                    // A deferred EOE waits on the epoch row, which the oracle writes as soon as it
+                    // applies the queued EpochChanged for that epoch - between scan batches during a
+                    // catch-up. EpochManagerEvent::EpochChanged only fires once the whole scan
+                    // reaches the lagged tip, so poll the data here rather than waiting for it.
+                    self.try_resume_pending_end_of_epoch().await?;
+
                     if let Err(e) = self.on_task_tick(&epoch_state).await {
                         self.hooks.on_error(&e);
                         error!(target: LOG_TARGET, "🚨Error during periodic task: {}", e);
@@ -705,7 +710,7 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
     /// (most likely the previous run crashed inside `process_end_of_epoch` while looking up an
     /// epoch the local oracle had not yet observed). When found, seeds the deferred-EOE state on
     /// the local-proposal handler and immediately attempts to resume; if the oracle is still
-    /// behind, the resume will re-defer and `on_epoch_manager_event` will retry later.
+    /// behind, the resume will re-defer and the worker's periodic retry will pick it up.
     async fn recover_pending_end_of_epoch(&mut self, current_epoch: Epoch) -> Result<(), HotStuffError> {
         let pending = self.state_store.with_read_tx(|tx| {
             // A successful end-of-epoch transition writes a checkpoint for `current_epoch`.
@@ -751,6 +756,22 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
         Ok(())
     }
 
+    /// Retries deferred end-of-epoch processing if the local oracle has since observed the next
+    /// epoch. A no-op when nothing is pending, and re-defers if the oracle is still behind.
+    async fn try_resume_pending_end_of_epoch(&mut self) -> Result<(), HotStuffError> {
+        if !self.on_receive_local_proposal.has_pending_end_of_epoch() {
+            return Ok(());
+        }
+        if let Err(err) = self.on_receive_local_proposal.try_resume_pending_end_of_epoch().await {
+            error!(
+                target: LOG_TARGET,
+                "Failed to resume deferred end-of-epoch processing: {err}"
+            );
+            return Err(err);
+        }
+        Ok(())
+    }
+
     async fn on_epoch_manager_event(&mut self, event: EpochManagerEvent) -> Result<(), HotStuffError> {
         match event {
             EpochManagerEvent::EpochChanged {
@@ -783,15 +804,7 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
                 // Oracle just observed `epoch`. If we previously deferred end-of-epoch
                 // processing because the oracle was lagging, retry now that the data is
                 // available.
-                if self.on_receive_local_proposal.has_pending_end_of_epoch() &&
-                    let Err(err) = self.on_receive_local_proposal.try_resume_pending_end_of_epoch().await
-                {
-                    error!(
-                        target: LOG_TARGET,
-                        "Failed to resume deferred end-of-epoch processing for {epoch}: {err}"
-                    );
-                    return Err(err);
-                }
+                self.try_resume_pending_end_of_epoch().await?;
             },
         }
 

--- a/crates/consensus/src/hotstuff/worker.rs
+++ b/crates/consensus/src/hotstuff/worker.rs
@@ -514,16 +514,18 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
                 },
 
                 _ = periodic_tasks.tick() => {
-                    // A deferred EOE waits on the epoch row, which the oracle writes as soon as it
-                    // applies the queued EpochChanged for that epoch - between scan batches during a
-                    // catch-up. EpochManagerEvent::EpochChanged only fires once the whole scan
-                    // reaches the lagged tip, so poll the data here rather than waiting for it.
-                    self.try_resume_pending_end_of_epoch().await?;
-
                     if let Err(e) = self.on_task_tick(&epoch_state).await {
                         self.hooks.on_error(&e);
                         error!(target: LOG_TARGET, "🚨Error during periodic task: {}", e);
                     }
+
+                    // A deferred EOE waits on the epoch row, which the oracle writes as soon as it
+                    // applies the queued EpochChanged for that epoch - between scan batches during a
+                    // catch-up. EpochManagerEvent::EpochChanged only fires once the whole scan
+                    // reaches the lagged tip, so poll the data here rather than waiting for it.
+                    // Ordered after `on_task_tick` because a successful resume advances the pacemaker
+                    // past `epoch_state`, which is only refreshed at the top of the next iteration.
+                    self.try_resume_pending_end_of_epoch().await?;
                 },
 
                 _ = self.shutdown.wait() => {

--- a/crates/consensus_tests/src/epoch_change.rs
+++ b/crates/consensus_tests/src/epoch_change.rs
@@ -277,6 +277,132 @@ async fn epoch_change_observed_boundary_is_voted_before_activation() {
     test.assert_clean_shutdown().await;
 }
 
+/// A validator that deferred its end-of-epoch processing must resume as soon as its oracle has the
+/// epoch row — not when the whole base-layer catch-up finishes.
+///
+/// `process_end_of_epoch` defers when `get_epoch_hash(next_epoch)` finds nothing, and the only retry
+/// used to be `EpochManagerEvent::EpochChanged`. In production that event is published from a single
+/// place, `on_scanning_complete`, which runs on `EpochEvent::DoneForNow` — emitted only once the scan
+/// reaches the lagged tip. But `activate_epoch` writes the epoch row as soon as the queued
+/// `EpochChanged` for that epoch is applied, which during a multi-batch catch-up happens *between*
+/// batches. The row lands early; nothing told consensus to look, so the node sat out the new epoch
+/// for the rest of the scan — a wait that scales with the scanner's lag, not with consensus lag.
+///
+/// The test:
+///   1. Gives validator "1" an observed boundary for `Epoch(2)` but no activated epoch — the exact mid-catch-up state:
+///      it can ratify the `EndEpoch` hash, so it votes and commits the EOE, but `get_epoch_hash(Epoch(2))` is
+///      `NoEpochFound`, so it defers.
+///   2. Asserts the deferral: EOE committed in `Epoch(1)`, no leaf in `Epoch(2)`. This is correct behaviour, not the
+///      bug.
+///   3. Makes `get_epoch_hash(Epoch(2))` start answering — standing in for `activate_epoch` running between scan
+///      batches — *without* publishing `EpochManagerEvent::EpochChanged`. The harness separates these: clearing a cap
+///      emits nothing, only `test.start_epoch()` sends the event.
+///   4. Asserts the node opens `Epoch(2)` anyway.
+///
+/// Step 4 is what fails without the fix and passes with it. It is deliberately fix-agnostic: it
+/// asserts the node resumes off the data, not which mechanism noticed, so it survives a later move
+/// from a polled retry to a narrower activation event.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn epoch_change_deferred_eoe_resumes_without_scan_completion() {
+    setup_logger();
+    let mut test = Test::builder()
+        .modify_config(|cfg| {
+            cfg.epoch_end_grace_period = Duration::from_millis(10);
+        })
+        .modify_consensus_constants(|c| {
+            c.pacemaker_block_time = Duration::from_secs(2);
+        })
+        .with_test_timeout(Duration::from_secs(120))
+        .add_committee(0, vec!["1", "2", "3", "4"])
+        .start()
+        .await;
+
+    let deferring_addr = TestAddress::new("1");
+
+    test.start_epoch(Epoch(1)).await;
+
+    for _ in 0..3 {
+        test.send_transaction_to_all(Decision::Commit, 1, 1, 1).await;
+    }
+
+    // The mid-catch-up state, which needs both halves set independently:
+    //   - the oracle has scanned the Epoch(2) boundary, so the node can ratify the EndEpoch hash and votes;
+    //   - the epoch is not activated, so `get_epoch_hash(Epoch(2))` is `NoEpochFound` and `process_end_of_epoch` defers
+    //     after the EOE commits.
+    let deferring = test.get_validator(&deferring_addr);
+    deferring.epoch_manager.set_oracle_observed_boundary(Epoch(2));
+    deferring.epoch_manager.set_oracle_visible_epoch(Epoch(1));
+
+    test.start_epoch(Epoch(2)).await;
+
+    for _ in 0..3 {
+        test.send_transaction_to_all(Decision::Commit, 1, 1, 1).await;
+    }
+
+    wait_for_validators_at_epoch(&mut test, &deferring_addr, Epoch(2), Duration::from_secs(45)).await;
+
+    let deferring = test.get_validator(&deferring_addr);
+    let committed_eoe = deferring
+        .state_store
+        .with_read_tx(|tx| chain_has_committed_epoch_end(tx, Epoch(1)))
+        .unwrap();
+    assert!(
+        committed_eoe,
+        "the deferring validator must have committed the EOE: it observed the boundary, so it ratifies and votes"
+    );
+    let leaf_at_2 = deferring
+        .state_store
+        .with_read_tx(|tx| LeafBlock::get(tx, Epoch(2)))
+        .optional()
+        .unwrap();
+    assert!(
+        leaf_at_2.is_none(),
+        "the validator must defer while its oracle has no Epoch(2) row; got {leaf_at_2:?}"
+    );
+
+    log::info!("✅ deferral reproduced: validator {deferring_addr} committed the EOE with no Epoch(2) genesis");
+
+    // Peers are proposing in Epoch(2) while this node's view is still Epoch(1). Once the cap clears,
+    // their QCs would also satisfy `probe_future_epoch_qc` and escalate to state sync, which would
+    // race the resume and decide the outcome. Taking the node offline leaves exactly one way for it
+    // to reach Epoch(2): noticing its own epoch row.
+    test.network().go_offline(deferring_addr.clone()).await;
+
+    // `activate_epoch` runs between scan batches: the epoch row lands, no event is published.
+    // `clear_oracle_visible_epoch` is the harness equivalent — it does not touch `tx_epoch_events`.
+    test.get_validator(&deferring_addr)
+        .epoch_manager
+        .clear_oracle_visible_epoch();
+
+    wait_for_leaf_at_epoch(&mut test, &deferring_addr, Epoch(2), Duration::from_secs(60)).await;
+
+    log::info!("✅ deferred end-of-epoch resumed off the epoch row alone, with no scan-completion event");
+
+    test.stop();
+    test.assert_clean_shutdown().await;
+}
+
+/// Waits until `addr` has a leaf block in `epoch`, i.e. it created that epoch's genesis.
+async fn wait_for_leaf_at_epoch(test: &mut Test, addr: &TestAddress, epoch: Epoch, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        // Drain block events so receiver buffers don't overflow.
+        let _unused = tokio::time::timeout(Duration::from_millis(100), test.on_block_committed()).await;
+
+        let has_leaf = test
+            .get_validator(addr)
+            .state_store
+            .with_read_tx(|tx| LeafBlock::get(tx, epoch))
+            .optional()
+            .unwrap()
+            .is_some();
+        if has_leaf {
+            return;
+        }
+    }
+    panic!("Timed out waiting for {addr} to open {epoch}");
+}
+
 /// Walks the chain from the leaf of `epoch` looking for a committed `EndEpoch` block.
 fn chain_has_committed_epoch_end<TTx: StateStoreReadTransaction>(
     tx: &TTx,

--- a/crates/consensus_tests/src/support/epoch_manager.rs
+++ b/crates/consensus_tests/src/support/epoch_manager.rs
@@ -56,6 +56,15 @@ pub struct TestEpochManager {
     /// `last_epoch_hash`. Like the lag fields, a fresh `Arc` is allocated per validator by
     /// `clone_for`.
     oracle_epoch_hash_override: Arc<StdMutex<Option<FixedHash>>>,
+    /// Epochs whose boundary block this validator's oracle has scanned but whose activation it has
+    /// not applied. `get_observed_epoch_hash` answers for these even while `get_epoch_hash` — the
+    /// activated view, gated by `oracle_visible_epoch` — reports `NoEpochFound`.
+    ///
+    /// Production keeps the two apart: the activated row wins, and the oracle's scanned boundary is
+    /// the fallback. Separating them here is what lets a test hold a validator in the state where it
+    /// can ratify an `EndEpoch` but cannot yet open the next epoch. Like the lag fields, a fresh
+    /// `Arc` is allocated per validator by `clone_for`.
+    oracle_observed_boundaries: Arc<StdMutex<HashSet<Epoch>>>,
 }
 
 impl TestEpochManager {
@@ -68,6 +77,7 @@ impl TestEpochManager {
             oracle_visible_epoch: Arc::new(StdMutex::new(None)),
             oracle_current_epoch_cap: Arc::new(StdMutex::new(None)),
             oracle_epoch_hash_override: Arc::new(StdMutex::new(None)),
+            oracle_observed_boundaries: Arc::new(StdMutex::new(HashSet::new())),
         }
     }
 
@@ -123,6 +133,19 @@ impl TestEpochManager {
         *self.oracle_epoch_hash_override.lock().unwrap()
     }
 
+    /// Mark `epoch`'s boundary block as scanned by this validator's oracle without activating the
+    /// epoch. `get_observed_epoch_hash(epoch)` then reports the boundary hash — enough to ratify an
+    /// `EndEpoch` — while a `set_oracle_visible_epoch` cap keeps `get_epoch_hash(epoch)` answering
+    /// `NoEpochFound`, so the node still cannot open the epoch. That pair is the real state of a node
+    /// mid-catch-up, and the two must be settable independently.
+    pub fn set_oracle_observed_boundary(&self, epoch: Epoch) {
+        self.oracle_observed_boundaries.lock().unwrap().insert(epoch);
+    }
+
+    fn has_oracle_observed_boundary(&self, epoch: Epoch) -> bool {
+        self.oracle_observed_boundaries.lock().unwrap().contains(&epoch)
+    }
+
     pub async fn set_current_epoch(&mut self, current_epoch: Epoch, shard_group: ShardGroup) -> &Self {
         self.current_epoch = current_epoch;
         {
@@ -157,6 +180,7 @@ impl TestEpochManager {
         copy.oracle_visible_epoch = Arc::new(StdMutex::new(None));
         copy.oracle_current_epoch_cap = Arc::new(StdMutex::new(None));
         copy.oracle_epoch_hash_override = Arc::new(StdMutex::new(None));
+        copy.oracle_observed_boundaries = Arc::new(StdMutex::new(HashSet::new()));
         if let Some(our_validator_node) = self.our_validator_node.clone() {
             copy.our_validator_node = Some(ValidatorNode {
                 address,
@@ -524,7 +548,18 @@ impl EpochManagerReader for TestEpochManager {
     }
 
     async fn get_observed_epoch_hash(&self, epoch: Epoch) -> Result<Option<FixedHash>, EpochManagerError> {
-        self.get_epoch_hash(epoch).await.optional()
+        // Mirrors the production ordering: an activated epoch's stored hash wins, otherwise fall back
+        // to a boundary the oracle has scanned but not yet activated.
+        if let Some(activated) = self.get_epoch_hash(epoch).await.optional()? {
+            return Ok(Some(activated));
+        }
+        if !self.has_oracle_observed_boundary(epoch) {
+            return Ok(None);
+        }
+        if let Some(hash) = self.oracle_epoch_hash_override() {
+            return Ok(Some(hash));
+        }
+        Ok(Some(self.inner.lock().await.last_epoch_hash))
     }
 
     async fn get_birthday_epoch(&self) -> Result<Option<Epoch>, EpochManagerError> {

--- a/crates/epoch_oracles/src/base_layer/oracle.rs
+++ b/crates/epoch_oracles/src/base_layer/oracle.rs
@@ -1395,6 +1395,64 @@ mod tests {
         heights.map(|h| make_header(h, h)).collect()
     }
 
+    /// Pins the ordering the deferred end-of-epoch bug depended on: during a multi-batch catch-up the
+    /// scanner emits an `EpochChanged` for every boundary it crosses *as it crosses it*, while
+    /// `DoneForNow` waits for the lagged tip.
+    ///
+    /// The epoch manager applies each `EpochChanged` on arrival — `activate_epoch` writes the epoch
+    /// row, assigns the validator set and clears the committee cache — but publishes its own
+    /// `EpochManagerEvent::EpochChanged` to consensus only from `on_scanning_complete`, i.e. on
+    /// `DoneForNow`. So between the first batch and the last, the data a deferred end-of-epoch waits
+    /// on is present while the notification that used to trigger its retry is still batches away.
+    #[tokio::test]
+    async fn catch_up_emits_epoch_changed_per_batch_but_done_for_now_only_at_the_tip() {
+        let store = InMemoryStore::default();
+        // Well past the 1000-header batch limit, so the catch-up needs several batches.
+        let client = MockBaseNode::new(linear_chain(0..=3000));
+        let mut inner = make_inner(store, client, 5);
+
+        let mut has_more = inner.scan_blockchain(false).await.unwrap();
+        assert!(has_more, "a 3000-header chain cannot be caught up in one batch");
+
+        let epochs_activated: Vec<u64> = inner
+            .pending_events
+            .iter()
+            .filter_map(|e| match e {
+                EpochEvent::EpochChanged { epoch, .. } => Some(epoch.as_u64()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            epochs_activated.first().copied(),
+            Some(1),
+            "the first batch must already carry the boundaries it crossed; got {epochs_activated:?}"
+        );
+        assert!(
+            !inner
+                .pending_events
+                .iter()
+                .any(|e| matches!(e, EpochEvent::DoneForNow { .. })),
+            "DoneForNow must not be emitted while the scan is still short of the lagged tip"
+        );
+
+        // Drive the remaining batches, keeping only the last batch's events.
+        let mut batches = 1;
+        while has_more {
+            inner.pending_events.clear();
+            has_more = inner.scan_blockchain(has_more).await.unwrap();
+            batches += 1;
+        }
+        assert!(batches > 1, "expected a multi-batch catch-up, ran {batches}");
+
+        assert!(
+            inner
+                .pending_events
+                .iter()
+                .any(|e| matches!(e, EpochEvent::DoneForNow { .. })),
+            "DoneForNow must be emitted once the scan reaches the lagged tip"
+        );
+    }
+
     #[tokio::test]
     async fn observed_boundary_hash_is_readable_before_the_epoch_is_activated() {
         let store = InMemoryStore::default();

--- a/crates/epoch_oracles/src/base_layer/oracle.rs
+++ b/crates/epoch_oracles/src/base_layer/oracle.rs
@@ -1404,6 +1404,11 @@ mod tests {
     /// `EpochManagerEvent::EpochChanged` to consensus only from `on_scanning_complete`, i.e. on
     /// `DoneForNow`. So between the first batch and the last, the data a deferred end-of-epoch waits
     /// on is present while the notification that used to trigger its retry is still batches away.
+    ///
+    /// Only the emission half is asserted below — it is the half that lives in this crate. The epoch
+    /// manager's publish-on-`DoneForNow` side is context, guarded by
+    /// `epoch_change_deferred_eoe_resumes_without_scan_completion` in `consensus_tests`, and it is the
+    /// half a future change would most likely move.
     #[tokio::test]
     async fn catch_up_emits_epoch_changed_per_batch_but_done_for_now_only_at_the_tip() {
         let store = InMemoryStore::default();

--- a/crates/epoch_oracles/src/base_layer/oracle.rs
+++ b/crates/epoch_oracles/src/base_layer/oracle.rs
@@ -1405,10 +1405,12 @@ mod tests {
     /// `DoneForNow`. So between the first batch and the last, the data a deferred end-of-epoch waits
     /// on is present while the notification that used to trigger its retry is still batches away.
     ///
-    /// Only the emission half is asserted below — it is the half that lives in this crate. The epoch
-    /// manager's publish-on-`DoneForNow` side is context, guarded by
-    /// `epoch_change_deferred_eoe_resumes_without_scan_completion` in `consensus_tests`, and it is the
-    /// half a future change would most likely move.
+    /// Only the emission half is asserted below — it is the half that lives in this crate. Nothing
+    /// pins the epoch manager's publish-on-`DoneForNow` policy itself: the consensus-side test,
+    /// `epoch_change_deferred_eoe_resumes_without_scan_completion`, runs against `TestEpochManager`
+    /// and so pins the consequence — a deferred end-of-epoch resumes without a scan-completion event
+    /// — not the policy. Making `on_scanning_complete` publish per activation would fail neither test,
+    /// which is the point: consensus must not depend on when that event arrives.
     #[tokio::test]
     async fn catch_up_emits_epoch_changed_per_batch_but_done_for_now_only_at_the_tip() {
         let store = InMemoryStore::default();


### PR DESCRIPTION
Fixes #2581.

## Problem

`process_end_of_epoch` defers when the local oracle has not yet observed `next_epoch`, and the retry was driven by `EpochManagerEvent::EpochChanged`. That event is published from exactly one place — `on_scanning_complete`, on `EpochEvent::DoneForNow` — which the base-layer oracle emits only when the scan reaches the lagged tip. A multi-batch catch-up emits nothing until the last batch.

The data the deferral waits on is written far earlier: `activate_epoch` writes the epoch row, assigns the validator set and clears the committee cache as soon as the queued `EpochChanged` for that epoch is applied, which during a catch-up happens between batches. The row is there; nothing told consensus to look.

Since #2572 a lagging node votes for the `EndEpoch` off an observed boundary and commits the EOE promptly, making this the normal path. Between committing the EOE and finishing its scan the node has no genesis in the new epoch — it cannot propose or vote there, and is not on the leaf its peers are building on. The wait scales with the scanner's lag (batches are up to 1000 headers), not with consensus lag.

## Change

Retry on the data, not the event (option 1 in the issue): the worker polls `try_resume_pending_end_of_epoch` on its existing 10s periodic tick, so a deferred EOE resumes within one batch instead of one catch-up. The `EpochChanged` and startup retries are unchanged; the shared check/log/propagate is factored into one worker helper.

No new event, no epoch-manager change. Resume errors (`NeedsSync`, `NotRegisteredForCurrentEpoch`) propagate from the tick exactly as they did from the event arm.
