### PR TITLE
fix(consensus): classify sync-class and byzantine-triggerable errors correctly

### DIFF
--- a/crates/consensus/src/hotstuff/error.rs
+++ b/crates/consensus/src/hotstuff/error.rs
@@ -131,6 +131,18 @@ impl HotStuffError {
             _ => None,
         }
     }
+
+    /// True for errors that mean this node is behind its peers and must sync. These are a designed transition out
+    /// of the Running state, not a consensus failure, and must be classified as such wherever consensus errors are
+    /// reported. The state machine (see `state_machine::running`) maps exactly these variants to `NeedSync`.
+    pub fn is_sync_required(&self) -> bool {
+        matches!(
+            self,
+            Self::NeedsSync { .. } |
+                Self::FallenBehind { .. } |
+                Self::ProposalValidationError(ProposalValidationError::FutureEpoch { .. })
+        )
+    }
 }
 
 impl From<EpochManagerError> for HotStuffError {

--- a/crates/consensus/src/hotstuff/error.rs
+++ b/crates/consensus/src/hotstuff/error.rs
@@ -134,7 +134,7 @@ impl HotStuffError {
 
     /// True for errors that mean this node is behind its peers and must sync. These are a designed transition out
     /// of the Running state, not a consensus failure, and must be classified as such wherever consensus errors are
-    /// reported. The state machine (see `state_machine::running`) maps exactly these variants to `NeedSync`.
+    /// reported. `state_machine::running` maps them to `NeedSync`.
     pub fn is_sync_required(&self) -> bool {
         matches!(
             self,

--- a/crates/consensus/src/hotstuff/event.rs
+++ b/crates/consensus/src/hotstuff/event.rs
@@ -14,6 +14,9 @@ pub enum HotstuffEvent {
     },
     #[error("Consensus failure: {message}")]
     Failure { message: String },
+    /// This node is behind its peers and is leaving consensus to sync. A designed transition, not a failure.
+    #[error("Sync required: {message}")]
+    SyncRequired { message: String },
     #[error("Leader timeout: height {height}")]
     LeaderTimeout { height: NodeHeight },
     #[error("Block {block} has been parked ({num_missing_txs} missing, {num_awaiting_txs} awaiting execution)")]

--- a/crates/consensus/src/hotstuff/state_machine/running.rs
+++ b/crates/consensus/src/hotstuff/state_machine/running.rs
@@ -6,7 +6,6 @@ use log::*;
 use crate::{
     hotstuff::{
         HotStuffError,
-        ProposalValidationError,
         WorkerExitReason,
         state_machine::{
             check_sync::CheckSync,
@@ -41,9 +40,7 @@ where TSpec: ConsensusSpec
                 info!(target: LOG_TARGET, "Not registered for current epoch ({err})");
                 Ok(ConsensusStateEvent::NotRegisteredForEpoch { epoch })
             },
-            Err(err @ HotStuffError::NeedsSync { .. }) |
-            Err(err @ HotStuffError::FallenBehind { .. }) |
-            Err(err @ HotStuffError::ProposalValidationError(ProposalValidationError::FutureEpoch { .. })) => {
+            Err(err) if err.is_sync_required() => {
                 info!(target: LOG_TARGET, "⚠️ Behind peers, starting sync ({err})");
                 // From the Running state we have no specific target — re-enter CheckSync to
                 // resolve one via the probe/oracle.

--- a/crates/consensus/src/hotstuff/worker.rs
+++ b/crates/consensus/src/hotstuff/worker.rs
@@ -836,10 +836,17 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
 
     async fn on_failure(&mut self, context: &str, err: &HotStuffError) {
         self.hooks.on_error(err);
-        self.publish_event(HotstuffEvent::Failure {
-            message: err.to_string(),
-        });
-        error!(target: LOG_TARGET, "Error ({}): {}", context, err);
+        if err.is_sync_required() {
+            info!(target: LOG_TARGET, "⚠️ Behind peers ({}): {}", context, err);
+            self.publish_event(HotstuffEvent::SyncRequired {
+                message: err.to_string(),
+            });
+        } else {
+            self.publish_event(HotstuffEvent::Failure {
+                message: err.to_string(),
+            });
+            error!(target: LOG_TARGET, "Error ({}): {}", context, err);
+        }
         if let Err(e) = self.pacemaker.stop().await {
             error!(target: LOG_TARGET, "Error while stopping pacemaker: {}", e);
         }

--- a/crates/consensus/src/hotstuff/worker.rs
+++ b/crates/consensus/src/hotstuff/worker.rs
@@ -835,13 +835,13 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
     }
 
     async fn on_failure(&mut self, context: &str, err: &HotStuffError) {
-        self.hooks.on_error(err);
         if err.is_sync_required() {
-            info!(target: LOG_TARGET, "⚠️ Behind peers ({}): {}", context, err);
+            debug!(target: LOG_TARGET, "⚠️ Behind peers ({}): {}", context, err);
             self.publish_event(HotstuffEvent::SyncRequired {
                 message: err.to_string(),
             });
         } else {
+            self.hooks.on_error(err);
             self.publish_event(HotstuffEvent::Failure {
                 message: err.to_string(),
             });

--- a/crates/consensus_tests/src/epoch_change.rs
+++ b/crates/consensus_tests/src/epoch_change.rs
@@ -484,7 +484,7 @@ async fn wait_for_all_validators_at_epoch(test: &mut Test, epoch: Epoch, timeout
 ///    base-layer scanner caught up). The next Epoch(2) Proposal that the network delivers to it goes through
 ///    `MessageBuffer::next`, where the probe verifies the embedded QC against the Epoch(2) committee and raises
 ///    `HotStuffError::NeedsSync`.
-/// 5. We assert on the resulting `HotstuffEvent::Failure` event — its message identifies the QC-based reason. No
+/// 5. We assert on the resulting `HotstuffEvent::SyncRequired` event — its message identifies the QC-based reason. No
 ///    time-based sleeps: the assertion fires deterministically when an authenticated Epoch(2) QC reaches the validator.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn epoch_change_no_vote_wedge_escalates_on_future_qc() {
@@ -561,7 +561,7 @@ async fn epoch_change_no_vote_wedge_escalates_on_future_qc() {
     log::info!("✅ wedge reproduced: validator {lagging_addr} stuck on Epoch(1) while peers committed Epoch(2)");
 
     // Subscribe to validator "1"'s event stream BEFORE clearing the oracle cap and going
-    // online, so we don't miss the Failure event the worker publishes when it raises
+    // online, so we don't miss the SyncRequired event the worker publishes when it raises
     // `HotStuffError::NeedsSync`.
     let mut events = lagged.events.resubscribe();
 
@@ -578,12 +578,12 @@ async fn epoch_change_no_vote_wedge_escalates_on_future_qc() {
         test.send_transaction_to_all(Decision::Commit, 1, 1, 1).await;
     }
 
-    // Wait for the Failure event whose message identifies the QC-based escalation. This is
+    // Wait for the SyncRequired event whose message identifies the QC-based escalation. This is
     // deterministic — fires on the first authenticated Epoch(2) QC that arrives.
     let outcome = tokio::time::timeout(Duration::from_secs(20), async {
         loop {
             match events.recv().await {
-                Ok(HotstuffEvent::Failure { message }) if message.contains("Received valid 2f+1 QC") => {
+                Ok(HotstuffEvent::SyncRequired { message }) if message.contains("Received valid 2f+1 QC") => {
                     return message;
                 },
                 Ok(_) => continue,
@@ -692,7 +692,7 @@ async fn epoch_change_multi_epoch_lag_escalates_on_future_qc() {
     let outcome = tokio::time::timeout(Duration::from_secs(20), async {
         loop {
             match events.recv().await {
-                Ok(HotstuffEvent::Failure { message }) if message.contains("Received valid 2f+1 QC") => {
+                Ok(HotstuffEvent::SyncRequired { message }) if message.contains("Received valid 2f+1 QC") => {
                     return message;
                 },
                 Ok(_) => continue,

--- a/crates/consensus_tests/src/support/harness.rs
+++ b/crates/consensus_tests/src/support/harness.rs
@@ -45,7 +45,11 @@ use tari_state_store_rocksdb::column_families::{
     finalized_transaction::FinalizedTransactionLinkCf,
     transaction::TransactionCf,
 };
-use tokio::{sync::broadcast, task, time::sleep};
+use tokio::{
+    sync::broadcast,
+    task,
+    time::{Instant, sleep},
+};
 
 use super::{
     MessageFilter,
@@ -261,9 +265,12 @@ impl Test {
     }
 
     pub async fn on_block_committed(&mut self) -> (TestAddress, BlockId, Epoch, NodeHeight) {
+        // The deadline is a wall-clock bound on the wait for a committed block. Events that are ignored below
+        // must not extend it, otherwise a consensus livelock that keeps emitting events never trips the timeout.
+        let deadline = self.timeout.map(|timeout| Instant::now() + timeout);
         loop {
-            let (address, event) = if let Some(timeout) = self.timeout {
-                match tokio::time::timeout(timeout, self.on_hotstuff_event()).await {
+            let (address, event) = if let Some(deadline) = deadline {
+                match tokio::time::timeout_at(deadline, self.on_hotstuff_event()).await {
                     Ok(v) => v,
                     Err(_) => {
                         self.dump_pool_info();


### PR DESCRIPTION
Three independent fixes to how consensus errors are classified, plus the test-harness change that makes the resulting failures legible. Follows on from #2573/#2574/#2585, but does not depend on them.

### 1. Sync-class errors are not consensus failures

`on_failure` published `HotstuffEvent::Failure` and stopped the pacemaker for *every* error leaving the HotStuff worker loop, including `NeedsSync`, `FallenBehind` and `ProposalValidationError::FutureEpoch`. Those three are a designed transition out of the Running state — `state_machine::running` classifies exactly them as `NeedSync` — so subscribers saw a consensus failure emitted immediately before the state machine logged `⚠️ Behind peers, starting sync`. Both halves appear back-to-back in CI logs.

Note this is *not* the `handle_hotstuff_error` classifier, which already returns `Ok(())` for these shapes; the `on_failure` call sites never reach it.

Adds `HotStuffError::is_sync_required()` and a `HotstuffEvent::SyncRequired` variant, and routes the sync-class arm through it. `pacemaker.stop()` is deliberately kept — the state machine re-enters sync regardless.

This also removes the ability of `epoch_change::epoch_change_hash_divergence_self_heals` to fail on a spurious `Failure` event, which it did intermittently.

### 2. `EvictNode` for an unknown public key no longer aborts consensus

`ValidatorConsensusStats::get_by_public_key` returns `NotFound` for a key with no stats in the epoch. That error reached `handle_hotstuff_error`'s fatal catch-all, so a byzantine leader proposing an `EvictNode` for an arbitrary key could drive a replica into a `Failure` → `Sleeping` → 5s → re-init loop on demand.

A key with no recorded stats has missed no proposals and is never eligible for eviction, so the missing row is treated as zero missed proposals and takes the existing `ShouldNotEvictNode` no-vote path.

### 3. Test harness timeout is now a wall-clock bound

`on_block_committed` wrapped each individual `on_hotstuff_event()` await in `tokio::time::timeout` from inside its loop, so every ignored event reset the timer and the declared budget was never a bound. A consensus livelock that keeps emitting non-commit events therefore never tripped it: the `foreign_shard_group_decides_to_abort` livelock burned nextest's 600s slow-timeout and produced a 14 GB job log instead of panicking at its declared 60s with the pool/block dumps the code already emits. Hoists a deadline out of the loop and uses `timeout_at`.

### Compatibility

Replica evaluation of well-formed proposals is untouched, no block format or hash input moves, and no network coordination is required. `HotstuffEvent::SyncRequired` is a new variant on an internal event enum; all external consumers match non-exhaustively.

### Testing

`cargo test -p consensus_tests` — 68 passed, run green on each commit individually.