### PR TITLE
feat(template_builtin): add proof-taking account methods

### DIFF
--- a/crates/engine/tests/access_rules.rs
+++ b/crates/engine/tests/access_rules.rs
@@ -675,6 +675,115 @@ mod resource_access_rules {
         );
     }
 
+    /// A resource's withdraw and deposit rules are evaluated in the account's own frame, and a `Proof` argument
+    /// is how a badge reaches a frame. The account holds the transaction's signer badge and nothing else of its
+    /// own, so a rule naming some other badge is satisfied only by handing that badge in.
+    #[test]
+    fn the_account_takes_a_badge_restricted_resource_when_handed_the_badge() {
+        let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/access_rules"]);
+
+        let (owner_proof, _, owner_key) = test.create_owner_proof();
+        let (user_account, user_proof, user_key) = test.create_empty_account();
+
+        let access_rules_template = test.get_template_address("AccessRulesTest");
+
+        let result = test.execute_expect_success(
+            Transaction::builder_localnet(Epoch(1))
+                .call_function(access_rules_template, "using_resource_rules", args![])
+                .build_and_seal(&owner_key),
+            vec![owner_proof.clone()],
+        );
+
+        let access_rules_component = result.finalize.execution_results[0]
+            .decode::<ComponentAddress>()
+            .unwrap();
+        let resources = result
+            .finalize
+            .result
+            .any_accept()
+            .unwrap()
+            .up_iter()
+            .filter_map(|(addr, s)| s.substate_value().as_resource().map(|r| (addr, r)))
+            .map(|(addr, r)| (r.resource_type().is_non_fungible(), addr.as_resource_address().unwrap()))
+            .collect::<Vec<_>>();
+        let badge_resource = resources.iter().find(|(is_nft, _)| *is_nft).unwrap().1;
+        let token_resource = resources.iter().find(|(is_nft, _)| !*is_nft).unwrap().1;
+
+        // Give the user a badge and, with it, some of the restricted tokens. Both the resource's withdraw and
+        // deposit rules name the badge.
+        test.execute_expect_success(
+            Transaction::builder_localnet(Epoch(1))
+                .call_method(access_rules_component, "mint_new_badge", args![])
+                .put_last_instruction_output_on_workspace("permission")
+                .call_method(user_account, "deposit", args![Workspace("permission")])
+                .build_and_seal(&owner_key),
+            vec![owner_proof],
+        );
+
+        test.execute_expect_success(
+            Transaction::builder_localnet(Epoch(1))
+                .call_method(user_account, "create_proof_by_amount", args![badge_resource, 1])
+                .put_last_instruction_output_on_workspace("proof")
+                .call_method(access_rules_component, "take_tokens_using_proof", args![
+                    Workspace("proof"),
+                    100
+                ])
+                .put_last_instruction_output_on_workspace("tokens")
+                .call_method(user_account, "deposit", args![Workspace("tokens")])
+                .drop_all_proofs_in_workspace()
+                .build_and_seal(&user_key),
+            vec![user_proof.clone()],
+        );
+
+        // The account frame carries the signer badge, which the resource's withdraw rule does not name.
+        let reason = test.execute_expect_failure(
+            Transaction::builder_localnet(Epoch(1))
+                .call_method(user_account, "withdraw", args![token_resource, 10])
+                .put_last_instruction_output_on_workspace("tokens")
+                .call_method(user_account, "deposit", args![Workspace("tokens")])
+                .build_and_seal(&user_key),
+            vec![user_proof.clone()],
+        );
+
+        assert_access_denied_for_action(reason, ResourceAuthAction::Withdraw);
+
+        // Handing the badge to the account's frame satisfies it.
+        test.execute_expect_success(
+            Transaction::builder_localnet(Epoch(1))
+                .call_method(user_account, "create_proof_by_amount", args![badge_resource, 1])
+                .put_last_instruction_output_on_workspace("badge")
+                .call_method(user_account, "withdraw_with_auth", args![
+                    token_resource,
+                    10,
+                    Workspace("badge")
+                ])
+                .put_last_instruction_output_on_workspace("tokens")
+                .call_method(user_account, "deposit_with_auth", args![
+                    Workspace("tokens"),
+                    Workspace("badge")
+                ])
+                .drop_all_proofs_in_workspace()
+                .build_and_seal(&user_key),
+            vec![user_proof.clone()],
+        );
+
+        // A proof over the restricted vault is checked against the same rule.
+        test.execute_expect_success(
+            Transaction::builder_localnet(Epoch(1))
+                .call_method(user_account, "create_proof_by_amount", args![badge_resource, 1])
+                .put_last_instruction_output_on_workspace("badge")
+                .call_method(user_account, "create_proof_by_amount_with_auth", args![
+                    token_resource,
+                    10,
+                    Workspace("badge")
+                ])
+                .put_last_instruction_output_on_workspace("token_proof")
+                .drop_all_proofs_in_workspace()
+                .build_and_seal(&user_key),
+            vec![user_proof],
+        );
+    }
+
     #[test]
     fn it_locks_resources_used_in_proofs() {
         let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/access_rules"]);

--- a/crates/template_builtin/templates/account/src/lib.rs
+++ b/crates/template_builtin/templates/account/src/lib.rs
@@ -99,9 +99,23 @@ mod account_template {
             v.withdraw(amount)
         }
 
+        /// Withdraws with `auth` authorizing the resource's withdraw rule.
+        ///
+        /// A resource whose withdraw rule names a badge is reachable only by a frame that holds that badge, and a
+        /// `Proof` is how a badge reaches a frame. `auth` remains the caller's: it authorizes for the duration of
+        /// this call and is neither consumed nor dropped here.
+        pub fn withdraw_with_auth(&mut self, resource: ResourceAddress, amount: Amount, auth: Proof) -> Bucket {
+            auth.authorize_with(|| self.withdraw(resource, amount))
+        }
+
         pub fn withdraw_all(&mut self, resource: ResourceAddress) -> Bucket {
             let v = self.get_vault_mut(resource);
             v.withdraw_all()
+        }
+
+        /// [`Self::withdraw_all`] with `auth` authorizing the resource's withdraw rule.
+        pub fn withdraw_all_with_auth(&mut self, resource: ResourceAddress, auth: Proof) -> Bucket {
+            auth.authorize_with(|| self.withdraw_all(resource))
         }
 
         pub fn withdraw_non_fungible(&mut self, resource: ResourceAddress, nf_id: NonFungibleId) -> Bucket {
@@ -110,10 +124,30 @@ mod account_template {
             v.withdraw_non_fungibles([nf_id])
         }
 
+        /// [`Self::withdraw_non_fungible`] with `auth` authorizing the resource's withdraw rule.
+        pub fn withdraw_non_fungible_with_auth(
+            &mut self,
+            resource: ResourceAddress,
+            nf_id: NonFungibleId,
+            auth: Proof,
+        ) -> Bucket {
+            auth.authorize_with(|| self.withdraw_non_fungible(resource, nf_id))
+        }
+
         pub fn withdraw_many_non_fungibles(&mut self, resource: ResourceAddress, nf_ids: Vec<NonFungibleId>) -> Bucket {
             // An event is emitted by the vault.withdraw_non_fungibles method
             let v = self.get_vault_mut(resource);
             v.withdraw_non_fungibles(nf_ids)
+        }
+
+        /// [`Self::withdraw_many_non_fungibles`] with `auth` authorizing the resource's withdraw rule.
+        pub fn withdraw_many_non_fungibles_with_auth(
+            &mut self,
+            resource: ResourceAddress,
+            nf_ids: Vec<NonFungibleId>,
+            auth: Proof,
+        ) -> Bucket {
+            auth.authorize_with(|| self.withdraw_many_non_fungibles(resource, nf_ids))
         }
 
         pub fn withdraw_confidential(
@@ -124,6 +158,16 @@ mod account_template {
             // An event is emitted by the vault.withdraw_confidential method
             let v = self.get_vault_mut(resource);
             v.withdraw_confidential(withdraw_proof)
+        }
+
+        /// [`Self::withdraw_confidential`] with `auth` authorizing the resource's withdraw rule.
+        pub fn withdraw_confidential_with_auth(
+            &mut self,
+            resource: ResourceAddress,
+            withdraw_proof: ConfidentialWithdrawProof,
+            auth: Proof,
+        ) -> Bucket {
+            auth.authorize_with(|| self.withdraw_confidential(resource, withdraw_proof))
         }
 
         pub fn deposit(&mut self, bucket: Bucket) {
@@ -139,6 +183,11 @@ mod account_template {
                 .entry(resource_address)
                 .or_insert_with(|| Vault::new_empty(resource_address));
             vault_mut.deposit(bucket);
+        }
+
+        /// [`Self::deposit`] with `auth` authorizing the resource's deposit rule.
+        pub fn deposit_with_auth(&mut self, bucket: Bucket, auth: Proof) {
+            auth.authorize_with(|| self.deposit(bucket));
         }
 
         fn get_vault(&self, resource: ResourceAddress) -> &Vault {
@@ -185,6 +234,12 @@ mod account_template {
             v.create_proof()
         }
 
+        /// [`Self::create_proof_for_resource`] with `auth` authorizing the resource's withdraw rule, which is what
+        /// taking a proof over a vault is checked against.
+        pub fn create_proof_for_resource_with_auth(&mut self, resource: ResourceAddress, auth: Proof) -> Proof {
+            auth.authorize_with(|| self.create_proof_for_resource(resource))
+        }
+
         pub fn create_proof_by_non_fungible(&mut self, nft: NonFungibleAddress) -> Proof {
             self.create_proof_by_non_fungible_ids(*nft.resource_address(), vec![nft.id().clone()])
         }
@@ -198,9 +253,29 @@ mod account_template {
             v.create_proof_by_non_fungible_ids(ids.into_iter().collect())
         }
 
+        /// [`Self::create_proof_by_non_fungible_ids`] with `auth` authorizing the resource's withdraw rule.
+        pub fn create_proof_by_non_fungible_ids_with_auth(
+            &mut self,
+            resource: ResourceAddress,
+            ids: Vec<NonFungibleId>,
+            auth: Proof,
+        ) -> Proof {
+            auth.authorize_with(|| self.create_proof_by_non_fungible_ids(resource, ids))
+        }
+
         pub fn create_proof_by_amount(&mut self, resource: ResourceAddress, amount: Amount) -> Proof {
             let v = self.get_vault_mut(resource);
             v.create_proof_by_amount(amount)
+        }
+
+        /// [`Self::create_proof_by_amount`] with `auth` authorizing the resource's withdraw rule.
+        pub fn create_proof_by_amount_with_auth(
+            &mut self,
+            resource: ResourceAddress,
+            amount: Amount,
+            auth: Proof,
+        ) -> Proof {
+            auth.authorize_with(|| self.create_proof_by_amount(resource, amount))
         }
 
         pub fn create_ownership_proof(&mut self) -> Proof {


### PR DESCRIPTION
Groundwork for the wave-3 proof-scope change (boundary checks, Radix-style), shipped ahead of it so call sites can migrate before the protocol flips.

## Why

A resource's withdraw and deposit rules are evaluated in the frame that touches the vault — for an account, the account's own frame (`impl.rs` `check_resource_access_rules`, reached from `VaultAction::Withdraw`, `Deposit` and all three `CreateProof*`). That frame carries the transaction's signer badge and nothing else of its own, so a rule naming another badge is satisfied only by handing that badge in, and a `Proof` argument is how a badge reaches a frame.

Today a top-level caller's workspace proofs are copied into the callee's frame, so the account picks up a badge proof without being given one. Wave 3 removes that copy. These methods are the explicit route that survives it.

## What

A `_with_auth` variant of each affected method, taking the proof that authorizes the rule for the duration of the call:

- `withdraw_with_auth`, `withdraw_all_with_auth`
- `withdraw_non_fungible_with_auth`, `withdraw_many_non_fungibles_with_auth`
- `withdraw_confidential_with_auth`
- `deposit_with_auth`
- `create_proof_for_resource_with_auth`, `create_proof_by_non_fungible_ids_with_auth`, `create_proof_by_amount_with_auth`

The proof remains the caller's — neither consumed nor dropped, so the caller's `DropAllProofsInWorkspace` still accounts for it.

Not included: `join_confidential` and `pay_fee`/`pay_fee_stealth`. The first composes from the two variants above; the second moves TARI, whose withdraw rule is `AllowAll`.

## Honest limitation

**These methods are inert under the current scope model.** With the proof on the workspace, the plain method already succeeds — verified by stripping the `authorize_with` out of `withdraw_with_auth` and watching the test still pass. They become load-bearing only when wave 3 stops frames inheriting the caller's proofs.

So the test pins what is provable now: the methods exist, accept a proof, and drive a badge-restricted withdraw/deposit/create-proof end to end; and the same withdraw with no proof anywhere fails with `AccessDenied`.

## Compatibility

Additive. No existing signature changes, so every current manifest and SDK call site is unaffected, and no wallet needs updating — `ResourceAccessRules::new()` sets `withdraw`/`deposit` to `AllowAll` and TARI uses those defaults, so nothing wallets move today is badge-restricted.

The builtin account binary changes, so validators and indexers roll together; the template address is the `[0u8; 32]` constant and no substate moves.

## Tests

`access_rules.rs::the_account_takes_a_badge_restricted_resource_when_handed_the_badge` — a resource whose withdraw *and* deposit rules both name a badge, exercised through `withdraw_with_auth`, `deposit_with_auth` and `create_proof_by_amount_with_auth`, with the no-proof withdraw as the negative control.

`cargo nextest run -p tari_engine`: 423 passed, 0 failed. `cargo lints clippy -p tari_engine --all-targets` clean.
