### PR TITLE
fix(consensus): anchor the whole proposal at the state anchor

### DIFF
--- a/crates/consensus/src/hotstuff/on_propose.rs
+++ b/crates/consensus/src/hotstuff/on_propose.rs
@@ -302,7 +302,7 @@ where TConsensusSpec: ConsensusSpec
     /// Returns Ok(None) if the command cannot be sequenced yet due to lock conflicts.
     fn transaction_pool_record_to_command<TTx: StateStoreReadTransaction>(
         &self,
-        start_of_chain_id: &LeafBlock,
+        state_anchor: &LeafBlock,
         locked_epoch: &LockedEpoch,
         pool_tx: TransactionPoolRecord,
         local_committee_info: &CommitteeInfo,
@@ -313,7 +313,7 @@ where TConsensusSpec: ConsensusSpec
     ) -> Result<Option<Command>, HotStuffError> {
         match pool_tx.current_stage() {
             TransactionPoolStage::New => self.prepare_transaction(
-                start_of_chain_id,
+                state_anchor,
                 locked_epoch,
                 pool_tx,
                 local_committee_info,
@@ -325,7 +325,7 @@ where TConsensusSpec: ConsensusSpec
             // Leader thinks all foreign PREPARE pledges have been received (condition for LocalPrepared stage to be
             // ready)
             TransactionPoolStage::LocalPrepared => self.local_accept_transaction(
-                start_of_chain_id,
+                state_anchor,
                 local_committee_info,
                 change_set,
                 pool_tx,
@@ -336,7 +336,7 @@ where TConsensusSpec: ConsensusSpec
             // Leader thinks that all foreign ACCEPT pledges have been received and, we are ready to accept the result
             // (COMMIT/ABORT)
             TransactionPoolStage::LocalAccepted => {
-                self.accept_transaction(start_of_chain_id, &pool_tx, local_committee_info, substate_store)
+                self.accept_transaction(state_anchor, &pool_tx, local_committee_info, substate_store)
             },
             // Not reachable as there is nothing to propose for these stages. To confirm that all local nodes
             // agreed with the Accept, more (possibly empty) blocks with QCs will be
@@ -369,7 +369,6 @@ where TConsensusSpec: ConsensusSpec
     ) -> Result<NextBlock, HotStuffError> {
         let high_qc_id = high_qc_certificate.calculate_id();
         let justify_block = Block::get_justified_block(tx, &high_qc_certificate, epoch)?;
-        let start_of_chain_block = highest_seen_block;
         let parent_block = dummy_block.unwrap_or_else(|| highest_seen_block.as_leaf());
         let highest_seen_block = Block::get(tx, highest_seen_block.block_id())?;
         let is_end_of_epoch_in_chain = highest_seen_block.is_epoch_end_proposed_in_chain(tx)?;
@@ -383,8 +382,8 @@ where TConsensusSpec: ConsensusSpec
         };
 
         let mut total_leader_fee = 0u64;
-        // The block the candidate extends from, and therefore the point every part of this proposal is read
-        // at. When filling a timeout gap with a dummy chain that is justify_block, not the highest seen block:
+        // The block the candidate extends from, and the point at which every speculative state and pool read
+        // for this proposal is taken. When filling a timeout gap with a dummy chain that is justify_block:
         // the dummies are empty blocks carrying justify_block's accumulated_data and state forward (see
         // `calculate_last_dummy_block`), so the candidate's parent chain runs back through them to
         // justify_block and never through a locally-stored fork above the high QC. A validator recomputes
@@ -392,20 +391,16 @@ where TConsensusSpec: ConsensusSpec
         // changes and leader-fee burn surface as an exhaust-burn or state Merkle-root mismatch, and pool
         // records read there carry stages and decisions from blocks the candidate abandons.
         //
-        // Every read for the candidate follows this anchor — accumulated_data, the substate store, the
-        // pending state tree diff lookup, foreign proposal processing, the proposal batch, the change set and
-        // command generation. They must agree, and `highest_seen_block` is only the right answer for the
-        // non-dummy case, where the two are the same block.
-        let state_anchor_leaf = if dummy_block.is_some() {
-            justify_block.as_leaf()
+        // The epoch-boundary checks above and the locked epoch below are read at `highest_seen_block`
+        // instead. They gate whether commands are proposed at all, so reading them a block early only ever
+        // suppresses commands, and the candidate's own header takes its epoch hash from the same block.
+        let state_anchor = if dummy_block.is_some() {
+            &justify_block
         } else {
-            start_of_chain_block.as_leaf()
+            &highest_seen_block
         };
-        let mut accumulated_data = if dummy_block.is_some() {
-            *justify_block.header().accumulated_data()
-        } else {
-            *highest_seen_block.header().accumulated_data()
-        };
+        let state_anchor_leaf = state_anchor.as_leaf();
+        let mut accumulated_data = *state_anchor.header().accumulated_data();
 
         let mut substate_store =
             PendingSubstateStore::new(tx, state_anchor_leaf, self.config.consensus_constants.num_preshards);
@@ -771,7 +766,7 @@ where TConsensusSpec: ConsensusSpec
     #[allow(clippy::too_many_lines)]
     fn prepare_transaction<TTx: StateStoreReadTransaction>(
         &self,
-        parent_block: &LeafBlock,
+        state_anchor: &LeafBlock,
         locked_epoch: &LockedEpoch,
         mut pool_tx: TransactionPoolRecord,
         local_committee_info: &CommitteeInfo,
@@ -795,7 +790,7 @@ where TConsensusSpec: ConsensusSpec
                 substate_store,
                 local_committee_info,
                 &pool_tx,
-                *parent_block,
+                *state_anchor,
                 change_set,
             )
             .map_err(|e| HotStuffError::TransactionExecutorError(e.to_string()))?;
@@ -970,7 +965,7 @@ where TConsensusSpec: ConsensusSpec
 
     fn local_accept_transaction<TTx: StateStoreReadTransaction>(
         &self,
-        parent_block: &LeafBlock,
+        state_anchor: &LeafBlock,
         local_committee_info: &CommitteeInfo,
         change_set: &ProposedBlockChangeSet,
         mut tx_rec: TransactionPoolRecord,
@@ -991,7 +986,7 @@ where TConsensusSpec: ConsensusSpec
 
         let tx = substate_store.read_transaction();
         let transaction = tx_rec.get_transaction(tx)?;
-        let execution = self.execute_transaction(tx, parent_block, transaction, change_set, locked_epoch.clone())?;
+        let execution = self.execute_transaction(tx, state_anchor, transaction, change_set, locked_epoch.clone())?;
 
         // Try to lock all local outputs
         let local_outputs = execution
@@ -1033,7 +1028,7 @@ where TConsensusSpec: ConsensusSpec
 
     fn accept_transaction<TTx: StateStoreReadTransaction>(
         &self,
-        parent_block: &LeafBlock,
+        state_anchor: &LeafBlock,
         tx_rec: &TransactionPoolRecord,
         local_committee_info: &CommitteeInfo,
         substate_store: &mut PendingSubstateStore<TTx>,
@@ -1044,7 +1039,7 @@ where TConsensusSpec: ConsensusSpec
 
         let tx = substate_store.read_transaction();
         let execution = tx_rec
-            .get_pending_execution_for_block(tx, parent_block)
+            .get_pending_execution_for_block(tx, state_anchor)
             .optional()?
             .ok_or_else(|| {
                 HotStuffError::InvariantError(format!(
@@ -1097,14 +1092,14 @@ where TConsensusSpec: ConsensusSpec
     fn execute_transaction<TTx: StateStoreReadTransaction>(
         &self,
         tx: &TTx,
-        parent_block: &LeafBlock,
+        state_anchor: &LeafBlock,
         transaction: TransactionRecord,
         change_set: &ProposedBlockChangeSet,
         locked_epoch: LockedEpoch,
     ) -> Result<TransactionExecution, HotStuffError> {
         // Should have been executed already if all inputs are local
         if let Some(execution) =
-            BlockTransactionExecution::get_pending_for_block(tx, transaction.id(), parent_block).optional()?
+            BlockTransactionExecution::get_pending_for_block(tx, transaction.id(), state_anchor).optional()?
         {
             info!(
                 target: LOG_TARGET,

--- a/crates/consensus/src/hotstuff/on_propose.rs
+++ b/crates/consensus/src/hotstuff/on_propose.rs
@@ -383,14 +383,19 @@ where TConsensusSpec: ConsensusSpec
         };
 
         let mut total_leader_fee = 0u64;
-        // When filling a timeout gap with a dummy chain, the candidate effectively extends from justify_block (the
-        // dummies are empty blocks that carry justify_block's accumulated_data and state forward — see
-        // `calculate_last_dummy_block`). Anchor accumulated_data, the substate store, the pending state tree
-        // diff lookup and propose-time foreign proposal processing at justify_block to match what validators
-        // recompute from the reconstructed dummy chain.
-        // Otherwise speculative state and leader-fee burn that accumulated on a locally-stored fork above the high QC
-        // would be incorrectly carried into the new candidate and validators would reject with either an
-        // exhaust-burn mismatch or a state Merkle-root mismatch.
+        // The block the candidate extends from, and therefore the point every part of this proposal is read
+        // at. When filling a timeout gap with a dummy chain that is justify_block, not the highest seen block:
+        // the dummies are empty blocks carrying justify_block's accumulated_data and state forward (see
+        // `calculate_last_dummy_block`), so the candidate's parent chain runs back through them to
+        // justify_block and never through a locally-stored fork above the high QC. A validator recomputes
+        // that same chain, so anything read at a fork block is state it does not have: speculative substate
+        // changes and leader-fee burn surface as an exhaust-burn or state Merkle-root mismatch, and pool
+        // records read there carry stages and decisions from blocks the candidate abandons.
+        //
+        // Every read for the candidate follows this anchor — accumulated_data, the substate store, the
+        // pending state tree diff lookup, foreign proposal processing, the proposal batch, the change set and
+        // command generation. They must agree, and `highest_seen_block` is only the right answer for the
+        // non-dummy case, where the two are the same block.
         let state_anchor_leaf = if dummy_block.is_some() {
             justify_block.as_leaf()
         } else {
@@ -410,7 +415,7 @@ where TConsensusSpec: ConsensusSpec
         let batch = if should_not_propose_commands {
             ProposalBatch::default()
         } else {
-            self.fetch_next_proposal_batch(tx, start_of_chain_block)?
+            self.fetch_next_proposal_batch(tx, state_anchor_leaf)?
         };
         debug!(target: LOG_TARGET, "🌿 PROPOSE: {} (justify: {}) {batch}", highest_seen_block.height(), justify_block.height());
 
@@ -428,7 +433,7 @@ where TConsensusSpec: ConsensusSpec
         };
 
         // NOTE: the block for the change set is not used.
-        let mut change_set = ProposedBlockChangeSet::new(start_of_chain_block.as_leaf());
+        let mut change_set = ProposedBlockChangeSet::new(state_anchor_leaf);
         let mut invalid_foreign_proposals = Vec::new();
         let mut dropped_foreign_proposals = false;
 
@@ -560,7 +565,7 @@ where TConsensusSpec: ConsensusSpec
             // for this block, so only count executions newly produced by the command conversion below.
             let had_execution = executed_transactions.contains_key(&tx_id);
             let maybe_command = self.transaction_pool_record_to_command(
-                &start_of_chain_block.as_leaf(),
+                &state_anchor_leaf,
                 // This locked epoch is used to set the transaction LockedEpoch if necessary
                 &locked_epoch,
                 transaction,
@@ -707,7 +712,7 @@ where TConsensusSpec: ConsensusSpec
     fn fetch_next_proposal_batch<TTx: StateStoreReadTransaction>(
         &self,
         tx: &TTx,
-        start_of_chain_block: HighestSeenBlock,
+        state_anchor_leaf: LeafBlock,
     ) -> Result<ProposalBatch, HotStuffError> {
         let _timer = TraceTimer::debug(LOG_TARGET, "fetch_next_proposal_batch");
         // A block is budgeted by total command weight (`max_block_weight`), not a flat command count.
@@ -722,7 +727,7 @@ where TConsensusSpec: ConsensusSpec
         let max_commands = self.config.consensus_constants.max_commands_in_block;
 
         let foreign_proposals =
-            ForeignProposalRecord::get_all_new(tx, start_of_chain_block.block_id(), MAX_FOREIGN_PROPOSALS_PER_BLOCK)?;
+            ForeignProposalRecord::get_all_new(tx, state_anchor_leaf.block_id(), MAX_FOREIGN_PROPOSALS_PER_BLOCK)?;
 
         if !foreign_proposals.is_empty() {
             debug!(
@@ -750,7 +755,7 @@ where TConsensusSpec: ConsensusSpec
                     tx,
                     weight_budget,
                     max_tx_count,
-                    start_of_chain_block.block_id(),
+                    state_anchor_leaf.block_id(),
                 )
             })
             .transpose()?

--- a/crates/consensus_tests/src/dummy_fill_anchor.rs
+++ b/crates/consensus_tests/src/dummy_fill_anchor.rs
@@ -1,0 +1,202 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use tari_consensus::messages::HotstuffMessage;
+use tari_consensus_types::{BlockId, Decision};
+use tari_ootle_common_types::{Epoch, NodeHeight, optional::Optional};
+use tari_ootle_storage::{StateStore, StorageError, consensus_models::Block};
+use tari_ootle_transaction::TransactionId;
+
+use crate::support::{MessageFilter, Test, TestAddress, Validator, logging::setup_logger};
+
+/// The committee whose chain the assertions read. Only its proposals may be withheld: a block orphaned in
+/// the other committee says nothing about this one's dummy fill.
+const COMMITTEE: [&str; 3] = ["1", "2", "3"];
+/// The validator whose store is inspected. It must never be starved of a proposal, and two of the three
+/// votes it takes part in are one short of quorum.
+const OBSERVER: &str = "1";
+
+#[derive(Default)]
+struct OrphanPlan {
+    transaction_id: Option<TransactionId>,
+    orphan_block_id: Option<BlockId>,
+    orphan_height: Option<NodeHeight>,
+    /// The orphan's command for the transaction, captured off the wire: a block that never gathers a QC is
+    /// pruned from every store before the assertions run.
+    orphan_command: Option<String>,
+}
+
+/// Denies one committee member the first proposal to carry a command for the transaction, and records what
+/// that block said.
+fn withhold_first_command_for(plan: Arc<Mutex<OrphanPlan>>) -> MessageFilter {
+    let observer = TestAddress::new(OBSERVER);
+    let committee: Vec<TestAddress> = COMMITTEE.into_iter().map(TestAddress::new).collect();
+
+    Box::new(move |from, to, msg| {
+        let HotstuffMessage::Proposal(proposal) = msg else {
+            return true;
+        };
+        // The proposer already holds its own block, so starving it changes nothing.
+        if to == from || *to == observer || !committee.contains(to) {
+            return true;
+        }
+        let mut plan = plan.lock().unwrap();
+        if plan.orphan_block_id.is_some() {
+            return true;
+        }
+        let Some(transaction_id) = plan.transaction_id else {
+            return true;
+        };
+        let Some(command) = proposal
+            .block
+            .commands()
+            .iter()
+            .find(|cmd| cmd.transaction().is_some_and(|atom| atom.id == transaction_id))
+        else {
+            return true;
+        };
+        log::info!("🔇 Withholding {} from {to}", proposal.block);
+        plan.orphan_command = Some(command.to_string());
+        plan.orphan_height = Some(proposal.block.height());
+        plan.orphan_block_id = Some(*proposal.block.id());
+        false
+    })
+}
+
+/// The blocks from the leaf back to the oldest ancestor still held, oldest first. The height index holds one
+/// entry per height, so this is the only view that excludes an orphan; blocks below the committed chain may
+/// already have been pruned, so the walk ends at whatever the store holds.
+fn canonical_chain(vn: &Validator) -> Vec<Block> {
+    let leaf = vn.get_leaf_block();
+    vn.state_store()
+        .with_read_tx(|tx| {
+            let mut chain = Vec::new();
+            let mut cursor = *leaf.block_id();
+            while let Some(block) = Block::get(tx, &cursor).optional()? {
+                let parent = *block.parent();
+                let is_genesis = block.height().is_zero();
+                chain.push(block);
+                if is_genesis {
+                    break;
+                }
+                cursor = parent;
+            }
+            chain.reverse();
+            Ok::<_, StorageError>(chain)
+        })
+        .unwrap()
+}
+
+fn describe(chain: &[Block]) -> String {
+    chain
+        .iter()
+        .map(|b| {
+            format!(
+                "h={} dummy={} cmds={} id={}",
+                b.height(),
+                b.is_dummy(),
+                b.commands().len(),
+                &b.id().to_string()[..8]
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n  ")
+}
+
+/// A leader filling a timeout gap with a dummy chain extends from the justify block, so every read for that
+/// proposal must be taken there. The highest seen block is an orphan the candidate abandons, and commands
+/// derived from it describe pool state no replica reproduces.
+///
+/// One committee member is denied the proposal that first carries a command for the transaction. That block
+/// is stored and evaluated by the rest of the committee — so it is the highest seen block — but two of three
+/// votes cannot reach quorum, so it gathers no QC and the pacemaker fills its height with a dummy. The
+/// proposal built on that dummy must repeat the orphan's command: both are entitled to see only the justify
+/// block's state.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn dummy_fill_proposes_from_the_justify_block_not_the_orphan() {
+    setup_logger();
+
+    let plan = Arc::new(Mutex::new(OrphanPlan::default()));
+
+    let mut test = Test::builder()
+        .with_test_timeout(Duration::from_secs(60))
+        .modify_consensus_constants(|config_mut| {
+            config_mut.missed_proposal_suspend_threshold = 10;
+            config_mut.pacemaker_block_time = Duration::from_secs(2);
+        })
+        .add_committee(0, COMMITTEE.to_vec())
+        .add_committee(1, vec!["4", "5", "6"])
+        .with_message_filter(withhold_first_command_for(plan.clone()))
+        .start()
+        .await;
+
+    let (tx, _, _) = test.send_transaction_to_all(Decision::Commit, 1, 2, 1).await;
+    let tx_id = *tx.id();
+    plan.lock().unwrap().transaction_id = Some(tx_id);
+
+    test.start_epoch(Epoch(1)).await;
+
+    loop {
+        let (_, _, _, committed_height) = test.on_block_committed().await;
+        if test.is_transaction_pool_empty() {
+            break;
+        }
+        if committed_height > NodeHeight(30) {
+            panic!("Transaction not finalized after {committed_height} blocks");
+        }
+    }
+
+    test.stop();
+
+    let (orphan_id, orphan_height, orphan_command) = {
+        let plan = plan.lock().unwrap();
+        (
+            plan.orphan_block_id
+                .expect("no proposal carrying the transaction was ever withheld"),
+            plan.orphan_height.unwrap(),
+            plan.orphan_command.clone().unwrap(),
+        )
+    };
+
+    let chain = canonical_chain(test.get_validator(&TestAddress::new(OBSERVER)));
+    let shape = describe(&chain);
+    log::info!(
+        "canonical chain:\n  {shape}\norphan: {} at {orphan_height}",
+        &orphan_id.to_string()[..8]
+    );
+
+    assert!(
+        !chain.iter().any(|b| *b.id() == orphan_id),
+        "the withheld block was committed rather than orphaned; chain shape:\n  {shape}"
+    );
+
+    let by_id = chain.iter().map(|b| (*b.id(), b)).collect::<HashMap<_, _>>();
+    let post_dummy = chain
+        .iter()
+        .find(|b| {
+            !b.is_dummy() && b.height() > orphan_height && by_id.get(b.parent()).is_some_and(|parent| parent.is_dummy())
+        })
+        .unwrap_or_else(|| panic!("no proposal was built on a dummy chain above the orphan; chain shape:\n  {shape}"));
+
+    let post_dummy_command = post_dummy
+        .commands()
+        .iter()
+        .find(|cmd| cmd.transaction().is_some_and(|atom| atom.id == tx_id))
+        .map(|cmd| cmd.to_string());
+
+    assert_eq!(
+        post_dummy_command.as_deref(),
+        Some(orphan_command.as_str()),
+        "proposal on the dummy chain must repeat the orphan's command. Orphan at height {orphan_height}, proposal at \
+         height {}; chain shape:\n  {shape}",
+        post_dummy.height(),
+    );
+
+    test.assert_clean_shutdown().await;
+}

--- a/crates/consensus_tests/src/dummy_fill_anchor.rs
+++ b/crates/consensus_tests/src/dummy_fill_anchor.rs
@@ -9,6 +9,7 @@ use std::{
 
 use tari_consensus::messages::HotstuffMessage;
 use tari_consensus_types::{BlockId, Decision};
+use tari_epoch_manager::EpochManagerReader;
 use tari_ootle_common_types::{Epoch, NodeHeight, optional::Optional};
 use tari_ootle_storage::{StateStore, StorageError, consensus_models::Block};
 use tari_ootle_transaction::TransactionId;
@@ -27,6 +28,9 @@ struct OrphanPlan {
     transaction_id: Option<TransactionId>,
     orphan_block_id: Option<BlockId>,
     orphan_height: Option<NodeHeight>,
+    /// The committee member denied the orphan. Its own highest seen block is the justify block, so a
+    /// proposal it makes on the dummy chain reads the same either way and cannot discriminate.
+    starved: Option<TestAddress>,
     /// The orphan's command for the transaction, captured off the wire: a block that never gathers a QC is
     /// pruned from every store before the assertions run.
     orphan_command: Option<String>,
@@ -62,6 +66,7 @@ fn withhold_first_command_for(plan: Arc<Mutex<OrphanPlan>>) -> MessageFilter {
             return true;
         };
         log::info!("🔇 Withholding {} from {to}", proposal.block);
+        plan.starved = Some(to.clone());
         plan.orphan_command = Some(command.to_string());
         plan.orphan_height = Some(proposal.block.height());
         plan.orphan_block_id = Some(*proposal.block.id());
@@ -154,17 +159,19 @@ async fn dummy_fill_proposes_from_the_justify_block_not_the_orphan() {
 
     test.stop();
 
-    let (orphan_id, orphan_height, orphan_command) = {
+    let (orphan_id, orphan_height, orphan_command, starved) = {
         let plan = plan.lock().unwrap();
         (
             plan.orphan_block_id
                 .expect("no proposal carrying the transaction was ever withheld"),
             plan.orphan_height.unwrap(),
             plan.orphan_command.clone().unwrap(),
+            plan.starved.clone().unwrap(),
         )
     };
 
-    let chain = canonical_chain(test.get_validator(&TestAddress::new(OBSERVER)));
+    let observer = test.get_validator(&TestAddress::new(OBSERVER));
+    let chain = canonical_chain(observer);
     let shape = describe(&chain);
     log::info!(
         "canonical chain:\n  {shape}\norphan: {} at {orphan_height}",
@@ -177,12 +184,37 @@ async fn dummy_fill_proposes_from_the_justify_block_not_the_orphan() {
     );
 
     let by_id = chain.iter().map(|b| (*b.id(), b)).collect::<HashMap<_, _>>();
-    let post_dummy = chain
+    let dummy_extensions = chain
         .iter()
-        .find(|b| {
+        .filter(|b| {
             !b.is_dummy() && b.height() > orphan_height && by_id.get(b.parent()).is_some_and(|parent| parent.is_dummy())
         })
-        .unwrap_or_else(|| panic!("no proposal was built on a dummy chain above the orphan; chain shape:\n  {shape}"));
+        .collect::<Vec<_>>();
+    assert!(
+        !dummy_extensions.is_empty(),
+        "no proposal was built on a dummy chain above the orphan; chain shape:\n  {shape}"
+    );
+
+    // Only a proposer that saw the orphan has a highest seen block above the justify block, so only its
+    // proposal distinguishes the two anchors.
+    let mut post_dummy = None;
+    for block in dummy_extensions {
+        let proposer = observer
+            .epoch_manager
+            .get_validator_node_by_public_key(Epoch(1), *block.proposed_by())
+            .await
+            .unwrap();
+        if proposer.address != starved {
+            post_dummy = Some(block);
+            break;
+        }
+    }
+    let post_dummy = post_dummy.unwrap_or_else(|| {
+        panic!(
+            "every proposal on the dummy chain came from {starved}, which never saw the orphan; chain shape:\n  \
+             {shape}"
+        )
+    });
 
     let post_dummy_command = post_dummy
         .commands()

--- a/crates/consensus_tests/src/lib.rs
+++ b/crates/consensus_tests/src/lib.rs
@@ -7,6 +7,8 @@ mod consensus;
 #[cfg(test)]
 mod dummy_blocks;
 #[cfg(test)]
+mod dummy_fill_anchor;
+#[cfg(test)]
 mod epoch_change;
 #[cfg(test)]
 #[cfg(test)]

--- a/crates/consensus_tests/src/lib.rs
+++ b/crates/consensus_tests/src/lib.rs
@@ -11,7 +11,6 @@ mod dummy_fill_anchor;
 #[cfg(test)]
 mod epoch_change;
 #[cfg(test)]
-#[cfg(test)]
 mod last_voted_persistence;
 #[cfg(test)]
 mod leader_failure;


### PR DESCRIPTION
## Problem

When a leader fills a timeout gap with a dummy chain, the candidate extends from the **justify block**, not from the highest seen block. The dummies are empty blocks carrying the justify block's `accumulated_data` and state forward (see `calculate_last_dummy_block`), so the candidate's parent chain runs back through them to the justify block and never through a locally stored fork above the high QC.

`accumulated_data`, the substate store, the pending state tree diff lookup and propose-time foreign proposal processing already followed that anchor. The **proposal batch**, the transaction pool query, foreign proposal *selection* (`get_all_new`), the change set and command generation still read at the highest seen block.

That block is an orphan the candidate abandons. Its pool records carry stages and decisions no replica reproduces, so the leader can skip a transaction that is still pending on the chain it is actually building, or emit a command for a stage the candidate's ancestors never reached.

## Change

`state_anchor_leaf` — the justify block when `dummy_block.is_some()`, the extended leaf otherwise — now drives all of it. `start_of_chain_block` survives only as the non-dummy arm of that conditional, so this is a **strict no-op when `dummy_block.is_none()`**.

This is distinct from #2574, which moved one argument: foreign proposal *processing*. This moves *selection* and command generation. #2574 changed how records resolve; this changes which transactions get proposed.

## Scope

Like #2573 and #2574, this is **proposer-side only**:

- replica evaluation is untouched,
- no block format or hash input moves,
- the only blocks whose content changes are ones no honest replica votes for.

## Test

`crates/consensus_tests/src/dummy_fill_anchor.rs` withholds the first command-bearing proposal from one of three committee members. The block is stored and evaluated by the rest of the committee — so it is the highest seen block — but two of three votes are one short of quorum, so it never gathers a QC and the pacemaker fills its height with a dummy. The proposal built on that dummy must repeat the orphan's command.

Verified to fail on `development` with only `on_propose.rs` reverted:

```
assertion `left == right` failed: proposal on the dummy chain must repeat the orphan's command.
  left: None
 right: Some("LocalPrepare(fe1ea88a…, Commit)")
```

Without the change, the post-dummy proposal carries no command for the transaction at all — the batch was selected against the orphan, where the record already looked handled.

- `cargo test -p consensus_tests` — 68 passed, 0 failed.
- `cargo lints clippy -p tari_consensus --all-targets` / `-p consensus_tests --all-targets` — clean.