### PR TITLE
fix(engine)!: bind the write-mode chokepoint, substate size and event size

### DIFF
--- a/crates/engine/src/runtime/error.rs
+++ b/crates/engine/src/runtime/error.rs
@@ -499,14 +499,16 @@ pub enum ArgumentValidationError {
 
 #[derive(Debug, thiserror::Error)]
 pub enum LimitError {
-    #[error("Substate size of {size} bytes exceeds the maximum allowed size of {} bytes", limits::ENGINE_LIMITS.max_substate_size)]
-    SubstateSizeExceeded { size: usize },
+    #[error("Substate {id} of {size} bytes exceeds the maximum allowed size of {} bytes", limits::ENGINE_LIMITS.max_substate_size)]
+    SubstateSizeExceeded { id: SubstateId, size: usize },
     #[error("Log entry of {size} bytes exceeds maximum size of {} bytes", limits::ENGINE_LIMITS.max_log_size_bytes)]
     LogSizeExceeded { size: usize },
     #[error("Exceeded maximum number of logs per transaction: {}", limits::ENGINE_LIMITS.max_logs)]
     MaxLogsExceeded,
     #[error("Exceeded maximum number of events per transaction: {}", limits::ENGINE_LIMITS.max_events)]
     MaxEventsExceeded,
+    #[error("Event of {size} bytes exceeds maximum size of {} bytes", limits::ENGINE_LIMITS.max_event_size_bytes)]
+    EventSizeExceeded { size: usize },
     #[error("Requested random bytes length {len} exceeds maximum of {} bytes", limits::ENGINE_LIMITS.max_random_bytes_len)]
     MaxRandomBytesLenExceeded { len: usize },
 }

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -1866,6 +1866,7 @@ where
                             nf_id: addr.id().clone(),
                         })?;
                     contents.set_mutable_data(arg.data);
+                    state_mut.enforce_size_limit_of(&locked)?;
 
                     let payload = Metadata::from_iter([("resource_type", ResourceType::NonFungible.to_string())]);
                     Self::emit_std_event(
@@ -2029,6 +2030,7 @@ where
                     if let Some(symbol) = resource_mut.token_symbol() {
                         payload.insert(TOKEN_SYMBOL, symbol);
                     }
+                    state_mut.enforce_size_limit_of(&resource_lock)?;
                     Self::emit_std_event("resource", "update_metadata", resource_address, payload, state_mut)?;
 
                     state_mut.unlock_substate(resource_lock)?;

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -1866,7 +1866,6 @@ where
                             nf_id: addr.id().clone(),
                         })?;
                     contents.set_mutable_data(arg.data);
-                    state_mut.enforce_size_limit_of(&locked)?;
 
                     let payload = Metadata::from_iter([("resource_type", ResourceType::NonFungible.to_string())]);
                     Self::emit_std_event(
@@ -2030,7 +2029,6 @@ where
                     if let Some(symbol) = resource_mut.token_symbol() {
                         payload.insert(TOKEN_SYMBOL, symbol);
                     }
-                    state_mut.enforce_size_limit_of(&resource_lock)?;
                     Self::emit_std_event("resource", "update_metadata", resource_address, payload, state_mut)?;
 
                     state_mut.unlock_substate(resource_lock)?;

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -252,8 +252,8 @@ impl<TStore: StateReader + Clone + 'static, TTemplateProvider: TemplateProvider<
     }
 
     /// Layer (b) of the frame sandbox: deny the effectful or non-deterministic host ops that are NOT mediated by the
-    /// write-lock chokepoint (layer (a) in `WorkingState::write_lock_substate` / `new_substate`, which neutralises
-    /// every state write). Together they make a spend-script predicate provably side-effect-free and deterministic,
+    /// write-lock chokepoint (layer (a) in `WorkingState::try_lock` / `new_substate`, which neutralises every state
+    /// write). Together they make a spend-script predicate provably side-effect-free and deterministic,
     /// and confine a resource auth hook to its own component state.
     ///
     /// Events are permitted in both modes: an event is an output of execution that no later code can observe, and it

--- a/crates/engine/src/runtime/scope.rs
+++ b/crates/engine/src/runtime/scope.rs
@@ -407,10 +407,10 @@ impl Display for CallScope {
 pub enum FrameWriteMode {
     /// Any substate the frame can lock may be written.
     Full,
-    /// Only the component the frame is executing on, through the lock taken at push. Every other write funnelling
-    /// through `WorkingState::write_lock_substate` / `new_substate` is rejected, so the frame cannot touch a vault,
-    /// resource or any other component. Resource auth hooks run in this mode: the acting component did not choose
-    /// the hook code, so the hook must not be able to act on the acting component's behalf beyond its own state.
+    /// Only the component the frame is executing on, through the lock taken at push. Every write lock the frame
+    /// asks for and every new substate it creates is rejected, so it cannot touch a vault, resource or any other
+    /// component. Resource auth hooks run in this mode: the acting component did not choose the hook code, so the
+    /// hook must not be able to act on the acting component's behalf beyond its own state.
     OwnComponent,
     /// No state mutation at all. Spend-script predicate frames run in this mode so they are provably
     /// side-effect-free.

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -25,7 +25,7 @@ use tari_engine_types::{
     id_provider::{IdProvider, ObjectIds},
     indexed_value::{IndexedValue, IndexedWellKnownTypes},
     limits,
-    lock::LockFlag,
+    lock::{LockFlag, LockId},
     logs::LogEntry,
     non_fungible::NonFungibleContainer,
     proof::{ContainerRef, LockedResource, Proof},
@@ -234,14 +234,14 @@ impl<TStore: StateReader> WorkingState<TStore> {
         self.store.exists(address)
     }
 
-    fn enforce_substate_size_limit(&self, value: &SubstateValue) -> Result<(), RuntimeError> {
+    fn enforce_substate_size_limit(id: &SubstateId, value: &SubstateValue) -> Result<(), RuntimeError> {
         // Published template has its own size restriction
         if value.published_template().is_some() {
             return Ok(());
         }
         let size = encoded_len(value);
         if size > limits::ENGINE_LIMITS.max_substate_size {
-            return Err(LimitError::SubstateSizeExceeded { size }.into());
+            return Err(LimitError::SubstateSizeExceeded { id: id.clone(), size }.into());
         }
         Ok(())
     }
@@ -254,15 +254,24 @@ impl<TStore: StateReader> WorkingState<TStore> {
         let address = address.into();
         self.check_write_allowed(&address)?;
         let value = value.into();
-        self.enforce_substate_size_limit(&value)?;
+        Self::enforce_substate_size_limit(&address, &value)?;
         self.current_call_scope_mut()?.add_substate_to_scope(address.clone())?;
         self.store.insert(address, value)?;
         Ok(())
     }
 
     fn lock_substate(&mut self, addr: SubstateId, lock_flag: LockFlag) -> Result<LockedSubstate, RuntimeError> {
-        let lock_id = self.store.try_lock(addr.clone(), lock_flag)?;
+        let lock_id = self.try_lock(addr.clone(), lock_flag)?;
         Ok(LockedSubstate::new(addr, lock_id, lock_flag))
+    }
+
+    /// Every lock this state takes goes through here, so a write lock cannot be acquired without the frame write
+    /// mode permitting it. Callers that need the raw [`LockId`] use this directly rather than the store.
+    fn try_lock(&mut self, addr: SubstateId, lock_flag: LockFlag) -> Result<LockId, RuntimeError> {
+        if lock_flag.is_write() {
+            self.check_write_allowed(&addr)?;
+        }
+        self.store.try_lock(addr, lock_flag)
     }
 
     pub fn read_lock_substate(&mut self, addr: SubstateId) -> Result<LockedSubstate, RuntimeError> {
@@ -270,7 +279,6 @@ impl<TStore: StateReader> WorkingState<TStore> {
     }
 
     pub fn write_lock_substate(&mut self, addr: SubstateId) -> Result<LockedSubstate, RuntimeError> {
-        self.check_write_allowed(&addr)?;
         self.lock_substate(addr, LockFlag::Write)
     }
 
@@ -387,7 +395,7 @@ impl<TStore: StateReader> WorkingState<TStore> {
 
         for input in &stmt.inputs_statement.inputs {
             let address = UtxoAddress::new(resource_address, input.commitment.into());
-            let lock_id = self.store.try_lock(address.clone().into(), LockFlag::Write)?;
+            let lock_id = self.try_lock(address.clone().into(), LockFlag::Write)?;
             let utxo = self.store.down_utxo(lock_id)?;
             self.store.try_unlock(lock_id)?;
             if utxo.is_frozen() {
@@ -541,6 +549,12 @@ impl<TStore: StateReader> WorkingState<TStore> {
     }
 
     pub(super) fn validate_finalized(&self) -> Result<(), RuntimeError> {
+        // A substate can be grown through any of the `&mut SubstateValue` handles this state hands out, so the
+        // size limit binds on what is actually persisted rather than on what was created.
+        for (id, value) in self.store.mutated_substates() {
+            Self::enforce_substate_size_limit(id, value)?;
+        }
+
         if self.buckets.iter().any(|(_, b)| !b.is_empty()) {
             return Err(TransactionCommitError::DanglingBuckets {
                 count: self.buckets.len(),
@@ -656,7 +670,7 @@ impl<TStore: StateReader> WorkingState<TStore> {
             .into_iter()
             .map(|commitment| {
                 let address = ConfidentialOutputAddress::new(resource_address, commitment);
-                let lock_id = self.store.try_lock(address.clone().into(), LockFlag::Write)?;
+                let lock_id = self.try_lock(address.clone().into(), LockFlag::Write)?;
                 let output = self.store.down_confidential_output(lock_id)?;
                 self.store.try_unlock(lock_id)?;
                 if output.is_frozen() {
@@ -1899,6 +1913,11 @@ impl<TStore: StateReader> WorkingState<TStore> {
     }
 
     pub fn push_event(&mut self, event: Event) -> Result<(), RuntimeError> {
+        let size = encoded_len(&event);
+        if size > limits::ENGINE_LIMITS.max_event_size_bytes {
+            return Err(LimitError::EventSizeExceeded { size }.into());
+        }
+
         if self.events.len() >= limits::ENGINE_LIMITS.max_events {
             return Err(LimitError::MaxEventsExceeded.into());
         }

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -1914,13 +1914,15 @@ impl<TStore: StateReader> WorkingState<TStore> {
     }
 
     pub fn push_event(&mut self, event: Event) -> Result<(), RuntimeError> {
+        // The count cap is tested first because measuring the event walks its payload, unlike `push_log`, whose
+        // size check is a `String::len`.
+        if self.events.len() >= limits::ENGINE_LIMITS.max_events {
+            return Err(LimitError::MaxEventsExceeded.into());
+        }
+
         let size = encoded_len(&event);
         if size > limits::ENGINE_LIMITS.max_event_size_bytes {
             return Err(LimitError::EventSizeExceeded { size }.into());
-        }
-
-        if self.events.len() >= limits::ENGINE_LIMITS.max_events {
-            return Err(LimitError::MaxEventsExceeded.into());
         }
         self.events.push(event);
         Ok(())

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -550,7 +550,8 @@ impl<TStore: StateReader> WorkingState<TStore> {
 
     pub(super) fn validate_finalized(&self) -> Result<(), RuntimeError> {
         // A substate can be grown through any of the `&mut SubstateValue` handles this state hands out, so the
-        // size limit binds on what is actually persisted rather than on what was created.
+        // size limit binds on every substate the transaction's instructions persist rather than on what was
+        // created.
         for (id, value) in self.store.mutated_substates() {
             Self::enforce_substate_size_limit(id, value)?;
         }

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -246,16 +246,6 @@ impl<TStore: StateReader> WorkingState<TStore> {
         Ok(())
     }
 
-    /// Enforces [`limits::ENGINE_LIMITS::max_substate_size`] on a substate the current instruction has just
-    /// written, so an instruction that takes a substate over the limit is the one that fails. Only worth calling
-    /// where a single write can cross the limit — where the new value came from an engine argument, which
-    /// `max_internal_call_size` allows to be as large as the substate limit itself. Growth that accumulates a few
-    /// bytes at a time, such as a vault's non-fungible ids, is caught by the sweep in [`Self::validate_finalized`]
-    /// instead, which measures each substate once rather than once per write.
-    pub fn enforce_size_limit_of(&self, locked: &LockedSubstate) -> Result<(), RuntimeError> {
-        Self::enforce_substate_size_limit(locked.substate_id(), self.get_locked_substate(locked)?)
-    }
-
     pub fn new_substate<K: Into<SubstateId>, V: Into<SubstateValue>>(
         &mut self,
         address: K,
@@ -360,7 +350,6 @@ impl<TStore: StateReader> WorkingState<TStore> {
             return Ok(());
         };
 
-        self.enforce_size_limit_of(locked)?;
         self.validate_component_state(Some(&before), &after)?;
 
         // add event to indicate that there is a change in component
@@ -560,9 +549,10 @@ impl<TStore: StateReader> WorkingState<TStore> {
     }
 
     pub(super) fn validate_finalized(&self) -> Result<(), RuntimeError> {
-        // The backstop for the size limit. A write that can cross it in one step is caught where it happens, but a
-        // substate also grows a few bytes at a time — a vault's non-fungible ids most of all — and no single write
-        // can see that. Measured here once per substate rather than once per write.
+        // A substate can be grown through any of the `&mut SubstateValue` handles this state hands out, so the
+        // size limit binds on every substate the transaction's instructions persist rather than on what was
+        // created. Measured here, where the set to persist is known, rather than at each write: a substate a
+        // transaction writes many times would otherwise be measured many times.
         for (id, value) in self.store.mutated_substates() {
             Self::enforce_substate_size_limit(id, value)?;
         }

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -246,6 +246,16 @@ impl<TStore: StateReader> WorkingState<TStore> {
         Ok(())
     }
 
+    /// Enforces [`limits::ENGINE_LIMITS::max_substate_size`] on a substate the current instruction has just
+    /// written, so an instruction that takes a substate over the limit is the one that fails. Only worth calling
+    /// where a single write can cross the limit — where the new value came from an engine argument, which
+    /// `max_internal_call_size` allows to be as large as the substate limit itself. Growth that accumulates a few
+    /// bytes at a time, such as a vault's non-fungible ids, is caught by the sweep in [`Self::validate_finalized`]
+    /// instead, which measures each substate once rather than once per write.
+    pub fn enforce_size_limit_of(&self, locked: &LockedSubstate) -> Result<(), RuntimeError> {
+        Self::enforce_substate_size_limit(locked.substate_id(), self.get_locked_substate(locked)?)
+    }
+
     pub fn new_substate<K: Into<SubstateId>, V: Into<SubstateValue>>(
         &mut self,
         address: K,
@@ -350,6 +360,7 @@ impl<TStore: StateReader> WorkingState<TStore> {
             return Ok(());
         };
 
+        self.enforce_size_limit_of(locked)?;
         self.validate_component_state(Some(&before), &after)?;
 
         // add event to indicate that there is a change in component
@@ -549,9 +560,9 @@ impl<TStore: StateReader> WorkingState<TStore> {
     }
 
     pub(super) fn validate_finalized(&self) -> Result<(), RuntimeError> {
-        // A substate can be grown through any of the `&mut SubstateValue` handles this state hands out, so the
-        // size limit binds on every substate the transaction's instructions persist rather than on what was
-        // created.
+        // The backstop for the size limit. A write that can cross it in one step is caught where it happens, but a
+        // substate also grows a few bytes at a time — a vault's non-fungible ids most of all — and no single write
+        // can see that. Measured here once per substate rather than once per write.
         for (id, value) in self.store.mutated_substates() {
             Self::enforce_substate_size_limit(id, value)?;
         }

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -1914,8 +1914,6 @@ impl<TStore: StateReader> WorkingState<TStore> {
     }
 
     pub fn push_event(&mut self, event: Event) -> Result<(), RuntimeError> {
-        // The count cap is tested first because measuring the event walks its payload, unlike `push_log`, whose
-        // size check is a `String::len`.
         if self.events.len() >= limits::ENGINE_LIMITS.max_events {
             return Err(LimitError::MaxEventsExceeded.into());
         }

--- a/crates/engine/tests/limits.rs
+++ b/crates/engine/tests/limits.rs
@@ -1,13 +1,28 @@
 //   Copyright 2025 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::slice;
+use std::{collections::BTreeSet, slice};
 
-use tari_engine::{runtime::LimitError, wasm::WasmExecutionError};
-use tari_engine_types::limits;
+use tari_bor::encoded_len;
+use tari_crypto::ristretto::RistrettoSecretKey;
+use tari_engine::{runtime::LimitError, state_store::StateWriter, wasm::WasmExecutionError};
+use tari_engine_types::{
+    events::Event,
+    limits,
+    resource_container::ResourceContainer,
+    substate::{Substate, SubstateId, SubstateValue},
+    vault::Vault,
+};
 use tari_ootle_transaction::{Epoch, Transaction, args};
 use tari_template_abi::CallInfo;
-use tari_template_lib::types::bytes::Bytes;
+use tari_template_lib::types::{
+    ComponentAddress,
+    Metadata,
+    NonFungibleId,
+    TemplateAddress,
+    bytes::Bytes,
+    constants::{NFT_FAUCET_COMPONENT_ADDRESS, NFT_FAUCET_RESOURCE_ADDRESS},
+};
 use tari_template_test_tooling::{TemplateTest, support::assert_error::assert_reject_reason};
 
 const TEMPLATE_PATHS: &[&str] = &["tests/templates/limits"];
@@ -72,4 +87,154 @@ fn max_random_bytes_len_limit() {
     });
 }
 
-// TODO: add tests for other limits
+/// The event `PushItToTheLimit::emit_event_of_size` builds for a payload of `len` bytes. The engine prefixes the
+/// topic with the module name and attaches no substate id, the call being a function rather than a method.
+fn event_of_size(template: TemplateAddress, len: usize) -> Event {
+    let mut payload = Metadata::new();
+    payload.insert("data", "a".repeat(len));
+    Event::custom(None, template, format!("{TEMPLATE_NAME}.big"), payload)
+}
+
+/// The largest payload whose whole event still fits within `max_event_size_bytes`. Solved for rather than computed,
+/// because a CBOR length prefix widens as the payload crosses 24, 256 and 65536 bytes.
+fn largest_fitting_payload(template: TemplateAddress) -> usize {
+    let limit = limits::ENGINE_LIMITS.max_event_size_bytes;
+    let mut len = limit - encoded_len(&event_of_size(template, 0));
+    while encoded_len(&event_of_size(template, len)) > limit {
+        len -= 1;
+    }
+    len
+}
+
+#[test]
+fn max_event_size_limit() {
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
+    let template = test.get_template_address(TEMPLATE_NAME);
+    let max_len = largest_fitting_payload(template);
+
+    let result = test.execute_expect_success(
+        Transaction::builder_localnet(Epoch(1))
+            .call_function(template, "emit_event_of_size", args!(max_len as u32))
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+    assert!(
+        result
+            .finalize
+            .events
+            .iter()
+            .any(|event| event.topic().ends_with(".big")),
+        "the event at the size limit is emitted"
+    );
+
+    let reason = test.execute_expect_failure(
+        Transaction::builder_localnet(Epoch(1))
+            .call_function(template, "emit_event_of_size", args!(max_len as u32 + 1))
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+
+    assert_reject_reason(reason, LimitError::EventSizeExceeded {
+        size: encoded_len(&event_of_size(template, max_len + 1)),
+    });
+}
+
+/// A vault holding `count` non-fungible ids of the builtin NFT faucet resource. The ids are seeded far above the
+/// faucet's own serial numbers so that a later faucet mint never collides with a seeded id.
+fn nft_vault_of(count: u64) -> SubstateValue {
+    const SEED_BASE: u64 = 1_000_000;
+    let ids = (SEED_BASE..SEED_BASE + count)
+        .map(NonFungibleId::Uint64)
+        .collect::<BTreeSet<_>>();
+    SubstateValue::Vault(Vault::new(ResourceContainer::non_fungible(
+        NFT_FAUCET_RESOURCE_ADDRESS,
+        ids,
+    )))
+}
+
+/// The largest non-fungible id count whose vault substate still fits within `max_substate_size`.
+fn largest_fitting_nft_count() -> u64 {
+    let limit = limits::ENGINE_LIMITS.max_substate_size;
+    let (mut lo, mut hi) = (0u64, 200_000u64);
+    assert!(encoded_len(&nft_vault_of(hi)) > limit, "the search is bracketed");
+    while lo < hi {
+        let mid = lo + (hi - lo).div_ceil(2);
+        if encoded_len(&nft_vault_of(mid)) <= limit {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    lo
+}
+
+/// A transaction minting `batches` faucet-sized batches of tokens from the builtin NFT faucet into `account`.
+fn deposit_nfts(account: ComponentAddress, key: &RistrettoSecretKey, batches: u64) -> Transaction {
+    // The builtin faucet mints fewer than ten tokens per call.
+    const PER_MINT: u64 = 9;
+
+    let mut builder = Transaction::builder_localnet(Epoch(1));
+    for batch in 0..batches {
+        let workspace_key = format!("nft{batch}");
+        builder = builder
+            .call_method(NFT_FAUCET_COMPONENT_ADDRESS, "mint", args![
+                PER_MINT,
+                tari_bor::Value::Null
+            ])
+            .put_last_instruction_output_on_workspace(&workspace_key)
+            .call_method(account, "deposit", args![Workspace(workspace_key.as_str())]);
+    }
+    builder.build_and_seal(key)
+}
+
+/// Overwrites the account's NFT faucet vault with one holding `count` ids, keeping its substate version.
+fn seed_nft_vault(test: &mut TemplateTest, count: u64) {
+    let (vault_id, version) = test
+        .get_state_store_mut()
+        .iter()
+        .find_map(|(id, substate)| {
+            let SubstateId::Vault(vault_id) = id else {
+                return None;
+            };
+            let vault = substate.substate_value().vault()?;
+            (*vault.resource_address() == NFT_FAUCET_RESOURCE_ADDRESS).then_some((*vault_id, substate.version()))
+        })
+        .expect("the account holds a vault for the NFT faucet resource");
+
+    let value = nft_vault_of(count);
+    assert!(
+        encoded_len(&value) <= limits::ENGINE_LIMITS.max_substate_size,
+        "the seeded vault is itself within the limit, so only the deposit can take it over"
+    );
+    test.get_state_store_mut()
+        .set_state(SubstateId::Vault(vault_id), Substate::new(version, value))
+        .unwrap();
+}
+
+/// The size limit binds on every substate a transaction persists, not only on those it creates: a vault grows one
+/// deposit at a time and crosses the limit in a transaction that creates no substate of its own.
+#[test]
+fn max_substate_size_limit_applies_to_mutations() {
+    // Enough tokens per deposit that the vault's growth dwarfs the slack between the largest fitting id count and
+    // the limit itself.
+    const DEPOSIT_BATCHES: u64 = 5;
+
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
+    let (account, owner_proof, account_key) = test.create_funded_account();
+
+    // Give the account a vault for the faucet resource to seed.
+    test.execute_expect_success(deposit_nfts(account, &account_key, 1), vec![owner_proof.clone()]);
+
+    let max_count = largest_fitting_nft_count();
+
+    // A deposit into a vault with room to spare is accepted.
+    seed_nft_vault(&mut test, max_count - 100);
+    test.execute_expect_success(deposit_nfts(account, &account_key, DEPOSIT_BATCHES), vec![
+        owner_proof.clone(),
+    ]);
+
+    // One that takes the vault over the limit is not.
+    seed_nft_vault(&mut test, max_count);
+    let reason = test.execute_expect_failure(deposit_nfts(account, &account_key, DEPOSIT_BATCHES), vec![owner_proof]);
+    assert_reject_reason(reason, "exceeds the maximum allowed size");
+}

--- a/crates/engine/tests/limits.rs
+++ b/crates/engine/tests/limits.rs
@@ -187,19 +187,21 @@ fn deposit_nfts(account: ComponentAddress, key: &RistrettoSecretKey, batches: u6
     builder.build_and_seal(key)
 }
 
-/// Overwrites the account's NFT faucet vault with one holding `count` ids, keeping its substate version.
-fn seed_nft_vault(test: &mut TemplateTest, count: u64) {
-    let (vault_id, version) = test
-        .get_state_store_mut()
+/// Overwrites `account`'s NFT faucet vault with one holding `count` ids, keeping its substate version.
+fn seed_nft_vault(test: &mut TemplateTest, account: ComponentAddress, count: u64) {
+    let vault_id = *test
+        .read_only_state_store()
+        .get_vaults_for_component(account)
+        .unwrap()
         .iter()
-        .find_map(|(id, substate)| {
-            let SubstateId::Vault(vault_id) = id else {
-                return None;
-            };
-            let vault = substate.substate_value().vault()?;
-            (*vault.resource_address() == NFT_FAUCET_RESOURCE_ADDRESS).then_some((*vault_id, substate.version()))
-        })
-        .expect("the account holds a vault for the NFT faucet resource");
+        .find(|(_, vault)| *vault.resource_address() == NFT_FAUCET_RESOURCE_ADDRESS)
+        .expect("the account holds a vault for the NFT faucet resource")
+        .0;
+    let version = test
+        .read_only_state_store()
+        .get_substate(&SubstateId::Vault(vault_id))
+        .unwrap()
+        .version();
 
     let value = nft_vault_of(count);
     assert!(
@@ -228,13 +230,13 @@ fn max_substate_size_limit_applies_to_mutations() {
     let max_count = largest_fitting_nft_count();
 
     // A deposit into a vault with room to spare is accepted.
-    seed_nft_vault(&mut test, max_count - 100);
+    seed_nft_vault(&mut test, account, max_count - 100);
     test.execute_expect_success(deposit_nfts(account, &account_key, DEPOSIT_BATCHES), vec![
         owner_proof.clone(),
     ]);
 
     // One that takes the vault over the limit is not.
-    seed_nft_vault(&mut test, max_count);
+    seed_nft_vault(&mut test, account, max_count);
     let reason = test.execute_expect_failure(deposit_nfts(account, &account_key, DEPOSIT_BATCHES), vec![owner_proof]);
     assert_reject_reason(reason, "exceeds the maximum allowed size");
 }

--- a/crates/engine/tests/templates/limits/src/lib.rs
+++ b/crates/engine/tests/templates/limits/src/lib.rs
@@ -27,5 +27,12 @@ mod template {
         pub fn emit_log_of_size(len: u32) {
             debug!("{}", "a".repeat(len as usize));
         }
+
+        /// Emits an event whose payload holds a single `len`-byte value under the key `data`.
+        pub fn emit_event_of_size(len: u32) {
+            let mut payload = Metadata::new();
+            payload.insert("data", "a".repeat(len as usize));
+            emit_event("big", payload);
+        }
     }
 }

--- a/crates/engine/tests/templates/limits/src/lib.rs
+++ b/crates/engine/tests/templates/limits/src/lib.rs
@@ -20,6 +20,7 @@ mod template {
             self.data = data;
         }
 
+
         pub fn request_random_bytes(len: u32) -> Vec<u8> {
             rand::random_bytes(len)
         }

--- a/crates/engine_types/src/limits.rs
+++ b/crates/engine_types/src/limits.rs
@@ -169,6 +169,14 @@ pub struct EngineLimits {
     pub max_logs: usize,
     pub max_log_size_bytes: usize,
     pub max_events: usize,
+    /// Maximum CBOR-encoded size of a single event.
+    ///
+    /// Every event a transaction emits is carried in its transaction receipt, which is persisted as a
+    /// substate like any other but is built after fees settle, so it cannot be rejected for being
+    /// oversized. Its event payload is bounded here instead: `max_events * max_event_size_bytes` must
+    /// stay under [`EngineLimits::max_substate_size`] with room for the receipt's diff summary
+    /// (up to [`EngineLimits::max_substate_outputs`] entries) and fee breakdown.
+    pub max_event_size_bytes: usize,
     pub max_panic_message_size: usize,
     pub max_template_binary_size_bytes: usize,
     pub max_template_name_length: usize,
@@ -184,7 +192,8 @@ pub const ENGINE_LIMITS: EngineLimits = EngineLimits {
     max_logs: 256,
     max_log_size_bytes: 32 * 1024, // 32 KiB
     max_events: 256,
-    max_panic_message_size: 32 * 1024,              // 32 KiB
+    max_event_size_bytes: 2 * 1024, // 2 KiB; 256 * 2 KiB = 512 KiB of the 1 MiB substate budget
+    max_panic_message_size: 32 * 1024, // 32 KiB
     max_template_binary_size_bytes: 3 * 512 * 1024, // 1.5 MiB
     max_template_name_length: 64,
     max_call_depth: 10,


### PR DESCRIPTION
Engine audit wave 4, first of four. Three limits the engine documents but does not enforce on every path. Independent of the other wave-4 PRs.

## Write-mode chokepoint

`check_write_allowed` is documented as *the* single chokepoint for `FrameWriteMode`, but only `write_lock_substate` and `new_substate` called it. Five sites took a write lock without it — `validate_and_spend_stealth_utxos` and `spend_confidential_outputs` through `store.try_lock`, and the NFT lock in `burn_bucket`, the vault lock in `drop_proof` and `withdraw_fees_from_pool_up_to` through the private `lock_substate`.

The check now lives in a `try_lock` helper that every lock passes through, so the mode binds on the lock flag rather than on which helper a caller reached for.

**This is defence in depth, not a live exploit.** I went looking for a reachable path and did not find one: `stealth_transfer` is reachable only from the instruction processor, and the confidential-spend and burn paths need a bucket or a vault write lock that a `ReadOnly` or `OwnComponent` frame is already refused. The point is that the invariant is now structural — the next site to take a write lock gets the check for free instead of having to remember it.

## Substate size on mutation

`enforce_substate_size_limit` ran only in `new_substate`, so `max_substate_size` bound creation and nothing else. A substate can be grown through any of the `&mut SubstateValue` handles the working state hands out (`modify_component_with`, `get_vault_mut`, `get_resource_mut`, `get_non_fungible_mut`), and one of them accumulates without any call-size bound above it: a vault's non-fungible id set grows one deposit at a time, across transactions, with nothing measuring it.

The limit now binds where it means something — a sweep of `mutated_substates()` in `validate_finalized`, which is the one place every persisted substate passes through. The error names the offending substate.

## Event payload size

`push_event` capped the event count at 256 but not the payload, unlike `push_log`. Every event lands in the transaction receipt, which is persisted as a substate like any other but is built after fees settle, so it cannot be rejected for being oversized.

New `max_event_size_bytes` of 2 KiB, enforced against the whole encoded event rather than the payload alone, since it is the whole event the receipt carries. 256 × 2 KiB = 512 KiB, which leaves the receipt room for its diff summary (up to `max_substate_outputs` entries) and fee breakdown inside the 1 MiB substate budget.

## Compatibility

The last two change which transactions succeed, so validators and indexers need to upgrade together. No protocol version bump is involved. Two consequences worth stating outright:

- **An already-oversized substate becomes unusable until it is shrunk.** Creation was always checked and growth never was, so the on-chain set may hold a substate over 1 MiB — that is the gap being closed. After this, any transaction that *touches* one is rejected, and `get_for_mut` moves a substate into `new_substates` on any `&mut` access, so a read through a mutable handle is enough. The remedy is one transaction that brings it back under the limit; an oversized NFT vault does not block fee payment, since fees come from the TARI vault. If a fee-intent substate were the oversized one the transaction is rejected with no fee collected. I do not expect esmeralda to have any, but that should be confirmed rather than assumed.
- **`resource.create`'s `image_url` is now indirectly capped at ~2 KiB.** It is the only builtin event payload field carrying an unbounded user-controlled value (the token symbol is already capped at 10 bytes), so a resource created with a larger `image_url` fails with `EventSizeExceeded`. That is the intended shape of the limit, but it is a behaviour change a template author can hit without emitting an event of their own.

## Tests

- `max_event_size_limit` — an event at the size limit is emitted; one byte more is rejected with the exact measured size. The boundary is solved for rather than computed, because a CBOR length prefix widens at 24/256/65536 bytes.
- `max_substate_size_limit_applies_to_mutations` — seeds an account's NFT vault near the limit and deposits faucet tokens into it. A deposit with room to spare commits; one that takes the vault over is rejected, in a transaction that creates no substate of its own.
- Full `-p tari_engine` suite: 425 passed.
