### PR TITLE
fix(engine): make the workspace deterministic and enforce the lock scope

### DIFF
--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -3450,9 +3450,7 @@ where
 
             WorkspaceAction::DropAllProofs => {
                 args.assert_no_args("WorkspaceAction::DropAllProofs")?;
-                let proofs = self
-                    .tracker
-                    .with_workspace_mut(|workspace| workspace.drain_all_proofs());
+                let proofs = self.tracker.with_workspace_mut(|workspace| workspace.take_all_proofs());
 
                 self.tracker.write_with(|state| {
                     for proof_id in proofs {
@@ -3475,7 +3473,7 @@ where
                 args.assert_no_args("WorkspaceAction::DropAll")?;
                 let proofs = self.tracker.with_workspace_mut(|workspace| {
                     workspace.clear_items();
-                    workspace.drain_all_proofs()
+                    workspace.take_all_proofs()
                 });
 
                 self.tracker.write_with(|state| {

--- a/crates/engine/src/runtime/scope.rs
+++ b/crates/engine/src/runtime/scope.rs
@@ -14,11 +14,7 @@ use tari_template_lib::{
     },
 };
 
-use crate::runtime::{
-    AuthorizationScope,
-    RuntimeError,
-    locking::{LockError, LockedSubstate},
-};
+use crate::runtime::{AuthorizationScope, RuntimeError, locking::LockedSubstate};
 
 #[derive(Debug, Clone)]
 pub struct CallScope {
@@ -76,10 +72,6 @@ impl CallScope {
         self.inherited_proofs.extend(scope.proofs().iter().copied());
         self.proof_scope.extend(scope.proofs().iter().copied());
         self.auth_scope = scope;
-    }
-
-    pub fn is_lock_in_scope(&self, lock_id: LockId) -> bool {
-        self.lock_scope.contains(&lock_id)
     }
 
     pub fn lock_scope(&self) -> &IndexSet<LockId> {
@@ -153,11 +145,11 @@ impl CallScope {
         self.auth_scope.remove_proof(proof_id);
     }
 
-    pub fn remove_lock_from_scope(&mut self, lock_id: LockId) -> Result<(), RuntimeError> {
-        if !self.lock_scope.swap_remove(&lock_id) {
-            return Err(RuntimeError::LockError(LockError::LockIdNotFound { lock_id }));
-        }
-        Ok(())
+    /// Releases `lock_id` from this frame, reporting whether the frame held it. A frame may release a lock its
+    /// caller took — a component lock is taken by the caller and released when the frame it was pushed into is
+    /// popped — so the caller of this searches the frame stack rather than assuming the current frame.
+    pub fn remove_lock_from_scope(&mut self, lock_id: LockId) -> bool {
+        self.lock_scope.swap_remove(&lock_id)
     }
 
     pub fn get_current_component_lock(&self) -> Option<&LockedSubstate> {

--- a/crates/engine/src/runtime/tracker.rs
+++ b/crates/engine/src/runtime/tracker.rs
@@ -671,7 +671,7 @@ impl<TStore: StateReader + Clone> StateTracker<TStore> {
 
             // After checkpointing, the main intent has a cleared workspace
             state.workspace_mut().clear_items();
-            let proofs = state.workspace_mut().drain_all_proofs();
+            let proofs = state.workspace_mut().take_all_proofs();
             for proof_id in proofs {
                 state.drop_proof(proof_id)?;
             }

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -145,8 +145,10 @@ pub(super) struct WorkingState<TStore> {
     events: Vec<Event>,
     logs: Vec<LogEntry>,
     buckets: HashMap<BucketId, Bucket>,
-    address_allocations: HashMap<AddressAllocationId, AllocatedAddress>,
-    used_address_allocations: HashMap<AddressAllocationId, SubstateId>,
+    /// Insertion-ordered: `get_allocated_address_by_address` scans these, so a hashed map would let the iteration
+    /// order decide which allocation a lookup finds.
+    address_allocations: IndexMap<AddressAllocationId, AllocatedAddress>,
+    used_address_allocations: IndexMap<AddressAllocationId, SubstateId>,
     address_allocation_id: u32,
     proofs: HashMap<ProofId, Proof>,
     object_ids: ObjectIds,
@@ -197,8 +199,8 @@ impl<TStore: StateReader> WorkingState<TStore> {
             buckets: HashMap::new(),
             proofs: HashMap::new(),
             address_allocation_id: 0,
-            address_allocations: HashMap::new(),
-            used_address_allocations: HashMap::new(),
+            address_allocations: IndexMap::new(),
+            used_address_allocations: IndexMap::new(),
 
             store: WorkingStateStore::new(state_store),
 
@@ -262,6 +264,12 @@ impl<TStore: StateReader> WorkingState<TStore> {
 
     fn lock_substate(&mut self, addr: SubstateId, lock_flag: LockFlag) -> Result<LockedSubstate, RuntimeError> {
         let lock_id = self.try_lock(addr.clone(), lock_flag)?;
+        // Every lock a frame takes must be released before that frame is popped, which `pop_frame` enforces. A lock
+        // taken before the first frame is pushed — fee settlement, transaction setup — belongs to no frame and is
+        // left untracked.
+        if let Some(frame) = self.call_frames.last_mut() {
+            frame.scope_mut().add_lock_to_scope(lock_id);
+        }
         Ok(LockedSubstate::new(addr, lock_id, lock_flag))
     }
 
@@ -295,6 +303,13 @@ impl<TStore: StateReader> WorkingState<TStore> {
 
     pub fn unlock_substate(&mut self, lock: LockedSubstate) -> Result<(), RuntimeError> {
         self.store.try_unlock(lock.lock_id())?;
+        // The frame releasing a lock need not be the one that took it: a component lock is taken by the caller and
+        // released when the frame it was pushed into is popped, by which point that frame is off the stack.
+        for frame in self.call_frames.iter_mut().rev() {
+            if frame.scope_mut().remove_lock_from_scope(lock.lock_id()) {
+                break;
+            }
+        }
         Ok(())
     }
 
@@ -1245,7 +1260,7 @@ impl<TStore: StateReader> WorkingState<TStore> {
         }
         let alloc_addr = self
             .address_allocations
-            .remove(&id)
+            .shift_remove(&id)
             .ok_or(RuntimeError::AddressAllocationNotFound { id })?;
         self.current_call_scope_mut()?.remove_address_allocation_from_scope(id);
         self.used_address_allocations

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -148,6 +148,7 @@ pub(super) struct WorkingState<TStore> {
     /// Insertion-ordered: `get_allocated_address_by_address` scans these, so a hashed map would let the iteration
     /// order decide which allocation a lookup finds.
     address_allocations: IndexMap<AddressAllocationId, AllocatedAddress>,
+    /// Only ever inserted into and looked up by id. Ordered for symmetry with `address_allocations`.
     used_address_allocations: IndexMap<AddressAllocationId, SubstateId>,
     address_allocation_id: u32,
     proofs: HashMap<ProofId, Proof>,
@@ -1328,6 +1329,7 @@ impl<TStore: StateReader> WorkingState<TStore> {
         let (amount, resource_container) = pool_mut.withdraw_up_to(max_amount)?;
         self.validator_fee_withdrawals
             .push(ValidatorFeeWithdrawal { address, amount });
+        self.unlock_substate(locked_substate)?;
         Ok(resource_container)
     }
 

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -145,8 +145,9 @@ pub(super) struct WorkingState<TStore> {
     events: Vec<Event>,
     logs: Vec<LogEntry>,
     buckets: HashMap<BucketId, Bucket>,
-    /// Insertion-ordered: `get_allocated_address_by_address` scans these, so a hashed map would let the iteration
-    /// order decide which allocation a lookup finds.
+    /// `get_allocated_address_by_address` scans these, and two allocations can name the same address, so the
+    /// iteration order decides which one a lookup finds. It must therefore follow from the transaction's own
+    /// operations rather than from a hash seed.
     address_allocations: IndexMap<AddressAllocationId, AllocatedAddress>,
     /// Only ever inserted into and looked up by id. Ordered for symmetry with `address_allocations`.
     used_address_allocations: IndexMap<AddressAllocationId, SubstateId>,
@@ -1261,7 +1262,7 @@ impl<TStore: StateReader> WorkingState<TStore> {
         }
         let alloc_addr = self
             .address_allocations
-            .shift_remove(&id)
+            .swap_remove(&id)
             .ok_or(RuntimeError::AddressAllocationNotFound { id })?;
         self.current_call_scope_mut()?.remove_address_allocation_from_scope(id);
         self.used_address_allocations

--- a/crates/engine/src/runtime/workspace.rs
+++ b/crates/engine/src/runtime/workspace.rs
@@ -19,7 +19,7 @@ pub enum WorkspaceError {
     WorkspaceIdAlreadyExists(WorkspaceId),
 }
 
-/// NOTE: the collections here must be insertion-ordered rather than hashed. `drain_all_proofs` drives the order in
+/// NOTE: the collections here must be insertion-ordered rather than hashed. `take_all_proofs` drives the order in
 /// which proofs are dropped, and dropping a vault-backed proof can append that vault to the substates the
 /// transaction persists — whose order becomes `DiffSummary::upped` in the `TransactionReceipt`, and is hashed.
 #[derive(Debug, Clone, Default)]
@@ -58,7 +58,7 @@ impl Workspace {
         Ok(())
     }
 
-    pub fn drain_all_proofs(&mut self) -> IndexSet<ProofId> {
+    pub fn take_all_proofs(&mut self) -> IndexSet<ProofId> {
         mem::take(&mut self.proofs)
     }
 

--- a/crates/engine/src/runtime/workspace.rs
+++ b/crates/engine/src/runtime/workspace.rs
@@ -21,8 +21,7 @@ pub enum WorkspaceError {
 
 /// NOTE: the collections here must be insertion-ordered rather than hashed. `drain_all_proofs` drives the order in
 /// which proofs are dropped, and dropping a vault-backed proof can append that vault to the substates the
-/// transaction persists — whose order is hashed into the `TransactionReceipt` diff. `all_ids_iter` likewise lands
-/// in reject strings, which validators compare.
+/// transaction persists — whose order becomes `DiffSummary::upped` in the `TransactionReceipt`, and is hashed.
 #[derive(Debug, Clone, Default)]
 pub struct Workspace {
     items: IndexMap<WorkspaceId, IndexedValue>,

--- a/crates/engine/src/runtime/workspace.rs
+++ b/crates/engine/src/runtime/workspace.rs
@@ -1,11 +1,9 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::{
-    collections::{HashMap, HashSet},
-    mem,
-};
+use std::mem;
 
+use indexmap::{IndexMap, IndexSet};
 use tari_bor::Value;
 use tari_engine_types::indexed_value::{IndexedValue, IndexedValueError};
 use tari_ootle_transaction::args::{WorkspaceId, WorkspaceOffsetId};
@@ -21,10 +19,14 @@ pub enum WorkspaceError {
     WorkspaceIdAlreadyExists(WorkspaceId),
 }
 
+/// NOTE: the collections here must be insertion-ordered rather than hashed. `drain_all_proofs` drives the order in
+/// which proofs are dropped, and dropping a vault-backed proof can append that vault to the substates the
+/// transaction persists — whose order is hashed into the `TransactionReceipt` diff. `all_ids_iter` likewise lands
+/// in reject strings, which validators compare.
 #[derive(Debug, Clone, Default)]
 pub struct Workspace {
-    items: HashMap<WorkspaceId, IndexedValue>,
-    proofs: HashSet<ProofId>,
+    items: IndexMap<WorkspaceId, IndexedValue>,
+    proofs: IndexSet<ProofId>,
 }
 
 impl Workspace {
@@ -57,7 +59,7 @@ impl Workspace {
         Ok(())
     }
 
-    pub fn drain_all_proofs(&mut self) -> HashSet<ProofId> {
+    pub fn drain_all_proofs(&mut self) -> IndexSet<ProofId> {
         mem::take(&mut self.proofs)
     }
 

--- a/crates/engine/tests/asserts.rs
+++ b/crates/engine/tests/asserts.rs
@@ -174,6 +174,34 @@ mod assert_bucket_contains {
             existing_ids: vec![0],
         });
     }
+
+    /// The ids a reject reason lists are part of the reason validators compare, so they must come out in the order
+    /// they went on rather than in a hash order that differs between runs.
+    #[test]
+    fn it_lists_existing_workspace_ids_in_insertion_order() {
+        let mut test: AssertTest = setup();
+
+        let reason = test.template_test.execute_expect_failure(
+            Transaction::builder_localnet(Epoch(1))
+                .call_method(test.account, "withdraw", args![test.faucet_resource, 1u64])
+                .put_last_instruction_output_on_workspace("first")
+                .call_method(test.account, "withdraw", args![test.faucet_resource, 1u64])
+                .put_last_instruction_output_on_workspace("second")
+                .call_method(test.account, "withdraw", args![test.faucet_resource, 1u64])
+                .put_last_instruction_output_on_workspace("third")
+                .add_instruction(Instruction::Assert {
+                    key: WorkspaceOffsetId::new(999),
+                    assertion: Assertion::IsNotNull,
+                })
+                .build_and_seal(&test.account_key),
+            vec![test.account_proof.clone()],
+        );
+
+        assert_reject_reason(reason, RuntimeError::ItemNotOnWorkspace {
+            id: WorkspaceOffsetId::new(999),
+            existing_ids: vec![0, 1, 2],
+        });
+    }
 }
 
 mod assert_is_not_null {

--- a/crates/engine/tests/validator_fees.rs
+++ b/crates/engine/tests/validator_fees.rs
@@ -65,3 +65,42 @@ fn test_claim_validator_fees_up_to() {
         .get_substate(&SubstateId::ValidatorFeePool(addr));
     assert!(result.is_err(), "ValidatorFeePool should be destroyed when empty");
 }
+
+/// A claim must release the fee pool's lock, so a second claim against the same pool in the same transaction can
+/// take it.
+#[test]
+fn test_two_claims_against_one_pool_in_a_transaction() {
+    use ootle_byte_type::ToByteType;
+    use tari_crypto::{keys::PublicKey, ristretto::RistrettoPublicKey};
+
+    let mut test = TemplateTest::new(CRATE_PATH, std::iter::empty::<&str>());
+    let (account, _token, private_key) = test.create_funded_account();
+
+    let public_key = RistrettoPublicKey::from_secret_key(&private_key);
+    let pk: tari_template_lib::types::crypto::RistrettoPublicKeyBytes = public_key.to_byte_type();
+    let addr = ValidatorFeePoolAddress::from_array(pk.into_array());
+
+    test.get_state_store_mut()
+        .set_state(
+            SubstateId::ValidatorFeePool(addr),
+            Substate::new(0, ValidatorFeePool::new(pk, 100)),
+        )
+        .unwrap();
+
+    test.execute_expect_success(
+        Transaction::builder_localnet(Epoch(1))
+            .claim_validator_fees_up_to(addr, 60u64)
+            .put_last_instruction_output_on_workspace("first")
+            .call_method(account, "deposit", args![Workspace("first")])
+            .claim_validator_fees_up_to(addr, 40u64)
+            .put_last_instruction_output_on_workspace("second")
+            .call_method(account, "deposit", args![Workspace("second")])
+            .build_and_seal(&private_key),
+        vec![],
+    );
+
+    let result = test
+        .read_only_state_store()
+        .get_substate(&SubstateId::ValidatorFeePool(addr));
+    assert!(result.is_err(), "both claims emptied the pool, so it is destroyed");
+}


### PR DESCRIPTION
Engine audit wave 4, second of four. Two hygiene items in the call-frame and workspace machinery. Independent of #2591; both touch `working_state.rs`, so whichever lands second needs a trivial rebase.

## Deterministic workspace collections

`Workspace.items` was a `HashMap` and `Workspace.proofs` a `HashSet`, and both get iterated on paths that reach consensus:

- `drain_all_proofs` drives the order `drop_proof` runs in (`tracker.rs` fee checkpoint, `WorkspaceAction::DropAllProofs`, `WorkspaceAction::DropAll`). Dropping a vault-backed proof can append that vault to `new_substates`, and that order is hashed into the `TransactionReceipt` diff.
- `all_ids_iter` lands in `ItemNotOnWorkspace` reject strings. These are local/UX only — a block's `TransactionAtom` carries `Decision`, `AbortReason` collapses every execution failure to `ExecutionFailure`, and the receipt carries an outcome with no reason — so this half is cosmetic. The `drain_all_proofs` half stands on its own.

Neither diverges today — a vault-backed proof has already mutated its vault by the time it is dropped, so the append is a no-op on ordering — but the safety is incidental, not structural. `CallScope` already carries a `NOTE: HashSet is not appropriate due to non-determinism`; `Workspace` now carries the same reasoning and the same collection types.

`WorkingState::address_allocations` has the same shape and is included: `get_allocated_address_by_address` scans it, so a hashed map would let iteration order decide which allocation a lookup finds.

## Lock scope

`CallScope::add_lock_to_scope`, `remove_lock_from_scope` and `is_lock_in_scope` had no callers. `lock_scope` was therefore always empty, and the `DanglingSubstateLocks` branch in `pop_frame` was unreachable — a callee could leak a lock and grief the rest of the caller's transaction with a lock nothing would ever release.

`lock_substate` now records into the current frame and `unlock_substate` releases. The release searches the frame stack rather than assuming the current frame, because the frame releasing a lock need not be the one that took it: a component lock is taken by the caller and released when the frame it was pushed into is popped, by which point that frame is off the stack. A lock taken before the first frame exists (fee settlement, transaction setup) belongs to no frame and stays untracked.

`remove_lock_from_scope` now reports whether the frame held the lock instead of returning an error, which is what a stack search needs; `is_lock_in_scope` is deleted rather than left dead.

I checked the check is genuinely live rather than newly-inert in a different way: disabling the release side turns every nested component call into `2 substate locks were still active after call`, and inverting the emptiness test fails every frame. Both directions behave, and the suite passes with the real code.

## Fee pool lock leak

`withdraw_fees_from_pool_up_to` took the fee pool's write lock and returned the container without ever releasing it. Because `ClaimValidatorFees` runs at instruction level there is no frame to record the lock against, so the new check cannot see it either — the one place the engine actually leaks a lock was exempt from the motivation for this PR. Fixed here. The live consequence was that a second `ClaimValidatorFees` against the same pool in one transaction failed with `MultipleWriteLockRequested`; it now succeeds.

## Tests

- `test_two_claims_against_one_pool_in_a_transaction` — two claims against one pool in one transaction. Fails on the pre-fix code with `Multiple write locks requested for substate vnfp_5c7f0fe…`.
- `it_lists_existing_workspace_ids_in_insertion_order` — three workspace outputs then a bad reference, asserting the reject string lists `[0, 1, 2]`. The existing sibling test only ever had one id on the workspace, so it could not see the order.
- Full `-p tari_engine` suite: 425 passed.
