### PR TITLE
fix(engine)!: resource and proof lifecycle corrections

### DIFF
--- a/crates/engine/src/runtime/error.rs
+++ b/crates/engine/src/runtime/error.rs
@@ -446,7 +446,7 @@ pub enum AssertError {
 
 #[derive(Debug, thiserror::Error)]
 pub enum TransactionCommitError {
-    #[error("{count} dangling bucket(s) remain after transaction execution")]
+    #[error("{count} dangling buckets remain after transaction execution")]
     DanglingBuckets { count: usize },
     #[error(
         "{count} dangling proofs remain after transaction execution. You may need to add a `DropAllProofsOnWorkspace` \

--- a/crates/engine/src/runtime/error.rs
+++ b/crates/engine/src/runtime/error.rs
@@ -303,8 +303,12 @@ pub enum RuntimeError {
     InvalidReturnValue(IndexedValueError),
     #[error("Attempt to pop auth scope stack but it was empty")]
     AuthScopeStackEmpty,
-    #[error("Invalid deposit of bucket {bucket_id} has locked value amounting to {locked_amount}")]
-    InvalidOpDepositLockedBucket { bucket_id: BucketId, locked_amount: Amount },
+    #[error("Cannot {op} bucket {bucket_id}: it has funds locked by a proof (revealed amount {locked_amount})")]
+    InvalidOpLockedBucket {
+        op: &'static str,
+        bucket_id: BucketId,
+        locked_amount: Amount,
+    },
     #[error("Duplicate substate {address}")]
     DuplicateSubstate { address: SubstateId },
     #[error("Substate {id} is orphaned")]
@@ -442,19 +446,17 @@ pub enum AssertError {
 
 #[derive(Debug, thiserror::Error)]
 pub enum TransactionCommitError {
-    #[error("{count} dangling buckets remain after transaction execution")]
+    #[error("{count} dangling bucket(s) remain after transaction execution")]
     DanglingBuckets { count: usize },
     #[error(
         "{count} dangling proofs remain after transaction execution. You may need to add a `DropAllProofsOnWorkspace` \
          instruction"
     )]
     DanglingProofs { count: usize },
-    #[error("Locked value (amount: {locked_amount}) remaining in vault {vault_id}")]
+    #[error("Locked value (revealed amount: {locked_amount}) remaining in vault {vault_id}")]
     DanglingLockedValueInVault { vault_id: VaultId, locked_amount: Amount },
     #[error("{count} dangling address allocations remain after transaction execution")]
     DanglingAddressAllocations { count: usize },
-    #[error("{count} dangling items in workspace after transaction execution")]
-    WorkspaceNotEmpty { count: usize },
     #[error(transparent)]
     StateStoreError(#[from] StateStoreError),
     #[error(transparent)]

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -125,6 +125,7 @@ use tari_template_lib::{
         Metadata,
         NonFungibleAddress,
         OwnerRule,
+        ResourceAddress,
         ResourceInfo,
         ResourceType,
         SubstateOwnerRule,
@@ -544,11 +545,21 @@ impl<TStore: StateReader + Clone + 'static, TTemplateProvider: TemplateProvider<
         })
     }
 
-    /// It is invalid to burn a bucket that has locked funds (e.g. by a proof). Burning downs only the unlocked
-    /// commitments, so a locked one would be left live with nothing referencing it.
-    fn check_bucket_is_burnable(bucket_id: BucketId, bucket: &Bucket) -> Result<(), RuntimeError> {
+    /// Takes a resource's write lock back after its auth hook has run. A hook must be able to read the resource it
+    /// guards, so the lock cannot be held across the call; the hook frame cannot write, so what it reads is what
+    /// the operation goes on to alter.
+    fn relock_resource_for_write(&mut self, resource_address: ResourceAddress) -> Result<LockedSubstate, RuntimeError> {
+        self.tracker
+            .write_with(|state_mut| state_mut.write_lock_substate(SubstateId::Resource(resource_address)))
+    }
+
+    /// A bucket with funds locked by a proof may only be held, never consumed. Every operation that empties one —
+    /// deposit, burn, join, fee payment — operates on the unlocked funds alone, so consuming a locked bucket would
+    /// destroy the locked portion while the proof still points at it.
+    fn check_bucket_is_unlocked(op: &'static str, bucket_id: BucketId, bucket: &Bucket) -> Result<(), RuntimeError> {
         if bucket.has_locked_funds() {
-            return Err(RuntimeError::InvalidOpDepositLockedBucket {
+            return Err(RuntimeError::InvalidOpLockedBucket {
+                op,
                 bucket_id,
                 locked_amount: bucket.locked_amount(),
             });
@@ -1447,11 +1458,13 @@ where
 
                 args.assert_no_args("Component::GetOwnerRule")?;
 
-                // The owner rule can never change so we'll just fetch the component
+                // The owner rule can never change, so this reads the component without locking it. It must read
+                // what the transaction has, not what the store had: a component created earlier in this same
+                // transaction is not in the store yet.
                 self.tracker.write_with(|state_mut| {
-                    let substate = state_mut.store().get_unmodified_substate(&component_address.into())?;
-                    let component = substate
-                        .substate_value()
+                    let component = state_mut
+                        .store()
+                        .get_latest_substate(&component_address.into())?
                         .component()
                         .ok_or(RuntimeError::InvariantError {
                             function: "GetOwnerProof",
@@ -1670,7 +1683,7 @@ where
                         })?;
                 let mint_resource: MintResourceArg = args.assert_one_arg()?;
 
-                let (resource_lock, maybe_auth_hook, auth_caller, has_view_key, tracks_supply) =
+                let (maybe_auth_hook, auth_caller, has_view_key, tracks_supply) =
                     self.tracker.write_with(|state_mut| {
                         let resource_lock = state_mut.write_lock_substate(SubstateId::Resource(resource_address))?;
 
@@ -1685,18 +1698,16 @@ where
                         let auth_caller = state_mut.get_auth_caller(&resource_lock)?;
                         let has_view_key = resource.view_key().is_some();
                         let tracks_supply = resource.is_supply_tracking_enabled();
-                        Ok::<_, RuntimeError>((
-                            resource_lock,
-                            resource.auth_hook().cloned(),
-                            auth_caller,
-                            has_view_key,
-                            tracks_supply,
-                        ))
+                        let auth_hook = resource.auth_hook().cloned();
+                        state_mut.unlock_substate(resource_lock)?;
+                        Ok::<_, RuntimeError>((auth_hook, auth_caller, has_view_key, tracks_supply))
                     })?;
 
                 if let Some(auth_hook) = maybe_auth_hook {
                     self.invoke_resource_access_hook(auth_hook, auth_caller, ResourceAuthAction::Mint)?;
                 }
+
+                let resource_lock = self.relock_resource_for_write(resource_address)?;
 
                 // Charge the mint's native verification cost against the payment-funded allowance
                 // before its proof crypto runs.
@@ -1992,7 +2003,7 @@ where
 
                 Self::check_token_symbol_length(&new_metadata)?;
 
-                let (resource_lock, maybe_auth_hook, auth_caller) = self.tracker.write_with(|state_mut| {
+                let (maybe_auth_hook, auth_caller) = self.tracker.write_with(|state_mut| {
                     let resource_lock = state_mut.write_lock_substate(SubstateId::Resource(resource_address))?;
 
                     let resource = state_mut.get_resource(&resource_lock)?;
@@ -2014,12 +2025,16 @@ where
                     }
 
                     let auth_caller = state_mut.get_auth_caller(&resource_lock)?;
-                    Ok::<_, RuntimeError>((resource_lock, resource.auth_hook().cloned(), auth_caller))
+                    let auth_hook = resource.auth_hook().cloned();
+                    state_mut.unlock_substate(resource_lock)?;
+                    Ok::<_, RuntimeError>((auth_hook, auth_caller))
                 })?;
 
                 if let Some(auth_hook) = maybe_auth_hook {
                     self.invoke_resource_access_hook(auth_hook, auth_caller, ResourceAuthAction::UpdateMetadata)?;
                 }
+
+                let resource_lock = self.relock_resource_for_write(resource_address)?;
 
                 self.tracker.write_with(|state_mut| {
                     let resource_mut = state_mut.get_resource_mut(&resource_lock)?;
@@ -2469,13 +2484,7 @@ where
 
                 self.tracker.write_with(move |state_mut| {
                     let bucket = state_mut.take_bucket(bucket_id)?;
-                    // It is invalid to deposit a bucket that has locked funds
-                    if bucket.has_locked_funds() {
-                        return Err(RuntimeError::InvalidOpDepositLockedBucket {
-                            bucket_id,
-                            locked_amount: bucket.locked_amount(),
-                        });
-                    }
+                    Self::check_bucket_is_unlocked("deposit", bucket_id, &bucket)?;
 
                     // Emit a builtin event for the deposit
                     let payload = Metadata::from_iter([
@@ -3107,6 +3116,7 @@ where
 
                 self.tracker.write_with(|state| {
                     let other_bucket = state.take_bucket(other_bucket_id)?;
+                    Self::check_bucket_is_unlocked("join", other_bucket_id, &other_bucket)?;
                     let bucket = state.get_bucket_mut(bucket_id)?;
                     bucket.join(other_bucket)?;
                     Ok(InvokeResult::encode(&bucket_id)?)
@@ -3120,15 +3130,15 @@ where
 
                 let arg: BurnBucketArg = args.assert_one_arg()?;
 
-                let (resource_lock, maybe_auth_hook, auth_caller, tracks_supply) =
+                let (resource_address, maybe_auth_hook, auth_caller, tracks_supply) =
                     self.tracker.write_with(|state_mut| {
                         let bucket = state_mut.get_bucket(bucket_id)?;
                         // Reject a burn that cannot succeed before the auth hook runs or anything is charged for it.
                         // This is re-checked after the hook, which may lock funds itself.
-                        Self::check_bucket_is_burnable(bucket_id, bucket)?;
+                        Self::check_bucket_is_unlocked("burn", bucket_id, bucket)?;
 
-                        let resource_lock =
-                            state_mut.write_lock_substate(SubstateId::Resource(*bucket.resource_address()))?;
+                        let resource_address = *bucket.resource_address();
+                        let resource_lock = state_mut.write_lock_substate(SubstateId::Resource(resource_address))?;
 
                         let resource = state_mut.get_resource(&resource_lock)?;
 
@@ -3139,24 +3149,24 @@ where
                         )?;
 
                         let auth_caller = state_mut.get_auth_caller(&resource_lock)?;
-                        Ok::<_, RuntimeError>((
-                            resource_lock,
-                            resource.auth_hook().cloned(),
-                            auth_caller,
-                            resource.is_supply_tracking_enabled(),
-                        ))
+                        let auth_hook = resource.auth_hook().cloned();
+                        let tracks_supply = resource.is_supply_tracking_enabled();
+                        state_mut.unlock_substate(resource_lock)?;
+                        Ok::<_, RuntimeError>((resource_address, auth_hook, auth_caller, tracks_supply))
                     })?;
 
                 if let Some(auth_hook) = maybe_auth_hook {
                     self.invoke_resource_access_hook(auth_hook, auth_caller, ResourceAuthAction::Burn)?;
                 }
 
+                let resource_lock = self.relock_resource_for_write(resource_address)?;
+
                 // The hook may have altered the bucket, so it is re-inspected after the hook runs and before
                 // anything is charged: a hook that locked funds makes the burn fail, and the charge must cover the
                 // proofs actually verified below rather than those held when the hook was scheduled.
                 let value_proof_points = self.tracker.write_with(|state_mut| {
                     let bucket = state_mut.get_bucket(bucket_id)?;
-                    Self::check_bucket_is_burnable(bucket_id, bucket)?;
+                    Self::check_bucket_is_unlocked("burn", bucket_id, bucket)?;
                     if !tracks_supply {
                         return Ok::<_, RuntimeError>(0);
                     }
@@ -4129,6 +4139,7 @@ where
                             reason: format!("PayFee::FromBucket: Expected workspace ID to contain a BucketId: {e}"),
                         })?;
                     let bucket = state_mut.take_bucket(input_bucket)?;
+                    Self::check_bucket_is_unlocked("pay a fee from", input_bucket, &bucket)?;
 
                     // No refunds
                     state_mut.pay_fee(bucket.take_all(), None)?;

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -1105,7 +1105,7 @@ where
     TStore: StateReader + Clone + 'static,
     TTemplateProvider: TemplateProvider<Template = LoadedTemplate>,
 {
-    fn next_entity_id(&self) -> Result<EntityId, RuntimeError> {
+    fn next_entity_id(&mut self) -> Result<EntityId, RuntimeError> {
         let id = self.entity_id_provider.next_entity_id()?;
         Ok(id)
     }
@@ -3584,10 +3584,9 @@ where
 
     fn generate_uuid(&mut self) -> Result<[u8; 32], RuntimeError> {
         self.invoke_modules_on_runtime_call("generate_uuid")?;
-        self.tracker.read_with(|state| {
+        self.tracker.write_with(|state| {
             let epoch_hash = state.get_current_epoch_hash()?;
-            let id_provider = state.id_provider()?;
-            Ok(id_provider.new_uuid(&epoch_hash)?)
+            Ok(state.id_provider()?.new_uuid(&epoch_hash)?)
         })
     }
 
@@ -3775,11 +3774,11 @@ where
                         })
                         .transpose()?;
 
-                    let template = state.current_template()?;
-                    let id_provider = state.id_provider()?;
+                    let template = *state.current_template()?;
+                    let mut id_provider = state.id_provider()?;
                     let address = public_key
                         .as_ref()
-                        .map(|public_key| id_provider.derive_new_component_address(template, public_key))
+                        .map(|public_key| id_provider.derive_new_component_address(&template, public_key))
                         .unwrap_or_else(|| id_provider.new_component_address())?;
 
                     let id = state.new_address_allocation(address)?;
@@ -4037,29 +4036,25 @@ where
         entity_id: EntityId,
         workspace_id: WorkspaceId,
     ) -> Result<AllocateAddressResult, RuntimeError> {
-        self.tracker.write_with(|state| {
-            let id_provider = state.id_provider_for_entity(entity_id);
-
-            match substate_type {
-                AllocatableAddressType::Component => {
-                    let address = id_provider.new_component_address()?;
-                    let id = state.new_address_allocation(address)?;
-                    let value = IndexedValue::from_type(&ComponentAddressAllocation::new(id))?;
-                    state.workspace_mut().insert(workspace_id, value)?;
-                    Ok(AllocateAddressResult::ComponentAddress(
-                        ComponentAddressAllocation::new(id),
-                    ))
-                },
-                AllocatableAddressType::Resource => {
-                    let address = id_provider.new_resource_address()?;
-                    let id = state.new_address_allocation(address)?;
-                    let value = IndexedValue::from_type(&ResourceAddressAllocation::new(id))?;
-                    state.workspace_mut().insert(workspace_id, value)?;
-                    Ok(AllocateAddressResult::ResourceAddress(ResourceAddressAllocation::new(
-                        id,
-                    )))
-                },
-            }
+        self.tracker.write_with(|state| match substate_type {
+            AllocatableAddressType::Component => {
+                let address = state.id_provider_for_entity(entity_id).new_component_address()?;
+                let id = state.new_address_allocation(address)?;
+                let value = IndexedValue::from_type(&ComponentAddressAllocation::new(id))?;
+                state.workspace_mut().insert(workspace_id, value)?;
+                Ok(AllocateAddressResult::ComponentAddress(
+                    ComponentAddressAllocation::new(id),
+                ))
+            },
+            AllocatableAddressType::Resource => {
+                let address = state.id_provider_for_entity(entity_id).new_resource_address()?;
+                let id = state.new_address_allocation(address)?;
+                let value = IndexedValue::from_type(&ResourceAddressAllocation::new(id))?;
+                state.workspace_mut().insert(workspace_id, value)?;
+                Ok(AllocateAddressResult::ResourceAddress(ResourceAddressAllocation::new(
+                    id,
+                )))
+            },
         })
     }
 

--- a/crates/engine/src/runtime/mod.rs
+++ b/crates/engine/src/runtime/mod.rs
@@ -117,7 +117,7 @@ pub use working_state::ChargeableState;
 use crate::runtime::{locking::LockedSubstate, scope::PushCallFrame};
 
 pub trait RuntimeInterface {
-    fn next_entity_id(&self) -> Result<EntityId, RuntimeError>;
+    fn next_entity_id(&mut self) -> Result<EntityId, RuntimeError>;
     fn emit_event(&mut self, topic: String, payload: Metadata) -> Result<(), RuntimeError>;
 
     fn emit_log(&mut self, level: LogLevel, message: String) -> Result<(), RuntimeError>;

--- a/crates/engine/src/runtime/state_store.rs
+++ b/crates/engine/src/runtime/state_store.rs
@@ -297,6 +297,24 @@ impl<TStore: StateReader> WorkingStateStore<TStore> {
         })
     }
 
+    /// The value this transaction currently has for `id`: what it has written, else what it has loaded, else the
+    /// backing store. Unlike [`Self::get_unmodified_substate`] this sees a substate the transaction created, and
+    /// unlike the locked accessors it needs no lock, so it is only for reads of immutable fields.
+    pub(super) fn get_latest_substate(&self, id: &SubstateId) -> Result<&SubstateValue, RuntimeError> {
+        if let Some(value) = self.new_substates.get(id) {
+            return Ok(value);
+        }
+        if let Some(substate) = self.loaded_substates.get(id) {
+            return Ok(substate.substate_value());
+        }
+        let substate = self
+            .state_store
+            .get_state(id)
+            .optional()?
+            .ok_or_else(|| RuntimeError::SubstateNotFound { id: id.clone() })?;
+        Ok(substate.substate_value())
+    }
+
     pub(super) fn get_unmodified_substate(&self, id: &SubstateId) -> Result<&Substate, RuntimeError> {
         match self.loaded_substates.get(id) {
             Some(substate) => Ok(substate),

--- a/crates/engine/src/runtime/tracker.rs
+++ b/crates/engine/src/runtime/tracker.rs
@@ -216,13 +216,12 @@ impl<TStore: StateReader> StateTracker<TStore> {
         self.read_with(|state| state.get_current_epoch_hash())
     }
 
-    pub fn get_pseudorandom_bytes(&self, length: usize) -> Result<Vec<u8>, RuntimeError> {
-        self.read_with(|state| {
-            let id_provider = state.id_provider()?;
+    pub fn get_pseudorandom_bytes(&mut self, length: usize) -> Result<Vec<u8>, RuntimeError> {
+        self.write_with(|state| {
             // TODO: epoch_hash is a bad source of entropy. Agreeing on randomness at a consensus level is challenging
             // in multi-sharded consensus.
             let epoch_hash = state.get_current_epoch_hash()?;
-            let bytes = id_provider.get_random_bytes(&epoch_hash, length)?;
+            let bytes = state.id_provider()?.get_random_bytes(&epoch_hash, length)?;
             Ok(bytes)
         })
     }

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -1516,15 +1516,17 @@ impl<TStore: StateReader> WorkingState<TStore> {
         Ok(frame.current_template_name())
     }
 
-    pub fn id_provider(&self) -> Result<IdProvider<'_>, RuntimeError> {
-        self.call_frames
+    pub fn id_provider(&mut self) -> Result<IdProvider<'_>, RuntimeError> {
+        let entity_id = self
+            .call_frames
             .last()
-            .map(|frame| IdProvider::new(frame.entity_id(), self.transaction_hash, &self.object_ids))
-            .ok_or(RuntimeError::NoActiveCallFrame)
+            .map(|frame| frame.entity_id())
+            .ok_or(RuntimeError::NoActiveCallFrame)?;
+        Ok(IdProvider::new(entity_id, self.transaction_hash, &mut self.object_ids))
     }
 
-    pub fn id_provider_for_entity(&self, entity_id: EntityId) -> IdProvider<'_> {
-        IdProvider::new(entity_id, self.transaction_hash, &self.object_ids)
+    pub fn id_provider_for_entity(&mut self, entity_id: EntityId) -> IdProvider<'_> {
+        IdProvider::new(entity_id, self.transaction_hash, &mut self.object_ids)
     }
 
     pub fn new_bucket_id(&mut self) -> BucketId {

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -2172,6 +2172,17 @@ impl<TStore: StateReader> WorkingState<TStore> {
         }
 
         let revealed_funds_bucket = revealed_funds_bucket_id.map(|id| self.take_bucket(id)).transpose()?;
+        // The bucket is consumed whole by the transfer, so funds a proof has locked in it would be destroyed while
+        // the proof still names it.
+        if let (Some(bucket_id), Some(bucket)) = (revealed_funds_bucket_id, revealed_funds_bucket.as_ref()) &&
+            bucket.has_locked_funds()
+        {
+            return Err(RuntimeError::InvalidOpLockedBucket {
+                op: "stealth transfer from",
+                bucket_id,
+                locked_amount: bucket.locked_amount(),
+            });
+        }
         if let Some(ref bucket) = revealed_funds_bucket &&
             *bucket.resource_address() != resource_address
         {

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -557,9 +557,11 @@ impl<TStore: StateReader> WorkingState<TStore> {
             Self::enforce_substate_size_limit(id, value)?;
         }
 
-        if self.buckets.iter().any(|(_, b)| !b.is_empty()) {
+        // An emptied bucket carries nothing and is tolerated, so the count is of those that are not empty.
+        let dangling_buckets = self.buckets.iter().filter(|(_, bucket)| !bucket.is_empty()).count();
+        if dangling_buckets > 0 {
             return Err(TransactionCommitError::DanglingBuckets {
-                count: self.buckets.len(),
+                count: dangling_buckets,
             }
             .into());
         }
@@ -579,7 +581,9 @@ impl<TStore: StateReader> WorkingState<TStore> {
         }
 
         for (vault_id, vault) in self.store.new_vaults() {
-            if !vault.locked_balance().is_zero() {
+            // A confidential vault's locked value is a set of commitments whose amounts are hidden, so the locked
+            // balance alone reports zero for it.
+            if vault.has_locked_funds() {
                 return Err(TransactionCommitError::DanglingLockedValueInVault {
                     vault_id,
                     locked_amount: vault.locked_balance(),
@@ -792,7 +796,8 @@ impl<TStore: StateReader> WorkingState<TStore> {
         // it. Callers reject this earlier to avoid charging for a burn that cannot succeed; the check lives here so
         // that it holds for every caller.
         if bucket.has_locked_funds() {
-            return Err(RuntimeError::InvalidOpDepositLockedBucket {
+            return Err(RuntimeError::InvalidOpLockedBucket {
+                op: "burn",
                 bucket_id,
                 locked_amount: bucket.locked_amount(),
             });

--- a/crates/engine/src/transaction/processor.rs
+++ b/crates/engine/src/transaction/processor.rs
@@ -637,7 +637,7 @@ where
         substate_type: AllocatableAddressType,
         workspace_id: WorkspaceId,
     ) -> Result<InstructionResult, TransactionErrorKind> {
-        let entity_id = runtime.interface().next_entity_id()?;
+        let entity_id = runtime.interface_mut().next_entity_id()?;
         let result = runtime
             .interface_mut()
             .allocate_address(substate_type, entity_id, workspace_id)?;
@@ -862,7 +862,7 @@ where
             template_address: *template_address,
             module_name: template.template_name().to_string(),
             arg_scope,
-            entity_id: runtime.interface().next_entity_id()?,
+            entity_id: runtime.interface_mut().next_entity_id()?,
         };
 
         runtime.interface_mut().push_call_frame(frame)?;

--- a/crates/engine/tests/access_rules.rs
+++ b/crates/engine/tests/access_rules.rs
@@ -1030,7 +1030,8 @@ mod resource_access_rules {
             vec![user_proof.clone()],
         );
 
-        assert_reject_reason(reason, RuntimeError::InvalidOpDepositLockedBucket {
+        assert_reject_reason(reason, RuntimeError::InvalidOpLockedBucket {
+            op: "deposit",
             // badges is the 1st bucket
             bucket_id: 0.into(),
             locked_amount: Amount::from(2u64),
@@ -1409,6 +1410,49 @@ mod resource_access_rules {
         );
 
         assert_reject_reason(result, "attempted in a resource auth hook");
+    }
+
+    /// Mint takes the resource's write lock. The hook guards that resource and may legitimately read it, so the
+    /// lock must not be held across the hook call.
+    #[test]
+    fn it_allows_a_hook_to_read_the_resource_it_guards() {
+        let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/access_rules"]);
+
+        let (_owner_account, owner_proof, owner_key) = test.create_empty_account();
+        let (user_account, user_proof, user_key) = test.create_empty_account();
+
+        let access_rules_template = test.get_template_address("AccessRulesTest");
+
+        let result = test.execute_expect_success(
+            Transaction::builder_localnet(Epoch(1))
+                .call_function(access_rules_template, "with_mintable_auth_hook", args![
+                    "hook_reads_own_resource"
+                ])
+                .build_and_seal(&owner_key),
+            vec![owner_proof.clone()],
+        );
+
+        let token_resource = result
+            .finalize
+            .result
+            .any_accept()
+            .unwrap()
+            .up_iter()
+            .filter_map(|(addr, s)| s.substate_value().as_resource().map(|r| (addr, r)))
+            .find(|(_, r)| !r.resource_type().is_non_fungible())
+            .map(|(addr, _)| addr.as_resource_address().unwrap())
+            .unwrap();
+
+        // `mint_resource` is a function rather than a method, so the mint acts on the resource from outside the
+        // hook's own component and the hook runs.
+        test.execute_expect_success(
+            Transaction::builder_localnet(Epoch(1))
+                .call_function(access_rules_template, "mint_resource", args![token_resource])
+                .put_last_instruction_output_on_workspace("tokens")
+                .call_method(user_account, "deposit", args![Workspace("tokens")])
+                .build_and_seal(&user_key),
+            vec![user_proof.clone()],
+        );
     }
 
     #[test]

--- a/crates/engine/tests/shenanigans.rs
+++ b/crates/engine/tests/shenanigans.rs
@@ -15,11 +15,13 @@ use tari_template_lib::{
 use tari_template_test_tooling::{TemplateTest, support::assert_error::assert_reject_reason};
 
 const CRATE_PATH: &str = env!("CARGO_MANIFEST_DIR");
+const TEMPLATE_PATHS: &[&str] = &["tests/templates/shenanigans"];
+const RESOURCE_TEMPLATE_PATHS: &[&str] = &["tests/templates/resource_shenanigans"];
 const TEMPLATE_NAME: &str = "Shenanigans";
 
 #[test]
 fn it_rejects_dangling_vaults_in_constructor() {
-    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/shenanigans"]);
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
     let template_addr = test.get_template_address(TEMPLATE_NAME);
 
     let reason = test.execute_expect_failure(
@@ -38,7 +40,7 @@ fn it_rejects_dangling_vaults_in_constructor() {
 
 #[test]
 fn it_rejects_dangling_vault_that_has_been_returned() {
-    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/shenanigans"]);
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
     let template_addr = test.get_template_address(TEMPLATE_NAME);
 
     let reason = test.execute_expect_failure(
@@ -53,7 +55,7 @@ fn it_rejects_dangling_vault_that_has_been_returned() {
 
 #[test]
 fn it_rejects_dangling_vaults_in_component() {
-    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/shenanigans"]);
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
     let template_addr = test.get_template_address(TEMPLATE_NAME);
 
     //  Create with vault
@@ -84,7 +86,7 @@ fn it_rejects_dangling_vaults_in_component() {
 
 #[test]
 fn it_rejects_dangling_resources() {
-    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/shenanigans"]);
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
     let template_addr = test.get_template_address(TEMPLATE_NAME);
 
     let reason = test.execute_expect_failure(
@@ -99,7 +101,7 @@ fn it_rejects_dangling_resources() {
 
 #[test]
 fn it_rejects_unknown_substate_ids() {
-    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/shenanigans"]);
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
     let template_addr = test.get_template_address(TEMPLATE_NAME);
 
     let reason = test.execute_expect_failure(
@@ -121,7 +123,7 @@ fn it_rejects_unknown_substate_ids() {
 
 #[test]
 fn it_rejects_references_to_buckets_that_arent_in_scope() {
-    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/shenanigans"]);
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
     let template_addr = test.get_template_address(TEMPLATE_NAME);
     let (account, owner_token, owner_key) = test.create_funded_account();
 
@@ -151,7 +153,7 @@ fn it_rejects_references_to_buckets_that_arent_in_scope() {
 
 #[test]
 fn it_rejects_double_ownership_of_vault() {
-    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/shenanigans"]);
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
     let template_addr = test.get_template_address(TEMPLATE_NAME);
 
     let reason = test.execute_expect_failure(
@@ -166,7 +168,7 @@ fn it_rejects_double_ownership_of_vault() {
 
 #[test]
 fn it_prevents_access_to_vault_id_in_component_context() {
-    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/shenanigans"]);
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
     let template_addr = test.get_template_address(TEMPLATE_NAME);
     let (account, _, _) = test.create_funded_account();
 
@@ -203,7 +205,7 @@ fn it_prevents_access_to_vault_id_in_component_context() {
 
 #[test]
 fn it_prevents_access_to_out_of_scope_component() {
-    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/shenanigans"]);
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
     let template_addr = test.get_template_address(TEMPLATE_NAME);
     let (account, _, _) = test.create_funded_account();
 
@@ -234,7 +236,7 @@ fn it_prevents_access_to_out_of_scope_component() {
 
 #[test]
 fn it_disallows_calls_on_vaults_that_are_not_owned_by_current_component() {
-    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/shenanigans"]);
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
     let template_addr = test.get_template_address(TEMPLATE_NAME);
     let (victim, _, _) = test.create_funded_account();
     let (attacker, _, _) = test.create_empty_account();
@@ -265,7 +267,7 @@ fn it_disallows_calls_on_vaults_that_are_not_owned_by_current_component() {
 
 #[test]
 fn it_disallows_vault_access_if_vault_is_not_owned() {
-    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/shenanigans"]);
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
     let template_addr = test.get_template_address(TEMPLATE_NAME);
     let (victim, _, _) = test.create_funded_account();
 
@@ -289,7 +291,7 @@ fn it_disallows_vault_access_if_vault_is_not_owned() {
 
 #[test]
 fn it_disallows_minting_different_resource_type() {
-    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/resource_shenanigans"]);
+    let mut test = TemplateTest::new(CRATE_PATH, RESOURCE_TEMPLATE_PATHS);
     let template_addr = test.get_template_address(TEMPLATE_NAME);
     let (account, _, _) = test.create_empty_account();
 
@@ -324,7 +326,7 @@ fn it_disallows_minting_different_resource_type() {
 
 #[test]
 fn it_does_not_bring_non_owned_vault_id_into_scope() {
-    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/shenanigans"]);
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
     let template_addr = test.get_template_address(TEMPLATE_NAME);
     let (account, _, _) = test.create_funded_account();
     let vault_id = {
@@ -349,7 +351,7 @@ fn it_does_not_bring_non_owned_vault_id_into_scope() {
 
 #[test]
 fn it_disallows_withdraws_from_vaults_outside_of_component_context() {
-    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/shenanigans"]);
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
     let (account, _, _) = test.create_funded_account();
     let vault_id = {
         let store = test.read_only_state_store();
@@ -394,7 +396,7 @@ fn it_disallows_withdraws_from_vaults_outside_of_component_context() {
 
 #[test]
 fn it_disallows_withdraws_from_vaults_outside_of_owning_component() {
-    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/shenanigans"]);
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
     let (account, _, _) = test.create_funded_account();
     let vault_id = {
         let store = test.read_only_state_store();
@@ -438,7 +440,7 @@ fn it_disallows_withdraws_from_vaults_outside_of_owning_component() {
 
 #[test]
 fn it_does_not_leak_a_callees_vaults_into_the_callers_scope() {
-    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/shenanigans"]);
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
     let template_addr = test.get_template_address(TEMPLATE_NAME);
     let (victim, _, _) = test.create_funded_account();
     let (attacker, _, _) = test.create_empty_account();
@@ -469,7 +471,7 @@ fn it_does_not_leak_a_callees_vaults_into_the_callers_scope() {
 
 #[test]
 fn it_rejects_a_bucket_that_is_neither_consumed_nor_returned_by_a_call() {
-    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/shenanigans"]);
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
     let template_addr = test.get_template_address(TEMPLATE_NAME);
 
     let result = test.execute_expect_success(
@@ -496,7 +498,7 @@ fn it_rejects_a_bucket_that_is_neither_consumed_nor_returned_by_a_call() {
 /// portion while the proof still names it.
 #[test]
 fn it_rejects_joining_a_bucket_with_locked_funds() {
-    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/shenanigans"]);
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
     let template_addr = test.get_template_address(TEMPLATE_NAME);
 
     let result = test.execute_expect_success(
@@ -521,7 +523,7 @@ fn it_rejects_joining_a_bucket_with_locked_funds() {
 
 #[test]
 fn it_rejects_a_proof_that_is_neither_dropped_nor_returned_by_a_call() {
-    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/shenanigans"]);
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
     let template_addr = test.get_template_address(TEMPLATE_NAME);
 
     let result = test.execute_expect_success(
@@ -546,7 +548,7 @@ fn it_rejects_a_proof_that_is_neither_dropped_nor_returned_by_a_call() {
 
 #[test]
 fn a_proof_outlives_the_authorization_taken_from_it() {
-    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/shenanigans"]);
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
     let template_addr = test.get_template_address(TEMPLATE_NAME);
 
     let result = test.execute_expect_success(
@@ -578,7 +580,7 @@ fn a_proof_outlives_the_authorization_taken_from_it() {
 
 #[test]
 fn it_does_not_leak_a_callees_vaults_into_a_calling_components_scope() {
-    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/shenanigans"]);
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
     let template_addr = test.get_template_address(TEMPLATE_NAME);
     let (victim, _, _) = test.create_funded_account();
     let (attacker_account, _, _) = test.create_empty_account();
@@ -620,7 +622,7 @@ fn it_does_not_leak_a_callees_vaults_into_a_calling_components_scope() {
 
 #[test]
 fn it_does_not_leak_a_callees_address_allocation_into_the_callers_scope() {
-    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/shenanigans"]);
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
     let template_addr = test.get_template_address(TEMPLATE_NAME);
 
     let result = test.execute_expect_success(
@@ -647,7 +649,7 @@ fn it_does_not_leak_a_callees_address_allocation_into_the_callers_scope() {
 
 #[test]
 fn it_refuses_to_authorize_a_proof_the_frame_does_not_hold() {
-    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/shenanigans"]);
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
     let template_addr = test.get_template_address(TEMPLATE_NAME);
 
     let result = test.execute_expect_success(
@@ -684,7 +686,7 @@ fn it_refuses_to_authorize_a_proof_the_frame_does_not_hold() {
 
 #[test]
 fn it_refuses_to_read_a_proof_the_frame_does_not_hold() {
-    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/shenanigans"]);
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
     let template_addr = test.get_template_address(TEMPLATE_NAME);
 
     let result = test.execute_expect_success(
@@ -725,7 +727,7 @@ fn it_refuses_to_read_a_proof_the_frame_does_not_hold() {
 /// exercise something gated on the badge, there being no engine query for `auth_scope` membership.
 #[test]
 fn it_answers_a_drop_authorize_for_any_proof_id() {
-    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/shenanigans"]);
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
     let template_addr = test.get_template_address(TEMPLATE_NAME);
 
     let result = test.execute_expect_success(

--- a/crates/engine/tests/shenanigans.rs
+++ b/crates/engine/tests/shenanigans.rs
@@ -492,6 +492,33 @@ fn it_rejects_a_bucket_that_is_neither_consumed_nor_returned_by_a_call() {
     assert_reject_reason(reason, "were neither consumed nor returned by the call");
 }
 
+/// `Bucket::join` moves only the unlocked funds, so joining a bucket a proof has locked would destroy the locked
+/// portion while the proof still names it.
+#[test]
+fn it_rejects_joining_a_bucket_with_locked_funds() {
+    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/shenanigans"]);
+    let template_addr = test.get_template_address(TEMPLATE_NAME);
+
+    let result = test.execute_expect_success(
+        test.transaction()
+            .call_function(template_addr, "with_fungible_vault", args![])
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+    let component = result.finalize.execution_results[0]
+        .decode::<ComponentAddress>()
+        .unwrap();
+
+    let reason = test.execute_expect_failure(
+        test.transaction()
+            .call_method(component, "join_locked_bucket", args![])
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+
+    assert_reject_reason(reason, "Cannot join bucket");
+}
+
 #[test]
 fn it_rejects_a_proof_that_is_neither_dropped_nor_returned_by_a_call() {
     let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/shenanigans"]);

--- a/crates/engine/tests/stealth.rs
+++ b/crates/engine/tests/stealth.rs
@@ -376,7 +376,9 @@ fn transfer_revealed_between_accounts() {
 }
 
 /// A stealth transfer consumes its revealed-funds bucket whole, so funds a proof has locked in that bucket would
-/// be destroyed while the proof still names it.
+/// be destroyed while the proof still names it. A bucket proof locks the whole bucket, so the shape that reaches
+/// the drop is a statement with no revealed input: the unlocked amount matches its zero and the locked funds go
+/// unexamined.
 #[test]
 fn transfer_rejects_a_revealed_funds_bucket_with_locked_funds() {
     let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
@@ -402,7 +404,15 @@ fn transfer_rejects_a_revealed_funds_bucket_with_locked_funds() {
         [999, 9901],
         100,
     );
-    let onward_transfer = stealth::generate_transfer_data(NO_INPUTS, 100u64, [25, 25, 25], 25);
+    let onward_transfer = stealth::generate_transfer_data(
+        [MaskAndValue {
+            mask: mint.output_masks[0].clone(),
+            value: 100,
+        }],
+        0u64,
+        [40, 60],
+        0u64,
+    );
 
     let reason = test.execute_expect_failure(
         Transaction::builder_localnet(Epoch(1))
@@ -414,8 +424,12 @@ fn transfer_rejects_a_revealed_funds_bucket_with_locked_funds() {
             .call_function(template_addr, "lock_bucket", args![Workspace("funds")])
             .put_last_instruction_output_on_workspace("locked")
             .stealth_transfer_with_input_bucket(faucet_resx, onward_transfer.statement, "locked.0")
+            // Dropping the proof clears the dangling-proof check, leaving the guard as the only thing between
+            // this transfer and a bucket whose locked funds are gone.
+            .drop_all_proofs_in_workspace()
             .finish()
             // In tests, we set the spend condition to require the mask as a signer
+            .add_signer(&test.to_public_key_bytes(), &mint.output_masks[0])
             .add_signer(&test.to_public_key_bytes(), &mint.output_masks[1])
             .add_signer(&test.to_public_key_bytes(), &mint.output_masks[2])
             .seal(&alice_sk),

--- a/crates/engine/tests/stealth.rs
+++ b/crates/engine/tests/stealth.rs
@@ -375,6 +375,56 @@ fn transfer_revealed_between_accounts() {
     assert_eq!(vault.balance(), 25);
 }
 
+/// A stealth transfer consumes its revealed-funds bucket whole, so funds a proof has locked in that bucket would
+/// be destroyed while the proof still names it.
+#[test]
+fn transfer_rejects_a_revealed_funds_bucket_with_locked_funds() {
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
+    let template_addr = test.get_template_address(TEMPLATE_NAME);
+    let (alice, _alice_proof, alice_sk) = test.create_empty_account();
+
+    let outputs = [100, 1000, 10000];
+    let mint = stealth::generate_mint_statement(outputs, 0u64, None);
+    let (_faucet, faucet_resx) = setup(&mut test, &mint, None);
+
+    let transfer_from_faucet = stealth::generate_transfer_data(
+        [
+            MaskAndValue {
+                mask: mint.output_masks[2].clone(),
+                value: 10000,
+            },
+            MaskAndValue {
+                mask: mint.output_masks[1].clone(),
+                value: 1000,
+            },
+        ],
+        0u64,
+        [999, 9901],
+        100,
+    );
+    let onward_transfer = stealth::generate_transfer_data(NO_INPUTS, 100u64, [25, 25, 25], 25);
+
+    let reason = test.execute_expect_failure(
+        Transaction::builder_localnet(Epoch(1))
+            .stealth_transfer(faucet_resx, transfer_from_faucet.statement)
+            .put_last_instruction_output_on_workspace("withdrawn")
+            .call_method(alice, "deposit", args![Workspace("withdrawn")])
+            .call_method(alice, "withdraw", args![faucet_resx, 100])
+            .put_last_instruction_output_on_workspace("funds")
+            .call_function(template_addr, "lock_bucket", args![Workspace("funds")])
+            .put_last_instruction_output_on_workspace("locked")
+            .stealth_transfer_with_input_bucket(faucet_resx, onward_transfer.statement, "locked.0")
+            .finish()
+            // In tests, we set the spend condition to require the mask as a signer
+            .add_signer(&test.to_public_key_bytes(), &mint.output_masks[1])
+            .add_signer(&test.to_public_key_bytes(), &mint.output_masks[2])
+            .seal(&alice_sk),
+        vec![],
+    );
+
+    assert_reject_reason(reason, "Cannot stealth transfer from bucket");
+}
+
 #[test]
 fn transfer_invalid_balance_in_statement() {
     let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);

--- a/crates/engine/tests/templates/access_rules/src/lib.rs
+++ b/crates/engine/tests/templates/access_rules/src/lib.rs
@@ -93,6 +93,31 @@ mod access_rules_template {
             .create()
         }
 
+        /// As `with_auth_hook`, but anyone may mint and burn the tokens, so the hook can be exercised on the
+        /// resource actions that take the resource's write lock.
+        pub fn with_mintable_auth_hook(hook: FunctionName) -> Component<AccessRulesTest> {
+            let badges = create_badge_resource(rule!(deny_all));
+
+            let address_alloc = CallerContext::allocate_component_address(None);
+
+            let tokens = ResourceBuilder::public_fungible()
+                .with_authorization_hook(address_alloc.get_address(), hook)
+                .mintable(rule!(allow_all), LOCKED)
+                .burnable(rule!(allow_all), LOCKED)
+                .initial_supply(1000u32);
+
+            Component::new(Self {
+                value: 0,
+                tokens: Vault::from_bucket(tokens),
+                badges: Vault::from_bucket(badges),
+                allowed: true,
+                attack_component: None,
+            })
+            .with_address_allocation(address_alloc)
+            .with_access_rules(ComponentAccessRules::new().default(rule!(allow_all)))
+            .create()
+        }
+
         /// As `with_auth_hook`, but the hook may be replaced or removed by whoever satisfies `updater`.
         pub fn with_updatable_auth_hook(
             allowed: bool,
@@ -340,6 +365,17 @@ mod access_rules_template {
         /// component state, so the engine refuses the vault creation.
         pub fn hook_creates_vault(&self, _action: ResourceAuthAction, _caller: AuthHookCaller) {
             let _vault = Vault::new_empty(self.tokens.resource_address());
+        }
+
+        /// Reads the resource the hook guards. A resource action that write-locks the resource must release that
+        /// lock across the hook call, or this read is refused.
+        pub fn hook_reads_own_resource(&self, action: ResourceAuthAction, _caller: AuthHookCaller) {
+            let manager = ResourceManager::get(self.tokens.resource_address());
+            assert_eq!(
+                manager.resource_type(),
+                ResourceType::Fungible,
+                "hook read the wrong resource for action {action:?}"
+            );
         }
 
         pub fn invalid_auth_hook2(&self, _action: String, _caller: AuthHookCaller) {}

--- a/crates/engine/tests/templates/component_manager/src/lib.rs
+++ b/crates/engine/tests/templates/component_manager/src/lib.rs
@@ -32,5 +32,18 @@ mod template {
         pub fn get_template_address_for_component(component_address: ComponentAddress) -> TemplateAddress {
             ComponentManager::get(component_address).get_template_address()
         }
+
+        /// Creates a component and immediately asks for its owner proof. The component is not in the state store
+        /// yet, so the proof must come from what this transaction has written.
+        pub fn owner_proof_for_a_component_created_here() -> ComponentAddress {
+            let component = Component::new(Self)
+                .with_owner_rule(OwnerRule::OwnedBySigner)
+                .with_access_rules(AccessRules::allow_all())
+                .create();
+            let address = *component.address();
+            let proof = ComponentManager::get(address).get_owner_proof();
+            proof.drop();
+            address
+        }
     }
 }

--- a/crates/engine/tests/templates/shenanigans/src/lib.rs
+++ b/crates/engine/tests/templates/shenanigans/src/lib.rs
@@ -302,5 +302,16 @@ mod template {
         pub fn deposit(&mut self, bucket: Bucket) {
             self.vault.as_mut().unwrap().deposit(bucket);
         }
+
+        /// Joins a bucket whose funds a proof has locked into another. `join` moves only the unlocked funds, so
+        /// the engine must refuse it rather than let the locked portion vanish while the proof still names it.
+        pub fn join_locked_bucket(&mut self) {
+            let locked = self.vault.as_mut().unwrap().withdraw(Amount::from(10u64));
+            let target = self.vault.as_mut().unwrap().withdraw(Amount::from(10u64));
+            let proof = locked.create_proof();
+            let joined = target.join(locked);
+            proof.drop();
+            self.vault.as_mut().unwrap().deposit(joined);
+        }
     }
 }

--- a/crates/engine/tests/templates/stealth/src/lib.rs
+++ b/crates/engine/tests/templates/stealth/src/lib.rs
@@ -63,6 +63,13 @@ mod template {
             .create()
         }
 
+        /// Returns the bucket alongside a proof that locks its funds, so a caller can hand a partially locked
+        /// bucket to an instruction that consumes buckets whole.
+        pub fn lock_bucket(bucket: Bucket) -> (Bucket, Proof) {
+            let proof = bucket.create_proof();
+            (bucket, proof)
+        }
+
         pub fn take_funds(&self, amount: Amount) -> Bucket {
             self.supply_vault.withdraw(amount)
         }

--- a/crates/engine/tests/test.rs
+++ b/crates/engine/tests/test.rs
@@ -391,6 +391,20 @@ fn test_get_template_address() {
     assert_eq!(addr, template_test.get_template_address("Account"));
 }
 
+/// A component's owner rule is immutable, so `GetOwnerProof` reads it without a lock — but it must read what the
+/// transaction has written, not what the store had, or a component created in this same transaction has no proof.
+#[test]
+fn test_get_owner_proof_for_a_component_created_in_the_same_transaction() {
+    let mut template_test = TemplateTest::new(CRATE_PATH, vec!["tests/templates/component_manager"]);
+
+    let _: ComponentAddress = template_test.call_function(
+        "ComponentManagerTest",
+        "owner_proof_for_a_component_created_here",
+        args![],
+        vec![],
+    );
+}
+
 #[test]
 fn test_random() {
     let mut template_test = TemplateTest::new(CRATE_PATH, vec!["tests/templates/random"]);

--- a/crates/engine_types/src/entity_id_provider.rs
+++ b/crates/engine_types/src/entity_id_provider.rs
@@ -1,17 +1,15 @@
 //   Copyright 2024 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::sync::{Arc, atomic::AtomicU32};
-
 use tari_template_lib::types::{EntityId, Hash32};
 
 use crate::hashing::{EngineHashDomainLabel, hasher32};
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct EntityIdProvider {
     transaction_hash: Hash32,
     max_ids: u32,
-    current_id: Arc<AtomicU32>,
+    current_id: u32,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -27,15 +25,16 @@ impl EntityIdProvider {
         Self {
             transaction_hash,
             max_ids,
-            current_id: Arc::new(AtomicU32::new(0)),
+            current_id: 0,
         }
     }
 
-    fn next(&self) -> Result<u32, EntityIdProviderError> {
-        let id = self.current_id.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    fn next(&mut self) -> Result<u32, EntityIdProviderError> {
+        let id = self.current_id;
         if id >= self.max_ids {
             return Err(EntityIdProviderError::MaxIdsExceeded { max: self.max_ids });
         }
+        self.current_id += 1;
         Ok(id)
     }
 
@@ -44,8 +43,9 @@ impl EntityIdProvider {
     }
 
     /// Generates a new entity id trailing_24_bytes(H(tx_hash || n))
-    pub fn next_entity_id(&self) -> Result<EntityId, EntityIdProviderError> {
-        let id = generate_entity_id(&self.transaction_hash, self.next()?);
+    pub fn next_entity_id(&mut self) -> Result<EntityId, EntityIdProviderError> {
+        let n = self.next()?;
+        let id = generate_entity_id(&self.transaction_hash, n);
         Ok(id)
     }
 }

--- a/crates/engine_types/src/id_provider.rs
+++ b/crates/engine_types/src/id_provider.rs
@@ -130,8 +130,9 @@ fn generate_output_id(transaction_hash: &Hash32, n: u32) -> Hash32 {
 pub struct ObjectIds {
     max_ids: usize,
     current_id: AtomicU32,
-    bucket_id: AtomicU32,
-    proof_id: AtomicU32,
+    /// Buckets and proofs draw from one counter: both are transient handles held in the same runtime
+    /// scope, and a shared space keeps a bucket id from ever colliding with a proof id.
+    bucket_or_proof_id: AtomicU32,
     uuid: AtomicU32,
 }
 
@@ -140,8 +141,7 @@ impl ObjectIds {
         Self {
             max_ids,
             current_id: AtomicU32::new(0),
-            bucket_id: AtomicU32::new(0),
-            proof_id: AtomicU32::new(0),
+            bucket_or_proof_id: AtomicU32::new(0),
             uuid: AtomicU32::new(0),
         }
     }
@@ -155,11 +155,15 @@ impl ObjectIds {
     }
 
     pub fn next_bucket_id(&self) -> BucketId {
-        self.bucket_id.fetch_add(1, atomic::Ordering::SeqCst).into()
+        self.next_bucket_or_proof_id().into()
     }
 
     pub fn next_proof_id(&self) -> ProofId {
-        self.proof_id.fetch_add(1, atomic::Ordering::SeqCst).into()
+        self.next_bucket_or_proof_id().into()
+    }
+
+    fn next_bucket_or_proof_id(&self) -> u32 {
+        self.bucket_or_proof_id.fetch_add(1, atomic::Ordering::SeqCst)
     }
 
     pub fn next_uuid_id(&self) -> u32 {
@@ -172,8 +176,7 @@ impl Clone for ObjectIds {
         Self {
             max_ids: self.max_ids,
             current_id: AtomicU32::new(self.current_id.load(atomic::Ordering::SeqCst)),
-            bucket_id: AtomicU32::new(self.bucket_id.load(atomic::Ordering::SeqCst)),
-            proof_id: AtomicU32::new(self.proof_id.load(atomic::Ordering::SeqCst)),
+            bucket_or_proof_id: AtomicU32::new(self.bucket_or_proof_id.load(atomic::Ordering::SeqCst)),
             uuid: AtomicU32::new(self.uuid.load(atomic::Ordering::SeqCst)),
         }
     }

--- a/crates/engine_types/src/id_provider.rs
+++ b/crates/engine_types/src/id_provider.rs
@@ -131,6 +131,7 @@ pub struct ObjectIds {
     max_ids: usize,
     current_id: AtomicU32,
     bucket_id: AtomicU32,
+    proof_id: AtomicU32,
     uuid: AtomicU32,
 }
 
@@ -140,6 +141,7 @@ impl ObjectIds {
             max_ids,
             current_id: AtomicU32::new(0),
             bucket_id: AtomicU32::new(0),
+            proof_id: AtomicU32::new(0),
             uuid: AtomicU32::new(0),
         }
     }
@@ -157,7 +159,7 @@ impl ObjectIds {
     }
 
     pub fn next_proof_id(&self) -> ProofId {
-        self.bucket_id.fetch_add(1, atomic::Ordering::SeqCst).into()
+        self.proof_id.fetch_add(1, atomic::Ordering::SeqCst).into()
     }
 
     pub fn next_uuid_id(&self) -> u32 {
@@ -171,6 +173,7 @@ impl Clone for ObjectIds {
             max_ids: self.max_ids,
             current_id: AtomicU32::new(self.current_id.load(atomic::Ordering::SeqCst)),
             bucket_id: AtomicU32::new(self.bucket_id.load(atomic::Ordering::SeqCst)),
+            proof_id: AtomicU32::new(self.proof_id.load(atomic::Ordering::SeqCst)),
             uuid: AtomicU32::new(self.uuid.load(atomic::Ordering::SeqCst)),
         }
     }

--- a/crates/engine_types/src/id_provider.rs
+++ b/crates/engine_types/src/id_provider.rs
@@ -1,8 +1,6 @@
 //   Copyright 2024 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::sync::{atomic, atomic::AtomicU32};
-
 use tari_template_lib::{
     models::{BucketId, ProofId},
     types::{
@@ -23,11 +21,11 @@ use crate::{
     hashing::{EngineHashDomainLabel, hasher32},
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct IdProvider<'a> {
     entity_id: EntityId,
     transaction_hash: Hash32,
-    object_ids: &'a ObjectIds,
+    object_ids: &'a mut ObjectIds,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -39,7 +37,7 @@ pub enum IdProviderError {
 }
 
 impl<'a> IdProvider<'a> {
-    pub fn new(entity_id: EntityId, transaction_hash: Hash32, object_ids: &'a ObjectIds) -> Self {
+    pub fn new(entity_id: EntityId, transaction_hash: Hash32, object_ids: &'a mut ObjectIds) -> Self {
         Self {
             entity_id,
             transaction_hash,
@@ -47,15 +45,16 @@ impl<'a> IdProvider<'a> {
         }
     }
 
-    pub fn new_resource_address(&self) -> Result<ResourceAddress, IdProviderError> {
+    pub fn new_resource_address(&mut self) -> Result<ResourceAddress, IdProviderError> {
         let key = self.next_object_key()?;
         Ok(ResourceAddress::new(key))
     }
 
-    pub fn new_component_address(&self) -> Result<ComponentAddress, IdProviderError> {
+    pub fn new_component_address(&mut self) -> Result<ComponentAddress, IdProviderError> {
+        let n = self.next()?;
         let component_id = hasher32(EngineHashDomainLabel::ComponentAddress)
             .chain(&self.transaction_hash)
-            .chain(&self.next()?)
+            .chain(&n)
             .result();
 
         let object_key = ObjectKey::new(self.entity_id, ComponentKey::new(component_id.trailing_bytes()));
@@ -70,20 +69,20 @@ impl<'a> IdProvider<'a> {
         Ok(derive_component_address_from_public_key(template_address, public_key))
     }
 
-    pub fn new_vault_id(&self) -> Result<VaultId, IdProviderError> {
+    pub fn new_vault_id(&mut self) -> Result<VaultId, IdProviderError> {
         let v = VaultId::new(self.next_object_key()?);
         Ok(v)
     }
 
-    pub fn new_bucket_id(&self) -> BucketId {
+    pub fn new_bucket_id(&mut self) -> BucketId {
         self.object_ids.next_bucket_id()
     }
 
-    pub fn new_proof_id(&self) -> ProofId {
+    pub fn new_proof_id(&mut self) -> ProofId {
         self.object_ids.next_proof_id()
     }
 
-    pub fn new_uuid(&self, entropy: &[u8]) -> Result<[u8; 32], IdProviderError> {
+    pub fn new_uuid(&mut self, entropy: &[u8]) -> Result<[u8; 32], IdProviderError> {
         let n = self.object_ids.next_uuid_id();
         let h = hasher32(EngineHashDomainLabel::UuidOutput)
             .chain(&self.transaction_hash)
@@ -93,7 +92,7 @@ impl<'a> IdProvider<'a> {
         Ok(h.result().into_array())
     }
 
-    pub fn get_random_bytes(&self, entropy: &[u8], len: usize) -> Result<Vec<u8>, IdProviderError> {
+    pub fn get_random_bytes(&mut self, entropy: &[u8], len: usize) -> Result<Vec<u8>, IdProviderError> {
         let mut result = Vec::with_capacity(len);
         while result.len() < len {
             let bytes = self.new_uuid(entropy)?;
@@ -109,12 +108,13 @@ impl<'a> IdProvider<'a> {
         self.entity_id
     }
 
-    fn next(&self) -> Result<u32, IdProviderError> {
+    fn next(&mut self) -> Result<u32, IdProviderError> {
         self.object_ids.next_id()
     }
 
-    fn next_object_key(&self) -> Result<ObjectKey, IdProviderError> {
-        let hash = generate_output_id(&self.transaction_hash, self.next()?);
+    fn next_object_key(&mut self) -> Result<ObjectKey, IdProviderError> {
+        let n = self.next()?;
+        let hash = generate_output_id(&self.transaction_hash, n);
         Ok(ObjectKey::new(self.entity_id, ComponentKey::new(hash.trailing_bytes())))
     }
 }
@@ -126,59 +126,53 @@ fn generate_output_id(transaction_hash: &Hash32, n: u32) -> Hash32 {
         .result()
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ObjectIds {
     max_ids: usize,
-    current_id: AtomicU32,
+    current_id: u32,
     /// Buckets and proofs draw from one counter: both are transient handles held in the same runtime
     /// scope, and a shared space keeps a bucket id from ever colliding with a proof id.
-    bucket_or_proof_id: AtomicU32,
-    uuid: AtomicU32,
+    bucket_or_proof_id: u32,
+    uuid: u32,
 }
 
 impl ObjectIds {
     pub fn new(max_ids: usize) -> Self {
         Self {
             max_ids,
-            current_id: AtomicU32::new(0),
-            bucket_or_proof_id: AtomicU32::new(0),
-            uuid: AtomicU32::new(0),
+            current_id: 0,
+            bucket_or_proof_id: 0,
+            uuid: 0,
         }
     }
 
-    pub fn next_id(&self) -> Result<u32, IdProviderError> {
-        let id = self.current_id.fetch_add(1, atomic::Ordering::SeqCst);
+    pub fn next_id(&mut self) -> Result<u32, IdProviderError> {
+        let id = self.current_id;
         if id as usize >= self.max_ids {
             return Err(IdProviderError::MaxIdsExceeded { max: self.max_ids });
         }
+        self.current_id += 1;
         Ok(id)
     }
 
-    pub fn next_bucket_id(&self) -> BucketId {
+    pub fn next_bucket_id(&mut self) -> BucketId {
         self.next_bucket_or_proof_id().into()
     }
 
-    pub fn next_proof_id(&self) -> ProofId {
+    pub fn next_proof_id(&mut self) -> ProofId {
         self.next_bucket_or_proof_id().into()
     }
 
-    fn next_bucket_or_proof_id(&self) -> u32 {
-        self.bucket_or_proof_id.fetch_add(1, atomic::Ordering::SeqCst)
+    fn next_bucket_or_proof_id(&mut self) -> u32 {
+        let id = self.bucket_or_proof_id;
+        self.bucket_or_proof_id += 1;
+        id
     }
 
-    pub fn next_uuid_id(&self) -> u32 {
-        self.uuid.fetch_add(1, atomic::Ordering::SeqCst)
-    }
-}
-
-impl Clone for ObjectIds {
-    fn clone(&self) -> Self {
-        Self {
-            max_ids: self.max_ids,
-            current_id: AtomicU32::new(self.current_id.load(atomic::Ordering::SeqCst)),
-            bucket_or_proof_id: AtomicU32::new(self.bucket_or_proof_id.load(atomic::Ordering::SeqCst)),
-            uuid: AtomicU32::new(self.uuid.load(atomic::Ordering::SeqCst)),
-        }
+    pub fn next_uuid_id(&mut self) -> u32 {
+        let id = self.uuid;
+        self.uuid += 1;
+        id
     }
 }
 
@@ -188,19 +182,19 @@ mod tests {
 
     #[test]
     fn it_fails_if_generating_more_ids_than_the_max() {
-        let object_ids = ObjectIds::new(0);
-        let id_provider = IdProvider::new(EntityId::default(), Hash32::default(), &object_ids);
+        let mut object_ids = ObjectIds::new(0);
+        let mut id_provider = IdProvider::new(EntityId::default(), Hash32::default(), &mut object_ids);
         id_provider.next_object_key().unwrap_err();
-        let object_ids = ObjectIds::new(1);
-        let id_provider = IdProvider::new(EntityId::default(), Hash32::default(), &object_ids);
+        let mut object_ids = ObjectIds::new(1);
+        let mut id_provider = IdProvider::new(EntityId::default(), Hash32::default(), &mut object_ids);
         id_provider.next_object_key().unwrap();
         id_provider.next_object_key().unwrap_err();
     }
 
     #[test]
     fn get_random_bytes() {
-        let object_ids = ObjectIds::new(0);
-        let id_provider = IdProvider::new(EntityId::default(), Hash32::default(), &object_ids);
+        let mut object_ids = ObjectIds::new(0);
+        let mut id_provider = IdProvider::new(EntityId::default(), Hash32::default(), &mut object_ids);
         const CASES: [usize; 7] = [0, 4, 32, 33, 64, 65, 129];
         for len in CASES {
             let b = id_provider.get_random_bytes(&[], len).unwrap();

--- a/crates/engine_types/src/resource_container.rs
+++ b/crates/engine_types/src/resource_container.rs
@@ -527,17 +527,14 @@ impl ResourceContainer {
                         ));
                     }
 
-                    if *revealed_amount < validated_proof.change_revealed_amount {
-                        return Err(ResourceError::InsufficientBalance {
-                            details: format!(
-                                "withdraw_confidential: resource container did not contain enough revealed funds for \
-                                 change. Required: {}, Available: {}",
-                                validated_proof.change_revealed_amount, revealed_amount
-                            ),
-                        });
-                    }
-
-                    *revealed_amount += validated_proof.change_revealed_amount;
+                    // The change's revealed amount returns to the container, so the balance proof — not a
+                    // sufficiency check — is what constrains it. Only the sum can fail here.
+                    *revealed_amount = revealed_amount
+                        .checked_add(validated_proof.change_revealed_amount)
+                        .ok_or(ResourceError::BalanceOverflow {
+                            operate: "withdraw_confidential change",
+                            amount: validated_proof.change_revealed_amount,
+                        })?;
                     created_outputs.push((change_commitment, change.into_output_body()));
                 }
 

--- a/crates/engine_types/src/vault.rs
+++ b/crates/engine_types/src/vault.rs
@@ -121,6 +121,12 @@ impl Vault {
         self.resource_container.locked_amount()
     }
 
+    /// Whether any funds in this vault are locked, e.g. by a proof. See
+    /// [`ResourceContainer::has_locked_funds`] for why the balance alone cannot answer this.
+    pub fn has_locked_funds(&self) -> bool {
+        self.resource_container.has_locked_funds()
+    }
+
     pub fn get_commitment_count(&self) -> u64 {
         self.resource_container.get_commitment_count()
     }


### PR DESCRIPTION
Engine audit wave 4, third of four. Six items in the resource and proof lifecycle. Independent of #2591 and #2592; all three touch `working_state.rs`, so whichever lands later needs a small rebase.

## Consuming a bucket with locked funds

A bucket whose funds a proof has locked may only be held, never consumed — every operation that empties one works on the unlocked funds alone, so consuming a locked bucket destroys the locked portion while the proof still names it.

Deposit and burn checked for this. Two paths did not:

- `Bucket::join` moved the source bucket in with no check. The locked funds went away and the proof failed later with nothing pointing at the cause.
- `PayFee::FromBucket` likewise. This one was caught eventually by `validate_finalized`, but only after the fee had been metered against a bucket that could not pay it.
- `execute_stealth_transfer`'s revealed-funds bucket, which is compared on `unlocked_amount()` and then dropped, so a bucket whose unlocked amount matches the statement passes with its locked portion destroyed.

All five now reject up front. The error carries the operation, so `InvalidOpDepositLockedBucket` becomes `InvalidOpLockedBucket` and stops claiming every failure is a deposit.

`BucketAction::DropEmpty` needs no such check: it gates on `ResourceContainer::is_empty()`, whose confidential arm counts `commitments.len() + locked_commitments.len()`, so a bucket holding locked commitments is not empty and does not drop.

## `GetOwnerProof` on a component created in the same transaction

It read through `get_unmodified_substate`, which sees the backing store and the loaded set but not what this transaction has written. Asking for the owner proof of a component created earlier in the same transaction therefore failed with `SubstateNotFound` — the create-then-use shape that address allocations exist to support.

It now reads the value the transaction has, through a new `WorkingStateStore::get_latest_substate`. The owner rule is immutable, which is why this read needs no lock; that reasoning is unchanged and now stated where it applies.

## Auth hooks and the resource write lock

Mint, UpdateMetadata and Burn take the resource's write lock, then invoke the resource's auth hook while still holding it. A hook that reads the resource it guards — `total_supply()`, `resource_type()`, anything — is refused:

```
Resource Auth Hook Denied Access for action native.resource.Mint: Runtime error: Lock error:
Requested Read lock on substate resource_ed5e... but it is already locked with Write
```

The lock is released across the hook call and retaken after it. Nothing can slip in between: the hook frame runs in `FrameWriteMode::OwnComponent` and cannot write, so what it reads is what the operation goes on to alter. The eight other hook sites hold a read lock, which stacks, and are untouched.

## `validate_finalized`

- Vaults were tested with `locked_balance()`, which reports zero for a confidential vault whose locked value is a set of commitments with hidden amounts. `has_locked_funds()` exists for exactly this distinction and is now used; `Vault` grows the forwarding accessor `ResourceContainer` already had.
- The dangling-bucket count included buckets that had already been emptied. An emptied bucket carries nothing, so only buckets that still hold funds are counted.
- `TransactionCommitError::WorkspaceNotEmpty` was never constructed. Deleted rather than left as a claim the engine does not make.

## `withdraw_confidential` change guard

```rust
if *revealed_amount < validated_proof.change_revealed_amount { ...InsufficientBalance... }
*revealed_amount += validated_proof.change_revealed_amount;
```

The guard compares the remaining revealed amount against the change and then *adds* the change to it, so it can never fire. The balance proof is what constrains the change; the only thing that can go wrong on that line is the sum. It is now a checked add reporting `BalanceOverflow`.

## Id counters

`next_proof_id` incremented the bucket counter. That is now deliberate rather than incidental: one counter, named `bucket_or_proof_id`, shared by both. Buckets and proofs are transient handles in the same runtime scope, and a shared counter guarantees an id is never both.

The counters also lose their atomics and their `Arc`. Execution is single threaded, and `Runtime` holds a `NonNull` to one boxed `RuntimeInterface`, so `runtime.clone()` shares that single instance — no copy ever needed a counter of its own.

**Breaking.** `IdProvider::new` takes `&mut ObjectIds`; the `IdProvider`, `ObjectIds` and `EntityIdProvider` allocators take `&mut self`; `EntityIdProvider` is no longer `Clone`; `RuntimeInterface::next_entity_id` takes `&mut self`. `tari_engine_types` and `tari_engine` are both published, hence the `!` on the title.

## Tests

- `it_rejects_joining_a_bucket_with_locked_funds` — a template locks part of a bucket with a proof and joins it into another.
- `it_allows_a_hook_to_read_the_resource_it_guards` — a mint from outside the hook's own component, with a hook that reads the resource. Verified it fails on the pre-fix code with the `InvalidLockRequest` above.
- `transfer_rejects_a_revealed_funds_bucket_with_locked_funds` — a stealth transfer handed a bucket a proof has locked. A bucket proof locks the whole bucket, so the statement reveals no input: that is the shape whose unlocked amount matches and reaches the drop. The proof is dropped in the same transaction so the dangling-proof check does not stand in for the guard. Verified it fails on the pre-fix code with `Bucket not found with id BucketId(1)` at the drop.
- `test_get_owner_proof_for_a_component_created_in_the_same_transaction`.
- Full `-p tari_engine -p tari_engine_types` suite: 534 passed.

