### PR TITLE
chore(engine): small hardening

### DIFF
--- a/crates/engine/src/intrinsics/mod.rs
+++ b/crates/engine/src/intrinsics/mod.rs
@@ -43,6 +43,10 @@ use tari_template_lib::{
 
 use crate::runtime::{EngineArgs, RuntimeError};
 
+/// The fewest bytes a [`RistrettoPublicKeyBytes`] can occupy inside an encoded list: 32 bytes of key and the
+/// CBOR byte-string header in front of them. `encoded_point_len_is_at_least_the_minimum` pins it.
+const MIN_ENCODED_POINT_LEN: u64 = 33;
+
 /// The metering points an intrinsic call costs, derived from its declared arguments alone.
 ///
 /// Charged before [`dispatch`] runs, so the price may not depend on anything the work itself
@@ -59,12 +63,14 @@ pub fn price(intrinsic: IntrinsicId, args: &EngineArgs) -> Result<u64, RuntimeEr
         I::RISTRETTO_MUL => NativeExecutionPoints::PER_RISTRETTO_MUL,
         I::RISTRETTO_MUL_BASE => NativeExecutionPoints::PER_RISTRETTO_MUL_BASE,
         I::RISTRETTO_MSM => {
-            // Priced off the declared point count, which is read before any point is decompressed.
-            // A mismatch against the scalar count is rejected in `dispatch`, after this charge —
-            // a caller cannot get free work out of an argument this never looks at.
-            let points_len = args.get::<Vec<RistrettoPublicKeyBytes>>(0)?.len() as u64;
+            // Priced off the encoded length of the point list rather than a decoded one: pricing must not do
+            // work proportional to the input it is pricing, and that decode is unmetered. Dividing by the
+            // smallest a point can encode to bounds the term count from above, so the charge is never short. A
+            // mismatch against the scalar count is rejected in `dispatch`, after this charge — a caller cannot
+            // get free work out of an argument this never looks at.
+            let terms = args.arg_encoded_len(0) / MIN_ENCODED_POINT_LEN;
             NativeExecutionPoints::PER_RISTRETTO_MSM
-                .saturating_add(NativeExecutionPoints::PER_RISTRETTO_MSM_TERM.saturating_mul(points_len))
+                .saturating_add(NativeExecutionPoints::PER_RISTRETTO_MSM_TERM.saturating_mul(terms))
         },
         I::SCALAR_ADD |
         I::SCALAR_SUB |
@@ -313,6 +319,21 @@ fn encode_scalar(s: RistrettoSecretKey) -> Result<InvokeResult, RuntimeError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `price` bounds an MSM's term count by dividing the encoded argument by [`MIN_ENCODED_POINT_LEN`], which
+    /// only bounds from above while a point never encodes to less than that.
+    #[test]
+    fn encoded_point_len_is_at_least_the_minimum() {
+        for len in [1usize, 2, 32, 1000] {
+            let points = vec![RistrettoPublicKeyBytes::zero(); len];
+            let encoded = tari_bor::encode(&points).unwrap().len() as u64;
+            assert!(
+                encoded >= MIN_ENCODED_POINT_LEN * len as u64,
+                "{len} points encode to {encoded} bytes, under the {MIN_ENCODED_POINT_LEN} per point assumed when \
+                 pricing"
+            );
+        }
+    }
 
     /// An id priced but not dispatched charges for work never done; one dispatched but not priced
     /// runs unmetered native code, which is the hole the pricing discipline exists to close. Empty

--- a/crates/engine/src/runtime/engine_args.rs
+++ b/crates/engine/src/runtime/engine_args.rs
@@ -45,6 +45,12 @@ impl EngineArgs {
         self.args.iter().map(|arg| arg.len() as u64).sum()
     }
 
+    /// Encoded size of one argument, or zero if there is no argument at `index`. Available without decoding, for
+    /// the same reason as [`Self::encoded_len`].
+    pub fn arg_encoded_len(&self, index: usize) -> u64 {
+        self.args.get(index).map_or(0, |arg| arg.len() as u64)
+    }
+
     pub fn assert_one_arg<T>(&self) -> Result<T, RuntimeError>
     where T: DeserializeOwned + for<'b> tari_bor::Decode<'b, ()> {
         if self.len() == 1 {

--- a/crates/engine/src/runtime/error.rs
+++ b/crates/engine/src/runtime/error.rs
@@ -111,8 +111,6 @@ pub enum RuntimeError {
     AddressAllocationNotInScope { id: AddressAllocationId },
     #[error("Encountered unknown or out of scope signer badge with public key {public_key}")]
     SignerBadgeNotInScope { public_key: RistrettoPublicKeyBytes },
-    #[error("Component not found with address '{address}'")]
-    ComponentNotFound { address: ComponentAddress },
     #[error("Layer one commitment not found with address '{address}'")]
     LayerOneCommitmentNotFound { address: ClaimedOutputTombstoneAddress },
     #[error("Invalid argument {argument}: {reason}")]
@@ -404,19 +402,16 @@ impl RuntimeError {
     }
 }
 
+/// Only the absence of a substate counts as "not found". The runtime objects a transaction holds — buckets,
+/// proofs, vaults — go missing because a call is wrong about what is in scope, not because the ledger lacks
+/// something, and an `.optional()` that swallowed those would turn a scope error into a silent `None`.
 impl IsNotFoundError for RuntimeError {
     fn is_not_found_error(&self) -> bool {
-        matches!(
-            self,
-            RuntimeError::SubstateNotFound { .. } |
-                RuntimeError::ComponentNotFound { .. } |
-                RuntimeError::VaultNotFound { .. } |
-                RuntimeError::BucketNotFound { .. } |
-                RuntimeError::ResourceNotFound { .. } |
-                RuntimeError::NonFungibleNotFound { .. } |
-                RuntimeError::ProofNotFound { .. } |
-                RuntimeError::VirtualSubstateNotFound { .. }
-        )
+        match self {
+            RuntimeError::SubstateNotFound { .. } => true,
+            RuntimeError::StateStoreError(err) => err.is_not_found_error(),
+            _ => false,
+        }
     }
 }
 

--- a/crates/engine/src/runtime/locking.rs
+++ b/crates/engine/src/runtime/locking.rs
@@ -66,7 +66,10 @@ impl LockedSubstates {
         match entry {
             Entry::Occupied(mut val) => match val.get_mut() {
                 LockState::Read(count_mut) => {
-                    *count_mut -= 1;
+                    *count_mut = count_mut.checked_sub(1).ok_or(LockError::InvariantError {
+                        function: "LockedSubstates::try_unlock",
+                        details: "read lock count underflowed".to_string(),
+                    })?;
                     if *count_mut == 0 {
                         val.remove_entry();
                     }

--- a/crates/engine/src/runtime/scope.rs
+++ b/crates/engine/src/runtime/scope.rs
@@ -315,8 +315,7 @@ impl CallScope {
     /// Brings what a caller passed in as arguments into this frame. Buckets and proofs stay the caller's — they are
     /// recorded as inherited, so this frame need not account for them — but a proof among them also *authorizes*
     /// here from the moment it arrives, without the frame calling `authorize()` on it. Passing a proof is therefore
-    /// the act of lending the authority it carries, and a caller that only wants the callee to inspect a proof has
-    /// no way to say so.
+    /// the act of lending the authority it carries.
     pub fn include_refs_in_scope(&mut self, values: &IndexedWellKnownTypes) {
         for addr in values.referenced_substates() {
             // Never able to bring these into scope

--- a/crates/engine/src/runtime/scope.rs
+++ b/crates/engine/src/runtime/scope.rs
@@ -312,6 +312,11 @@ impl CallScope {
         }
     }
 
+    /// Brings what a caller passed in as arguments into this frame. Buckets and proofs stay the caller's — they are
+    /// recorded as inherited, so this frame need not account for them — but a proof among them also *authorizes*
+    /// here from the moment it arrives, without the frame calling `authorize()` on it. Passing a proof is therefore
+    /// the act of lending the authority it carries, and a caller that only wants the callee to inspect a proof has
+    /// no way to say so.
     pub fn include_refs_in_scope(&mut self, values: &IndexedWellKnownTypes) {
         for addr in values.referenced_substates() {
             // Never able to bring these into scope

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -1193,7 +1193,13 @@ impl<TStore: StateReader> WorkingState<TStore> {
         address: T,
     ) -> Result<AddressAllocationId, RuntimeError> {
         let id = self.address_allocation_id;
-        self.address_allocation_id += 1;
+        self.address_allocation_id = self
+            .address_allocation_id
+            .checked_add(1)
+            .ok_or(RuntimeError::InvariantError {
+                function: "new_address_allocation",
+                details: "address allocation id counter overflowed".to_string(),
+            })?;
         let current_template = self.current_template().ok().copied();
         self.address_allocations
             .insert(id, AllocatedAddress::new(address.into(), current_template));
@@ -2039,7 +2045,15 @@ impl<TStore: StateReader> WorkingState<TStore> {
                         // If there are no fees left, do not up the fee pool
                         continue;
                     }
-                    Substate::new(existing_state.version() + 1, substate)
+                    let version =
+                        existing_state
+                            .version()
+                            .checked_add(1)
+                            .ok_or_else(|| RuntimeError::InvariantError {
+                                function: "generate_substate_diff",
+                                details: format!("version of substate {id} overflowed"),
+                            })?;
+                    Substate::new(version, substate)
                 },
                 None => Substate::new(0, substate),
             };


### PR DESCRIPTION
Engine audit wave 4, last of four. Defence-in-depth items with no behaviour change a template can see. Independent of #2591, #2592 and #2593; small overlaps in `working_state.rs` and `error.rs`, so whichever lands later needs a rebase.

## MSM pricing decoded its argument twice

`price(RISTRETTO_MSM)` did `args.get::<Vec<RistrettoPublicKeyBytes>>(0)?.len()` — a full CBOR decode of the point vector to read one number — and `dispatch` then decoded the same vector again. Pricing must not do work proportional to the input it is pricing: that first decode runs *before* anything is charged, so a caller gets it for free, and `max_call_size` allows a few thousand points.

The term count now comes from the encoded length of argument 0 divided by the smallest a point can encode to (32 bytes plus a CBOR byte-string header). That bounds the count from above, so the charge is never short, and a new unit test pins the per-point minimum so a future encoding change cannot silently make the bound wrong. This matches how `per_byte` already prices the hash and Schnorr intrinsics.

## Unchecked arithmetic

Three sites get what `LockedSubstates::next_id` already had:

- `address_allocation_id += 1` — u32 counter in `new_address_allocation`
- `existing_state.version() + 1` — u32 version bump in `generate_substate_diff`
- `*count_mut -= 1` — usize read-lock refcount in `try_unlock`

None is reachable today. The point is the failure mode if one ever becomes reachable: the release profile is `panic = 'abort'`, so an overflow takes the validator down rather than failing the transaction.

## `IsNotFoundError for RuntimeError` was too wide

It classified eight variants as not-found: `SubstateNotFound`, `ComponentNotFound`, `VaultNotFound`, `BucketNotFound`, `ResourceNotFound`, `NonFungibleNotFound`, `ProofNotFound`, `VirtualSubstateNotFound`.

Most of those are not "the ledger does not have this". A missing bucket or proof means a call is wrong about what is in its scope — which is exactly the kind of error that must surface, not become `None`. No current `.optional()` caller reaches one, but the trait is an open invitation: the next `.optional()` added anywhere in the engine would swallow them silently.

Narrowed to `SubstateNotFound` and a not-found `StateStoreError`, which is what all six existing callers mean. `ComponentNotFound` is never constructed anywhere in the workspace, so it goes too.

## Documentation

Passing a `Proof` as an argument authorizes it in the callee, with no `authorize()` call — `include_refs_in_scope` routes argument proofs through `add_proof_to_scope`, which adds to the auth scope. `add_proof_to_scope` said so; the crossing point did not, which is where a reader is when the question arises. Now noted there, including the consequence: a caller that wants a callee to merely inspect a proof has no way to say so.

## Already done elsewhere

Two items from the audit list were fixed by wave 1 and needed nothing here: the `expect`s in `finalize_fees_and_refunds` (#2579) and the stale comment in `check_component_scope` (#2575).

## Tests

- `encoded_point_len_is_at_least_the_minimum` — pins the constant the MSM price divides by.
- Full `-p tari_engine -p tari_engine_types` suite: 512 passed.
