### PR TITLE
feat(transaction): add put_workspace alias on the transaction builder

### DIFF
--- a/crates/transaction/src/builder/mod.rs
+++ b/crates/transaction/src/builder/mod.rs
@@ -558,6 +558,11 @@ impl<D> TransactionBuilder<D> {
         self.add_instruction(Instruction::PutLastInstructionOutputOnWorkspace { key })
     }
 
+    /// Alias for [`Self::put_last_instruction_output_on_workspace`].
+    pub fn put_workspace<T: Into<BuilderWorkspaceKey>>(self, label: T) -> Self {
+        self.put_last_instruction_output_on_workspace(label)
+    }
+
     pub fn take_from_bucket<I: Into<BuilderWorkspaceKey>, A: Into<Amount>, O: Into<BuilderWorkspaceKey>>(
         mut self,
         label: I,


### PR DESCRIPTION
`put_last_instruction_output_on_workspace` is the most-used call in builder chains. This adds a short `put_workspace` alias that forwards to it; the original name is unchanged, so nothing else needs to move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A357R7azUjRU9qwrRwVi4i