### PR TITLE
feat(substate)!: widen the substate version to u64

### DIFF
--- a/applications/tari_indexer/src/rest_api/handlers/substates.rs
+++ b/applications/tari_indexer/src/rest_api/handlers/substates.rs
@@ -48,7 +48,7 @@ fn substate_lookup_error(e: SubstateManagerError) -> ErrorResponse {
     params(
         ("substate_id" = String, Path, description = "The substate ID to fetch"),
         ("local_search_only" = bool, Query, description = "If true, only search local storage for the substate"),
-        ("version" = Option<u32>, Query, description = "Minimum version of the substate to fetch"),
+        ("version" = Option<u64>, Query, description = "Minimum version of the substate to fetch"),
     ),
     responses(
         (status = 200, description = "Substate details", body = GetSubstateResponse),

--- a/applications/tari_indexer/src/storage_sqlite/migrations/2026-09-11-000000_substate_version_u64/down.sql
+++ b/applications/tari_indexer/src/storage_sqlite/migrations/2026-09-11-000000_substate_version_u64/down.sql
@@ -1,0 +1,125 @@
+alter table substates rename to substates_old;
+
+create table substates
+(
+    id               integer   not NULL primary key AUTOINCREMENT,
+    address          text      not NULL,
+    version          int       not NULL,
+    data             text      not NULL,
+    template_address text      NULL,
+    module_name      text      NULL,
+    updated_at       timestamp not null default current_timestamp,
+    created_at       timestamp not null default current_timestamp
+);
+
+insert into substates (id, address, version, data, template_address, module_name, updated_at, created_at)
+select id, address, version, data, template_address, module_name, updated_at, created_at
+from substates_old;
+
+drop table substates_old;
+
+create unique index uniq_substates_address on substates (address);
+
+alter table substate_transitions rename to substate_transitions_old;
+
+create table substate_transitions
+(
+    id            integer   not NULL primary key AUTOINCREMENT,
+    shard         int       not NULL,
+    state_version bigint    not NULL,
+    epoch         bigint    not NULL,
+    substate_id   text      not NULL,
+    version       int       not NULL,
+    substate_type text      not NULL,
+    is_up         bool      not NULL,
+    value_hash    text      NULL,
+    created_at    timestamp not null default current_timestamp
+);
+
+insert into substate_transitions (id, shard, state_version, epoch, substate_id, version, substate_type, is_up,
+                                 value_hash, created_at)
+select id,
+       shard,
+       state_version,
+       epoch,
+       substate_id,
+       version,
+       substate_type,
+       is_up,
+       value_hash,
+       created_at
+from substate_transitions_old;
+
+drop table substate_transitions_old;
+
+create unique index substate_transitions_substate_id_version_uniq on substate_transitions (substate_id, version, is_up);
+create index substate_transitions_shard_state_version_idx on substate_transitions (shard, state_version);
+
+alter table utxos rename to utxos_old;
+
+create table utxos
+(
+    id               integer   not NULL primary key AUTOINCREMENT,
+    commitment       text      not NULL,
+    public_nonce     text      not NULL,
+    version          int       not NULL,
+    resource_address text      not NULL,
+    shard            int       not NULL,
+    state_version    bigint    not NULL,
+    output           blob      NULL,
+    utxo_tag         int       not NULL,
+    epoch            bigint    not NULL,
+    is_spent         boolean   not NULL,
+    is_burnt         boolean   not NULL,
+    is_frozen        boolean   not NULL,
+    created_at       timestamp not null default current_timestamp
+);
+
+insert into utxos (id, commitment, public_nonce, version, resource_address, shard, state_version, output, utxo_tag,
+                   epoch, is_spent, is_burnt, is_frozen, created_at)
+select id,
+       commitment,
+       public_nonce,
+       version,
+       resource_address,
+       shard,
+       state_version,
+       output,
+       utxo_tag,
+       epoch,
+       is_spent,
+       is_burnt,
+       is_frozen,
+       created_at
+from utxos_old;
+
+drop table utxos_old;
+
+CREATE INDEX utxos_resource_state_version_shard_epoch_idx ON utxos (resource_address, state_version, shard, epoch);
+CREATE UNIQUE INDEX utxos_resource_public_nonce_utxo_tag_uniq_partial ON utxos (resource_address, public_nonce, utxo_tag) WHERE is_spent = false;
+
+drop table substate_cache;
+
+create table substate_cache
+(
+    substate_id     text    not null primary key,
+    version         integer null,
+    verified        boolean not null,
+    substate_result blob    not null,
+    cached_at       bigint  not null
+);
+
+create index idx_substate_cache_evict on substate_cache (cached_at);
+
+drop table substate_cache_invalidations;
+
+create table substate_cache_invalidations
+(
+    substate_id      text    not null primary key,
+    state_version    bigint  not null,
+    substate_version integer not null,
+    spent            boolean not null,
+    invalidated_at   bigint  not null
+);
+
+create index idx_substate_cache_invalidations_expiry on substate_cache_invalidations (invalidated_at);

--- a/applications/tari_indexer/src/storage_sqlite/migrations/2026-09-11-000000_substate_version_u64/up.sql
+++ b/applications/tari_indexer/src/storage_sqlite/migrations/2026-09-11-000000_substate_version_u64/up.sql
@@ -1,0 +1,138 @@
+-- Widen every substate version column to hold a u64.
+--
+-- A version counts one write per transaction that touches the substate, so its ceiling is a
+-- throughput ceiling on a single contended substate, not a calendar one. The column must hold the
+-- full range the protocol admits, which a signed 32-bit integer does not.
+--
+-- SQLite cannot change a column's declared type in place, so each table that keeps its rows is
+-- rebuilt around the new declaration; the two derived caches are recreated empty and refilled from
+-- the committee on demand.
+
+alter table substates rename to substates_old;
+
+create table substates
+(
+    id               integer   not NULL primary key AUTOINCREMENT,
+    address          text      not NULL,
+    version          bigint    not NULL,
+    data             text      not NULL,
+    template_address text      NULL,
+    module_name      text      NULL,
+    updated_at       timestamp not null default current_timestamp,
+    created_at       timestamp not null default current_timestamp
+);
+
+insert into substates (id, address, version, data, template_address, module_name, updated_at, created_at)
+select id, address, version, data, template_address, module_name, updated_at, created_at
+from substates_old;
+
+drop table substates_old;
+
+create unique index uniq_substates_address on substates (address);
+
+alter table substate_transitions rename to substate_transitions_old;
+
+create table substate_transitions
+(
+    id            integer   not NULL primary key AUTOINCREMENT,
+    shard         int       not NULL,
+    state_version bigint    not NULL,
+    epoch         bigint    not NULL,
+    substate_id   text      not NULL,
+    version       bigint    not NULL,
+    substate_type text      not NULL,
+    is_up         bool      not NULL,
+    value_hash    text      NULL,
+    created_at    timestamp not null default current_timestamp
+);
+
+insert into substate_transitions (id, shard, state_version, epoch, substate_id, version, substate_type, is_up,
+                                 value_hash, created_at)
+select id,
+       shard,
+       state_version,
+       epoch,
+       substate_id,
+       version,
+       substate_type,
+       is_up,
+       value_hash,
+       created_at
+from substate_transitions_old;
+
+drop table substate_transitions_old;
+
+create unique index substate_transitions_substate_id_version_uniq on substate_transitions (substate_id, version, is_up);
+create index substate_transitions_shard_state_version_idx on substate_transitions (shard, state_version);
+
+alter table utxos rename to utxos_old;
+
+create table utxos
+(
+    id               integer   not NULL primary key AUTOINCREMENT,
+    commitment       text      not NULL,
+    public_nonce     text      not NULL,
+    version          bigint    not NULL,
+    resource_address text      not NULL,
+    shard            int       not NULL,
+    state_version    bigint    not NULL,
+    output           blob      NULL,
+    utxo_tag         int       not NULL,
+    epoch            bigint    not NULL,
+    is_spent         boolean   not NULL,
+    is_burnt         boolean   not NULL,
+    is_frozen        boolean   not NULL,
+    created_at       timestamp not null default current_timestamp
+);
+
+insert into utxos (id, commitment, public_nonce, version, resource_address, shard, state_version, output, utxo_tag,
+                   epoch, is_spent, is_burnt, is_frozen, created_at)
+select id,
+       commitment,
+       public_nonce,
+       version,
+       resource_address,
+       shard,
+       state_version,
+       output,
+       utxo_tag,
+       epoch,
+       is_spent,
+       is_burnt,
+       is_frozen,
+       created_at
+from utxos_old;
+
+drop table utxos_old;
+
+CREATE INDEX utxos_resource_state_version_shard_epoch_idx ON utxos (resource_address, state_version, shard, epoch);
+CREATE UNIQUE INDEX utxos_resource_public_nonce_utxo_tag_uniq_partial ON utxos (resource_address, public_nonce, utxo_tag) WHERE is_spent = false;
+
+drop table substate_cache;
+
+create table substate_cache
+(
+    substate_id     text    not null primary key,
+    -- The substate's head version, or null when the substate does not exist.
+    version         bigint  null,
+    verified        boolean not null,
+    substate_result blob    not null,
+    cached_at       bigint  not null
+);
+
+create index idx_substate_cache_evict on substate_cache (cached_at);
+
+drop table substate_cache_invalidations;
+
+create table substate_cache_invalidations
+(
+    substate_id      text    not null primary key,
+    state_version    bigint  not null,
+    -- The substate version the transition showed: the version created, or the version destroyed.
+    substate_version bigint  not null,
+    -- Whether `substate_version` was destroyed rather than created.
+    spent            boolean not null,
+    invalidated_at   bigint  not null
+);
+
+create index idx_substate_cache_invalidations_expiry on substate_cache_invalidations (invalidated_at);

--- a/applications/tari_indexer/src/storage_sqlite/models/substate.rs
+++ b/applications/tari_indexer/src/storage_sqlite/models/substate.rs
@@ -39,7 +39,7 @@ use crate::{
 pub struct SubstateRecord {
     pub id: i32,
     pub address: String,
-    pub version: i32,
+    pub version: i64,
     pub data: String,
     pub template_address: Option<String>,
     pub module_name: Option<String>,
@@ -57,7 +57,7 @@ impl TryFrom<SubstateRecord> for SubstateResponse {
                 item: "Substate",
                 details: format!("Invalid substate address {}: {}", row.address, e),
             })?,
-            version: row.version as u32,
+            version: row.version as u64,
             substate: deserialize_json(&row.data)?,
         })
     }
@@ -67,7 +67,7 @@ impl TryFrom<SubstateRecord> for SubstateResponse {
 #[diesel(table_name = substates)]
 pub struct NewSubstate {
     pub address: String,
-    pub version: i32,
+    pub version: i64,
     pub data: String,
     pub template_address: Option<String>,
     pub module_name: Option<String>,

--- a/applications/tari_indexer/src/storage_sqlite/models/substate_cache.rs
+++ b/applications/tari_indexer/src/storage_sqlite/models/substate_cache.rs
@@ -8,7 +8,7 @@ use tari_indexer_lib::substate_cache::caches_nonexistence;
 pub(crate) struct SubstateCacheRow {
     #[allow(dead_code)]
     pub substate_id: String,
-    pub version: Option<i32>,
+    pub version: Option<i64>,
     pub verified: bool,
     pub substate_result: Vec<u8>,
     pub cached_at: i64,
@@ -23,9 +23,9 @@ pub(crate) struct SubstateCacheRow {
 #[derive(Debug, Clone)]
 pub struct SubstateCacheInvalidation {
     substate_id: SubstateId,
-    retires_up_to: Option<u32>,
+    retires_up_to: Option<u64>,
     retires_nonexistence: bool,
-    observed_version: u32,
+    observed_version: u64,
     spent: bool,
 }
 
@@ -37,7 +37,7 @@ impl SubstateCacheInvalidation {
     /// retraction of a cached nonexistence. Where nothing caches that, it carries nothing, and is
     /// not one of these at all: emitting it would put a journal row on the sync path for every
     /// created-once substate in the stream and buy nothing with it.
-    pub fn created(substate_id: &SubstateId, version: u32) -> Option<Self> {
+    pub fn created(substate_id: &SubstateId, version: u64) -> Option<Self> {
         let retires_up_to = version.checked_sub(1);
         let retires_nonexistence = caches_nonexistence(substate_id);
         if retires_up_to.is_none() && !retires_nonexistence {
@@ -56,7 +56,7 @@ impl SubstateCacheInvalidation {
     ///
     /// A destroy leaves a cached nonexistence alone. `DoesNotExist` says the substate has no live
     /// version, which a destroy makes more true rather than less.
-    pub fn destroyed(substate_id: SubstateId, version: u32) -> Self {
+    pub fn destroyed(substate_id: SubstateId, version: u64) -> Self {
         Self {
             substate_id,
             retires_up_to: Some(version),
@@ -72,7 +72,7 @@ impl SubstateCacheInvalidation {
 
     /// The version the stream showed the substate at: created at it, or destroyed at it. A head
     /// below this is one the substate has already been watched past, whoever offers it.
-    pub fn observed_version(&self) -> u32 {
+    pub fn observed_version(&self) -> u64 {
         self.observed_version
     }
 
@@ -85,7 +85,7 @@ impl SubstateCacheInvalidation {
     }
 
     /// The highest cached head version this retires, if any.
-    pub fn retires_up_to(&self) -> Option<u32> {
+    pub fn retires_up_to(&self) -> Option<u64> {
         self.retires_up_to
     }
 

--- a/applications/tari_indexer/src/storage_sqlite/models/utxo.rs
+++ b/applications/tari_indexer/src/storage_sqlite/models/utxo.rs
@@ -15,7 +15,7 @@ use crate::storage_sqlite::{schema::utxos, serialization::deserialize_bincode};
 #[diesel(table_name = utxos)]
 pub(crate) struct UtxoRecordUpdate {
     pub epoch: Option<i64>,
-    pub version: Option<i32>,
+    pub version: Option<i64>,
     pub output: Option<Option<Vec<u8>>>,
     pub state_version: Option<i64>,
     pub is_spent: Option<bool>,
@@ -28,7 +28,7 @@ pub(crate) struct UtxoRecordUpdate {
 pub(crate) struct UtxoRecordInsert {
     pub commitment: String,
     pub public_nonce: String,
-    pub version: i32,
+    pub version: i64,
     pub shard: i32,
     pub resource_address: String,
     pub state_version: i64,
@@ -45,7 +45,7 @@ pub(crate) struct UtxoRecord {
     pub _id: i32,
     pub commitment: String,
     pub _public_nonce: String,
-    pub version: i32,
+    pub version: i64,
     pub resource_address: String,
     pub _shard: i32,
     pub state_version: i64,
@@ -69,7 +69,7 @@ impl UtxoRecord {
                         StateVersion::new(self.state_version as u64),
                         WalletUtxoUpdate::Burnt(UtxoBurnt {
                             id,
-                            version: self.version as u32,
+                            version: self.version as u64,
                         }),
                     ))
                 } else {
@@ -77,7 +77,7 @@ impl UtxoRecord {
                         StateVersion::new(self.state_version as u64),
                         WalletUtxoUpdate::Spent(UtxoSpent {
                             id,
-                            version: self.version as u32,
+                            version: self.version as u64,
                         }),
                     ))
                 }

--- a/applications/tari_indexer/src/storage_sqlite/models/utxo_update.rs
+++ b/applications/tari_indexer/src/storage_sqlite/models/utxo_update.rs
@@ -15,7 +15,7 @@ pub enum UtxoUpdateRecord {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UtxoUnspent {
     pub address: UtxoAddress,
-    pub version: u32,
+    pub version: u64,
     pub shard: Shard,
     pub state_version: StateVersion,
     pub utxo_output: UtxoOutput,
@@ -25,7 +25,7 @@ pub struct UtxoUnspent {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UtxoSpent {
     pub address: UtxoAddress,
-    pub version: u32,
+    pub version: u64,
     pub shard: Shard,
     pub state_version: StateVersion,
 }

--- a/applications/tari_indexer/src/storage_sqlite/reader.rs
+++ b/applications/tari_indexer/src/storage_sqlite/reader.rs
@@ -163,7 +163,7 @@ impl IndexerStoreReadTransaction for SqliteStoreReadTransaction<'_> {
                 let substate_id = SubstateId::from_str(&s.address).map_err(|e| StorageError::DataInconsistency {
                     details: format!("Invalid substate address {}: {}", s.address, e),
                 })?;
-                let version = s.version as u32;
+                let version = s.version as u64;
                 let template_address = s.template_address.map(|h| deserialize_hex_try_from(&h)).transpose()?;
                 let timestamp = s.updated_at;
                 Ok(ListSubstateItem {
@@ -185,7 +185,7 @@ impl IndexerStoreReadTransaction for SqliteStoreReadTransaction<'_> {
     fn get_substate(
         &mut self,
         address: &SubstateId,
-        version: Option<u32>,
+        version: Option<u64>,
     ) -> Result<Option<SubstateRecord>, StorageError> {
         use crate::storage_sqlite::schema::substates;
 
@@ -193,7 +193,7 @@ impl IndexerStoreReadTransaction for SqliteStoreReadTransaction<'_> {
             .into_boxed()
             .filter(substates::address.eq(address.to_string()));
         if let Some(version) = version {
-            substate_query = substate_query.filter(substates::version.eq(version as i32));
+            substate_query = substate_query.filter(substates::version.eq(version as i64));
         } else {
             substate_query = substate_query.order_by(substates::version.desc())
         }
@@ -1178,7 +1178,7 @@ impl IndexerStoreReadTransaction for SqliteStoreReadTransaction<'_> {
 
         row.map(|row| {
             Ok(SubstateCacheEntry {
-                version: row.version.map(|v| v as u32),
+                version: row.version.map(|v| v as u64),
                 substate_result: deserialize_bincode(&row.substate_result)?,
                 cached_at: row.cached_at as u64,
                 verified: row.verified,

--- a/applications/tari_indexer/src/storage_sqlite/schema.rs
+++ b/applications/tari_indexer/src/storage_sqlite/schema.rs
@@ -55,7 +55,7 @@ diesel::table! {
         state_version -> BigInt,
         epoch -> BigInt,
         substate_id -> Text,
-        version -> Integer,
+        version -> BigInt,
         substate_type -> Text,
         is_up -> Bool,
         value_hash -> Nullable<Text>,
@@ -67,7 +67,7 @@ diesel::table! {
     substates (id) {
         id -> Integer,
         address -> Text,
-        version -> Integer,
+        version -> BigInt,
         data -> Text,
         template_address -> Nullable<Text>,
         module_name -> Nullable<Text>,
@@ -114,7 +114,7 @@ diesel::table! {
         id -> Integer,
         commitment -> Text,
         public_nonce -> Text,
-        version -> Integer,
+        version -> BigInt,
         resource_address -> Text,
         shard -> Integer,
         state_version -> BigInt,
@@ -143,7 +143,7 @@ diesel::table! {
 diesel::table! {
     substate_cache (substate_id) {
         substate_id -> Text,
-        version -> Nullable<Integer>,
+        version -> Nullable<BigInt>,
         verified -> Bool,
         substate_result -> Binary,
         cached_at -> BigInt,
@@ -154,7 +154,7 @@ diesel::table! {
     substate_cache_invalidations (substate_id) {
         substate_id -> Text,
         state_version -> BigInt,
-        substate_version -> Integer,
+        substate_version -> BigInt,
         spent -> Bool,
         invalidated_at -> BigInt,
     }

--- a/applications/tari_indexer/src/storage_sqlite/store_factory.rs
+++ b/applications/tari_indexer/src/storage_sqlite/store_factory.rs
@@ -1097,7 +1097,7 @@ mod tests {
     async fn put_entry(
         store: &SqliteIndexerStore,
         id: &SubstateId,
-        version: u32,
+        version: u64,
         verified: bool,
         cached_at: u64,
         watermark: u64,
@@ -1122,13 +1122,13 @@ mod tests {
             .unwrap()
     }
 
-    async fn put(store: &SqliteIndexerStore, id: &SubstateId, version: u32, watermark: u64) -> bool {
+    async fn put(store: &SqliteIndexerStore, id: &SubstateId, version: u64, watermark: u64) -> bool {
         put_entry(store, id, version, true, now_secs(), watermark).await
     }
 
     /// A committee member answering that `version` is live, as against the `Down` every other put
     /// helper here records.
-    async fn put_up(store: &SqliteIndexerStore, id: &SubstateId, version: u32, watermark: u64) -> bool {
+    async fn put_up(store: &SqliteIndexerStore, id: &SubstateId, version: u64, watermark: u64) -> bool {
         use tari_engine_types::{
             non_fungible::NonFungibleContainer,
             substate::{Substate, SubstateValue},
@@ -1161,7 +1161,7 @@ mod tests {
 
     /// The cached head version. `None` covers both no row at all and a row recording that the
     /// substate does not exist; use [`read_entry`] where the two must be told apart.
-    async fn read(store: &SqliteIndexerStore, id: &SubstateId) -> Option<u32> {
+    async fn read(store: &SqliteIndexerStore, id: &SubstateId) -> Option<u64> {
         read_entry(store, id).await.and_then(|entry| entry.version)
     }
 

--- a/applications/tari_indexer/src/storage_sqlite/writer.rs
+++ b/applications/tari_indexer/src/storage_sqlite/writer.rs
@@ -133,7 +133,7 @@ impl IndexerStoreWriteTransaction for SqliteStoreWriteTransaction<'_> {
                             substate_transitions::epoch.eq(epoch.as_u64() as i64),
                             substate_transitions::substate_id.eq(proof.substate_id().to_string()),
                             substate_transitions::substate_type.eq(SubstateType::from(proof.substate_id()).to_string()),
-                            substate_transitions::version.eq(proof.version() as i32),
+                            substate_transitions::version.eq(proof.version() as i64),
                             substate_transitions::is_up.eq(proof.is_create()),
                             substate_transitions::value_hash.eq(proof.as_create().map(|v| {
                                 serialize_hex(v.substate.value.to_value_hash(network, proof.version(), epoch))
@@ -165,7 +165,7 @@ impl IndexerStoreWriteTransaction for SqliteStoreWriteTransaction<'_> {
                     let insert = UtxoRecordInsert {
                         commitment,
                         public_nonce: serialize_hex(unspent.utxo_output.output.public_nonce),
-                        version: unspent.version as i32,
+                        version: unspent.version as i64,
                         output: Some(serialize_bincode(&unspent.utxo_output)?),
                         shard: unspent.shard.as_u32() as i32,
                         resource_address,
@@ -187,7 +187,7 @@ impl IndexerStoreWriteTransaction for SqliteStoreWriteTransaction<'_> {
                     let commitment = spent.address.id().to_commitment_hex_string();
                     let update = UtxoRecordUpdate {
                         epoch: Some(epoch.as_u64() as i64),
-                        version: Some(spent.version as i32),
+                        version: Some(spent.version as i64),
                         // Prune the UTXO data for spent outputs
                         output: Some(None),
                         // Update to deleted state version
@@ -218,7 +218,7 @@ impl IndexerStoreWriteTransaction for SqliteStoreWriteTransaction<'_> {
             .map(|c| c.template_address().to_string());
         let new_substate = NewSubstate {
             address: substate.substate_id.to_string(),
-            version: substate.version as i32,
+            version: substate.version as i64,
             data: substate
                 .value
                 .value()
@@ -544,7 +544,7 @@ impl IndexerStoreWriteTransaction for SqliteStoreWriteTransaction<'_> {
         use crate::storage_sqlite::schema::{substate_cache, substate_cache_invalidations};
 
         let id = substate_id.to_string();
-        let version = entry.version.map(|v| v as i32);
+        let version = entry.version.map(|v| v as i64);
 
         // Nothing journals a first creation for a substate outside `caches_nonexistence`, so a
         // record here that one does not exist could never be retracted and would stand until it
@@ -559,7 +559,7 @@ impl IndexerStoreWriteTransaction for SqliteStoreWriteTransaction<'_> {
 
         // Read inside this transaction so that the journal and the insert cannot straddle a
         // concurrent invalidation commit.
-        let journalled: Option<(i64, i32, bool)> = substate_cache_invalidations::table
+        let journalled: Option<(i64, i64, bool)> = substate_cache_invalidations::table
             .select((
                 substate_cache_invalidations::state_version,
                 substate_cache_invalidations::substate_version,
@@ -612,7 +612,7 @@ impl IndexerStoreWriteTransaction for SqliteStoreWriteTransaction<'_> {
         }
 
         // A committee member that is behind can answer with a version below the head already held.
-        let cached: Option<(Option<i32>, bool, i64)> = substate_cache::table
+        let cached: Option<(Option<i64>, bool, i64)> = substate_cache::table
             .select((
                 substate_cache::version,
                 substate_cache::verified,
@@ -822,7 +822,7 @@ impl SqliteStoreWriteTransaction<'_> {
             retired += diesel::delete(
                 substate_cache::table
                     .filter(substate_cache::substate_id.eq(&id))
-                    .filter(substate_cache::version.le(retires_up_to as i32)),
+                    .filter(substate_cache::version.le(retires_up_to as i64)),
             )
             .execute(self.connection())
             .map_err(|e| StorageError::general(OPERATION, e))?;
@@ -842,7 +842,7 @@ impl SqliteStoreWriteTransaction<'_> {
             .values((
                 substate_cache_invalidations::substate_id.eq(&id),
                 substate_cache_invalidations::state_version.eq(state_version.as_u64() as i64),
-                substate_cache_invalidations::substate_version.eq(invalidation.observed_version() as i32),
+                substate_cache_invalidations::substate_version.eq(invalidation.observed_version() as i64),
                 substate_cache_invalidations::spent.eq(invalidation.is_observed_version_spent()),
                 substate_cache_invalidations::invalidated_at.eq(now),
             ))
@@ -853,7 +853,7 @@ impl SqliteStoreWriteTransaction<'_> {
                 // A floor only ever rises. The transitions of one batch arrive in no stated order,
                 // and a destroy of the version below a creation must not lower what the creation
                 // showed.
-                substate_cache_invalidations::substate_version.eq(diesel::dsl::sql::<diesel::sql_types::Integer>(
+                substate_cache_invalidations::substate_version.eq(diesel::dsl::sql::<diesel::sql_types::BigInt>(
                     "max(substate_version, excluded.substate_version)",
                 )),
                 // The provenance belongs to whichever version the floor ends up holding, so it

--- a/applications/tari_indexer/src/store.rs
+++ b/applications/tari_indexer/src/store.rs
@@ -104,7 +104,7 @@ pub trait IndexerStoreReadTransaction {
     fn get_substate(
         &mut self,
         address: &SubstateId,
-        version: Option<u32>,
+        version: Option<u64>,
     ) -> Result<Option<SubstateRecord>, StorageError>;
 
     fn get_substates(&mut self, ids: &[SubstateId]) -> Result<HashMap<SubstateId, Substate>, StorageError>;

--- a/applications/tari_indexer/src/substate_cache/mod.rs
+++ b/applications/tari_indexer/src/substate_cache/mod.rs
@@ -310,7 +310,7 @@ mod tests {
     }
 
     async fn cache_with_head(
-        version: u32,
+        version: u64,
         confirm_shard: bool,
     ) -> (tempfile::TempDir, SqliteSubstateCache, SubstateId) {
         let dir = tempfile::tempdir().unwrap();
@@ -429,7 +429,7 @@ mod tests {
         assert!(head_cache.read(&head_id).await.unwrap().is_some());
     }
 
-    async fn write_head(cache: &SqliteSubstateCache, id: &SubstateId, version: u32, watermark: u64) {
+    async fn write_head(cache: &SqliteSubstateCache, id: &SubstateId, version: u64, watermark: u64) {
         let result = SubstateResult::Down { version };
         cache
             .write(
@@ -448,7 +448,7 @@ mod tests {
 
     /// A committee member answering that `version` is live, as against the `Down` [`write_head`]
     /// records.
-    async fn write_live_head(cache: &SqliteSubstateCache, id: &SubstateId, version: u32, watermark: u64) {
+    async fn write_live_head(cache: &SqliteSubstateCache, id: &SubstateId, version: u64, watermark: u64) {
         use tari_engine_types::{
             non_fungible::NonFungibleContainer,
             substate::{Substate, SubstateValue},

--- a/applications/tari_indexer/src/substate_manager.rs
+++ b/applications/tari_indexer/src/substate_manager.rs
@@ -68,7 +68,7 @@ use crate::{
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SubstateResponse {
     pub id: SubstateId,
-    pub version: u32,
+    pub version: u64,
     pub substate: SubstateValue,
 }
 
@@ -375,7 +375,7 @@ impl SubstateManager {
     async fn get_substate_from_db(
         &self,
         substate_address: &SubstateId,
-        version: Option<u32>,
+        version: Option<u64>,
     ) -> Result<Option<SubstateResponse>, SubstateManagerError> {
         let substate_address = substate_address.clone();
         let row = self
@@ -409,7 +409,7 @@ pub enum SubstateManagerError {
     #[error("Storage error: {0}")]
     StorageError(#[from] StorageError),
     #[error("Input substate {substate_id} (v{version}) is down")]
-    InputSubstateIsDown { substate_id: SubstateId, version: u32 },
+    InputSubstateIsDown { substate_id: SubstateId, version: u64 },
     #[error("Input substate {substate_id} does not exist")]
     InputSubstateDoesNotExist { substate_id: SubstateId },
 }

--- a/applications/tari_walletd/src/handlers/accounts.rs
+++ b/applications/tari_walletd/src/handlers/accounts.rs
@@ -1946,7 +1946,7 @@ mod balance_change_handler_tests {
         // fsyncs dominate the test and scale with disk latency on CI.
         store
             .with_write_tx(|tx| {
-                for version in 2..=206u32 {
+                for version in 2..=206u64 {
                     tx.balance_changes_insert(
                         BalanceChangeSnapshot {
                             account_address: account,
@@ -1955,8 +1955,8 @@ mod balance_change_handler_tests {
                             resource_address: second_resource,
                             token_symbol: Some("TWO".to_string()),
                             divisibility: 2,
-                            revealed_before: Amount::from(199u64 + u64::from(version)),
-                            revealed_after: Amount::from(200u64 + u64::from(version)),
+                            revealed_before: Amount::from(199u64 + version),
+                            revealed_after: Amount::from(200u64 + version),
                             confidential_before: Amount::zero(),
                             confidential_after: Amount::zero(),
                         },

--- a/clients/tari_indexer_client/src/protobuf.rs
+++ b/clients/tari_indexer_client/src/protobuf.rs
@@ -53,14 +53,14 @@ pub struct UtxoUnspent {
 pub struct UtxoSpent {
     #[prost(bytes, tag = "1")]
     pub id: Vec<u8>,
-    #[prost(uint32, tag = "2")]
-    pub version: u32,
+    #[prost(uint64, tag = "2")]
+    pub version: u64,
 }
 
 #[derive(::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct UtxoBurnt {
     #[prost(bytes, tag = "1")]
     pub id: Vec<u8>,
-    #[prost(uint32, tag = "2")]
-    pub version: u32,
+    #[prost(uint64, tag = "2")]
+    pub version: u64,
 }

--- a/clients/tari_indexer_client/src/types.rs
+++ b/clients/tari_indexer_client/src/types.rs
@@ -43,7 +43,8 @@ pub struct ListSubstateItem {
     pub substate_id: SubstateId,
     #[cfg_attr(feature = "utoipa", schema(value_type = Option<String>))]
     pub module_name: Option<String>,
-    pub version: u32,
+    #[cfg_attr(feature = "ts", ts(type = "number"))]
+    pub version: u64,
     #[cfg_attr(feature = "utoipa", schema(value_type = Option<String>))]
     pub template_address: Option<TemplateAddress>,
     #[cfg_attr(feature = "ts", ts(type = "string"))]
@@ -58,7 +59,8 @@ pub struct ListSubstateItem {
 )]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct GetSubstateRequest {
-    pub version: Option<u32>,
+    #[cfg_attr(feature = "ts", ts(type = "number | null"))]
+    pub version: Option<u64>,
     #[serde(default)]
     pub local_search_only: bool,
 }
@@ -71,7 +73,8 @@ pub struct GetSubstateRequest {
 )]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct GetSubstateResponse {
-    pub version: u32,
+    #[cfg_attr(feature = "ts", ts(type = "number"))]
+    pub version: u64,
     #[cfg_attr(feature = "utoipa", schema(value_type = Object))]
     pub substate: SubstateValue,
     /// True when the indexer verified this substate's value against the shard group committee (via a
@@ -109,14 +112,16 @@ pub struct GetSubstatesResponse {
 pub struct InspectSubstateRequest {
     #[cfg_attr(feature = "utoipa", schema(value_type = String))]
     pub address: SubstateId,
-    pub version: Option<u32>,
+    #[cfg_attr(feature = "ts", ts(type = "number | null"))]
+    pub version: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export, export_to = "tari-indexer-client/"))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct InspectSubstateResponse {
-    pub version: u32,
+    #[cfg_attr(feature = "ts", ts(type = "number"))]
+    pub version: u64,
     #[cfg_attr(feature = "utoipa", schema(value_type = Object))]
     pub substate: SubstateValue,
 }
@@ -519,7 +524,8 @@ pub struct GetNonFungiblesResponse {
 pub struct NonFungibleSubstate {
     #[cfg_attr(feature = "utoipa", schema(value_type = String))]
     pub address: NonFungibleAddress,
-    pub version: u32,
+    #[cfg_attr(feature = "ts", ts(type = "number"))]
+    pub version: u64,
     #[cfg_attr(feature = "utoipa", schema(value_type = Object))]
     pub substate: SubstateValue,
 }
@@ -666,14 +672,16 @@ pub struct UtxoUnspent {
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub struct UtxoSpent {
     pub id: UtxoId,
-    pub version: u32,
+    #[cfg_attr(feature = "ts", ts(type = "number"))]
+    pub version: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub struct UtxoBurnt {
     pub id: UtxoId,
-    pub version: u32,
+    #[cfg_attr(feature = "ts", ts(type = "number"))]
+    pub version: u64,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -951,7 +959,8 @@ pub struct GetTransactionReceiptResponse {
 pub struct GetResourceResponse {
     #[cfg_attr(feature = "utoipa", schema(value_type = Object))]
     pub resource: Resource,
-    pub version: u32,
+    #[cfg_attr(feature = "ts", ts(type = "number"))]
+    pub version: u64,
     #[cfg_attr(feature = "utoipa", schema(value_type = Option<String>))]
     pub total_supply: Option<Amount>,
 }

--- a/clients/validator_node_client/src/types.rs
+++ b/clients/validator_node_client/src/types.rs
@@ -416,7 +416,8 @@ pub struct GetStateResponse {
 )]
 pub struct GetSubstateRequest {
     pub address: SubstateId,
-    pub version: u32,
+    #[cfg_attr(feature = "ts", ts(type = "number"))]
+    pub version: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/clients/wallet_daemon_client/src/types.rs
+++ b/clients/wallet_daemon_client/src/types.rs
@@ -1401,7 +1401,8 @@ pub struct WalletSubstateInfo {
     pub substate_id: SubstateId,
     pub parent_id: Option<SubstateId>,
     pub module_name: Option<String>,
-    pub version: u32,
+    #[cfg_attr(feature = "ts", ts(type = "number"))]
+    pub version: u64,
     pub template_address: Option<TemplateAddress>,
 }
 

--- a/crates/common_types/src/lock_intent.rs
+++ b/crates/common_types/src/lock_intent.rs
@@ -13,8 +13,8 @@ use crate::{SubstateAddress, ToSubstateAddress, VersionedSubstateIdRef};
 pub trait LockIntent {
     fn substate_id(&self) -> &SubstateId;
     fn lock_type(&self) -> SubstateLockType;
-    fn version_to_lock(&self) -> u32;
-    fn requested_version(&self) -> Option<u32>;
+    fn version_to_lock(&self) -> u64;
+    fn requested_version(&self) -> Option<u64>;
 
     fn to_versioned_substate_id_ref(&self) -> VersionedSubstateIdRef<'_> {
         VersionedSubstateIdRef::new(self.substate_id(), self.version_to_lock())

--- a/crates/common_types/src/substate_address.rs
+++ b/crates/common_types/src/substate_address.rs
@@ -33,10 +33,10 @@ pub struct SubstateAddress(
 );
 
 impl SubstateAddress {
-    pub const LENGTH: usize = ObjectKey::LENGTH + size_of::<u32>();
+    pub const LENGTH: usize = ObjectKey::LENGTH + size_of::<u64>();
 
     /// Defines the mapping of SubstateId,version to SubstateAddress
-    pub fn from_substate_id(id: &SubstateId, version: u32) -> Self {
+    pub fn from_substate_id(id: &SubstateId, version: u64) -> Self {
         Self::from_object_key(&id.to_object_key(), version)
     }
 
@@ -44,7 +44,7 @@ impl SubstateAddress {
         Self::from_substate_id(&tx_receipt.into(), 0)
     }
 
-    pub fn from_object_key(object_key: &ObjectKey, version: u32) -> Self {
+    pub fn from_object_key(object_key: &ObjectKey, version: u64) -> Self {
         // concatenate (entity_id, component_key), and version
         let mut buf = [0u8; SubstateAddress::LENGTH];
         buf[..ObjectKey::LENGTH].copy_from_slice(object_key);
@@ -66,10 +66,10 @@ impl SubstateAddress {
         }
         let obj_key_bytes = bytes.get(..ObjectKey::LENGTH).expect("length checked");
         let key = ObjectKey::try_from(obj_key_bytes).expect("ObjectKey length is correct");
-        let mut v_buf = [0u8; size_of::<u32>()];
+        let mut v_buf = [0u8; size_of::<u64>()];
         let version_bytes = bytes.get(ObjectKey::LENGTH..).expect("length checked");
         v_buf.copy_from_slice(version_bytes);
-        let version = u32::from_be_bytes(v_buf);
+        let version = u64::from_be_bytes(v_buf);
         Ok(Self::from_object_key(&key, version))
     }
 
@@ -97,7 +97,7 @@ impl SubstateAddress {
         Self([0xffu8; SubstateAddress::LENGTH])
     }
 
-    pub fn from_hash_and_version<T: Into<Hash32>>(hash: T, version: u32) -> Self {
+    pub fn from_hash_and_version<T: Into<Hash32>>(hash: T, version: u64) -> Self {
         // This will cause an error at compile-time if ObjectKey::LENGTH != Hash32::LENGTH
         // If ObjectKey should differ in length, then this function should ideally be removed.
         const _: () = [()][1 - (Hash32::LENGTH == ObjectKey::LENGTH) as usize];
@@ -111,7 +111,7 @@ impl SubstateAddress {
         Self::from_u256(address, 0)
     }
 
-    pub fn from_u256(address: U256, version: u32) -> Self {
+    pub fn from_u256(address: U256, version: u64) -> Self {
         let mut buf = [0u8; SubstateAddress::LENGTH];
         buf[..ObjectKey::LENGTH].copy_from_slice(&address.to_be_bytes());
         buf[ObjectKey::LENGTH..].copy_from_slice(&version.to_be_bytes());
@@ -256,7 +256,7 @@ impl ToSubstateAddress for &SubstateAddress {
     }
 }
 
-impl ToSubstateAddress for (&SubstateId, u32) {
+impl ToSubstateAddress for (&SubstateId, u64) {
     fn to_substate_address(&self) -> SubstateAddress {
         SubstateAddress::from_substate_id(self.0, self.1)
     }

--- a/crates/common_types/src/versioned_substate_id.rs
+++ b/crates/common_types/src/versioned_substate_id.rs
@@ -19,11 +19,12 @@ pub struct SubstateRequirement {
     #[cfg_attr(feature = "ts", ts(type = "string"))]
     pub substate_id: SubstateId,
     #[n(1)]
-    pub version: Option<u32>,
+    #[cfg_attr(feature = "ts", ts(type = "number | null"))]
+    pub version: Option<u64>,
 }
 
 impl SubstateRequirement {
-    pub const fn new(address: SubstateId, version: Option<u32>) -> Self {
+    pub const fn new(address: SubstateId, version: Option<u64>) -> Self {
         Self {
             substate_id: address,
             version,
@@ -37,7 +38,7 @@ impl SubstateRequirement {
         }
     }
 
-    pub fn versioned<T: Into<SubstateId>>(id: T, version: u32) -> Self {
+    pub fn versioned<T: Into<SubstateId>>(id: T, version: u64) -> Self {
         Self {
             substate_id: id.into(),
             version: Some(version),
@@ -56,11 +57,11 @@ impl SubstateRequirement {
         Self::unversioned(self.substate_id)
     }
 
-    pub fn version(&self) -> Option<u32> {
+    pub fn version(&self) -> Option<u64> {
         self.version
     }
 
-    pub fn with_version(self, version: u32) -> VersionedSubstateId {
+    pub fn with_version(self, version: u64) -> VersionedSubstateId {
         VersionedSubstateId::new(self.substate_id, version)
     }
 
@@ -191,15 +192,15 @@ impl Borrow<SubstateId> for SubstateRequirement {
 #[derive(Debug, Clone, Copy)]
 pub struct SubstateRequirementRef<'a> {
     pub substate_id: &'a SubstateId,
-    pub version: Option<u32>,
+    pub version: Option<u64>,
 }
 
 impl<'a> SubstateRequirementRef<'a> {
-    pub fn new(substate_id: &'a SubstateId, version: Option<u32>) -> Self {
+    pub fn new(substate_id: &'a SubstateId, version: Option<u64>) -> Self {
         Self { substate_id, version }
     }
 
-    pub fn versioned(substate_id: &'a SubstateId, version: u32) -> Self {
+    pub fn versioned(substate_id: &'a SubstateId, version: u64) -> Self {
         Self::new(substate_id, Some(version))
     }
 
@@ -211,7 +212,7 @@ impl<'a> SubstateRequirementRef<'a> {
         SubstateRequirement::new(self.substate_id.clone(), self.version)
     }
 
-    pub fn with_version(self, version: u32) -> VersionedSubstateIdRef<'a> {
+    pub fn with_version(self, version: u64) -> VersionedSubstateIdRef<'a> {
         VersionedSubstateIdRef::new(self.substate_id, version)
     }
 
@@ -220,7 +221,7 @@ impl<'a> SubstateRequirementRef<'a> {
         self.with_version(v)
     }
 
-    pub fn version(&self) -> Option<u32> {
+    pub fn version(&self) -> Option<u64> {
         self.version
     }
 
@@ -319,11 +320,12 @@ pub struct VersionedSubstateId {
     #[n(0)]
     substate_id: SubstateId,
     #[n(1)]
-    version: u32,
+    #[cfg_attr(feature = "ts", ts(type = "number"))]
+    version: u64,
 }
 
 impl VersionedSubstateId {
-    pub fn new<T: Into<SubstateId>>(substate_id: T, version: u32) -> Self {
+    pub fn new<T: Into<SubstateId>>(substate_id: T, version: u64) -> Self {
         Self {
             substate_id: substate_id.into(),
             version,
@@ -342,7 +344,7 @@ impl VersionedSubstateId {
         self.substate_id
     }
 
-    pub fn version(&self) -> u32 {
+    pub fn version(&self) -> u64 {
         self.version
     }
 
@@ -444,11 +446,11 @@ impl AsRef<SubstateId> for VersionedSubstateId {
 #[derive(Debug, Clone, Copy)]
 pub struct VersionedSubstateIdRef<'a> {
     pub substate_id: &'a SubstateId,
-    pub version: u32,
+    pub version: u64,
 }
 
 impl<'a> VersionedSubstateIdRef<'a> {
-    pub fn new(substate_id: &'a SubstateId, version: u32) -> Self {
+    pub fn new(substate_id: &'a SubstateId, version: u64) -> Self {
         Self { substate_id, version }
     }
 
@@ -463,7 +465,7 @@ impl<'a> VersionedSubstateIdRef<'a> {
         self.substate_id
     }
 
-    pub fn version(&self) -> u32 {
+    pub fn version(&self) -> u64 {
         self.version
     }
 

--- a/crates/consensus/src/hotstuff/block_change_set.rs
+++ b/crates/consensus/src/hotstuff/block_change_set.rs
@@ -721,9 +721,9 @@ mod tests {
             mem_new_sequence_transactions +
             mem_proposed_foreign_proposals +
             mem_proposed_utxo_mints;
-        // Last checked: 2024-06-03 (13,368000 bytes)
+        // Last checked: 2026-09-11 (14,328000 bytes)
         assert!(
-            total_mem < 14 * 1_000_000,
+            total_mem < 15 * 1_000_000,
             "Estimated max memory usage of ProposedBlockChangeSet is too high: {} bytes",
             total_mem
         );

--- a/crates/consensus/src/hotstuff/substate_store/pending_store.rs
+++ b/crates/consensus/src/hotstuff/substate_store/pending_store.rs
@@ -339,7 +339,7 @@ impl<'store, TTx: StateStoreReadTransaction> PendingSubstateStore<'store, TTx> {
         Ok(latest.is_some())
     }
 
-    pub fn get_many<I: IntoIterator<Item = (SubstateRequirement, u32)> + ExactSizeIterator>(
+    pub fn get_many<I: IntoIterator<Item = (SubstateRequirement, u64)> + ExactSizeIterator>(
         &self,
         ids: I,
     ) -> Result<HashMap<SubstateRequirement, Substate>, SubstateStoreError> {
@@ -966,7 +966,7 @@ impl LockStatus {
 
 #[derive(Debug, Clone)]
 pub struct LatestSubstateVersion {
-    version: u32,
+    version: u64,
     is_up: bool,
 }
 
@@ -979,7 +979,7 @@ impl LatestSubstateVersion {
         self.is_up
     }
 
-    pub fn version(&self) -> u32 {
+    pub fn version(&self) -> u64 {
         self.version
     }
 }

--- a/crates/consensus/src/hotstuff/transaction_manager/manager.rs
+++ b/crates/consensus/src/hotstuff/transaction_manager/manager.rs
@@ -401,7 +401,7 @@ impl<TStateStore: StateStore, TExecutor: BlockTransactionExecutor<TStateStore>>
         store: &mut PendingSubstateStore<TTx>,
         local_committee_info: &CommitteeInfo,
         transaction: &TransactionRecord,
-        local_versions: IndexMap<SubstateRequirementRef<'_>, u32>,
+        local_versions: IndexMap<SubstateRequirementRef<'_>, u64>,
         block: LeafBlock,
         execution_locked_epoch: LockedEpoch,
     ) -> Result<PreparedTransaction, BlockTransactionExecutorError> {
@@ -479,7 +479,7 @@ impl<TStateStore: StateStore, TExecutor: BlockTransactionExecutor<TStateStore>>
         store: &mut PendingSubstateStore<TTx>,
         local_committee_info: &CommitteeInfo,
         transaction: &TransactionRecord,
-        local_versions: IndexMap<SubstateRequirementRef<'_>, u32>,
+        local_versions: IndexMap<SubstateRequirementRef<'_>, u64>,
         non_local_inputs: IndexSet<SubstateRequirementRef<'_>>,
         block: LeafBlock,
     ) -> Result<PreparedTransaction, BlockTransactionExecutorError> {
@@ -545,7 +545,7 @@ impl<TStateStore: StateStore, TExecutor: BlockTransactionExecutor<TStateStore>>
         store: &mut PendingSubstateStore<TTx>,
         local_committee_info: &CommitteeInfo,
         transaction_id: TransactionId,
-        local_versions: IndexMap<SubstateRequirementRef<'_>, u32>,
+        local_versions: IndexMap<SubstateRequirementRef<'_>, u64>,
         non_local_inputs: IndexSet<SubstateRequirementRef<'_>>,
     ) -> Result<PreparedTransaction, BlockTransactionExecutorError> {
         // TODO: We do not know if the inputs locks required are Read/Write. Either we allow the user to
@@ -651,10 +651,10 @@ impl<TStateStore: StateStore, TExecutor: BlockTransactionExecutor<TStateStore>>
 
 enum ResolvedTransactionInputs<'a> {
     OnlyLocalInputs {
-        local_versions: IndexMap<SubstateRequirementRef<'a>, u32>,
+        local_versions: IndexMap<SubstateRequirementRef<'a>, u64>,
     },
     LocalAndForeignInputs {
-        local_versions: IndexMap<SubstateRequirementRef<'a>, u32>,
+        local_versions: IndexMap<SubstateRequirementRef<'a>, u64>,
         non_local_inputs: IndexSet<SubstateRequirementRef<'a>>,
     },
     /// Does not involve any local inputs, but involves one or more local tombstone outputs
@@ -670,7 +670,7 @@ enum ResolvedTransactionInputs<'a> {
 }
 
 struct ResolvedInputs<'a> {
-    pub local_inputs: IndexMap<SubstateRequirementRef<'a>, u32>,
+    pub local_inputs: IndexMap<SubstateRequirementRef<'a>, u64>,
     pub foreign_inputs: IndexSet<SubstateRequirementRef<'a>>,
     pub num_local_tombstones: usize,
 }

--- a/crates/consensus_tests/src/substate_store.rs
+++ b/crates/consensus_tests/src/substate_store.rs
@@ -236,7 +236,7 @@ fn a_substate_with_no_live_version_is_not_fatal_to_input_resolution() {
     );
 }
 
-fn add_substate(store: &TestStore, seed: u8, version: u32) -> VersionedSubstateId {
+fn add_substate(store: &TestStore, seed: u8, version: u64) -> VersionedSubstateId {
     let id = new_substate_id(seed);
     let value = new_substate_value(seed);
     let mut batch = SubstateUpdateBatch::new(Network::LocalNet, Epoch::zero());
@@ -285,7 +285,7 @@ fn new_substate_id(seed: u8) -> SubstateId {
     ComponentAddress::from_array([seed; ObjectKey::LENGTH]).into()
 }
 
-fn new_substate(seed: u8, version: u32) -> Substate {
+fn new_substate(seed: u8, version: u64) -> Substate {
     Substate::new(version, new_substate_value(seed))
 }
 

--- a/crates/engine_types/src/substate.rs
+++ b/crates/engine_types/src/substate.rs
@@ -72,11 +72,12 @@ pub struct Substate {
     #[n(0)]
     substate: SubstateValue,
     #[n(1)]
-    version: u32,
+    #[cfg_attr(feature = "ts", ts(type = "number"))]
+    version: u64,
 }
 
 impl Substate {
-    pub fn new<T: Into<SubstateValue>>(version: u32, substate: T) -> Self {
+    pub fn new<T: Into<SubstateValue>>(version: u64, substate: T) -> Self {
         Self {
             substate: substate.into(),
             version,
@@ -95,7 +96,7 @@ impl Substate {
         self.substate
     }
 
-    pub fn version(&self) -> u32 {
+    pub fn version(&self) -> u64 {
         self.version
     }
 
@@ -111,7 +112,7 @@ impl Substate {
         hash_substate(network, self.substate_value(), self.version, epoch)
     }
 
-    pub fn previous_version(&self) -> Option<u32> {
+    pub fn previous_version(&self) -> Option<u64> {
         self.version.checked_sub(1)
     }
 }
@@ -119,7 +120,7 @@ impl Substate {
 /// Hashes a substate into its canonical value hash. The `epoch` argument binds the schema version
 /// (derived from `network` and epoch via `ProtocolVersion::at`) into the hash preimage, so substates
 /// produced under different schema versions can never collide in the JMT.
-pub fn hash_substate(network: Network, substate: &SubstateValue, version: u32, epoch: Epoch) -> Hash32 {
+pub fn hash_substate(network: Network, substate: &SubstateValue, version: u64, epoch: Epoch) -> Hash32 {
     let proto_version = ProtocolVersion::at(network, epoch);
     substate_value_hasher32()
         .chain(&substate.as_hash_message(proto_version))
@@ -981,7 +982,7 @@ pub struct SubstateDiff {
     #[n(0)]
     up_substates: Vec<(SubstateId, Substate)>,
     #[n(1)]
-    down_substates: Vec<(SubstateId, u32)>,
+    down_substates: Vec<(SubstateId, u64)>,
     #[n(2)]
     fee_withdrawals: Vec<ValidatorFeeWithdrawal>,
 }
@@ -1014,11 +1015,11 @@ impl SubstateDiff {
         self
     }
 
-    pub fn down(&mut self, id: SubstateId, version: u32) {
+    pub fn down(&mut self, id: SubstateId, version: u64) {
         self.down_substates.push((id, version));
     }
 
-    pub fn extend_down(&mut self, iter: impl Iterator<Item = (SubstateId, u32)>) -> &mut Self {
+    pub fn extend_down(&mut self, iter: impl Iterator<Item = (SubstateId, u64)>) -> &mut Self {
         self.down_substates.extend(iter);
         self
     }
@@ -1031,7 +1032,7 @@ impl SubstateDiff {
         self.up_substates.into_iter()
     }
 
-    pub fn down_iter(&self) -> impl Iterator<Item = &(SubstateId, u32)> + '_ {
+    pub fn down_iter(&self) -> impl Iterator<Item = &(SubstateId, u64)> + '_ {
         self.down_substates.iter()
     }
 

--- a/crates/engine_types/src/substate_hasher.rs
+++ b/crates/engine_types/src/substate_hasher.rs
@@ -332,7 +332,7 @@ mod tests {
     fn hash_at(version: ProtocolVersion, value: &SubstateValue) -> Hash32 {
         hasher32(EngineHashDomainLabel::SubstateValue)
             .chain(&SubstateHashMessage::new(version, value))
-            .chain(&0u32)
+            .chain(&0u64)
             .chain(&Epoch(3))
             .result()
     }
@@ -341,14 +341,14 @@ mod tests {
         hex::encode(hash.as_ref() as &[u8])
     }
 
-    /// The hash a binary that predates `FeeReceipt::exhaust_burn` produced for this receipt (captured
-    /// from `hash_substate` at 2cc729b95). Version 0 must keep producing it, or no node can re-derive
-    /// the state roots that committed such receipts.
+    /// Pins the version 0 preimage for a receipt. Every substate value hash, and so every state root,
+    /// is derived from it: a change to this hash is a change to all of them, and nodes carrying state
+    /// hashed under the old preimage cannot re-derive their roots.
     #[test]
-    fn version_0_reproduces_the_pre_exhaust_burn_hash() {
+    fn version_0_receipt_hash_is_pinned() {
         assert_eq!(
             hex(hash_at(ProtocolVersion::V0, &receipt(0))),
-            "061d838f149c767043152d6362afd71f18d58ac41c1c7b0a7f130066e9e1efcb"
+            "b0e49359759f3845cfeaec2ddf6aaee6c7c3f1d1abb26524b082ddeb344ad115"
         );
         // Esmeralda is the network whose history was hashed under version 0.
         assert_eq!(ProtocolVersion::at(Network::Esmeralda, Epoch(3)), ProtocolVersion::V0);
@@ -363,18 +363,17 @@ mod tests {
     fn version_1_hash_is_pinned() {
         assert_eq!(
             hex(hash_at(ProtocolVersion::V1, &receipt(123))),
-            "78a85877d39682b55d299b5c3fad89b4261603bc2e261f5af728caa876fbbc78"
+            "1acb3bbf878dedc70e27215a30d597ef45a9adc7b8f587dee8f92f97c69ad676"
         );
     }
 
-    /// The hash a binary that predates `ResourceAccessRules::auth_hook_updater` produced for this
-    /// resource (captured from `hash_substate` at 4da937665). Version 0 must keep producing it, or no
-    /// node can re-derive the state roots that committed such resources.
+    /// Pins the version 0 preimage for a resource, as [`version_0_receipt_hash_is_pinned`] does for a
+    /// receipt.
     #[test]
-    fn version_0_reproduces_the_pre_auth_hook_updater_hash() {
+    fn version_0_resource_hash_is_pinned() {
         assert_eq!(
             hex(hash_at(ProtocolVersion::V0, &resource(UpdateRule::Locked))),
-            "e70d065a427a57fb18d8d03ff858411b7c542081863042b0753b2459759ecead"
+            "65ec63aee1f754f04615e86aa4147632a08abdb8e85055fec8cbbf14dd7a46be"
         );
     }
 

--- a/crates/engine_types/src/transaction_receipt.rs
+++ b/crates/engine_types/src/transaction_receipt.rs
@@ -112,7 +112,7 @@ impl TransactionReceipt {
             upped: upped
                 .map(|substate_id| UpSubstate {
                     substate_id: substate_id.clone(),
-                    version: u32::MAX,
+                    version: u64::MAX,
                     value_hash: Hash32::from_array([0xff; Hash32::LENGTH]),
                 })
                 .collect(),
@@ -227,7 +227,8 @@ pub struct UpSubstate {
     #[n(0)]
     pub substate_id: SubstateId,
     #[n(1)]
-    pub version: u32,
+    #[cfg_attr(feature = "ts", ts(type = "number"))]
+    pub version: u64,
     #[n(2)]
     pub value_hash: Hash32,
 }

--- a/crates/indexer_lib/src/cached_substate_manager.rs
+++ b/crates/indexer_lib/src/cached_substate_manager.rs
@@ -210,7 +210,7 @@ where
     pub async fn get_substate(
         &self,
         substate_id: &SubstateId,
-        specific_version: Option<u32>,
+        specific_version: Option<u64>,
     ) -> Result<SubstateLookupResult, IndexerError> {
         debug!(target: LOG_TARGET, "get_substate: {}v{}", substate_id, specific_version.display());
         let cache_res = self
@@ -510,7 +510,7 @@ where
     async fn fetch_substate_from_committee(
         &self,
         substate_id: &SubstateId,
-        specific_version: Option<u32>,
+        specific_version: Option<u64>,
     ) -> Result<SubstateLookupResult, IndexerError> {
         let requirement = SubstateRequirementRef::new(substate_id, specific_version);
         let lookup_result = self.get_specific_substate_from_committee(requirement).await?;
@@ -632,7 +632,7 @@ where
     async fn verify_substate_proof(
         &self,
         substate_id: &SubstateId,
-        version: u32,
+        version: u64,
         value: Option<&SubstateValue>,
         proof: SubstateProofData,
     ) -> Result<(), IndexerError> {

--- a/crates/indexer_lib/src/committee_read.rs
+++ b/crates/indexer_lib/src/committee_read.rs
@@ -169,7 +169,7 @@ mod tests {
 
     use super::*;
 
-    fn down(version: u32) -> SubstateResult {
+    fn down(version: u64) -> SubstateResult {
         SubstateResult::Down { version }
     }
 

--- a/crates/indexer_lib/src/substate_cache.rs
+++ b/crates/indexer_lib/src/substate_cache.rs
@@ -69,7 +69,7 @@ pub fn caches_nonexistence(id: &SubstateId) -> bool {
 #[derive(Debug, Clone)]
 pub struct SubstateCacheEntry {
     /// The substate's head version, or `None` when the substate does not exist.
-    pub version: Option<u32>,
+    pub version: Option<u64>,
     pub substate_result: SubstateResult,
     pub cached_at: u64,
     /// True if the value was committee-verified when it was fetched. Never true for a substate that
@@ -86,7 +86,7 @@ impl SubstateCacheEntry {
     /// and upping a substate downs its predecessor - or it is above it, which the cache knows
     /// nothing about. Nonexistence names no version and answers nothing about one: a destroyed
     /// substate whose history has been pruned reports the same thing as one never created.
-    pub fn answer_at(self, version: Option<u32>) -> Option<Self> {
+    pub fn answer_at(self, version: Option<u64>) -> Option<Self> {
         let Some(version) = version else {
             return Some(self);
         };
@@ -105,7 +105,7 @@ impl SubstateCacheEntry {
 #[derive(Debug, Clone, Copy)]
 pub struct SubstateCacheEntryRef<'a> {
     /// The substate's head version, or `None` when the substate does not exist.
-    pub version: Option<u32>,
+    pub version: Option<u64>,
     pub substate_result: &'a SubstateResult,
     pub cached_at: u64,
     pub verified: bool,
@@ -152,7 +152,7 @@ pub trait SubstateCache: Send + Sync {
 mod tests {
     use super::*;
 
-    fn head(version: Option<u32>) -> SubstateCacheEntry {
+    fn head(version: Option<u64>) -> SubstateCacheEntry {
         SubstateCacheEntry {
             version,
             substate_result: version.map_or(SubstateResult::DoesNotExist, |version| SubstateResult::Down { version }),

--- a/crates/ootle_sdk_core/src/inputs.rs
+++ b/crates/ootle_sdk_core/src/inputs.rs
@@ -146,7 +146,7 @@ pub struct FetchedSubstate {
     pub substate_id: String,
     /// The substate version the indexer returned (carried for the host; the resolver folds
     /// unversioned inputs).
-    pub version: u32,
+    pub version: u64,
     /// The indexer's `SubstateValue` JSON, passed through verbatim.
     pub substate_value: serde_json::Value,
 }

--- a/crates/ootle_sdk_core/src/types/intent.rs
+++ b/crates/ootle_sdk_core/src/types/intent.rs
@@ -30,7 +30,7 @@ pub struct InputRef {
     /// The canonical substate id, e.g. `component_<hex>` / `resource_<hex>`.
     pub substate_id: String,
     /// The optional explicit version.
-    pub version: Option<u32>,
+    pub version: Option<u64>,
 }
 
 impl InputRef {
@@ -43,7 +43,7 @@ impl InputRef {
     }
 
     /// Builds a versioned input ref.
-    pub fn versioned(substate_id: impl Into<String>, version: u32) -> Self {
+    pub fn versioned(substate_id: impl Into<String>, version: u64) -> Self {
         Self {
             substate_id: substate_id.into(),
             version: Some(version),

--- a/crates/ootle_sdk_core/src/types/result.rs
+++ b/crates/ootle_sdk_core/src/types/result.rs
@@ -169,7 +169,7 @@ pub struct UpSubstate {
     /// The substate id (canonical string form).
     pub substate_id: String,
     /// The created version.
-    pub version: u32,
+    pub version: u64,
 }
 
 /// A boundary diff summary — the ids + versions of created/destroyed substates (not their bodies).
@@ -178,7 +178,7 @@ pub struct DiffSummary {
     /// Created (`up`) substates.
     pub up: Vec<UpSubstate>,
     /// Destroyed (`down`) substates as `(id, version)`.
-    pub down: Vec<(String, u32)>,
+    pub down: Vec<(String, u64)>,
 }
 
 /// A boundary event summary — the engine [`tari_engine_types::events::Event`] flattened to strings.

--- a/crates/p2p/proto/common.proto
+++ b/crates/p2p/proto/common.proto
@@ -45,5 +45,5 @@ message SubstateRequirement {
 }
 
 message OptionalVersion {
-  uint32 version = 1;
+  uint64 version = 1;
 }

--- a/crates/p2p/proto/consensus.proto
+++ b/crates/p2p/proto/consensus.proto
@@ -238,7 +238,7 @@ message MissingTransactionsResponse {
 
 message Substate {
   bytes substate_id = 1;
-  uint32 version = 2;
+  uint64 version = 2;
   bytes substate = 3;
 
   // Required

--- a/crates/p2p/proto/rpc.proto
+++ b/crates/p2p/proto/rpc.proto
@@ -98,7 +98,7 @@ message GetSubstateRequest {
 
 message GetSubstateResponse {
   bytes address = 1;
-  uint32 version = 2;
+  uint64 version = 2;
   // Encoded Substate
   bytes substate = 3;
   SubstateStatus status = 4;
@@ -145,7 +145,7 @@ enum PayloadResultStatus {
 // Minimal substate data
 message SubstateData {
   bytes substate_id = 1;
-  uint32 version = 2;
+  uint64 version = 2;
   oneof substate_value_or_hash {
     bytes value = 3;
     bytes hash = 4;
@@ -169,7 +169,7 @@ message SubstateCreate {
 
 message SubstateDestroy {
   bytes substate_id = 1;
-  uint32 version = 2;
+  uint64 version = 2;
 }
 
 message SyncBlocksRequest {

--- a/crates/state_store_rocksdb/src/codecs/block_diff.rs
+++ b/crates/state_store_rocksdb/src/codecs/block_diff.rs
@@ -29,7 +29,7 @@ impl DbEncoder<BlockDiffKey> for BlockDiffKeyCodec<BlockIdSeqSubstateIdVersion> 
         let len = BlockId::byte_size() + // block_id
             4 + // sequence
             self.substate_id_codec.encode_len(&value.substate_id)? + // substate_id
-            4 + // version
+            8 + // version
             1; // is_up
         Ok(len)
     }
@@ -82,11 +82,11 @@ impl DbDecoder<BlockDiffKey> for BlockDiffKeyCodec<BlockIdSeqSubstateIdVersion> 
         let (substate_id, n) = self.substate_id_codec.decode(&bytes[offset..])?;
         offset += n;
 
-        let version_bytes: [u8; 4] = take_fixed(&bytes[offset..]).ok_or_else(|| RocksDbStorageError::DecodeError {
-            source: anyhow!("BlockIdSubstateIdVersionCodec: Invalid bytes for u32"),
+        let version_bytes: [u8; 8] = take_fixed(&bytes[offset..]).ok_or_else(|| RocksDbStorageError::DecodeError {
+            source: anyhow!("BlockIdSubstateIdVersionCodec: Invalid bytes for u64"),
         })?;
-        let version = u32::from_be_bytes(version_bytes);
-        offset += 4;
+        let version = u64::from_be_bytes(version_bytes);
+        offset += 8;
 
         let is_up_byte = bytes.get(offset).ok_or_else(|| RocksDbStorageError::DecodeError {
             source: anyhow!("BlockIdSubstateIdVersionCodec: not enough bytes for bool"),
@@ -110,7 +110,7 @@ impl DbEncoder<BlockDiffKey> for BlockDiffKeyCodec<SubstateIdBlockIdVersionSeq> 
     fn encode_len(&self, value: &BlockDiffKey) -> Result<usize, RocksDbStorageError> {
         let len = self.substate_id_codec.encode_len(&value.substate_id)? + // substate_id
             BlockId::byte_size() + // block_id
-            4 + // version
+            8 + // version
             1 + // is_up
             4; // sequence
         Ok(len)
@@ -163,11 +163,11 @@ impl DbDecoder<BlockDiffKey> for BlockDiffKeyCodec<SubstateIdBlockIdVersionSeq> 
         let block_id = FixedHash::new(block_id_bytes);
         offset += HASH_LEN;
 
-        let version_bytes: [u8; 4] = take_fixed(&bytes[offset..]).ok_or_else(|| RocksDbStorageError::DecodeError {
-            source: anyhow!("BlockIdSubstateIdVersionCodec: Invalid bytes for u32"),
+        let version_bytes: [u8; 8] = take_fixed(&bytes[offset..]).ok_or_else(|| RocksDbStorageError::DecodeError {
+            source: anyhow!("BlockIdSubstateIdVersionCodec: Invalid bytes for u64"),
         })?;
-        let version = u32::from_be_bytes(version_bytes);
-        offset += 4;
+        let version = u64::from_be_bytes(version_bytes);
+        offset += 8;
 
         let is_up_byte = bytes.get(offset).ok_or_else(|| RocksDbStorageError::DecodeError {
             source: anyhow!("BlockIdSubstateIdVersionCodec: not enough bytes for bool"),

--- a/crates/state_store_rocksdb/src/column_families/block_diff.rs
+++ b/crates/state_store_rocksdb/src/column_families/block_diff.rs
@@ -38,7 +38,7 @@ pub struct BlockDiffInsertEntry<'a> {
 pub struct BlockDiffKey {
     pub block_id: BlockId,
     pub substate_id: SubstateId,
-    pub version: u32,
+    pub version: u64,
     pub is_up: bool,
     /// Retains the ordering of the substate changes in the block. This limits the maximum number of substate changes
     /// in a block to u32::MAX (4,294,967,295).

--- a/crates/state_store_rocksdb/src/column_families/substate.rs
+++ b/crates/state_store_rocksdb/src/column_families/substate.rs
@@ -64,7 +64,7 @@ pub struct HeadIndex;
 #[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode, CborLen)]
 pub struct SubstateHeadData {
     #[n(0)]
-    pub version: u32,
+    pub version: u64,
     #[n(1)]
     pub is_up: bool,
 }

--- a/crates/state_store_rocksdb/src/reader.rs
+++ b/crates/state_store_rocksdb/src/reader.rs
@@ -356,7 +356,7 @@ impl<'a, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'a, R: RocksRea
         &self,
         end_block: &BlockId,
         substate_id: &SubstateId,
-        version: Option<u32>,
+        version: Option<u64>,
     ) -> Result<Option<BlockDiffKey>, RocksDbStorageError> {
         let applicable_blocks = self.get_pending_chain_until(end_block)?;
 
@@ -1482,7 +1482,7 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx, R: RocksR
         Ok(substates)
     }
 
-    fn substates_get_max_version_for_substate(&self, substate_id: &SubstateId) -> Result<(u32, bool), StorageError> {
+    fn substates_get_max_version_for_substate(&self, substate_id: &SubstateId) -> Result<(u64, bool), StorageError> {
         const OPERATION: &str = "substates_get_max_version_for_substate";
         let index_cf = self.db().cf(substate::HeadIndex)?;
         let data = index_cf.get(substate_id, OPERATION)?;
@@ -2015,6 +2015,6 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx, R: RocksR
 
 /// Orders two changes for the same substate within a branch. A substate version is only ever DOWNed after it is UPed,
 /// so a DOWN supersedes the UP of the same version.
-fn block_diff_change_order(key: &BlockDiffKey) -> (u32, bool) {
+fn block_diff_change_order(key: &BlockDiffKey) -> (u64, bool) {
     (key.version, !key.is_up)
 }

--- a/crates/state_store_rocksdb/tests/helpers.rs
+++ b/crates/state_store_rocksdb/tests/helpers.rs
@@ -117,7 +117,7 @@ pub fn transaction_id_from_seed(seed: u32) -> TransactionId {
     TransactionId::new(buf)
 }
 
-pub fn build_substate_record(substate_id: &SubstateId, version: u32, state_version: Version) -> SubstateRecord {
+pub fn build_substate_record(substate_id: &SubstateId, version: u64, state_version: Version) -> SubstateRecord {
     let entity_id = substate_id.to_object_key().as_entity_id();
     let value = build_substate_value(Some(entity_id));
     let at_epoch = Epoch::zero();
@@ -245,7 +245,7 @@ pub fn gen_substates(
     state_version: Version,
     shard: Shard,
     n: usize,
-    substate_version: u32,
+    substate_version: u64,
 ) -> impl Iterator<Item = SubstateRecord> {
     (0..n).map(move |_| {
         let substate_id = random_substate_id_for_shard(shard);
@@ -262,7 +262,7 @@ pub fn gen_substates_for_shards(
     epoch: Epoch,
     state_version: Version,
     shard_range: impl IntoIterator<Item = u32>,
-    substate_version: u32,
+    substate_version: u64,
 ) -> impl Iterator<Item = SubstateRecord> {
     shard_range.into_iter().map(move |i| {
         let substate_id = substate_id_seed(i);

--- a/crates/state_store_rocksdb/tests/substate_locks.rs
+++ b/crates/state_store_rocksdb/tests/substate_locks.rs
@@ -124,7 +124,7 @@ fn run_test(db: impl StateStore) {
 fn gen_locks(transaction_id: TransactionId, num: usize) -> impl Iterator<Item = (SubstateId, SubstateLock)> {
     (0..num as u64).map(move |i| {
         let id = substate_id_tx_seed(transaction_id, i as u32);
-        let lock = SubstateLock::new(transaction_id, i as u32, SubstateLockType::Write, false);
+        let lock = SubstateLock::new(transaction_id, i, SubstateLockType::Write, false);
         (id, lock)
     })
 }

--- a/crates/state_store_rocksdb/tests/substate_rewind.rs
+++ b/crates/state_store_rocksdb/tests/substate_rewind.rs
@@ -22,7 +22,7 @@ fn substate_id(seed: u8) -> SubstateId {
     SubstateId::Component(ComponentAddress::from_array([seed; ObjectKey::LENGTH]))
 }
 
-fn shard_for(id: &SubstateId, version: u32) -> Shard {
+fn shard_for(id: &SubstateId, version: u64) -> Shard {
     VersionedSubstateIdRef::new(id, version).to_shard(num_preshards())
 }
 

--- a/crates/state_tree/tests/support.rs
+++ b/crates/state_tree/tests/support.rs
@@ -17,7 +17,7 @@ use tari_template_lib_types::{ComponentAddress, Hash32, ObjectKey};
 pub fn make_value(seed: u8) -> VersionedSubstateId {
     VersionedSubstateId::new(
         SubstateId::Component(ComponentAddress::new(ObjectKey::from_array([seed; ObjectKey::LENGTH]))),
-        u32::from(seed),
+        u64::from(seed),
     )
 }
 

--- a/crates/storage/src/consensus_models/block_pledges.rs
+++ b/crates/storage/src/consensus_models/block_pledges.rs
@@ -91,7 +91,7 @@ impl BlockPledge {
     pub(crate) fn add_substate_pledge(
         &mut self,
         substate_id: SubstateId,
-        version: u32,
+        version: u64,
         substate_value: SubstateValue,
     ) -> &mut Self {
         self.pledges.insert(substate_id, Substate::new(version, substate_value));
@@ -202,7 +202,7 @@ impl SubstatePledge {
             self.substate_id() == req.substate_id()
     }
 
-    pub fn satisfies_substate_and_version(&self, substate_id: &SubstateId, version: u32) -> bool {
+    pub fn satisfies_substate_and_version(&self, substate_id: &SubstateId, version: u64) -> bool {
         self.versioned_substate_id().version() == version && self.substate_id() == substate_id
     }
 

--- a/crates/storage/src/consensus_models/evidence.rs
+++ b/crates/storage/src/consensus_models/evidence.rs
@@ -141,7 +141,7 @@ impl Evidence {
         })
     }
 
-    pub fn all_outputs_iter(&self) -> impl Iterator<Item = (&ShardGroup, &SubstateId, &u32)> {
+    pub fn all_outputs_iter(&self) -> impl Iterator<Item = (&ShardGroup, &SubstateId, &u64)> {
         self.evidence.iter().flat_map(|(sg, evidence)| {
             evidence
                 .outputs
@@ -448,7 +448,7 @@ pub struct ShardGroupEvidence {
     #[cfg_attr(feature = "ts", ts(type = "Record<string, number>"))]
     #[n(1)]
     #[cbor(with = "tari_bor::adapters::indexmap_codec")]
-    outputs: IndexMap<SubstateId, u32>,
+    outputs: IndexMap<SubstateId, u64>,
     #[cfg_attr(feature = "ts", ts(type = "string | null"))]
     #[n(2)]
     prepare_qc: Option<PcId>,
@@ -462,7 +462,7 @@ impl ShardGroupEvidence {
         self.insert(lock.substate_id().clone(), lock.version_to_lock(), lock.lock_type())
     }
 
-    pub fn insert(&mut self, substate_id: SubstateId, version_to_lock: u32, lock_type: SubstateLockType) -> &mut Self {
+    pub fn insert(&mut self, substate_id: SubstateId, version_to_lock: u64, lock_type: SubstateLockType) -> &mut Self {
         if lock_type.is_input() {
             self.inputs.insert_sorted(
                 substate_id,
@@ -482,7 +482,7 @@ impl ShardGroupEvidence {
         self
     }
 
-    pub fn insert_output(&mut self, substate_id: SubstateId, version: u32) -> &mut Self {
+    pub fn insert_output(&mut self, substate_id: SubstateId, version: u64) -> &mut Self {
         self.outputs.insert_sorted(substate_id, version);
         self
     }
@@ -514,7 +514,7 @@ impl ShardGroupEvidence {
         })
     }
 
-    pub fn outputs(&self) -> &IndexMap<SubstateId, u32> {
+    pub fn outputs(&self) -> &IndexMap<SubstateId, u64> {
         &self.outputs
     }
 
@@ -540,7 +540,7 @@ impl ShardGroupEvidence {
         self.outputs.sort_keys();
     }
 
-    pub fn contains_pledge(&self, substate_id: &SubstateId, version: u32, is_input: bool) -> bool {
+    pub fn contains_pledge(&self, substate_id: &SubstateId, version: u64, is_input: bool) -> bool {
         if is_input {
             return self
                 .inputs
@@ -640,7 +640,8 @@ pub struct EvidenceInputLockData {
     #[n(0)]
     pub is_write: bool,
     #[n(1)]
-    pub version: u32,
+    #[cfg_attr(feature = "ts", ts(type = "number"))]
+    pub version: u64,
 }
 
 impl EvidenceInputLockData {
@@ -805,11 +806,11 @@ mod tests {
         );
         assert_eq!(
             evidence1.get(&sg1).unwrap().outputs.get(&seed_substate_id(2)),
-            Some(&0u32)
+            Some(&0u64)
         );
         assert_eq!(
             evidence1.get(&sg1).unwrap().outputs.get(&seed_substate_id(2)),
-            Some(&0u32)
+            Some(&0u64)
         );
     }
 }

--- a/crates/storage/src/consensus_models/lock_intent.rs
+++ b/crates/storage/src/consensus_models/lock_intent.rs
@@ -68,7 +68,7 @@ impl VersionedSubstateIdLockIntent {
         self.versioned_substate_id.substate_id()
     }
 
-    pub fn version(&self) -> u32 {
+    pub fn version(&self) -> u64 {
         self.versioned_substate_id.version()
     }
 
@@ -110,11 +110,11 @@ impl LockIntent for VersionedSubstateIdLockIntent {
         self.lock_type
     }
 
-    fn version_to_lock(&self) -> u32 {
+    fn version_to_lock(&self) -> u64 {
         self.version()
     }
 
-    fn requested_version(&self) -> Option<u32> {
+    fn requested_version(&self) -> Option<u64> {
         if self.require_version {
             Some(self.version())
         } else {
@@ -132,11 +132,11 @@ impl LockIntent for &VersionedSubstateIdLockIntent {
         self.lock_type
     }
 
-    fn version_to_lock(&self) -> u32 {
+    fn version_to_lock(&self) -> u64 {
         self.version()
     }
 
-    fn requested_version(&self) -> Option<u32> {
+    fn requested_version(&self) -> Option<u64> {
         if self.require_version {
             Some(self.version())
         } else {
@@ -155,11 +155,11 @@ impl AsRef<SubstateId> for VersionedSubstateIdLockIntent {
 pub struct RequireLockIntentRef<'a> {
     substate_id: &'a SubstateId,
     lock_type: SubstateLockType,
-    version_to_lock: u32,
+    version_to_lock: u64,
 }
 
 impl<'a> RequireLockIntentRef<'a> {
-    pub fn new(substate_id: &'a SubstateId, version_to_lock: u32, lock: SubstateLockType) -> Self {
+    pub fn new(substate_id: &'a SubstateId, version_to_lock: u64, lock: SubstateLockType) -> Self {
         Self {
             substate_id,
             lock_type: lock,
@@ -187,11 +187,11 @@ impl LockIntent for RequireLockIntentRef<'_> {
         self.lock_type
     }
 
-    fn version_to_lock(&self) -> u32 {
+    fn version_to_lock(&self) -> u64 {
         self.version_to_lock
     }
 
-    fn requested_version(&self) -> Option<u32> {
+    fn requested_version(&self) -> Option<u64> {
         Some(self.version_to_lock)
     }
 }
@@ -209,14 +209,14 @@ impl fmt::Display for RequireLockIntentRef<'_> {
 #[derive(Debug, Clone)]
 pub struct SubstateRequirementLockIntent {
     substate_requirement: SubstateRequirement,
-    version_to_lock: u32,
+    version_to_lock: u64,
     lock_type: SubstateLockType,
 }
 
 impl SubstateRequirementLockIntent {
     pub fn new<T: Into<SubstateRequirement>>(
         substate_requirement: T,
-        version_to_lock: u32,
+        version_to_lock: u64,
         lock: SubstateLockType,
     ) -> Self {
         Self {
@@ -226,15 +226,15 @@ impl SubstateRequirementLockIntent {
         }
     }
 
-    pub fn read<T: Into<SubstateRequirement>>(substate_id: T, version_to_lock: u32) -> Self {
+    pub fn read<T: Into<SubstateRequirement>>(substate_id: T, version_to_lock: u64) -> Self {
         Self::new(substate_id, version_to_lock, SubstateLockType::Read)
     }
 
-    pub fn write<T: Into<SubstateRequirement>>(substate_id: T, version_to_lock: u32) -> Self {
+    pub fn write<T: Into<SubstateRequirement>>(substate_id: T, version_to_lock: u64) -> Self {
         Self::new(substate_id, version_to_lock, SubstateLockType::Write)
     }
 
-    pub fn output<T: Into<SubstateRequirement>>(substate_id: T, version_to_lock: u32) -> Self {
+    pub fn output<T: Into<SubstateRequirement>>(substate_id: T, version_to_lock: u64) -> Self {
         Self::new(substate_id, version_to_lock, SubstateLockType::Output)
     }
 
@@ -254,7 +254,7 @@ impl SubstateRequirementLockIntent {
         self.substate_requirement.substate_id()
     }
 
-    pub fn version_to_lock(&self) -> u32 {
+    pub fn version_to_lock(&self) -> u64 {
         self.version_to_lock
     }
 
@@ -280,11 +280,11 @@ impl LockIntent for &SubstateRequirementLockIntent {
         self.lock_type
     }
 
-    fn version_to_lock(&self) -> u32 {
+    fn version_to_lock(&self) -> u64 {
         self.version_to_lock
     }
 
-    fn requested_version(&self) -> Option<u32> {
+    fn requested_version(&self) -> Option<u64> {
         self.substate_requirement.version()
     }
 }
@@ -298,11 +298,11 @@ impl LockIntent for SubstateRequirementLockIntent {
         self.lock_type
     }
 
-    fn version_to_lock(&self) -> u32 {
+    fn version_to_lock(&self) -> u64 {
         self.version_to_lock
     }
 
-    fn requested_version(&self) -> Option<u32> {
+    fn requested_version(&self) -> Option<u64> {
         self.substate_requirement.version()
     }
 }

--- a/crates/storage/src/consensus_models/substate.rs
+++ b/crates/storage/src/consensus_models/substate.rs
@@ -37,7 +37,8 @@ pub struct SubstateRecord {
     #[n(0)]
     pub substate_id: SubstateId,
     #[n(1)]
-    pub version: u32,
+    #[cfg_attr(feature = "ts", ts(type = "number"))]
+    pub version: u64,
     #[n(2)]
     pub substate_value: Option<SubstateValue>,
     #[cfg_attr(feature = "ts", ts(type = "string"))]
@@ -54,7 +55,7 @@ impl SubstateRecord {
     pub fn new<V: Into<SubstateValueOrHash>>(
         network: Network,
         substate_id: SubstateId,
-        version: u32,
+        version: u64,
         value: V,
         created: SubstateCreated,
     ) -> Self {
@@ -111,7 +112,7 @@ impl SubstateRecord {
             .unwrap_or_else(|| self.state_hash.into())
     }
 
-    pub fn version(&self) -> u32 {
+    pub fn version(&self) -> u64 {
         self.version
     }
 
@@ -262,7 +263,7 @@ impl SubstateRecord {
     pub fn get_latest_version<TTx: StateStoreReadTransaction>(
         tx: &TTx,
         substate_id: &SubstateId,
-    ) -> Result<(u32, bool), StorageError> {
+    ) -> Result<(u64, bool), StorageError> {
         tx.substates_get_max_version_for_substate(substate_id)
     }
 
@@ -291,7 +292,7 @@ pub struct SubstateCreate {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SubstateDestroy {
     pub substate_id: SubstateId,
-    pub version: u32,
+    pub version: u64,
 }
 
 impl SubstateDestroy {
@@ -352,7 +353,7 @@ impl SubstateValueOrHash {
         }
     }
 
-    pub fn to_value_hash(&self, network: Network, version: u32, epoch: Epoch) -> Hash32 {
+    pub fn to_value_hash(&self, network: Network, version: u64, epoch: Epoch) -> Hash32 {
         match &self {
             SubstateValueOrHash::Value(v) => hash_substate(network, v, version, epoch),
             SubstateValueOrHash::Hash(hash) => *hash,
@@ -375,7 +376,7 @@ impl From<Hash32> for SubstateValueOrHash {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SubstateData {
     pub substate_id: SubstateId,
-    pub version: u32,
+    pub version: u64,
     pub value: SubstateValueOrHash,
     #[serde(default)]
     pub template_metadata: Option<PublishedTemplateMetadata>,
@@ -435,7 +436,7 @@ impl SubstateUpdateProof {
         }
     }
 
-    pub fn version(&self) -> u32 {
+    pub fn version(&self) -> u64 {
         match self {
             Self::Create(create) => create.substate.version,
             Self::Destroy(destroyed) => destroyed.version,

--- a/crates/storage/src/consensus_models/substate_change.rs
+++ b/crates/storage/src/consensus_models/substate_change.rs
@@ -61,7 +61,7 @@ impl SubstateChange {
         }
     }
 
-    pub fn version(&self) -> u32 {
+    pub fn version(&self) -> u64 {
         self.versioned_substate_id().version()
     }
 

--- a/crates/storage/src/consensus_models/substate_lock.rs
+++ b/crates/storage/src/consensus_models/substate_lock.rs
@@ -24,13 +24,13 @@ pub struct SubstateLock {
     #[n(1)]
     transaction_id: TransactionId,
     #[n(2)]
-    version: u32,
+    version: u64,
     #[n(3)]
     is_local_only: bool,
 }
 
 impl SubstateLock {
-    pub fn new(transaction_id: TransactionId, version: u32, lock_type: SubstateLockType, is_local_only: bool) -> Self {
+    pub fn new(transaction_id: TransactionId, version: u64, lock_type: SubstateLockType, is_local_only: bool) -> Self {
         Self {
             transaction_id,
             version,
@@ -47,7 +47,7 @@ impl SubstateLock {
         self.lock_type
     }
 
-    pub fn version(&self) -> u32 {
+    pub fn version(&self) -> u64 {
         self.version
     }
 

--- a/crates/storage/src/consensus_models/substate_update_batch.rs
+++ b/crates/storage/src/consensus_models/substate_update_batch.rs
@@ -32,7 +32,7 @@ impl SubstateUpdateBatch {
 pub enum SubstateTransition {
     Up {
         id: SubstateId,
-        version: u32,
+        version: u64,
         substate_or_hash: SubstateValueOrHash,
     },
     Down {

--- a/crates/storage/src/consensus_models/transaction_pool.rs
+++ b/crates/storage/src/consensus_models/transaction_pool.rs
@@ -952,7 +952,7 @@ impl TransactionPoolRecord {
     ) -> Result<bool, StorageError>
     where
         TTx: StateStoreReadTransaction,
-        TObj: IntoIterator<Item = (&'a SubstateId, Option<(u32, SubstateLockType)>)>,
+        TObj: IntoIterator<Item = (&'a SubstateId, Option<(u64, SubstateLockType)>)>,
     {
         for (substate_id, data) in involved_objects {
             let Some((version, lock_type)) = data else {

--- a/crates/storage/src/state_store/mod.rs
+++ b/crates/storage/src/state_store/mod.rs
@@ -273,7 +273,7 @@ pub trait StateStoreReadTransaction: Sized {
         I: IntoIterator<Item = &'a SubstateId>,
         I::IntoIter: ExactSizeIterator;
     /// Returns (version, is_up)
-    fn substates_get_max_version_for_substate(&self, substate_id: &SubstateId) -> Result<(u32, bool), StorageError>;
+    fn substates_get_max_version_for_substate(&self, substate_id: &SubstateId) -> Result<(u64, bool), StorageError>;
     fn substates_any_exist<'a, I>(&self, substates: I) -> Result<bool, StorageError>
     where I: IntoIterator<Item = VersionedSubstateIdRef<'a>>;
 

--- a/crates/storage/src/state_store/substate_value_proof.rs
+++ b/crates/storage/src/state_store/substate_value_proof.rs
@@ -137,7 +137,7 @@ impl<'a, TTx: StateStoreReadTransaction> SubstateProofGenerator<'a, TTx> {
 pub fn verify_substate_value_proof_against_root(
     value_proof_bytes: &[u8],
     substate_id: &SubstateId,
-    version: u32,
+    version: u64,
     value: Option<&SubstateValue>,
     network: Network,
     proof_epoch: Epoch,

--- a/crates/validator_node_rpc/src/client.rs
+++ b/crates/validator_node_rpc/src/client.rs
@@ -130,12 +130,12 @@ pub enum SubstateResult {
     #[n(2)]
     Down {
         #[n(0)]
-        version: u32,
+        version: u64,
     },
 }
 
 impl SubstateResult {
-    pub fn version(&self) -> Option<u32> {
+    pub fn version(&self) -> Option<u64> {
         match self {
             SubstateResult::Up { substate, .. } => Some(substate.version()),
             SubstateResult::Down { version, .. } => Some(*version),

--- a/crates/wallet/ootle-rs/src/provider/utxo_watcher.rs
+++ b/crates/wallet/ootle-rs/src/provider/utxo_watcher.rs
@@ -74,11 +74,11 @@ pub enum StealthUtxoFrame {
     },
     Spent {
         id: UtxoId,
-        version: u32,
+        version: u64,
     },
     Burnt {
         id: UtxoId,
-        version: u32,
+        version: u64,
     },
     /// Terminates a shard's updates. `max_state_version` is the resume point for the shard, chosen
     /// by the indexer: the last delivered state version while the shard has more to drain, and the

--- a/crates/wallet/sdk/src/apis/accounts.rs
+++ b/crates/wallet/sdk/src/apis/accounts.rs
@@ -214,7 +214,7 @@ impl<'a, TSpec: WalletSdkSpec> AccountsApi<'a, TSpec> {
     pub fn update_vault_balance_and_record_change(
         &self,
         vault_address: VaultId,
-        vault_version: u32,
+        vault_version: u64,
         revealed_balance: Amount,
         confidential_balance: Amount,
         source: BalanceChangeSource,
@@ -341,7 +341,7 @@ impl<'a, TSpec: WalletSdkSpec> AccountsApi<'a, TSpec> {
     pub fn attribute_balance_change_to_transaction(
         &self,
         vault_id: &VaultId,
-        vault_version: u32,
+        vault_version: u64,
         transaction_id: TransactionId,
     ) -> Result<bool, AccountsApiError> {
         let attributed = self
@@ -497,7 +497,7 @@ impl<'a, TSpec: WalletSdkSpec> AccountsApi<'a, TSpec> {
         &self,
         account_address: ComponentAddress,
         vault_address: VaultId,
-        vault_version: u32,
+        vault_version: u64,
         resource_address: ResourceAddress,
         resource_type: ResourceType,
         token_symbol: Option<String>,

--- a/crates/wallet/sdk/src/apis/substate.rs
+++ b/crates/wallet/sdk/src/apis/substate.rs
@@ -300,7 +300,7 @@ where
     pub async fn fetch_substate_from_network(
         &self,
         address: &SubstateId,
-        version_hint: Option<u32>,
+        version_hint: Option<u64>,
     ) -> Result<ValidatorScanResult, SubstateApiError> {
         debug!(
             target: LOG_TARGET,

--- a/crates/wallet/sdk/src/models/balance_change.rs
+++ b/crates/wallet/sdk/src/models/balance_change.rs
@@ -104,7 +104,7 @@ pub struct BalanceChange {
 pub struct BalanceChangeSnapshot {
     pub account_address: ComponentAddress,
     pub vault_address: Option<VaultId>,
-    pub vault_version: Option<u32>,
+    pub vault_version: Option<u64>,
     pub resource_address: ResourceAddress,
     pub token_symbol: Option<String>,
     pub divisibility: u8,

--- a/crates/wallet/sdk/src/models/event.rs
+++ b/crates/wallet/sdk/src/models/event.rs
@@ -119,7 +119,7 @@ pub struct AccountCreatedEvent {
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct AccountChangedEvent {
     pub account_address: ComponentAddress,
-    pub version: u32,
+    pub version: u64,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]

--- a/crates/wallet/sdk/src/models/vault.rs
+++ b/crates/wallet/sdk/src/models/vault.rs
@@ -10,7 +10,7 @@ const LOG_TARGET: &str = "tari::ootle::wallet_sdk::models::vault";
 pub struct VaultModel {
     pub account_address: ComponentAddress,
     pub id: VaultId,
-    pub vault_version: u32,
+    pub vault_version: u64,
     pub resource_address: ResourceAddress,
     pub resource_type: ResourceType,
     pub confidential_balance: Amount,

--- a/crates/wallet/sdk/src/network.rs
+++ b/crates/wallet/sdk/src/network.rs
@@ -56,7 +56,7 @@ pub trait WalletNetworkInterface {
     fn query_substate(
         &self,
         address: &SubstateId,
-        version: Option<u32>,
+        version: Option<u64>,
         local_search_only: bool,
     ) -> impl Future<Output = Result<SubstateQueryResult, Self::Error>> + Send;
 
@@ -122,7 +122,7 @@ pub trait WalletNetworkInterface {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct SubstateQueryResult {
-    pub version: u32,
+    pub version: u64,
     pub substate: SubstateValue,
 }
 

--- a/crates/wallet/sdk/src/storage/writer.rs
+++ b/crates/wallet/sdk/src/storage/writer.rs
@@ -130,7 +130,7 @@ pub trait WalletStoreWriter: CommittableStore {
     fn vaults_update(
         &mut self,
         vault_id: VaultId,
-        vault_version: u32,
+        vault_version: u64,
         revealed_balance: Amount,
         confidential_balance: Amount,
     ) -> Result<(), WalletStorageError>;
@@ -142,7 +142,7 @@ pub trait WalletStoreWriter: CommittableStore {
     fn balance_changes_attribute_transaction(
         &mut self,
         vault_id: &VaultId,
-        vault_version: u32,
+        vault_version: u64,
         transaction_id: TransactionId,
     ) -> Result<bool, WalletStorageError>;
     fn vaults_lock_revealed_funds(

--- a/crates/wallet/sdk_services/src/account_monitor/scanner.rs
+++ b/crates/wallet/sdk_services/src/account_monitor/scanner.rs
@@ -183,7 +183,7 @@ where TSpec: WalletSdkSpec
         &self,
         account_address: ComponentAddress,
         vault_id: VaultId,
-        vault_version: u32,
+        vault_version: u64,
         latest_vault: &Vault,
         updated_nft_data: HashMap<NonFungibleId, NonFungibleContainer>,
         source: BalanceChangeSource,

--- a/crates/wallet/sdk_services/src/indexer_rest_api.rs
+++ b/crates/wallet/sdk_services/src/indexer_rest_api.rs
@@ -98,7 +98,7 @@ impl WalletNetworkInterface for IndexerRestApiNetworkInterface {
     async fn query_substate(
         &self,
         substate_id: &SubstateId,
-        version: Option<u32>,
+        version: Option<u64>,
         local_search_only: bool,
     ) -> Result<SubstateQueryResult, Self::Error> {
         let client = self.get_client()?;

--- a/crates/wallet/sdk_tests/tests/support/harness.rs
+++ b/crates/wallet/sdk_tests/tests/support/harness.rs
@@ -229,7 +229,7 @@ impl WalletNetworkInterface for CannedTransactionResultInterface {
     async fn query_substate(
         &self,
         _address: &SubstateId,
-        _version: Option<u32>,
+        _version: Option<u64>,
         _local_search_only: bool,
     ) -> Result<SubstateQueryResult, Self::Error> {
         panic!("CannedTransactionResultInterface called")
@@ -321,7 +321,7 @@ impl WalletNetworkInterface for PanicNetworkInterface {
     async fn query_substate(
         &self,
         _address: &SubstateId,
-        _version: Option<u32>,
+        _version: Option<u64>,
         _local_search_only: bool,
     ) -> Result<SubstateQueryResult, Self::Error> {
         panic!("PanicNetworkInterface called")

--- a/crates/wallet/sdk_tests/tests/transaction_service.rs
+++ b/crates/wallet/sdk_tests/tests/transaction_service.rs
@@ -113,7 +113,7 @@ impl WalletNetworkInterface for ScriptedNetwork {
     async fn query_substate(
         &self,
         _address: &SubstateId,
-        _version: Option<u32>,
+        _version: Option<u64>,
         _local_search_only: bool,
     ) -> Result<SubstateQueryResult, Self::Error> {
         panic!("ScriptedNetwork::query_substate called")

--- a/crates/wallet/storage_sqlite/migrations/2026-09-11-000000_substate_version_u64/down.sql
+++ b/crates/wallet/storage_sqlite/migrations/2026-09-11-000000_substate_version_u64/down.sql
@@ -1,0 +1,9 @@
+ALTER TABLE substates ADD COLUMN version_narrow INTEGER NOT NULL DEFAULT 0;
+UPDATE substates SET version_narrow = version;
+ALTER TABLE substates DROP COLUMN version;
+ALTER TABLE substates RENAME COLUMN version_narrow TO version;
+
+ALTER TABLE vaults ADD COLUMN vault_version_narrow INTEGER NOT NULL DEFAULT 0;
+UPDATE vaults SET vault_version_narrow = vault_version;
+ALTER TABLE vaults DROP COLUMN vault_version;
+ALTER TABLE vaults RENAME COLUMN vault_version_narrow TO vault_version;

--- a/crates/wallet/storage_sqlite/migrations/2026-09-11-000000_substate_version_u64/up.sql
+++ b/crates/wallet/storage_sqlite/migrations/2026-09-11-000000_substate_version_u64/up.sql
@@ -1,0 +1,21 @@
+-- Widen the wallet's substate version columns to hold a u64.
+--
+-- A version counts one write per transaction that touches the substate, so its ceiling is a
+-- throughput ceiling on a single contended substate, not a calendar one. The column must hold the
+-- full range the protocol admits, which a signed 32-bit integer does not.
+--
+-- SQLite cannot change a column's declared type in place, and a table rebuild is not available here:
+-- `vaults` is a foreign key target, and inside the transaction a migration runs in, renaming it
+-- repoints every referencing table at the temporary name. Adding the wider column and dropping the
+-- narrow one leaves those references untouched. Both columns move to the end of their table as a
+-- result, which is where the generated schema expects them.
+
+ALTER TABLE substates ADD COLUMN version_wide BIGINT NOT NULL DEFAULT 0;
+UPDATE substates SET version_wide = version;
+ALTER TABLE substates DROP COLUMN version;
+ALTER TABLE substates RENAME COLUMN version_wide TO version;
+
+ALTER TABLE vaults ADD COLUMN vault_version_wide BIGINT NOT NULL DEFAULT 0;
+UPDATE vaults SET vault_version_wide = vault_version;
+ALTER TABLE vaults DROP COLUMN vault_version;
+ALTER TABLE vaults RENAME COLUMN vault_version_wide TO vault_version;

--- a/crates/wallet/storage_sqlite/src/models/substate.rs
+++ b/crates/wallet/storage_sqlite/src/models/substate.rs
@@ -20,16 +20,16 @@ pub struct Substate {
     pub address: String,
     pub parent_address: Option<String>,
     pub referenced_substates: String,
-    pub version: i32,
     pub template_address: Option<String>,
     pub created_at: PrimitiveDateTime,
+    pub version: i64,
 }
 
 impl Substate {
     pub fn try_to_record(&self) -> Result<SubstateModel, WalletStorageError> {
         Ok(SubstateModel {
             module_name: self.module_name.clone(),
-            substate_id: VersionedSubstateId::new(SubstateId::from_str(&self.address).unwrap(), self.version as u32),
+            substate_id: VersionedSubstateId::new(SubstateId::from_str(&self.address).unwrap(), self.version as u64),
             parent_address: self.parent_address.as_ref().map(|s| s.parse().unwrap()),
             referenced_substates: deserialize_json(&self.referenced_substates)?,
             template_address: self

--- a/crates/wallet/storage_sqlite/src/models/vault.rs
+++ b/crates/wallet/storage_sqlite/src/models/vault.rs
@@ -20,11 +20,11 @@ pub struct Vault {
     pub resource_type: String,
     pub revealed_balance: String,
     pub confidential_balance: String,
-    pub vault_version: i32,
     pub token_symbol: Option<String>,
     pub divisibility: i32,
     pub created_at: PrimitiveDateTime,
     pub updated_at: PrimitiveDateTime,
+    pub vault_version: i64,
 }
 
 impl Vault {
@@ -40,7 +40,7 @@ impl Vault {
                 item: "vault.address",
                 details: e.to_string(),
             })?,
-            vault_version: u32::try_from(self.vault_version).map_err(|e| WalletStorageError::DecodingError {
+            vault_version: u64::try_from(self.vault_version).map_err(|e| WalletStorageError::DecodingError {
                 operation: "try_into_vault",
                 item: "vault.vault_version",
                 details: e.to_string(),

--- a/crates/wallet/storage_sqlite/src/schema.rs
+++ b/crates/wallet/storage_sqlite/src/schema.rs
@@ -206,9 +206,9 @@ diesel::table! {
         address -> Text,
         parent_address -> Nullable<Text>,
         referenced_substates -> Text,
-        version -> Integer,
         template_address -> Nullable<Text>,
         created_at -> Timestamp,
+        version -> BigInt,
     }
 }
 
@@ -290,11 +290,11 @@ diesel::table! {
         resource_type -> Text,
         revealed_balance -> Text,
         confidential_balance -> Text,
-        vault_version -> Integer,
         token_symbol -> Nullable<Text>,
         divisibility -> Integer,
         created_at -> Timestamp,
         updated_at -> Timestamp,
+        vault_version -> BigInt,
     }
 }
 

--- a/crates/wallet/storage_sqlite/src/writer.rs
+++ b/crates/wallet/storage_sqlite/src/writer.rs
@@ -505,7 +505,7 @@ impl<'a> WriteTransaction<'a> {
         account_address: &ComponentAddress,
         resource_address: &ResourceAddress,
         diff: &SubstateDiff,
-    ) -> Result<Option<(VaultId, u32)>, WalletStorageError> {
+    ) -> Result<Option<(VaultId, u64)>, WalletStorageError> {
         for (id, substate) in diff.up_iter() {
             let Some(vault_id) = id.as_vault_id() else {
                 continue;
@@ -829,7 +829,7 @@ impl WalletStoreWriter for WriteTransaction<'_> {
                 substates::module_name.eq(&module_name),
                 substates::template_address.eq(template_addr.map(|a| a.to_string())),
                 substates::referenced_substates.eq(serialize_json(&referenced_substates)?),
-                substates::version.eq(substate_id.version() as i32),
+                substates::version.eq(substate_id.version() as i64),
             ))
             .on_conflict(substates::address)
             .do_update()
@@ -837,7 +837,7 @@ impl WalletStoreWriter for WriteTransaction<'_> {
                 substates::module_name.eq(&module_name),
                 substates::template_address.eq(template_addr.map(|a| a.to_string())),
                 substates::referenced_substates.eq(serialize_json(&referenced_substates)?),
-                substates::version.eq(substate_id.version() as i32),
+                substates::version.eq(substate_id.version() as i64),
             ))
             .execute(self.connection())
             .map_err(|e| WalletStorageError::general("substates_upsert_root", e))?;
@@ -858,14 +858,14 @@ impl WalletStoreWriter for WriteTransaction<'_> {
                 substates::address.eq(address.substate_id().to_string()),
                 substates::parent_address.eq(Some(parent.to_string())),
                 substates::referenced_substates.eq(serialize_json(&referenced_substates)?),
-                substates::version.eq(address.version() as i32),
+                substates::version.eq(address.version() as i64),
             ))
             .on_conflict(substates::address)
             .do_update()
             .set((
                 substates::parent_address.eq(Some(parent.to_string())),
                 substates::referenced_substates.eq(serialize_json(&referenced_substates)?),
-                substates::version.eq(address.version() as i32),
+                substates::version.eq(address.version() as i64),
             ))
             .execute(self.connection())
             .map_err(|e| WalletStorageError::general("substates_upsert_child", e))?;
@@ -1040,7 +1040,7 @@ impl WalletStoreWriter for WriteTransaction<'_> {
         let values = (
             vaults::account_id.eq(account_id),
             vaults::address.eq(vault.id.to_string()),
-            vaults::vault_version.eq(i32::try_from(vault.vault_version)
+            vaults::vault_version.eq(i64::try_from(vault.vault_version)
                 .map_err(|e| WalletStorageError::bad_query("vaults_insert", format!("invalid vault version: {e}")))?),
             vaults::revealed_balance.eq(vault.revealed_balance.to_string()),
             vaults::confidential_balance.eq(vault.confidential_balance.to_string()),
@@ -1060,14 +1060,14 @@ impl WalletStoreWriter for WriteTransaction<'_> {
     fn vaults_update(
         &mut self,
         vault_id: VaultId,
-        vault_version: u32,
+        vault_version: u64,
         revealed_balance: Amount,
         confidential_balance: Amount,
     ) -> Result<(), WalletStorageError> {
         use crate::schema::vaults;
 
         let changeset = (
-            vaults::vault_version.eq(i32::try_from(vault_version)
+            vaults::vault_version.eq(i64::try_from(vault_version)
                 .map_err(|e| WalletStorageError::bad_query("vaults_update", format!("invalid vault version: {e}")))?),
             vaults::revealed_balance.eq(revealed_balance.to_string()),
             vaults::confidential_balance.eq(confidential_balance.to_string()),
@@ -1120,7 +1120,7 @@ impl WalletStoreWriter for WriteTransaction<'_> {
             account_balance_changes::resource_id.eq(resource_id),
             account_balance_changes::account_address.eq(change.account_address.to_string()),
             account_balance_changes::vault_address.eq(change.vault_address.as_ref().map(ToString::to_string)),
-            account_balance_changes::vault_version.eq(change.vault_version.map(i64::from)),
+            account_balance_changes::vault_version.eq(change.vault_version.map(|v| v as i64)),
             account_balance_changes::resource_address.eq(change.resource_address.to_string()),
             account_balance_changes::token_symbol.eq(&change.token_symbol),
             account_balance_changes::divisibility.eq(i32::from(change.divisibility)),
@@ -1201,7 +1201,7 @@ impl WalletStoreWriter for WriteTransaction<'_> {
         let vault_address = vault_address.to_string();
         let maybe_existing = account_balance_changes::table
             .filter(account_balance_changes::vault_address.eq(Some(vault_address)))
-            .filter(account_balance_changes::vault_version.eq(Some(i64::from(vault_version))))
+            .filter(account_balance_changes::vault_version.eq(Some(vault_version as i64)))
             .select((
                 account_balance_changes::id,
                 account_balance_changes::source_type,
@@ -1366,7 +1366,7 @@ impl WalletStoreWriter for WriteTransaction<'_> {
     fn balance_changes_attribute_transaction(
         &mut self,
         vault_id: &VaultId,
-        vault_version: u32,
+        vault_version: u64,
         transaction_id: TransactionId,
     ) -> Result<bool, WalletStorageError> {
         const OPERATION: &str = "balance_changes_attribute_transaction";
@@ -1388,7 +1388,7 @@ impl WalletStoreWriter for WriteTransaction<'_> {
         let updated = diesel::update(
             account_balance_changes::table
                 .filter(account_balance_changes::vault_address.eq(Some(vault_address)))
-                .filter(account_balance_changes::vault_version.eq(Some(i64::from(vault_version))))
+                .filter(account_balance_changes::vault_version.eq(Some(vault_version as i64)))
                 .filter(account_balance_changes::transaction_id.is_null()),
         )
         .set((

--- a/crates/wallet/storage_sqlite/tests/balance_changes.rs
+++ b/crates/wallet/storage_sqlite/tests/balance_changes.rs
@@ -158,7 +158,7 @@ fn setup_store_at(path: impl AsRef<Path>) -> (SqliteWalletStore, VaultId, VaultI
 
 fn balance_change_snapshot(
     current: &VaultModel,
-    vault_version: u32,
+    vault_version: u64,
     revealed_after: Amount,
     confidential_after: Amount,
 ) -> BalanceChangeSnapshot {
@@ -187,7 +187,7 @@ fn temporary_database_path() -> std::path::PathBuf {
 fn record_change(
     store: &SqliteWalletStore,
     vault_address: VaultId,
-    vault_version: u32,
+    vault_version: u64,
     revealed_after: Amount,
     confidential_after: Amount,
     source: BalanceChangeSource,

--- a/integration_tests/src/indexer.rs
+++ b/integration_tests/src/indexer.rs
@@ -83,7 +83,7 @@ impl IndexerProcess {
         &self,
         world: &TariWorld,
         output_ref: String,
-        version: u32,
+        version: u64,
     ) -> Result<GetSubstateResponse, tari_indexer_client::error::IndexerRestClientError> {
         let address = get_address_from_output(world, output_ref);
         let client = self.get_indexer_client();

--- a/integration_tests/src/wallet_daemon_client.rs
+++ b/integration_tests/src/wallet_daemon_client.rs
@@ -716,7 +716,7 @@ pub fn find_output_version(
     world: &mut TariWorld,
     output_ref: &str,
     output_component_substate_id: SubstateId,
-) -> anyhow::Result<Option<u32>> {
+) -> anyhow::Result<Option<u64>> {
     let outputs_name = output_ref.split('/').next().ok_or(anyhow!("Output must have a name"))?;
     Ok(world
         .outputs

--- a/integration_tests/tests/steps/indexer.rs
+++ b/integration_tests/tests/steps/indexer.rs
@@ -255,7 +255,7 @@ async fn indexer_scans_network_events_for_resource(world: &mut TariWorld, indexe
 async fn assert_indexer_substate_version(
     world: &mut TariWorld,
     indexer_name: String,
-    version: u32,
+    version: u64,
     output_ref: String,
 ) {
     let indexer = world.indexers.get(&indexer_name).unwrap();


### PR DESCRIPTION
## Description

Widens the substate version from `u32` to `u64` everywhere it is carried: the engine, consensus, storage, the wire formats, and the wallet/indexer SQLite stores.

### Why

A version counts one write per transaction that touches the substate, so its ceiling is a **throughput** ceiling on a single contended substate, not a calendar one. Extrapolating from testnet traffic is misleading — the faucet vault reached v33,691 in about a month, which is ~10,600 years to exhaust `u32`. The rate that matters is the one a hot vault or AMM pool sees at target TPS:

| sustained writes/s on **one** substate | `u32` lifetime |
| --- | --- |
| 10 | 13.6 years |
| 100 | 1.4 years |
| 1,000 | **50 days** |

`u64` at 1,000/s is ~585 million years.

Overflow today is also unsafe rather than a clean reject. Every increment was a plain `+ 1` (`working_state.rs`, `versioned_substate_id.rs`, `pending_store.rs`), and the version is the low bytes of `SubstateAddress`, so a wrapped version collides with the substate's v0 address and reuses a JMT key for a substate that is already down — silent corruption instead of an aborted transaction.

### Consensus-breaking

Networks must **reset**. Upgrading every node at once is not sufficient, because the break is in the on-disk state, not in what nodes say to each other:

- The RocksDB substates column family is keyed by `SubstateAddress`, which grows 36 -> 40 bytes. Existing rows are not merely stale, they are at keys the new binary never looks up.
- `BlockDiffKey`'s codec reads a 4-byte version where it now writes 8, so existing block diff rows decode to garbage.
- JMT leaf keys are `jmt_node_hash(&VersionedSubstateId)`, which is Borsh and therefore fixed-width, so every leaf key moves; leaf value hashes come from `hash_substate`, likewise Borsh, so every value hash changes. The same logical state produces a different merkle root.
- Committed block headers ratify the old roots through their QCs, so an upgraded node recomputes roots that disagree with its own history.

A migration could re-key the substate rows deterministically (the new address is the old object key, four zero bytes, then the old four version bytes) and rebuild the tree from the live set, but the rebuilt root matches nothing in the committed history. That needs a fork point past which root verification starts fresh, and a sync path that declines to re-derive pre-fork roots - more work than the change itself, and not worth it for a testnet.

- `hash_substate` chains the version through **Borsh**, which is fixed-width, so every substate value hash changes. There is no "small values encode identically" escape as there would be with CBOR.
- `SubstateAddress` grows 36 → 40 bytes, so every JMT key changes with it.
- The version inside a transaction's input requirements is part of the signed preimage, so transaction hashing changes too.

Shard routing is untouched: the version is a pure suffix of the address and `to_shard` reads only its first byte, so the shard/shard-group/range maths is unaffected.

The pinned-preimage tests in `substate_hasher.rs` are re-pinned to the new hashes, and the `hash_at` helper now mirrors `hash_substate`'s u64 chaining. Their doc comments previously claimed a specific old binary's hash must be reproducible; that continuity is what this change deliberately breaks, so they now state what they pin rather than where the value came from.

### Notable details

- **TS bindings are unchanged.** `ts-rs` maps a bare `u64` to `bigint`, which would break every JS/TS consumer for no reason — a version stays far below 2^53. Each exported version field is pinned to `ts(type = "number")`, matching the existing precedent on `NodeHeight`. A static check over the tree confirms no exported version field is left unpinned.
- **`prost` wire types** move from `uint32` to `uint64` in `common.proto` (`OptionalVersion`), `consensus.proto` (`Substate`), and `rpc.proto` (`GetSubstateResponse`, `SubstateData`, `SubstateDestroy`), plus the hand-written prost types in `tari_indexer_client`. `IdentitySignature.version` and `ShardStateVersions` are unrelated and untouched.
- **SQLite migrations** widen the version columns in both the wallet and indexer stores. The indexer schema has no foreign keys, so those tables are rebuilt normally. The wallet's `vaults` **is** a foreign key target, and a rebuild is not available: inside the transaction a diesel migration runs in, `PRAGMA legacy_alter_table` does not take effect, so renaming `vaults` repoints every referencing table at the temporary name and the referencing queries then fail on `vaults_old`. Both wallet columns are therefore replaced in place with `ADD COLUMN` / `UPDATE` / `DROP COLUMN` / `RENAME COLUMN`, which leaves foreign key clauses untouched; they move to the end of their tables, and the generated schema and models were reordered to match.
- **Memory guardrail raised.** `ProposedBlockChangeSet`'s worst case moves from 13.4MB to 14.3MB — the ~960KB is the wider version fields in `SubstateChange` and `SubstateLock`. The assertion ceiling goes to 15MB and the "last checked" figure is updated.
- **Fee estimation** shifts marginally: `TransactionReceipt::encoded_size_upper_bound` now uses `u64::MAX` as the worst-case version, which is 9 CBOR bytes instead of 5 per upped substate.

## Motivation and Context

`u32` is not wide enough for a substate that is written at the rates Ootle is designed to sustain, and the failure mode at the ceiling is JMT key reuse rather than a rejected transaction. Doing this while networks are still being reset is far cheaper than doing it after mainnet.

## How Has This Been Tested?

`cargo lints clippy --all-targets` is clean, and `cargo +nightly-2025-12-05 fmt --all` has been applied.

`cargo nextest run` passes for: `tari_ootle_common_types`, `tari_engine_types`, `tari_ootle_storage`, `tari_state_tree`, `tari_state_store_rocksdb`, `tari_ootle_p2p`, `tari_consensus`, `consensus_tests`, `tari_indexer_lib`, `tari_indexer`, `tari_ootle_wallet_storage_sqlite`, `tari_ootle_wallet_sdk`, `tari_ootle_walletd`, `tari_engine`, `tari_ootle_transaction`, `tari_transaction_manifest`, `ootle_sdk_core` and `tari_validator_node_rpc`.

The wallet migration is exercised by the `tari_ootle_wallet_storage_sqlite` suite, which runs migrations against a fresh database on every test — the foreign-key breakage above was caught there and the current form passes.

Not run locally: the `integration_tests` cucumber suite and the bindings regeneration (`bindings/build.sh`), both left to CI.

## What process can a PR reviewer use to test or verify this change?

- Confirm the hash re-pinning is intended rather than accidental: `cargo nextest run -p tari_engine_types substate_hasher`.
- Check that the generated bindings really are unchanged by running `bindings/build.sh` and confirming an empty diff.
- Sanity-check the wallet migration against a populated pre-change wallet database: run the daemon against it and confirm vault balances and lock sweeping still work (the foreign keys on `vault_locks` are the thing to watch).

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->

### Breaking Changes

- [ ] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [x] Other - Please specify

Every substate value hash and every JMT key changes, so state roots committed by a pre-change binary cannot be re-derived, and the RocksDB substate and block-diff keys change shape underneath the existing store. Networks must be reset; a coordinated upgrade of every node does not avoid it. The wire formats (`SubstateRequirement`, substate RPC responses) and the signed transaction preimage change with them, so old and new nodes cannot interoperate.

