### PR TITLE
docs(common-types): correct the quorum threshold doc comments

### DIFF
--- a/crates/common_types/src/committee.rs
+++ b/crates/common_types/src/committee.rs
@@ -61,7 +61,8 @@ impl<TAddr: PartialEq> Committee<TAddr> {
         (power - VotePower::of(1)) / VotePower::of(3)
     }
 
-    /// Returns $n - f$ (i.e. $2f + 1$) where n is the number of committee members and f is the tolerated failure nodes.
+    /// Returns the quorum threshold $n - f$, where $n$ is the committee's total vote power and $f$ is the
+    /// tolerated faulty power. This equals $2f + 1$ exactly when $n = 3f + 1$.
     pub fn quorum_threshold(&self) -> VotePower {
         self.total_power() - self.max_failures()
     }
@@ -246,13 +247,13 @@ impl CommitteeInfo {
         self.epoch
     }
 
-    /// Returns $n - f$ (i.e $2f + 1$) where n is the total power of committee members and f is the tolerated failure
-    /// nodes.
+    /// Returns the quorum threshold $n - f$, where $n$ is the committee's total vote power and $f$ is the
+    /// tolerated faulty power. This equals $2f + 1$ exactly when $n = 3f + 1$.
     pub fn quorum_threshold(&self) -> VotePower {
         self.total_power() - self.max_failures()
     }
 
-    /// Returns the maximum number of failures $f$ that can be tolerated by this committee.
+    /// Returns the maximum faulty vote power $f$ that this committee tolerates.
     pub fn max_failures(&self) -> VotePower {
         if self.total_power().is_zero() {
             return VotePower::zero();


### PR DESCRIPTION
Description
---

Corrects three doc comments in `crates/common_types/src/committee.rs`. No behaviour change.

`quorum_threshold` on both `Committee` and `CommitteeInfo` documented its return as
`$n - f$ (i.e. $2f + 1$)`. That identity only holds when $n = 3f + 1$. With
`f = floor((n - 1) / 3)`, a committee of 41 has `f = 13`, so `n - f = 28` while
`2f + 1 = 27`. The implementation uses `n - f` directly at every committee size, so the
parenthetical named a threshold the code does not compute.

Two related imprecisions in the same block:

- `Committee::quorum_threshold` described $n$ as "the number of committee members". It is
  `total_power()` — the sum of the members' `VotePower`. That equals the member count only
  because vote power is currently one per validator.
- `CommitteeInfo::max_failures` described its result as a "number of failures"; it also
  returns `VotePower`.

Motivation and Context
---

Surfaced while reviewing #2571, which adds a Consensus concepts page that quotes
`quorum_threshold` and reasons about the quorum arithmetic. The page is correct and the
comment was not, which left the docs either misquoting the source or repeating an error.
Fixing the source is the better half of that choice, and the distinction matters
independently: the quorum code is deliberately written in terms of vote power so that
weighted power is a change of inputs rather than of the rule, and a comment that counts
members undercuts that.

How Has This Been Tested?
---

Comment-only change; `cargo +nightly-2025-12-05 fmt` leaves it unchanged. Nothing compiles
differently, so this rides on CI.

What process can a PR reviewer use to test or verify this change?
---

Read the two `quorum_threshold` bodies against their comments, and check the arithmetic for
a committee size that is not $3f + 1$ — e.g. `n = 41` gives `f = 13`, `n - f = 28`,
`2f + 1 = 27`.

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify
